### PR TITLE
cargo fmt of consensus

### DIFF
--- a/client/consensus/aura/src/import_queue.rs
+++ b/client/consensus/aura/src/import_queue.rs
@@ -18,36 +18,39 @@
 
 //! Module implementing the logic for verifying and importing AuRa blocks.
 
-use crate::{AuthorityId, find_pre_digest, slot_author, aura_err, Error, authorities};
-use std::{
-	sync::Arc, marker::PhantomData, hash::Hash, fmt::Debug,
-};
+use std::{fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
+
+use codec::{Codec, Decode, Encode};
 use log::{debug, info, trace};
 use prometheus_endpoint::Registry;
-use codec::{Encode, Decode, Codec};
-use sp_consensus::{
-	BlockImport, CanAuthorWith, ForkChoiceStrategy, BlockImportParams,
-	BlockOrigin, Error as ConsensusError,
-	import_queue::{
-		Verifier, BasicQueue, DefaultImportQueue, BoxJustificationImport,
-	},
-};
-use sc_client_api::{BlockOf, UsageProvider, backend::AuxStore};
-use sp_blockchain::{well_known_cache_keys::{self, Id as CacheKeyId}, ProvideCache, HeaderBackend};
+use sc_client_api::{backend::AuxStore, BlockOf, UsageProvider};
+use sc_consensus_slots::{check_equivocation, CheckedHeader, InherentDataProviderExt};
+use sc_telemetry::{telemetry, TelemetryHandle, CONSENSUS_DEBUG, CONSENSUS_TRACE};
+use sp_api::{ApiExt, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder as BlockBuilderApi;
-use sp_runtime::{generic::{BlockId, OpaqueDigestItemId}, Justifications};
-use sp_runtime::traits::{Block as BlockT, Header, DigestItemFor};
-use sp_api::ProvideRuntimeApi;
+use sp_blockchain::{
+	well_known_cache_keys::{self, Id as CacheKeyId},
+	HeaderBackend, ProvideCache,
+};
+use sp_consensus::{
+	import_queue::{BasicQueue, BoxJustificationImport, DefaultImportQueue, Verifier},
+	BlockImport, BlockImportParams, BlockOrigin, CanAuthorWith, Error as ConsensusError,
+	ForkChoiceStrategy,
+};
+use sp_consensus_aura::{
+	digests::CompatibleDigestItem, inherents::AuraInherentData, AuraApi, ConsensusLog,
+	AURA_ENGINE_ID,
+};
+use sp_consensus_slots::Slot;
 use sp_core::crypto::Pair;
 use sp_inherents::{CreateInherentDataProviders, InherentDataProvider as _};
-use sc_telemetry::{telemetry, TelemetryHandle, CONSENSUS_TRACE, CONSENSUS_DEBUG};
-use sc_consensus_slots::{CheckedHeader, check_equivocation, InherentDataProviderExt};
-use sp_consensus_slots::Slot;
-use sp_api::ApiExt;
-use sp_consensus_aura::{
-	digests::CompatibleDigestItem, AuraApi, inherents::AuraInherentData,
-	ConsensusLog, AURA_ENGINE_ID,
+use sp_runtime::{
+	generic::{BlockId, OpaqueDigestItemId},
+	traits::{Block as BlockT, DigestItemFor, Header},
+	Justifications,
 };
+
+use crate::{aura_err, authorities, find_pre_digest, slot_author, AuthorityId, Error};
 
 /// check a header has been signed by the right key. If the slot is too far in the future, an error
 /// will be returned. If it's successful, returns the pre-header and the digest item
@@ -61,7 +64,8 @@ fn check_header<C, B: BlockT, P: Pair>(
 	hash: B::Hash,
 	authorities: &[AuthorityId<P>],
 	check_for_equivocation: CheckForEquivocation,
-) -> Result<CheckedHeader<B::Header, (Slot, DigestItemFor<B>)>, Error<B>> where
+) -> Result<CheckedHeader<B::Header, (Slot, DigestItemFor<B>)>, Error<B>>
+where
 	DigestItemFor<B>: CompatibleDigestItem<P::Signature>,
 	P::Signature: Codec,
 	C: sc_client_api::backend::AuxStore,
@@ -69,9 +73,7 @@ fn check_header<C, B: BlockT, P: Pair>(
 {
 	let seal = header.digest_mut().pop().ok_or_else(|| Error::HeaderUnsealed(hash))?;
 
-	let sig = seal.as_aura_seal().ok_or_else(|| {
-		aura_err(Error::HeaderBadSeal(hash))
-	})?;
+	let sig = seal.as_aura_seal().ok_or_else(|| aura_err(Error::HeaderBadSeal(hash)))?;
 
 	let slot = find_pre_digest::<B, P::Signature>(&header)?;
 
@@ -81,20 +83,17 @@ fn check_header<C, B: BlockT, P: Pair>(
 	} else {
 		// check the signature is valid under the expected authority and
 		// chain state.
-		let expected_author = slot_author::<P>(slot, &authorities)
-			.ok_or_else(|| Error::SlotAuthorNotFound)?;
+		let expected_author =
+			slot_author::<P>(slot, &authorities).ok_or_else(|| Error::SlotAuthorNotFound)?;
 
 		let pre_hash = header.hash();
 
 		if P::verify(&sig, pre_hash.as_ref(), expected_author) {
 			if check_for_equivocation.check_for_equivocation() {
-				if let Some(equivocation_proof) = check_equivocation(
-					client,
-					slot_now,
-					slot,
-					&header,
-					expected_author,
-				).map_err(Error::Client)? {
+				if let Some(equivocation_proof) =
+					check_equivocation(client, slot_now, slot, &header, expected_author)
+						.map_err(Error::Client)?
+				{
 					info!(
 						target: "aura",
 						"Slot author is equivocating at slot {} with headers {:?} and {:?}",
@@ -141,7 +140,8 @@ impl<C, P, CAW, CIDP> AuraVerifier<C, P, CAW, CIDP> {
 	}
 }
 
-impl<C, P, CAW, CIDP> AuraVerifier<C, P, CAW, CIDP> where
+impl<C, P, CAW, CIDP> AuraVerifier<C, P, CAW, CIDP>
+where
 	P: Send + Sync + 'static,
 	CAW: Send + Sync + 'static,
 	CIDP: Send,
@@ -152,8 +152,10 @@ impl<C, P, CAW, CIDP> AuraVerifier<C, P, CAW, CIDP> where
 		block_id: BlockId<B>,
 		inherent_data: sp_inherents::InherentData,
 		create_inherent_data_providers: CIDP::InherentDataProviders,
-	) -> Result<(), Error<B>> where
-		C: ProvideRuntimeApi<B>, C::Api: BlockBuilderApi<B>,
+	) -> Result<(), Error<B>>
+	where
+		C: ProvideRuntimeApi<B>,
+		C::Api: BlockBuilderApi<B>,
 		CAW: CanAuthorWith<B>,
 		CIDP: CreateInherentDataProviders<B, ()>,
 	{
@@ -164,14 +166,14 @@ impl<C, P, CAW, CIDP> AuraVerifier<C, P, CAW, CIDP> where
 				e,
 			);
 
-			return Ok(())
+			return Ok(());
 		}
 
-		let inherent_res = self.client.runtime_api().check_inherents(
-			&block_id,
-			block,
-			inherent_data,
-		).map_err(|e| Error::Client(e.into()))?;
+		let inherent_res = self
+			.client
+			.runtime_api()
+			.check_inherents(&block_id, block, inherent_data)
+			.map_err(|e| Error::Client(e.into()))?;
 
 		if !inherent_res.ok() {
 			for (i, e) in inherent_res.into_errors() {
@@ -187,13 +189,14 @@ impl<C, P, CAW, CIDP> AuraVerifier<C, P, CAW, CIDP> where
 }
 
 #[async_trait::async_trait]
-impl<B: BlockT, C, P, CAW, CIDP> Verifier<B> for AuraVerifier<C, P, CAW, CIDP> where
-	C: ProvideRuntimeApi<B> +
-		Send +
-		Sync +
-		sc_client_api::backend::AuxStore +
-		ProvideCache<B> +
-		BlockOf,
+impl<B: BlockT, C, P, CAW, CIDP> Verifier<B> for AuraVerifier<C, P, CAW, CIDP>
+where
+	C: ProvideRuntimeApi<B>
+		+ Send
+		+ Sync
+		+ sc_client_api::backend::AuxStore
+		+ ProvideCache<B>
+		+ BlockOf,
 	C::Api: BlockBuilderApi<B> + AuraApi<B, AuthorityId<P>> + ApiExt<B>,
 	DigestItemFor<B>: CompatibleDigestItem<P::Signature>,
 	P: Pair + Send + Sync + 'static,
@@ -215,15 +218,14 @@ impl<B: BlockT, C, P, CAW, CIDP> Verifier<B> for AuraVerifier<C, P, CAW, CIDP> w
 		let authorities = authorities(self.client.as_ref(), &BlockId::Hash(parent_hash))
 			.map_err(|e| format!("Could not fetch authorities at {:?}: {:?}", parent_hash, e))?;
 
-		let create_inherent_data_providers = self.create_inherent_data_providers
-			.create_inherent_data_providers(
-				parent_hash,
-				(),
-			)
+		let create_inherent_data_providers = self
+			.create_inherent_data_providers
+			.create_inherent_data_providers(parent_hash, ())
 			.await
 			.map_err(|e| Error::<B>::Client(sp_blockchain::Error::Application(e)))?;
 
-		let mut inherent_data = create_inherent_data_providers.create_inherent_data()
+		let mut inherent_data = create_inherent_data_providers
+			.create_inherent_data()
 			.map_err(Error::<B>::Inherent)?;
 
 		let slot_now = create_inherent_data_providers.slot();
@@ -238,7 +240,8 @@ impl<B: BlockT, C, P, CAW, CIDP> Verifier<B> for AuraVerifier<C, P, CAW, CIDP> w
 			hash,
 			&authorities[..],
 			self.check_for_equivocation,
-		).map_err(|e| e.to_string())?;
+		)
+		.map_err(|e| e.to_string())?;
 		match checked_header {
 			CheckedHeader::Checked(pre_header, (slot, seal)) => {
 				// if the body is passed through, we need to use the runtime
@@ -250,7 +253,8 @@ impl<B: BlockT, C, P, CAW, CIDP> Verifier<B> for AuraVerifier<C, P, CAW, CIDP> w
 					inherent_data.aura_replace_inherent_data(slot);
 
 					// skip the inherents verification if the runtime API is old.
-					if self.client
+					if self
+						.client
 						.runtime_api()
 						.has_api_with::<dyn BlockBuilderApi<B>, _>(
 							&BlockId::Hash(parent_hash),
@@ -263,7 +267,9 @@ impl<B: BlockT, C, P, CAW, CIDP> Verifier<B> for AuraVerifier<C, P, CAW, CIDP> w
 							BlockId::Hash(parent_hash),
 							inherent_data,
 							create_inherent_data_providers,
-						).await.map_err(|e| e.to_string())?;
+						)
+						.await
+						.map_err(|e| e.to_string())?;
 					}
 
 					let (_, inner_body) = block.deconstruct();
@@ -279,16 +285,19 @@ impl<B: BlockT, C, P, CAW, CIDP> Verifier<B> for AuraVerifier<C, P, CAW, CIDP> w
 				);
 
 				// Look for an authorities-change log.
-				let maybe_keys = pre_header.digest()
+				let maybe_keys = pre_header
+					.digest()
 					.logs()
 					.iter()
-					.filter_map(|l| l.try_to::<ConsensusLog<AuthorityId<P>>>(
-						OpaqueDigestItemId::Consensus(&AURA_ENGINE_ID)
-					))
+					.filter_map(|l| {
+						l.try_to::<ConsensusLog<AuthorityId<P>>>(OpaqueDigestItemId::Consensus(
+							&AURA_ENGINE_ID,
+						))
+					})
 					.find_map(|l| match l {
-						ConsensusLog::AuthoritiesChange(a) => Some(
-							vec![(well_known_cache_keys::AUTHORITIES, a.encode())]
-						),
+						ConsensusLog::AuthoritiesChange(a) => {
+							Some(vec![(well_known_cache_keys::AUTHORITIES, a.encode())])
+						}
 						_ => None,
 					});
 
@@ -375,8 +384,9 @@ pub fn import_queue<'a, P, Block, I, C, S, CAW, CIDP>(
 		can_author_with,
 		check_for_equivocation,
 		telemetry,
-	}: ImportQueueParams<'a, Block, I, C, S, CAW, CIDP>
-) -> Result<DefaultImportQueue<Block, C>, sp_consensus::Error> where
+	}: ImportQueueParams<'a, Block, I, C, S, CAW, CIDP>,
+) -> Result<DefaultImportQueue<Block, C>, sp_consensus::Error>
+where
 	Block: BlockT,
 	C::Api: BlockBuilderApi<Block> + AuraApi<Block, AuthorityId<P>> + ApiExt<Block>,
 	C: 'static
@@ -388,7 +398,7 @@ pub fn import_queue<'a, P, Block, I, C, S, CAW, CIDP>(
 		+ AuxStore
 		+ UsageProvider<Block>
 		+ HeaderBackend<Block>,
-	I: BlockImport<Block, Error=ConsensusError, Transaction = sp_api::TransactionFor<C, Block>>
+	I: BlockImport<Block, Error = ConsensusError, Transaction = sp_api::TransactionFor<C, Block>>
 		+ Send
 		+ Sync
 		+ 'static,
@@ -401,23 +411,15 @@ pub fn import_queue<'a, P, Block, I, C, S, CAW, CIDP>(
 	CIDP: CreateInherentDataProviders<Block, ()> + Sync + Send + 'static,
 	CIDP::InherentDataProviders: InherentDataProviderExt + Send + Sync,
 {
-	let verifier = build_verifier::<P, _, _, _>(
-		BuildVerifierParams {
-			client,
-			create_inherent_data_providers,
-			can_author_with,
-			check_for_equivocation,
-			telemetry,
-		},
-	);
+	let verifier = build_verifier::<P, _, _, _>(BuildVerifierParams {
+		client,
+		create_inherent_data_providers,
+		can_author_with,
+		check_for_equivocation,
+		telemetry,
+	});
 
-	Ok(BasicQueue::new(
-		verifier,
-		Box::new(block_import),
-		justification_import,
-		spawner,
-		registry,
-	))
+	Ok(BasicQueue::new(verifier, Box::new(block_import), justification_import, spawner, registry))
 }
 
 /// Parameters of [`build_verifier`].
@@ -442,7 +444,7 @@ pub fn build_verifier<P, C, CIDP, CAW>(
 		can_author_with,
 		check_for_equivocation,
 		telemetry,
-	}: BuildVerifierParams<C, CIDP, CAW>
+	}: BuildVerifierParams<C, CIDP, CAW>,
 ) -> AuraVerifier<C, P, CAW, CIDP> {
 	AuraVerifier::<_, P, _, _>::new(
 		client,

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -31,50 +31,51 @@
 //! NOTE: Aura itself is designed to be generic over the crypto used.
 #![forbid(missing_docs, unsafe_code)]
 use std::{
-	sync::Arc, marker::PhantomData, hash::Hash, fmt::Debug, pin::Pin,
 	convert::{TryFrom, TryInto},
+	fmt::Debug,
+	hash::Hash,
+	marker::PhantomData,
+	pin::Pin,
+	sync::Arc,
 };
 
+use codec::{Codec, Decode, Encode};
 use futures::prelude::*;
 use log::{debug, trace};
-
-use codec::{Encode, Decode, Codec};
-
-use sp_consensus::{
-	BlockImport, Environment, Proposer, CanAuthorWith, ForkChoiceStrategy, BlockImportParams,
-	BlockOrigin, Error as ConsensusError, SelectChain, StateAction,
-};
 use sc_client_api::{backend::AuxStore, BlockOf, UsageProvider};
-use sp_blockchain::{Result as CResult, ProvideCache, HeaderBackend};
-use sp_core::crypto::Public;
-use sp_application_crypto::{AppKey, AppPublic};
-use sp_runtime::{generic::BlockId, traits::NumberFor};
-use sp_runtime::traits::{Block as BlockT, Header, DigestItemFor, Zero, Member};
-use sp_api::ProvideRuntimeApi;
-use sp_core::crypto::Pair;
-use sp_keystore::{SyncCryptoStorePtr, SyncCryptoStore};
-use sp_inherents::CreateInherentDataProviders;
-use sc_telemetry::TelemetryHandle;
 use sc_consensus_slots::{
-	SlotInfo, BackoffAuthoringBlocksStrategy, InherentDataProviderExt, StorageChanges,
+	BackoffAuthoringBlocksStrategy, InherentDataProviderExt, SlotInfo, StorageChanges,
+};
+use sc_telemetry::TelemetryHandle;
+use sp_api::ProvideRuntimeApi;
+use sp_application_crypto::{AppKey, AppPublic};
+use sp_blockchain::{HeaderBackend, ProvideCache, Result as CResult};
+use sp_consensus::{
+	BlockImport, BlockImportParams, BlockOrigin, CanAuthorWith, Environment,
+	Error as ConsensusError, ForkChoiceStrategy, Proposer, SelectChain, StateAction,
 };
 use sp_consensus_slots::Slot;
+use sp_core::crypto::{Pair, Public};
+use sp_inherents::CreateInherentDataProviders;
+use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
+use sp_runtime::{
+	generic::BlockId,
+	traits::{Block as BlockT, DigestItemFor, Header, Member, NumberFor, Zero},
+};
 
 mod import_queue;
 
-pub use sp_consensus_aura::{
-	ConsensusLog, AuraApi, AURA_ENGINE_ID, digests::CompatibleDigestItem,
-	inherents::{
-		InherentType as AuraInherent,
-		INHERENT_IDENTIFIER, InherentDataProvider,
-	},
-};
-pub use sp_consensus::SyncOracle;
 pub use import_queue::{
-	ImportQueueParams, import_queue, CheckForEquivocation,
-	build_verifier, BuildVerifierParams, AuraVerifier,
+	build_verifier, import_queue, AuraVerifier, BuildVerifierParams, CheckForEquivocation,
+	ImportQueueParams,
 };
 pub use sc_consensus_slots::SlotProportion;
+pub use sp_consensus::SyncOracle;
+pub use sp_consensus_aura::{
+	digests::CompatibleDigestItem,
+	inherents::{InherentDataProvider, InherentType as AuraInherent, INHERENT_IDENTIFIER},
+	AuraApi, ConsensusLog, AURA_ENGINE_ID,
+};
 
 type AuthorityId<P> = <P as Pair>::Public;
 
@@ -82,7 +83,8 @@ type AuthorityId<P> = <P as Pair>::Public;
 pub type SlotDuration = sc_consensus_slots::SlotDuration<sp_consensus_aura::SlotDuration>;
 
 /// Get type of `SlotDuration` for Aura.
-pub fn slot_duration<A, B, C>(client: &C) -> CResult<SlotDuration> where
+pub fn slot_duration<A, B, C>(client: &C) -> CResult<SlotDuration>
+where
 	A: Codec,
 	B: BlockT,
 	C: AuxStore + ProvideRuntimeApi<B> + UsageProvider<B>,
@@ -93,7 +95,9 @@ pub fn slot_duration<A, B, C>(client: &C) -> CResult<SlotDuration> where
 
 /// Get slot author for given block along with authorities.
 fn slot_author<P: Pair>(slot: Slot, authorities: &[AuthorityId<P>]) -> Option<&AuthorityId<P>> {
-	if authorities.is_empty() { return None }
+	if authorities.is_empty() {
+		return None;
+	}
 
 	let idx = *slot % (authorities.len() as u64);
 	assert!(
@@ -101,9 +105,10 @@ fn slot_author<P: Pair>(slot: Slot, authorities: &[AuthorityId<P>]) -> Option<&A
 		"It is impossible to have a vector with length beyond the address space; qed",
 	);
 
-	let current_author = authorities.get(idx as usize)
-		.expect("authorities not empty; index constrained to list length;\
-				this is a valid index; qed");
+	let current_author = authorities.get(idx as usize).expect(
+		"authorities not empty; index constrained to list length;\
+				this is a valid index; qed",
+	);
 
 	Some(current_author)
 }
@@ -323,14 +328,13 @@ where
 	Error: std::error::Error + Send + From<sp_consensus::Error> + 'static,
 {
 	type BlockImport = I;
-	type SyncOracle = SO;
-	type JustificationSyncLink = L;
-	type CreateProposer = Pin<Box<
-		dyn Future<Output = Result<E::Proposer, sp_consensus::Error>> + Send + 'static
-	>>;
-	type Proposer = E::Proposer;
 	type Claim = P::Public;
+	type CreateProposer =
+		Pin<Box<dyn Future<Output = Result<E::Proposer, sp_consensus::Error>> + Send + 'static>>;
 	type EpochData = Vec<AuthorityId<P>>;
+	type JustificationSyncLink = L;
+	type Proposer = E::Proposer;
+	type SyncOracle = SO;
 
 	fn logging_target(&self) -> &'static str {
 		"aura"
@@ -376,22 +380,25 @@ where
 		slot: Slot,
 		_claim: &Self::Claim,
 	) -> Vec<sp_runtime::DigestItem<B::Hash>> {
-		vec![
-			<DigestItemFor<B> as CompatibleDigestItem<P::Signature>>::aura_pre_digest(slot),
-		]
+		vec![<DigestItemFor<B> as CompatibleDigestItem<P::Signature>>::aura_pre_digest(slot)]
 	}
 
-	fn block_import_params(&self) -> Box<dyn Fn(
-		B::Header,
-		&B::Hash,
-		Vec<B::Extrinsic>,
-		StorageChanges<sp_api::TransactionFor<C, B>, B>,
-		Self::Claim,
-		Self::EpochData,
-	) -> Result<
-		sp_consensus::BlockImportParams<B, sp_api::TransactionFor<C, B>>,
-		sp_consensus::Error> + Send + 'static>
-	{
+	fn block_import_params(
+		&self,
+	) -> Box<
+		dyn Fn(
+				B::Header,
+				&B::Hash,
+				Vec<B::Extrinsic>,
+				StorageChanges<sp_api::TransactionFor<C, B>, B>,
+				Self::Claim,
+				Self::EpochData,
+			) -> Result<
+				sp_consensus::BlockImportParams<B, sp_api::TransactionFor<C, B>>,
+				sp_consensus::Error,
+			> + Send
+			+ 'static,
+	> {
 		let keystore = self.keystore.clone();
 		Box::new(move |header, header_hash, body, storage_changes, public, _epoch| {
 			// sign the pre-sealed hash of the block and then
@@ -402,28 +409,28 @@ where
 				&*keystore,
 				<AuthorityId<P> as AppKey>::ID,
 				&public_type_pair,
-				header_hash.as_ref()
-			).map_err(|e| sp_consensus::Error::CannotSign(
-				public.clone(), e.to_string(),
-			))?
-			.ok_or_else(|| sp_consensus::Error::CannotSign(
-				public.clone(), "Could not find key in keystore.".into(),
-			))?;
-			let signature = signature.clone().try_into()
-				.map_err(|_| sp_consensus::Error::InvalidSignature(
-					signature, public
-				))?;
+				header_hash.as_ref(),
+			)
+			.map_err(|e| sp_consensus::Error::CannotSign(public.clone(), e.to_string()))?
+			.ok_or_else(|| {
+				sp_consensus::Error::CannotSign(
+					public.clone(),
+					"Could not find key in keystore.".into(),
+				)
+			})?;
+			let signature = signature
+				.clone()
+				.try_into()
+				.map_err(|_| sp_consensus::Error::InvalidSignature(signature, public))?;
 
-			let signature_digest_item = <
-				DigestItemFor<B> as CompatibleDigestItem<P::Signature>
-			>::aura_seal(signature);
+			let signature_digest_item =
+				<DigestItemFor<B> as CompatibleDigestItem<P::Signature>>::aura_seal(signature);
 
 			let mut import_block = BlockImportParams::new(BlockOrigin::Own, header);
 			import_block.post_digests.push(signature_digest_item);
 			import_block.body = Some(body);
-			import_block.state_action = StateAction::ApplyChanges(
-				sp_consensus::StorageChanges::Changes(storage_changes)
-			);
+			import_block.state_action =
+				StateAction::ApplyChanges(sp_consensus::StorageChanges::Changes(storage_changes));
 			import_block.fork_choice = Some(ForkChoiceStrategy::LongestChain);
 
 			Ok(import_block)
@@ -458,9 +465,11 @@ where
 	}
 
 	fn proposer(&mut self, block: &B::Header) -> Self::CreateProposer {
-		Box::pin(self.env.init(block).map_err(|e| {
-			sp_consensus::Error::ClientImport(format!("{:?}", e)).into()
-		}))
+		Box::pin(
+			self.env
+				.init(block)
+				.map_err(|e| sp_consensus::Error::ClientImport(format!("{:?}", e)).into()),
+		)
 	}
 
 	fn telemetry(&self) -> Option<TelemetryHandle> {
@@ -530,13 +539,15 @@ fn find_pre_digest<B: BlockT, Signature: Codec>(header: &B::Header) -> Result<Sl
 	pre_digest.ok_or_else(|| aura_err(Error::NoDigestFound))
 }
 
-fn authorities<A, B, C>(client: &C, at: &BlockId<B>) -> Result<Vec<A>, ConsensusError> where
+fn authorities<A, B, C>(client: &C, at: &BlockId<B>) -> Result<Vec<A>, ConsensusError>
+where
 	A: Codec + Debug,
 	B: BlockT,
 	C: ProvideRuntimeApi<B> + BlockOf + ProvideCache<B>,
 	C::Api: AuraApi<B, A>,
 {
-	client.runtime_api()
+	client
+		.runtime_api()
 		.authorities(at)
 		.ok()
 		.ok_or_else(|| sp_consensus::Error::InvalidAuthoritiesSet.into())
@@ -544,27 +555,34 @@ fn authorities<A, B, C>(client: &C, at: &BlockId<B>) -> Result<Vec<A>, Consensus
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use sp_consensus::{
-		NoNetwork as DummyOracle, Proposal, AlwaysCanAuthor, DisableProofRecording,
-		import_queue::BoxJustificationImport, SlotData,
+	use std::{
+		task::Poll,
+		time::{Duration, Instant},
 	};
-	use sc_network_test::{Block as TestBlock, *};
-	use sp_runtime::traits::{Block as BlockT, DigestFor};
-	use sc_network::config::ProtocolConfig;
+
 	use parking_lot::Mutex;
-	use sp_keyring::sr25519::Keyring;
-	use sc_client_api::BlockchainEvents;
-	use sp_consensus_aura::sr25519::AuthorityPair;
-	use sc_consensus_slots::{SimpleSlotWorker, BackoffAuthoringOnFinalizedHeadLagging};
-	use std::{task::Poll, time::{Instant, Duration}};
 	use sc_block_builder::BlockBuilderProvider;
-	use sp_runtime::traits::Header as _;
-	use substrate_test_runtime_client::{TestClient, runtime::{Header, H256}};
+	use sc_client_api::BlockchainEvents;
+	use sc_consensus_slots::{BackoffAuthoringOnFinalizedHeadLagging, SimpleSlotWorker};
 	use sc_keystore::LocalKeystore;
+	use sc_network::config::ProtocolConfig;
+	use sc_network_test::{Block as TestBlock, *};
 	use sp_application_crypto::key_types::AURA;
+	use sp_consensus::{
+		import_queue::BoxJustificationImport, AlwaysCanAuthor, DisableProofRecording,
+		NoNetwork as DummyOracle, Proposal, SlotData,
+	};
+	use sp_consensus_aura::sr25519::AuthorityPair;
 	use sp_inherents::InherentData;
+	use sp_keyring::sr25519::Keyring;
+	use sp_runtime::traits::{Block as BlockT, DigestFor, Header as _};
 	use sp_timestamp::InherentDataProvider as TimestampInherentDataProvider;
+	use substrate_test_runtime_client::{
+		runtime::{Header, H256},
+		TestClient,
+	};
+
+	use super::*;
 
 	type Error = sp_blockchain::Error;
 
@@ -572,26 +590,22 @@ mod tests {
 	struct DummyProposer(u64, Arc<TestClient>);
 
 	impl Environment<TestBlock> for DummyFactory {
-		type Proposer = DummyProposer;
 		type CreateProposer = futures::future::Ready<Result<DummyProposer, Error>>;
 		type Error = Error;
+		type Proposer = DummyProposer;
 
-		fn init(&mut self, parent_header: &<TestBlock as BlockT>::Header)
-			-> Self::CreateProposer
-		{
+		fn init(&mut self, parent_header: &<TestBlock as BlockT>::Header) -> Self::CreateProposer {
 			futures::future::ready(Ok(DummyProposer(parent_header.number + 1, self.0.clone())))
 		}
 	}
 
 	impl Proposer<TestBlock> for DummyProposer {
 		type Error = Error;
-		type Transaction = sc_client_api::TransactionFor<
-			substrate_test_runtime_client::Backend,
-			TestBlock
-		>;
-		type Proposal = future::Ready<Result<Proposal<TestBlock, Self::Transaction, ()>, Error>>;
-		type ProofRecording = DisableProofRecording;
 		type Proof = ();
+		type ProofRecording = DisableProofRecording;
+		type Proposal = future::Ready<Result<Proposal<TestBlock, Self::Transaction, ()>, Error>>;
+		type Transaction =
+			sc_client_api::TransactionFor<substrate_test_runtime_client::Backend, TestBlock>;
 
 		fn propose(
 			self,
@@ -616,11 +630,13 @@ mod tests {
 		PeersFullClient,
 		AuthorityPair,
 		AlwaysCanAuthor,
-		Box<dyn CreateInherentDataProviders<
-			TestBlock,
-			(),
-			InherentDataProviders = (TimestampInherentDataProvider, InherentDataProvider)
-		>>
+		Box<
+			dyn CreateInherentDataProviders<
+				TestBlock,
+				(),
+				InherentDataProviders = (TimestampInherentDataProvider, InherentDataProvider),
+			>,
+		>,
 	>;
 	type AuraPeer = Peer<(), PeersClient>;
 
@@ -629,20 +645,21 @@ mod tests {
 	}
 
 	impl TestNetFactory for AuraTestNet {
-		type Verifier = AuraVerifier;
-		type PeerData = ();
 		type BlockImport = PeersClient;
+		type PeerData = ();
+		type Verifier = AuraVerifier;
 
 		/// Create new test network with peers and given config.
 		fn from_config(_config: &ProtocolConfig) -> Self {
-			AuraTestNet {
-				peers: Vec::new(),
-			}
+			AuraTestNet { peers: Vec::new() }
 		}
 
-		fn make_verifier(&self, client: PeersClient, _cfg: &ProtocolConfig, _peer_data: &())
-			-> Self::Verifier
-		{
+		fn make_verifier(
+			&self,
+			client: PeersClient,
+			_cfg: &ProtocolConfig,
+			_peer_data: &(),
+		) -> Self::Verifier {
 			match client {
 				PeersClient::Full(client, _) => {
 					let slot_duration = slot_duration(&*client).expect("slot duration available");
@@ -663,12 +680,15 @@ mod tests {
 						CheckForEquivocation::Yes,
 						None,
 					)
-				},
+				}
 				PeersClient::Light(_, _) => unreachable!("No (yet) tests for light client + Aura"),
 			}
 		}
 
-		fn make_block_import(&self, client: PeersClient) -> (
+		fn make_block_import(
+			&self,
+			client: PeersClient,
+		) -> (
 			BlockImportAdapter<Self::BlockImport>,
 			Option<BoxJustificationImport<Block>>,
 			Self::PeerData,
@@ -683,6 +703,7 @@ mod tests {
 		fn peers(&self) -> &Vec<AuraPeer> {
 			&self.peers
 		}
+
 		fn mut_peers<F: FnOnce(&mut Vec<AuraPeer>)>(&mut self, closure: F) {
 			closure(&mut self.peers);
 		}
@@ -693,11 +714,7 @@ mod tests {
 		sp_tracing::try_init_simple();
 		let net = AuraTestNet::new(3);
 
-		let peers = &[
-			(0, Keyring::Alice),
-			(1, Keyring::Bob),
-			(2, Keyring::Charlie),
-		];
+		let peers = &[(0, Keyring::Alice), (1, Keyring::Bob), (2, Keyring::Charlie)];
 
 		let net = Arc::new(Mutex::new(net));
 		let mut import_notifications = Vec::new();
@@ -710,9 +727,9 @@ mod tests {
 			let client = peer.client().as_full().expect("full clients are created").clone();
 			let select_chain = peer.select_chain().expect("full client has a select chain");
 			let keystore_path = tempfile::tempdir().expect("Creates keystore path");
-			let keystore = Arc::new(LocalKeystore::open(keystore_path.path(), None)
-				.expect("Creates keystore."));
-
+			let keystore = Arc::new(
+				LocalKeystore::open(keystore_path.path(), None).expect("Creates keystore."),
+			);
 
 			SyncCryptoStore::sr25519_generate_new(&*keystore, AURA, Some(&key.to_seed()))
 				.expect("Creates authority key");
@@ -720,38 +737,46 @@ mod tests {
 
 			let environ = DummyFactory(client.clone());
 			import_notifications.push(
-				client.import_notification_stream()
-					.take_while(|n| future::ready(!(n.origin != BlockOrigin::Own && n.header.number() < &5)))
-					.for_each(move |_| future::ready(()))
+				client
+					.import_notification_stream()
+					.take_while(|n| {
+						future::ready(!(n.origin != BlockOrigin::Own && n.header.number() < &5))
+					})
+					.for_each(move |_| future::ready(())),
 			);
 
 			let slot_duration = slot_duration(&*client).expect("slot duration available");
 
-			aura_futures.push(start_aura::<AuthorityPair, _, _, _, _, _, _, _, _, _, _, _>(StartAuraParams {
-				slot_duration,
-				block_import: client.clone(),
-				select_chain,
-				client,
-				proposer_factory: environ,
-				sync_oracle: DummyOracle,
-				justification_sync_link: (),
-				create_inherent_data_providers: |_, _| async {
-					let timestamp = TimestampInherentDataProvider::from_system_time();
-					let slot = InherentDataProvider::from_timestamp_and_duration(
-						*timestamp,
-						Duration::from_secs(6),
-					);
+			aura_futures.push(
+				start_aura::<AuthorityPair, _, _, _, _, _, _, _, _, _, _, _>(StartAuraParams {
+					slot_duration,
+					block_import: client.clone(),
+					select_chain,
+					client,
+					proposer_factory: environ,
+					sync_oracle: DummyOracle,
+					justification_sync_link: (),
+					create_inherent_data_providers: |_, _| async {
+						let timestamp = TimestampInherentDataProvider::from_system_time();
+						let slot = InherentDataProvider::from_timestamp_and_duration(
+							*timestamp,
+							Duration::from_secs(6),
+						);
 
-					Ok((timestamp, slot))
-				},
-				force_authoring: false,
-				backoff_authoring_blocks: Some(BackoffAuthoringOnFinalizedHeadLagging::default()),
-				keystore,
-				can_author_with: sp_consensus::AlwaysCanAuthor,
-				block_proposal_slot_portion: SlotProportion::new(0.5),
-				max_block_proposal_slot_portion: None,
-				telemetry: None,
-			}).expect("Starts aura"));
+						Ok((timestamp, slot))
+					},
+					force_authoring: false,
+					backoff_authoring_blocks: Some(
+						BackoffAuthoringOnFinalizedHeadLagging::default(),
+					),
+					keystore,
+					can_author_with: sp_consensus::AlwaysCanAuthor,
+					block_proposal_slot_portion: SlotProportion::new(0.5),
+					max_block_proposal_slot_portion: None,
+					telemetry: None,
+				})
+				.expect("Starts aura"),
+			);
 		}
 
 		futures::executor::block_on(future::select(
@@ -759,10 +784,7 @@ mod tests {
 				net.lock().poll(cx);
 				Poll::<()>::Pending
 			}),
-			future::select(
-				future::join_all(aura_futures),
-				future::join_all(import_notifications)
-			)
+			future::select(future::join_all(aura_futures), future::join_all(import_notifications)),
 		));
 	}
 
@@ -771,11 +793,14 @@ mod tests {
 		let client = substrate_test_runtime_client::new();
 
 		assert_eq!(client.chain_info().best_number, 0);
-		assert_eq!(authorities(&client, &BlockId::Number(0)).unwrap(), vec![
-			Keyring::Alice.public().into(),
-			Keyring::Bob.public().into(),
-			Keyring::Charlie.public().into()
-		]);
+		assert_eq!(
+			authorities(&client, &BlockId::Number(0)).unwrap(),
+			vec![
+				Keyring::Alice.public().into(),
+				Keyring::Bob.public().into(),
+				Keyring::Charlie.public().into()
+			]
+		);
 	}
 
 	#[test]
@@ -785,12 +810,11 @@ mod tests {
 		let mut authorities = vec![
 			Keyring::Alice.public().into(),
 			Keyring::Bob.public().into(),
-			Keyring::Charlie.public().into()
+			Keyring::Charlie.public().into(),
 		];
 
 		let keystore_path = tempfile::tempdir().expect("Creates keystore path");
-		let keystore = LocalKeystore::open(keystore_path.path(), None)
-			.expect("Creates keystore.");
+		let keystore = LocalKeystore::open(keystore_path.path(), None).expect("Creates keystore.");
 		let public = SyncCryptoStore::sr25519_generate_new(&keystore, AuthorityPair::ID, None)
 			.expect("Key should be created");
 		authorities.push(public.into());
@@ -822,7 +846,7 @@ mod tests {
 			H256::from_low_u64_be(0),
 			H256::from_low_u64_be(0),
 			Default::default(),
-			Default::default()
+			Default::default(),
 		);
 		assert!(worker.claim_slot(&head, 0.into(), &authorities).is_none());
 		assert!(worker.claim_slot(&head, 1.into(), &authorities).is_none());
@@ -839,12 +863,13 @@ mod tests {
 		let net = AuraTestNet::new(4);
 
 		let keystore_path = tempfile::tempdir().expect("Creates keystore path");
-		let keystore = LocalKeystore::open(keystore_path.path(), None)
-			.expect("Creates keystore.");
+		let keystore = LocalKeystore::open(keystore_path.path(), None).expect("Creates keystore.");
 		SyncCryptoStore::sr25519_generate_new(
 			&keystore,
-			AuthorityPair::ID, Some(&Keyring::Alice.to_seed()),
-		).expect("Key should be created");
+			AuthorityPair::ID,
+			Some(&Keyring::Alice.to_seed()),
+		)
+		.expect("Key should be created");
 
 		let net = Arc::new(Mutex::new(net));
 
@@ -870,17 +895,16 @@ mod tests {
 
 		let head = client.header(&BlockId::Number(0)).unwrap().unwrap();
 
-		let res = futures::executor::block_on(worker.on_slot(
-			SlotInfo {
-				slot: 0.into(),
-				timestamp: 0.into(),
-				ends_at: Instant::now() + Duration::from_secs(100),
-				inherent_data: InherentData::new(),
-				duration: Duration::from_millis(1000),
-				chain_head: head,
-				block_size_limit: None,
-			}
-		)).unwrap();
+		let res = futures::executor::block_on(worker.on_slot(SlotInfo {
+			slot: 0.into(),
+			timestamp: 0.into(),
+			ends_at: Instant::now() + Duration::from_secs(100),
+			inherent_data: InherentData::new(),
+			duration: Duration::from_millis(1000),
+			chain_head: head,
+			block_size_limit: None,
+		}))
+		.unwrap();
 
 		// The returned block should be imported and we should be able to get its header by now.
 		assert!(client.header(&BlockId::Hash(res.block.hash())).unwrap().is_some());

--- a/client/consensus/babe/src/authorship.rs
+++ b/client/consensus/babe/src/authorship.rs
@@ -18,22 +18,17 @@
 
 //! BABE authority selection and slot claiming.
 
+use codec::Encode;
+use schnorrkel::{keys::PublicKey, vrf::VRFInOut};
 use sp_application_crypto::AppKey;
 use sp_consensus_babe::{
-	BABE_VRF_PREFIX, AuthorityId, BabeAuthorityWeight, make_transcript, make_transcript_data,
-	Slot,
-};
-use sp_consensus_babe::digests::{
-	PreDigest, PrimaryPreDigest, SecondaryPlainPreDigest, SecondaryVRFPreDigest,
+	digests::{PreDigest, PrimaryPreDigest, SecondaryPlainPreDigest, SecondaryVRFPreDigest},
+	make_transcript, make_transcript_data, AuthorityId, BabeAuthorityWeight, Slot, BABE_VRF_PREFIX,
 };
 use sp_consensus_vrf::schnorrkel::{VRFOutput, VRFProof};
-use sp_core::{U256, blake2_256, crypto::Public};
-use sp_keystore::{SyncCryptoStorePtr, SyncCryptoStore};
-use codec::Encode;
-use schnorrkel::{
-	keys::PublicKey,
-	vrf::VRFInOut,
-};
+use sp_core::{blake2_256, crypto::Public, U256};
+use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
+
 use super::Epoch;
 
 /// Calculates the primary selection threshold for a given authority, taking
@@ -49,8 +44,7 @@ pub(super) fn calculate_primary_threshold(
 
 	let c = c.0 as f64 / c.1 as f64;
 
-	let theta =
-		authorities[authority_index].1 as f64 /
+	let theta = authorities[authority_index].1 as f64 /
 		authorities.iter().map(|(_, weight)| weight).sum::<u64>() as f64;
 
 	assert!(theta > 0.0, "authority with weight 0.");
@@ -74,14 +68,14 @@ pub(super) fn calculate_primary_threshold(
 		"returns None when the given value is negative; \
 		 p is defined as `1 - n` where n is defined in (0, 1]; \
 		 p must be a value in [0, 1); \
-		 qed."
+		 qed.",
 	);
 
 	let denom = p.denom().to_biguint().expect(
 		"returns None when the given value is negative; \
 		 p is defined as `1 - n` where n is defined in (0, 1]; \
 		 p must be a value in [0, 1); \
-		 qed."
+		 qed.",
 	);
 
 	((BigUint::one() << 128) * numer / denom).to_u128().expect(
@@ -116,9 +110,10 @@ pub(super) fn secondary_slot_author(
 	let authorities_len = U256::from(authorities.len());
 	let idx = rand % authorities_len;
 
-	let expected_author = authorities.get(idx.as_u32() as usize)
-		.expect("authorities not empty; index constrained to list length; \
-				this is a valid index; qed");
+	let expected_author = authorities.get(idx.as_u32() as usize).expect(
+		"authorities not empty; index constrained to list length; \
+				this is a valid index; qed",
+	);
 
 	Some(&expected_author.0)
 }
@@ -139,20 +134,12 @@ fn claim_secondary_slot(
 		return None;
 	}
 
-	let expected_author = secondary_slot_author(
-		slot,
-		authorities,
-		*randomness,
-	)?;
+	let expected_author = secondary_slot_author(slot, authorities, *randomness)?;
 
 	for (authority_id, authority_index) in keys {
 		if authority_id == expected_author {
 			let pre_digest = if author_secondary_vrf {
-				let transcript_data = make_transcript_data(
-					randomness,
-					slot,
-					*epoch_index,
-				);
+				let transcript_data = make_transcript_data(randomness, slot, *epoch_index);
 				let result = SyncCryptoStore::sr25519_vrf_sign(
 					&**keystore,
 					AuthorityId::ID,
@@ -169,7 +156,10 @@ fn claim_secondary_slot(
 				} else {
 					None
 				}
-			} else if SyncCryptoStore::has_keys(&**keystore, &[(authority_id.to_raw_vec(), AuthorityId::ID)]) {
+			} else if SyncCryptoStore::has_keys(
+				&**keystore,
+				&[(authority_id.to_raw_vec(), AuthorityId::ID)],
+			) {
 				Some(PreDigest::SecondaryPlain(SecondaryPlainPreDigest {
 					slot,
 					authority_index: *authority_index as u32,
@@ -196,7 +186,9 @@ pub fn claim_slot(
 	epoch: &Epoch,
 	keystore: &SyncCryptoStorePtr,
 ) -> Option<(PreDigest, AuthorityId)> {
-	let authorities = epoch.authorities.iter()
+	let authorities = epoch
+		.authorities
+		.iter()
 		.enumerate()
 		.map(|(index, a)| (a.0.clone(), index))
 		.collect::<Vec<_>>();
@@ -211,22 +203,21 @@ pub fn claim_slot_using_keys(
 	keystore: &SyncCryptoStorePtr,
 	keys: &[(AuthorityId, usize)],
 ) -> Option<(PreDigest, AuthorityId)> {
-	claim_primary_slot(slot, epoch, epoch.config.c, keystore, &keys)
-		.or_else(|| {
-			if epoch.config.allowed_slots.is_secondary_plain_slots_allowed() ||
-				epoch.config.allowed_slots.is_secondary_vrf_slots_allowed()
-			{
-				claim_secondary_slot(
-					slot,
-					&epoch,
-					keys,
-					&keystore,
-					epoch.config.allowed_slots.is_secondary_vrf_slots_allowed(),
-				)
-			} else {
-				None
-			}
-		})
+	claim_primary_slot(slot, epoch, epoch.config.c, keystore, &keys).or_else(|| {
+		if epoch.config.allowed_slots.is_secondary_plain_slots_allowed() ||
+			epoch.config.allowed_slots.is_secondary_vrf_slots_allowed()
+		{
+			claim_secondary_slot(
+				slot,
+				&epoch,
+				keys,
+				&keystore,
+				epoch.config.allowed_slots.is_secondary_vrf_slots_allowed(),
+			)
+		} else {
+			None
+		}
+	})
 }
 
 /// Claim a primary slot if it is our turn.  Returns `None` if it is not our turn.
@@ -243,16 +234,8 @@ fn claim_primary_slot(
 	let Epoch { authorities, randomness, epoch_index, .. } = epoch;
 
 	for (authority_id, authority_index) in keys {
-		let transcript = make_transcript(
-			randomness,
-			slot,
-			*epoch_index
-		);
-		let transcript_data = make_transcript_data(
-			randomness,
-			slot,
-			*epoch_index
-		);
+		let transcript = make_transcript(randomness, slot, *epoch_index);
+		let transcript_data = make_transcript_data(randomness, slot, *epoch_index);
 		// Compute the threshold we will use.
 		//
 		// We already checked that authorities contains `key.public()`, so it can't
@@ -289,11 +272,13 @@ fn claim_primary_slot(
 
 #[cfg(test)]
 mod tests {
-	use super::*;
 	use std::sync::Arc;
-	use sp_core::{sr25519::Pair, crypto::Pair as _};
-	use sp_consensus_babe::{AuthorityId, BabeEpochConfiguration, AllowedSlots};
+
 	use sc_keystore::LocalKeystore;
+	use sp_consensus_babe::{AllowedSlots, AuthorityId, BabeEpochConfiguration};
+	use sp_core::{crypto::Pair as _, sr25519::Pair};
+
+	use super::*;
 
 	#[test]
 	fn claim_secondary_plain_slot_works() {
@@ -302,7 +287,8 @@ mod tests {
 			&*keystore,
 			AuthorityId::ID,
 			Some(sp_core::crypto::DEV_PHRASE),
-		).unwrap();
+		)
+		.unwrap();
 
 		let authorities = vec![
 			(AuthorityId::from(Pair::generate().0.public()), 5),

--- a/client/consensus/babe/src/aux_schema.rs
+++ b/client/consensus/babe/src/aux_schema.rs
@@ -18,15 +18,15 @@
 
 //! Schema for BABE epoch changes in the aux-db.
 
-use log::info;
 use codec::{Decode, Encode};
-
+use log::info;
 use sc_client_api::backend::AuxStore;
-use sp_blockchain::{Result as ClientResult, Error as ClientError};
-use sp_runtime::traits::Block as BlockT;
+use sc_consensus_epochs::{migration::EpochChangesForV0, EpochChangesFor, SharedEpochChanges};
+use sp_blockchain::{Error as ClientError, Result as ClientResult};
 use sp_consensus_babe::{BabeBlockWeight, BabeGenesisConfiguration};
-use sc_consensus_epochs::{EpochChangesFor, SharedEpochChanges, migration::EpochChangesForV0};
-use crate::{Epoch, migration::EpochV0};
+use sp_runtime::traits::Block as BlockT;
+
+use crate::{migration::EpochV0, Epoch};
 
 const BABE_EPOCH_CHANGES_VERSION: &[u8] = b"babe_epoch_changes_version";
 const BABE_EPOCH_CHANGES_KEY: &[u8] = b"babe_epoch_changes";
@@ -38,16 +38,16 @@ pub fn block_weight_key<H: Encode>(block_hash: H) -> Vec<u8> {
 }
 
 fn load_decode<B, T>(backend: &B, key: &[u8]) -> ClientResult<Option<T>>
-	where
-		B: AuxStore,
-		T: Decode,
+where
+	B: AuxStore,
+	T: Decode,
 {
 	let corrupt = |e: codec::Error| {
 		ClientError::Backend(format!("BABE DB is corrupted. Decode error: {}", e))
 	};
 	match backend.get_aux(key)? {
 		None => Ok(None),
-		Some(t) => T::decode(&mut &t[..]).map(Some).map_err(corrupt)
+		Some(t) => T::decode(&mut &t[..]).map(Some).map_err(corrupt),
 	}
 }
 
@@ -59,32 +59,30 @@ pub fn load_epoch_changes<Block: BlockT, B: AuxStore>(
 	let version = load_decode::<_, u32>(backend, BABE_EPOCH_CHANGES_VERSION)?;
 
 	let maybe_epoch_changes = match version {
-		None => load_decode::<_, EpochChangesForV0<Block, EpochV0>>(
-			backend,
-			BABE_EPOCH_CHANGES_KEY,
-		)?.map(|v0| v0.migrate().map(|_, _, epoch| epoch.migrate(config))),
-		Some(1) => load_decode::<_, EpochChangesFor<Block, EpochV0>>(
-			backend,
-			BABE_EPOCH_CHANGES_KEY,
-		)?.map(|v1| v1.map(|_, _, epoch| epoch.migrate(config))),
-		Some(BABE_EPOCH_CHANGES_CURRENT_VERSION) => load_decode::<_, EpochChangesFor<Block, Epoch>>(
-			backend,
-			BABE_EPOCH_CHANGES_KEY,
-		)?,
+		None => {
+			load_decode::<_, EpochChangesForV0<Block, EpochV0>>(backend, BABE_EPOCH_CHANGES_KEY)?
+				.map(|v0| v0.migrate().map(|_, _, epoch| epoch.migrate(config)))
+		}
+		Some(1) => {
+			load_decode::<_, EpochChangesFor<Block, EpochV0>>(backend, BABE_EPOCH_CHANGES_KEY)?
+				.map(|v1| v1.map(|_, _, epoch| epoch.migrate(config)))
+		}
+		Some(BABE_EPOCH_CHANGES_CURRENT_VERSION) => {
+			load_decode::<_, EpochChangesFor<Block, Epoch>>(backend, BABE_EPOCH_CHANGES_KEY)?
+		}
 		Some(other) => {
-			return Err(ClientError::Backend(
-				format!("Unsupported BABE DB version: {:?}", other)
-			))
-		},
+			return Err(ClientError::Backend(format!("Unsupported BABE DB version: {:?}", other)))
+		}
 	};
 
-	let epoch_changes = SharedEpochChanges::<Block, Epoch>::new(maybe_epoch_changes.unwrap_or_else(|| {
-		info!(
-			target: "babe",
-			"👶 Creating empty BABE epoch changes on what appears to be first startup.",
-		);
-		EpochChangesFor::<Block, Epoch>::default()
-	}));
+	let epoch_changes =
+		SharedEpochChanges::<Block, Epoch>::new(maybe_epoch_changes.unwrap_or_else(|| {
+			info!(
+				target: "babe",
+				"👶 Creating empty BABE epoch changes on what appears to be first startup.",
+			);
+			EpochChangesFor::<Block, Epoch>::default()
+		}));
 
 	// rebalance the tree after deserialization. this isn't strictly necessary
 	// since the tree is now rebalanced on every update operation. but since the
@@ -99,15 +97,16 @@ pub fn load_epoch_changes<Block: BlockT, B: AuxStore>(
 pub(crate) fn write_epoch_changes<Block: BlockT, F, R>(
 	epoch_changes: &EpochChangesFor<Block, Epoch>,
 	write_aux: F,
-) -> R where
+) -> R
+where
 	F: FnOnce(&[(&'static [u8], &[u8])]) -> R,
 {
 	BABE_EPOCH_CHANGES_CURRENT_VERSION.using_encoded(|version| {
 		let encoded_epoch_changes = epoch_changes.encode();
-		write_aux(
-			&[(BABE_EPOCH_CHANGES_KEY, encoded_epoch_changes.as_slice()),
-			  (BABE_EPOCH_CHANGES_VERSION, version)],
-		)
+		write_aux(&[
+			(BABE_EPOCH_CHANGES_KEY, encoded_epoch_changes.as_slice()),
+			(BABE_EPOCH_CHANGES_VERSION, version),
+		])
 	})
 }
 
@@ -116,15 +115,12 @@ pub(crate) fn write_block_weight<H: Encode, F, R>(
 	block_hash: H,
 	block_weight: BabeBlockWeight,
 	write_aux: F,
-) -> R where
+) -> R
+where
 	F: FnOnce(&[(Vec<u8>, &[u8])]) -> R,
 {
 	let key = block_weight_key(block_hash);
-	block_weight.using_encoded(|s|
-		write_aux(
-			&[(key, s)],
-		)
-	)
+	block_weight.using_encoded(|s| write_aux(&[(key, s)]))
 }
 
 /// Load the cumulative chain-weight associated with a block.
@@ -137,16 +133,17 @@ pub fn load_block_weight<H: Encode, B: AuxStore>(
 
 #[cfg(test)]
 mod test {
-	use super::*;
-	use crate::migration::EpochV0;
 	use fork_tree::ForkTree;
-	use substrate_test_runtime_client;
+	use sc_consensus_epochs::{EpochHeader, PersistedEpoch, PersistedEpochHeader};
+	use sc_network_test::Block as TestBlock;
+	use sp_consensus::Error as ConsensusError;
+	use sp_consensus_babe::{AllowedSlots, BabeGenesisConfiguration};
 	use sp_core::H256;
 	use sp_runtime::traits::NumberFor;
-	use sp_consensus_babe::{AllowedSlots, BabeGenesisConfiguration};
-	use sc_consensus_epochs::{PersistedEpoch, PersistedEpochHeader, EpochHeader};
-	use sp_consensus::Error as ConsensusError;
-	use sc_network_test::Block as TestBlock;
+	use substrate_test_runtime_client;
+
+	use super::*;
+	use crate::migration::EpochV0;
 
 	#[test]
 	fn load_decode_from_v0_epoch_changes() {
@@ -159,26 +156,30 @@ mod test {
 		};
 		let client = substrate_test_runtime_client::new();
 		let mut v0_tree = ForkTree::<H256, NumberFor<TestBlock>, _>::new();
-		v0_tree.import::<_, ConsensusError>(
-			Default::default(),
-			Default::default(),
-			PersistedEpoch::Regular(epoch),
-			&|_, _| Ok(false), // Test is single item only so this can be set to false.
-		).unwrap();
+		v0_tree
+			.import::<_, ConsensusError>(
+				Default::default(),
+				Default::default(),
+				PersistedEpoch::Regular(epoch),
+				&|_, _| Ok(false), // Test is single item only so this can be set to false.
+			)
+			.unwrap();
 
-		client.insert_aux(
-			&[(BABE_EPOCH_CHANGES_KEY,
-			   &EpochChangesForV0::<TestBlock, EpochV0>::from_raw(v0_tree).encode()[..])],
-			&[],
-		).unwrap();
+		client
+			.insert_aux(
+				&[(
+					BABE_EPOCH_CHANGES_KEY,
+					&EpochChangesForV0::<TestBlock, EpochV0>::from_raw(v0_tree).encode()[..],
+				)],
+				&[],
+			)
+			.unwrap();
 
-		assert_eq!(
-			load_decode::<_, u32>(&client, BABE_EPOCH_CHANGES_VERSION).unwrap(),
-			None,
-		);
+		assert_eq!(load_decode::<_, u32>(&client, BABE_EPOCH_CHANGES_VERSION).unwrap(), None,);
 
 		let epoch_changes = load_epoch_changes::<TestBlock, _>(
-			&client, &BabeGenesisConfiguration {
+			&client,
+			&BabeGenesisConfiguration {
 				slot_duration: 10,
 				epoch_length: 4,
 				c: (3, 10),
@@ -186,10 +187,12 @@ mod test {
 				randomness: Default::default(),
 				allowed_slots: AllowedSlots::PrimaryAndSecondaryPlainSlots,
 			},
-		).unwrap();
+		)
+		.unwrap();
 
 		assert!(
-			epoch_changes.shared_data()
+			epoch_changes
+				.shared_data()
 				.tree()
 				.iter()
 				.map(|(_, _, epoch)| epoch.clone())
@@ -200,16 +203,10 @@ mod test {
 				})],
 		); // PersistedEpochHeader does not implement Debug, so we use assert! directly.
 
-		write_epoch_changes::<TestBlock, _, _>(
-			&epoch_changes.shared_data(),
-			|values| {
-				client.insert_aux(values, &[]).unwrap();
-			},
-		);
+		write_epoch_changes::<TestBlock, _, _>(&epoch_changes.shared_data(), |values| {
+			client.insert_aux(values, &[]).unwrap();
+		});
 
-		assert_eq!(
-			load_decode::<_, u32>(&client, BABE_EPOCH_CHANGES_VERSION).unwrap(),
-			Some(2),
-		);
+		assert_eq!(load_decode::<_, u32>(&client, BABE_EPOCH_CHANGES_VERSION).unwrap(), Some(2),);
 	}
 }

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -70,52 +70,44 @@ use std::{
 	borrow::Cow, collections::HashMap, convert::TryInto, pin::Pin, sync::Arc, time::Duration, u64,
 };
 
+pub use aux_schema::load_block_weight as block_weight;
 use codec::{Decode, Encode};
-use futures::channel::mpsc::{channel, Receiver, Sender};
-use futures::channel::oneshot;
-use futures::prelude::*;
+use futures::{
+	channel::{
+		mpsc::{channel, Receiver, Sender},
+		oneshot,
+	},
+	prelude::*,
+};
 use log::{debug, info, log, trace, warn};
 use parking_lot::Mutex;
 use prometheus_endpoint::Registry;
 use retain_mut::RetainMut;
-use schnorrkel::SignatureError;
-
 use sc_client_api::{backend::AuxStore, BlockchainEvents, ProvideUncles, UsageProvider};
 use sc_consensus_epochs::{
 	descendent_query, Epoch as EpochT, EpochChangesFor, SharedEpochChanges, ViableEpochDescriptor,
 };
+pub use sc_consensus_slots::SlotProportion;
 use sc_consensus_slots::{
 	check_equivocation, BackoffAuthoringBlocksStrategy, CheckedHeader, InherentDataProviderExt,
 	SlotInfo, StorageChanges,
 };
 use sc_telemetry::{telemetry, TelemetryHandle, CONSENSUS_DEBUG, CONSENSUS_TRACE};
-use sp_api::ApiExt;
-use sp_api::{NumberFor, ProvideRuntimeApi};
+use schnorrkel::SignatureError;
+use sp_api::{ApiExt, NumberFor, ProvideRuntimeApi};
 use sp_application_crypto::AppKey;
 use sp_block_builder::BlockBuilder as BlockBuilderApi;
 use sp_blockchain::{
 	Error as ClientError, HeaderBackend, HeaderMetadata, ProvideCache, Result as ClientResult,
 };
-use sp_consensus::{import_queue::BoxJustificationImport, CanAuthorWith, ImportResult};
+pub use sp_consensus::SyncOracle;
 use sp_consensus::{
-	import_queue::{BasicQueue, CacheKeyId, DefaultImportQueue, Verifier},
-	BlockCheckParams, BlockImport, BlockImportParams, BlockOrigin, Environment,
-	Error as ConsensusError, ForkChoiceStrategy, Proposer, SelectChain, SlotData,
+	import_queue::{BasicQueue, BoxJustificationImport, CacheKeyId, DefaultImportQueue, Verifier},
+	BlockCheckParams, BlockImport, BlockImportParams, BlockOrigin, CanAuthorWith, Environment,
+	Error as ConsensusError, ForkChoiceStrategy, ImportResult, Proposer, SelectChain, SlotData,
 	StateAction,
 };
 use sp_consensus_babe::inherents::BabeInherentData;
-use sp_consensus_slots::Slot;
-use sp_core::crypto::Public;
-use sp_inherents::{CreateInherentDataProviders, InherentData, InherentDataProvider};
-use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
-use sp_runtime::{
-	generic::{BlockId, OpaqueDigestItemId},
-	traits::{Block as BlockT, DigestItemFor, Header, Zero},
-	Justifications,
-};
-
-pub use sc_consensus_slots::SlotProportion;
-pub use sp_consensus::SyncOracle;
 pub use sp_consensus_babe::{
 	digests::{
 		CompatibleDigestItem, NextConfigDescriptor, NextEpochDescriptor, PreDigest,
@@ -125,8 +117,15 @@ pub use sp_consensus_babe::{
 	BabeEpochConfiguration, BabeGenesisConfiguration, ConsensusLog, BABE_ENGINE_ID,
 	VRF_OUTPUT_LENGTH,
 };
-
-pub use aux_schema::load_block_weight as block_weight;
+use sp_consensus_slots::Slot;
+use sp_core::crypto::Public;
+use sp_inherents::{CreateInherentDataProviders, InherentData, InherentDataProvider};
+use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
+use sp_runtime::{
+	generic::{BlockId, OpaqueDigestItemId},
+	traits::{Block as BlockT, DigestItemFor, Header, Zero},
+	Justifications,
+};
 
 mod migration;
 mod verification;
@@ -159,7 +158,7 @@ impl EpochT for Epoch {
 
 	fn increment(
 		&self,
-		(descriptor, config): (NextEpochDescriptor, BabeEpochConfiguration)
+		(descriptor, config): (NextEpochDescriptor, BabeEpochConfiguration),
 	) -> Epoch {
 		Epoch {
 			epoch_index: self.epoch_index + 1,
@@ -183,10 +182,7 @@ impl EpochT for Epoch {
 impl Epoch {
 	/// Create the genesis epoch (epoch #0). This is defined to start at the slot of
 	/// the first block, so that has to be provided.
-	pub fn genesis(
-		genesis_config: &BabeGenesisConfiguration,
-		slot: Slot,
-	) -> Epoch {
+	pub fn genesis(genesis_config: &BabeGenesisConfiguration, slot: Slot) -> Epoch {
 		Epoch {
 			epoch_index: 0,
 			start_slot: slot,
@@ -253,7 +249,11 @@ pub enum Error<B: BlockT> {
 	#[display(fmt = "No secondary author expected.")]
 	NoSecondaryAuthorExpected,
 	/// VRF verification of block by author failed
-	#[display(fmt = "VRF verification of block by author {:?} failed: threshold {} exceeded", _0, _1)]
+	#[display(
+		fmt = "VRF verification of block by author {:?} failed: threshold {} exceeded",
+		_0,
+		_1
+	)]
 	VRFVerificationOfBlockFailed(AuthorityId, u128),
 	/// VRF verification failed
 	#[display(fmt = "VRF verification failed: {:?}", _0)]
@@ -320,30 +320,31 @@ pub struct Config(sc_consensus_slots::SlotDuration<BabeGenesisConfiguration>);
 impl Config {
 	/// Either fetch the slot duration from disk or compute it from the genesis
 	/// state.
-	pub fn get_or_compute<B: BlockT, C>(client: &C) -> ClientResult<Self> where
-		C: AuxStore + ProvideRuntimeApi<B> + UsageProvider<B>, C::Api: BabeApi<B>,
+	pub fn get_or_compute<B: BlockT, C>(client: &C) -> ClientResult<Self>
+	where
+		C: AuxStore + ProvideRuntimeApi<B> + UsageProvider<B>,
+		C::Api: BabeApi<B>,
 	{
 		trace!(target: "babe", "Getting slot duration");
 		match sc_consensus_slots::SlotDuration::get_or_compute(client, |a, b| {
-			let has_api_v1 = a.has_api_with::<dyn BabeApi<B>, _>(
-				&b, |v| v == 1,
-			)?;
-			let has_api_v2 = a.has_api_with::<dyn BabeApi<B>, _>(
-				&b, |v| v == 2,
-			)?;
+			let has_api_v1 = a.has_api_with::<dyn BabeApi<B>, _>(&b, |v| v == 1)?;
+			let has_api_v2 = a.has_api_with::<dyn BabeApi<B>, _>(&b, |v| v == 2)?;
 
 			if has_api_v1 {
-				#[allow(deprecated)] {
+				#[allow(deprecated)]
+				{
 					Ok(a.configuration_before_version_2(b)?.into())
 				}
 			} else if has_api_v2 {
 				a.configuration(b).map_err(Into::into)
 			} else {
 				Err(sp_blockchain::Error::VersionInvalid(
-					"Unsupported or invalid BabeApi version".to_string()
+					"Unsupported or invalid BabeApi version".to_string(),
 				))
 			}
-		}).map(Self) {
+		})
+		.map(Self)
+		{
 			Ok(s) => Ok(s),
 			Err(s) => {
 				warn!(target: "babe", "Failed to get slot duration");
@@ -502,7 +503,8 @@ where
 
 	let (worker_tx, worker_rx) = channel(HANDLE_BUFFER_SIZE);
 
-	let answer_requests = answer_requests(worker_rx, config.0, client, babe_link.epoch_changes.clone());
+	let answer_requests =
+		answer_requests(worker_rx, config.0, client, babe_link.epoch_changes.clone());
 	Ok(BabeWorker {
 		inner: Box::pin(future::join(inner, answer_requests).map(|_| ())),
 		slot_notification_sinks,
@@ -515,28 +517,37 @@ async fn answer_requests<B: BlockT, C>(
 	genesis_config: sc_consensus_slots::SlotDuration<BabeGenesisConfiguration>,
 	client: Arc<C>,
 	epoch_changes: SharedEpochChanges<B, Epoch>,
-)
-	where C: ProvideRuntimeApi<B> + ProvideCache<B> + ProvideUncles<B> + BlockchainEvents<B>
-	+ HeaderBackend<B> + HeaderMetadata<B, Error = ClientError> + Send + Sync + 'static,
+) where
+	C: ProvideRuntimeApi<B>
+		+ ProvideCache<B>
+		+ ProvideUncles<B>
+		+ BlockchainEvents<B>
+		+ HeaderBackend<B>
+		+ HeaderMetadata<B, Error = ClientError>
+		+ Send
+		+ Sync
+		+ 'static,
 {
 	while let Some(request) = request_rx.next().await {
 		match request {
 			BabeRequest::EpochForChild(parent_hash, parent_number, slot_number, response) => {
 				let lookup = || {
 					let epoch_changes = epoch_changes.shared_data();
-					let epoch_descriptor = epoch_changes.epoch_descriptor_for_child_of(
-						descendent_query(&*client),
-						&parent_hash,
-						parent_number,
-						slot_number,
-					)
+					let epoch_descriptor = epoch_changes
+						.epoch_descriptor_for_child_of(
+							descendent_query(&*client),
+							&parent_hash,
+							parent_number,
+							slot_number,
+						)
 						.map_err(|e| Error::<B>::ForkTree(Box::new(e)))?
 						.ok_or_else(|| Error::<B>::FetchEpoch(parent_hash))?;
 
-					let viable_epoch = epoch_changes.viable_epoch(
-						&epoch_descriptor,
-						|slot| Epoch::genesis(&genesis_config, slot)
-					).ok_or_else(|| Error::<B>::FetchEpoch(parent_hash))?;
+					let viable_epoch = epoch_changes
+						.viable_epoch(&epoch_descriptor, |slot| {
+							Epoch::genesis(&genesis_config, slot)
+						})
+						.ok_or_else(|| Error::<B>::FetchEpoch(parent_hash))?;
 
 					Ok(sp_consensus_babe::Epoch {
 						epoch_index: viable_epoch.as_ref().epoch_index,
@@ -584,7 +595,7 @@ impl<B: BlockT> BabeWorkerHandle<B> {
 /// Worker for Babe which implements `Future<Output=()>`. This must be polled.
 #[must_use]
 pub struct BabeWorker<B: BlockT> {
-	inner: Pin<Box<dyn futures::Future<Output=()> + Send + 'static>>,
+	inner: Pin<Box<dyn futures::Future<Output = ()> + Send + 'static>>,
 	slot_notification_sinks: SlotNotificationSinks<B>,
 	handle: BabeWorkerHandle<B>,
 }
@@ -593,7 +604,7 @@ impl<B: BlockT> BabeWorker<B> {
 	/// Return an event stream of notifications for when new slot happens, and the corresponding
 	/// epoch descriptor.
 	pub fn slot_notification_stream(
-		&self
+		&self,
 	) -> Receiver<(Slot, ViableEpochDescriptor<B::Hash, NumberFor<B>, Epoch>)> {
 		const CHANNEL_BUFFER_SIZE: usize = 1024;
 
@@ -613,7 +624,7 @@ impl<B: BlockT> futures::Future for BabeWorker<B> {
 
 	fn poll(
 		mut self: Pin<&mut Self>,
-		cx: &mut futures::task::Context
+		cx: &mut futures::task::Context,
 	) -> futures::task::Poll<Self::Output> {
 		self.inner.as_mut().poll(cx)
 	}
@@ -621,7 +632,7 @@ impl<B: BlockT> futures::Future for BabeWorker<B> {
 
 /// Slot notification sinks.
 type SlotNotificationSinks<B> = Arc<
-	Mutex<Vec<Sender<(Slot, ViableEpochDescriptor<<B as BlockT>::Hash, NumberFor<B>, Epoch>)>>>
+	Mutex<Vec<Sender<(Slot, ViableEpochDescriptor<<B as BlockT>::Hash, NumberFor<B>, Epoch>)>>>,
 >;
 
 struct BabeSlotWorker<B: BlockT, C, E, I, SO, L, BS> {
@@ -658,15 +669,14 @@ where
 	BS: BackoffAuthoringBlocksStrategy<NumberFor<B>>,
 	Error: std::error::Error + Send + From<ConsensusError> + From<I::Error> + 'static,
 {
-	type EpochData = ViableEpochDescriptor<B::Hash, NumberFor<B>, Epoch>;
-	type Claim = (PreDigest, AuthorityId);
-	type SyncOracle = SO;
-	type JustificationSyncLink = L;
-	type CreateProposer = Pin<Box<
-		dyn Future<Output = Result<E::Proposer, sp_consensus::Error>> + Send + 'static
-	>>;
-	type Proposer = E::Proposer;
 	type BlockImport = I;
+	type Claim = (PreDigest, AuthorityId);
+	type CreateProposer =
+		Pin<Box<dyn Future<Output = Result<E::Proposer, sp_consensus::Error>> + Send + 'static>>;
+	type EpochData = ViableEpochDescriptor<B::Hash, NumberFor<B>, Epoch>;
+	type JustificationSyncLink = L;
+	type Proposer = E::Proposer;
+	type SyncOracle = SO;
 
 	fn logging_target(&self) -> &'static str {
 		"babe"
@@ -681,12 +691,14 @@ where
 		parent: &B::Header,
 		slot: Slot,
 	) -> Result<Self::EpochData, ConsensusError> {
-		self.epoch_changes.shared_data().epoch_descriptor_for_child_of(
-			descendent_query(&*self.client),
-			&parent.hash(),
-			parent.number().clone(),
-			slot,
-		)
+		self.epoch_changes
+			.shared_data()
+			.epoch_descriptor_for_child_of(
+				descendent_query(&*self.client),
+				&parent.hash(),
+				parent.number().clone(),
+				slot,
+			)
 			.map_err(|e| ConsensusError::ChainLookup(format!("{:?}", e)))?
 			.ok_or(sp_consensus::Error::InvalidAuthoritiesSet)
 	}
@@ -707,10 +719,10 @@ where
 		debug!(target: "babe", "Attempting to claim slot {}", slot);
 		let s = authorship::claim_slot(
 			slot,
-			self.epoch_changes.shared_data().viable_epoch(
-				&epoch_descriptor,
-				|slot| Epoch::genesis(&self.config, slot)
-			)?.as_ref(),
+			self.epoch_changes
+				.shared_data()
+				.viable_epoch(&epoch_descriptor, |slot| Epoch::genesis(&self.config, slot))?
+				.as_ref(),
 			&self.keystore,
 		);
 
@@ -727,20 +739,19 @@ where
 		slot: Slot,
 		epoch_descriptor: &ViableEpochDescriptor<B::Hash, NumberFor<B>, Epoch>,
 	) {
-		self.slot_notification_sinks.lock()
-			.retain_mut(|sink| {
-				match sink.try_send((slot, epoch_descriptor.clone())) {
-					Ok(()) => true,
-					Err(e) => {
-						if e.is_full() {
-							warn!(target: "babe", "Trying to notify a slot but the channel is full");
-							true
-						} else {
-							false
-						}
-					},
+		self.slot_notification_sinks.lock().retain_mut(|sink| {
+			match sink.try_send((slot, epoch_descriptor.clone())) {
+				Ok(()) => true,
+				Err(e) => {
+					if e.is_full() {
+						warn!(target: "babe", "Trying to notify a slot but the channel is full");
+						true
+					} else {
+						false
+					}
 				}
-			});
+			}
+		});
 	}
 
 	fn pre_digest_data(
@@ -748,59 +759,64 @@ where
 		_slot: Slot,
 		claim: &Self::Claim,
 	) -> Vec<sp_runtime::DigestItem<B::Hash>> {
-		vec![
-			<DigestItemFor<B> as CompatibleDigestItem>::babe_pre_digest(claim.0.clone()),
-		]
+		vec![<DigestItemFor<B> as CompatibleDigestItem>::babe_pre_digest(claim.0.clone())]
 	}
 
-	fn block_import_params(&self) -> Box<dyn Fn(
-		B::Header,
-		&B::Hash,
-		Vec<B::Extrinsic>,
-		StorageChanges<I::Transaction, B>,
-		Self::Claim,
-		Self::EpochData,
-	) -> Result<
-		sp_consensus::BlockImportParams<B, I::Transaction>,
-		sp_consensus::Error> + Send + 'static>
-	{
+	fn block_import_params(
+		&self,
+	) -> Box<
+		dyn Fn(
+				B::Header,
+				&B::Hash,
+				Vec<B::Extrinsic>,
+				StorageChanges<I::Transaction, B>,
+				Self::Claim,
+				Self::EpochData,
+			) -> Result<sp_consensus::BlockImportParams<B, I::Transaction>, sp_consensus::Error>
+			+ Send
+			+ 'static,
+	> {
 		let keystore = self.keystore.clone();
-		Box::new(move |header, header_hash, body, storage_changes, (_, public), epoch_descriptor| {
-			// sign the pre-sealed hash of the block and then
-			// add it to a digest item.
-			let public_type_pair = public.clone().into();
-			let public = public.to_raw_vec();
-			let signature = SyncCryptoStore::sign_with(
-				&*keystore,
-				<AuthorityId as AppKey>::ID,
-				&public_type_pair,
-				header_hash.as_ref()
-			)
-			.map_err(|e| sp_consensus::Error::CannotSign(
-				public.clone(), e.to_string(),
-			))?
-			.ok_or_else(|| sp_consensus::Error::CannotSign(
-				public.clone(), "Could not find key in keystore.".into(),
-			))?;
-			let signature: AuthoritySignature = signature.clone().try_into()
-				.map_err(|_| sp_consensus::Error::InvalidSignature(
-					signature, public
-				))?;
-			let digest_item = <DigestItemFor<B> as CompatibleDigestItem>::babe_seal(signature.into());
+		Box::new(
+			move |header, header_hash, body, storage_changes, (_, public), epoch_descriptor| {
+				// sign the pre-sealed hash of the block and then
+				// add it to a digest item.
+				let public_type_pair = public.clone().into();
+				let public = public.to_raw_vec();
+				let signature = SyncCryptoStore::sign_with(
+					&*keystore,
+					<AuthorityId as AppKey>::ID,
+					&public_type_pair,
+					header_hash.as_ref(),
+				)
+				.map_err(|e| sp_consensus::Error::CannotSign(public.clone(), e.to_string()))?
+				.ok_or_else(|| {
+					sp_consensus::Error::CannotSign(
+						public.clone(),
+						"Could not find key in keystore.".into(),
+					)
+				})?;
+				let signature: AuthoritySignature = signature
+					.clone()
+					.try_into()
+					.map_err(|_| sp_consensus::Error::InvalidSignature(signature, public))?;
+				let digest_item =
+					<DigestItemFor<B> as CompatibleDigestItem>::babe_seal(signature.into());
 
-			let mut import_block = BlockImportParams::new(BlockOrigin::Own, header);
-			import_block.post_digests.push(digest_item);
-			import_block.body = Some(body);
-			import_block.state_action = StateAction::ApplyChanges(
-				sp_consensus::StorageChanges::Changes(storage_changes)
-			);
-			import_block.intermediates.insert(
-				Cow::from(INTERMEDIATE_KEY),
-				Box::new(BabeIntermediate::<B> { epoch_descriptor }) as Box<_>,
-			);
+				let mut import_block = BlockImportParams::new(BlockOrigin::Own, header);
+				import_block.post_digests.push(digest_item);
+				import_block.body = Some(body);
+				import_block.state_action = StateAction::ApplyChanges(
+					sp_consensus::StorageChanges::Changes(storage_changes),
+				);
+				import_block.intermediates.insert(
+					Cow::from(INTERMEDIATE_KEY),
+					Box::new(BabeIntermediate::<B> { epoch_descriptor }) as Box<_>,
+				);
 
-			Ok(import_block)
-		})
+				Ok(import_block)
+			},
+		)
 	}
 
 	fn force_authoring(&self) -> bool {
@@ -809,8 +825,8 @@ where
 
 	fn should_backoff(&self, slot: Slot, chain_head: &B::Header) -> bool {
 		if let Some(ref strategy) = self.backoff_authoring_blocks {
-			if let Ok(chain_head_slot) = find_pre_digest::<B>(chain_head)
-				.map(|digest| digest.slot())
+			if let Ok(chain_head_slot) =
+				find_pre_digest::<B>(chain_head).map(|digest| digest.slot())
 			{
 				return strategy.should_backoff(
 					*chain_head.number(),
@@ -833,9 +849,11 @@ where
 	}
 
 	fn proposer(&mut self, block: &B::Header) -> Self::CreateProposer {
-		Box::pin(self.env.init(block).map_err(|e| {
-			sp_consensus::Error::ClientImport(format!("{:?}", e))
-		}))
+		Box::pin(
+			self.env
+				.init(block)
+				.map_err(|e| sp_consensus::Error::ClientImport(format!("{:?}", e))),
+		)
 	}
 
 	fn telemetry(&self) -> Option<TelemetryHandle> {
@@ -881,16 +899,20 @@ pub fn find_pre_digest<B: BlockT>(header: &B::Header) -> Result<PreDigest, Error
 }
 
 /// Extract the BABE epoch change digest from the given header, if it exists.
-fn find_next_epoch_digest<B: BlockT>(header: &B::Header)
-	-> Result<Option<NextEpochDescriptor>, Error<B>>
-	where DigestItemFor<B>: CompatibleDigestItem,
+fn find_next_epoch_digest<B: BlockT>(
+	header: &B::Header,
+) -> Result<Option<NextEpochDescriptor>, Error<B>>
+where
+	DigestItemFor<B>: CompatibleDigestItem,
 {
 	let mut epoch_digest: Option<_> = None;
 	for log in header.digest().logs() {
 		trace!(target: "babe", "Checking log {:?}, looking for epoch change digest.", log);
 		let log = log.try_to::<ConsensusLog>(OpaqueDigestItemId::Consensus(&BABE_ENGINE_ID));
 		match (log, epoch_digest.is_some()) {
-			(Some(ConsensusLog::NextEpochData(_)), true) => return Err(babe_err(Error::MultipleEpochChangeDigests)),
+			(Some(ConsensusLog::NextEpochData(_)), true) => {
+				return Err(babe_err(Error::MultipleEpochChangeDigests))
+			}
 			(Some(ConsensusLog::NextEpochData(epoch)), false) => epoch_digest = Some(epoch),
 			_ => trace!(target: "babe", "Ignoring digest not meant for us"),
 		}
@@ -900,16 +922,20 @@ fn find_next_epoch_digest<B: BlockT>(header: &B::Header)
 }
 
 /// Extract the BABE config change digest from the given header, if it exists.
-fn find_next_config_digest<B: BlockT>(header: &B::Header)
-	-> Result<Option<NextConfigDescriptor>, Error<B>>
-	where DigestItemFor<B>: CompatibleDigestItem,
+fn find_next_config_digest<B: BlockT>(
+	header: &B::Header,
+) -> Result<Option<NextConfigDescriptor>, Error<B>>
+where
+	DigestItemFor<B>: CompatibleDigestItem,
 {
 	let mut config_digest: Option<_> = None;
 	for log in header.digest().logs() {
 		trace!(target: "babe", "Checking log {:?}, looking for epoch change digest.", log);
 		let log = log.try_to::<ConsensusLog>(OpaqueDigestItemId::Consensus(&BABE_ENGINE_ID));
 		match (log, config_digest.is_some()) {
-			(Some(ConsensusLog::NextConfigData(_)), true) => return Err(babe_err(Error::MultipleConfigChangeDigests)),
+			(Some(ConsensusLog::NextConfigData(_)), true) => {
+				return Err(babe_err(Error::MultipleConfigChangeDigests))
+			}
 			(Some(ConsensusLog::NextConfigData(config)), false) => config_digest = Some(config),
 			_ => trace!(target: "babe", "Ignoring digest not meant for us"),
 		}
@@ -971,14 +997,14 @@ where
 				e,
 			);
 
-			return Ok(())
+			return Ok(());
 		}
 
-		let inherent_res = self.client.runtime_api().check_inherents(
-			&block_id,
-			block,
-			inherent_data,
-		).map_err(Error::RuntimeApi)?;
+		let inherent_res = self
+			.client
+			.runtime_api()
+			.check_inherents(&block_id, block, inherent_data)
+			.map_err(Error::RuntimeApi)?;
 
 		if !inherent_res.ok() {
 			for (i, e) in inherent_res.into_errors() {
@@ -1074,13 +1100,8 @@ where
 	}
 }
 
-type BlockVerificationResult<Block> = Result<
-	(
-		BlockImportParams<Block, ()>,
-		Option<Vec<(CacheKeyId, Vec<u8>)>>,
-	),
-	String,
->;
+type BlockVerificationResult<Block> =
+	Result<(BlockImportParams<Block, ()>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String>;
 
 #[async_trait::async_trait]
 impl<Block, Client, SelectChain, CAW, CIDP> Verifier<Block>
@@ -1129,24 +1150,26 @@ where
 
 		let slot_now = create_inherent_data_providers.slot();
 
-		let parent_header_metadata = self.client.header_metadata(parent_hash)
+		let parent_header_metadata = self
+			.client
+			.header_metadata(parent_hash)
 			.map_err(Error::<Block>::FetchParentHeader)?;
 
 		let pre_digest = find_pre_digest::<Block>(&header)?;
 		let (check_header, epoch_descriptor) = {
 			let epoch_changes = self.epoch_changes.shared_data();
-			let epoch_descriptor = epoch_changes.epoch_descriptor_for_child_of(
-				descendent_query(&*self.client),
-				&parent_hash,
-				parent_header_metadata.number,
-				pre_digest.slot(),
-			)
-			.map_err(|e| Error::<Block>::ForkTree(Box::new(e)))?
-			.ok_or_else(|| Error::<Block>::FetchEpoch(parent_hash))?;
-			let viable_epoch = epoch_changes.viable_epoch(
-				&epoch_descriptor,
-				|slot| Epoch::genesis(&self.config, slot)
-			).ok_or_else(|| Error::<Block>::FetchEpoch(parent_hash))?;
+			let epoch_descriptor = epoch_changes
+				.epoch_descriptor_for_child_of(
+					descendent_query(&*self.client),
+					&parent_hash,
+					parent_header_metadata.number,
+					pre_digest.slot(),
+				)
+				.map_err(|e| Error::<Block>::ForkTree(Box::new(e)))?
+				.ok_or_else(|| Error::<Block>::FetchEpoch(parent_hash))?;
+			let viable_epoch = epoch_changes
+				.viable_epoch(&epoch_descriptor, |slot| Epoch::genesis(&self.config, slot))
+				.ok_or_else(|| Error::<Block>::FetchEpoch(parent_hash))?;
 
 			// We add one to the current slot to allow for some small drift.
 			// FIXME #1019 in the future, alter this queue to allow deferring of headers
@@ -1162,20 +1185,25 @@ where
 
 		match check_header {
 			CheckedHeader::Checked(pre_header, verified_info) => {
-				let babe_pre_digest = verified_info.pre_digest.as_babe_pre_digest()
+				let babe_pre_digest = verified_info
+					.pre_digest
+					.as_babe_pre_digest()
 					.expect("check_header always returns a pre-digest digest item; qed");
 				let slot = babe_pre_digest.slot();
 
 				// the header is valid but let's check if there was something else already
 				// proposed at the same slot by the given author. if there was, we will
 				// report the equivocation to the runtime.
-				if let Err(err) = self.check_and_report_equivocation(
-					slot_now,
-					slot,
-					&header,
-					&verified_info.author,
-					&origin,
-				).await {
+				if let Err(err) = self
+					.check_and_report_equivocation(
+						slot_now,
+						slot,
+						&header,
+						&verified_info.author,
+						&origin,
+					)
+					.await
+				{
 					warn!(target: "babe", "Error checking/reporting BABE equivocation: {:?}", err);
 				}
 
@@ -1183,7 +1211,8 @@ where
 				// to check that the internally-set timestamp in the inherents
 				// actually matches the slot set in the seal.
 				if let Some(inner_body) = body.take() {
-					let mut inherent_data = create_inherent_data_providers.create_inherent_data()
+					let mut inherent_data = create_inherent_data_providers
+						.create_inherent_data()
 						.map_err(Error::<Block>::CreateInherents)?;
 					inherent_data.babe_replace_inherent_data(slot);
 					let block = Block::new(pre_header.clone(), inner_body);
@@ -1193,7 +1222,8 @@ where
 						BlockId::Hash(parent_hash),
 						inherent_data,
 						create_inherent_data_providers,
-					).await?;
+					)
+					.await?;
 
 					let (_, inner_body) = block.deconstruct();
 					body = Some(inner_body);
@@ -1266,22 +1296,23 @@ impl<Block: BlockT, Client, I> BabeBlockImport<Block, Client, I> {
 		block_import: I,
 		config: Config,
 	) -> Self {
-		BabeBlockImport {
-			client,
-			inner: block_import,
-			epoch_changes,
-			config,
-		}
+		BabeBlockImport { client, inner: block_import, epoch_changes, config }
 	}
 }
 
 #[async_trait::async_trait]
-impl<Block, Client, Inner> BlockImport<Block> for BabeBlockImport<Block, Client, Inner> where
+impl<Block, Client, Inner> BlockImport<Block> for BabeBlockImport<Block, Client, Inner>
+where
 	Block: BlockT,
 	Inner: BlockImport<Block, Transaction = sp_api::TransactionFor<Client, Block>> + Send + Sync,
 	Inner::Error: Into<ConsensusError>,
-	Client: HeaderBackend<Block> + HeaderMetadata<Block, Error = sp_blockchain::Error>
-		+ AuxStore + ProvideRuntimeApi<Block> + ProvideCache<Block> + Send + Sync,
+	Client: HeaderBackend<Block>
+		+ HeaderMetadata<Block, Error = sp_blockchain::Error>
+		+ AuxStore
+		+ ProvideRuntimeApi<Block>
+		+ ProvideCache<Block>
+		+ Send
+		+ Sync,
 	Client::Api: BabeApi<Block> + ApiExt<Block>,
 {
 	type Error = ConsensusError;
@@ -1302,36 +1333,39 @@ impl<Block, Client, Inner> BlockImport<Block> for BabeBlockImport<Block, Client,
 				// When re-importing existing block strip away intermediates.
 				let _ = block.take_intermediate::<BabeIntermediate<Block>>(INTERMEDIATE_KEY)?;
 				block.fork_choice = Some(ForkChoiceStrategy::Custom(false));
-				return self.inner.import_block(block, new_cache).await.map_err(Into::into)
-			},
-			Ok(sp_blockchain::BlockStatus::Unknown) => {},
+				return self.inner.import_block(block, new_cache).await.map_err(Into::into);
+			}
+			Ok(sp_blockchain::BlockStatus::Unknown) => {}
 			Err(e) => return Err(ConsensusError::ClientImport(e.to_string())),
 		}
 
-		let pre_digest = find_pre_digest::<Block>(&block.header)
-			.expect("valid babe headers must contain a predigest; \
-					 header has been already verified; qed");
+		let pre_digest = find_pre_digest::<Block>(&block.header).expect(
+			"valid babe headers must contain a predigest; \
+					 header has been already verified; qed",
+		);
 		let slot = pre_digest.slot();
 
 		let parent_hash = *block.header.parent_hash();
-		let parent_header = self.client.header(BlockId::Hash(parent_hash))
+		let parent_header = self
+			.client
+			.header(BlockId::Hash(parent_hash))
 			.map_err(|e| ConsensusError::ChainLookup(e.to_string()))?
-			.ok_or_else(|| ConsensusError::ChainLookup(babe_err(
-				Error::<Block>::ParentUnavailable(parent_hash, hash)
-			).into()))?;
+			.ok_or_else(|| {
+				ConsensusError::ChainLookup(
+					babe_err(Error::<Block>::ParentUnavailable(parent_hash, hash)).into(),
+				)
+			})?;
 
-		let parent_slot = find_pre_digest::<Block>(&parent_header)
-			.map(|d| d.slot())
-			.expect("parent is non-genesis; valid BABE headers contain a pre-digest; \
-					header has already been verified; qed");
+		let parent_slot = find_pre_digest::<Block>(&parent_header).map(|d| d.slot()).expect(
+			"parent is non-genesis; valid BABE headers contain a pre-digest; \
+					header has already been verified; qed",
+		);
 
 		// make sure that slot number is strictly increasing
 		if slot <= parent_slot {
-			return Err(
-				ConsensusError::ClientImport(babe_err(
-					Error::<Block>::SlotMustIncrease(parent_slot, slot)
-				).into())
-			);
+			return Err(ConsensusError::ClientImport(
+				babe_err(Error::<Block>::SlotMustIncrease(parent_slot, slot)).into(),
+			));
 		}
 
 		// if there's a pending epoch we'll save the previous epoch changes here
@@ -1354,14 +1388,16 @@ impl<Block, Client, Inner> BlockImport<Block> for BabeBlockImport<Block, Client,
 				} else {
 					aux_schema::load_block_weight(&*self.client, parent_hash)
 						.map_err(|e| ConsensusError::ClientImport(e.to_string()))?
-					.ok_or_else(|| ConsensusError::ClientImport(
-						babe_err(Error::<Block>::ParentBlockNoAssociatedWeight(hash)).into()
-					))?
+						.ok_or_else(|| {
+							ConsensusError::ClientImport(
+								babe_err(Error::<Block>::ParentBlockNoAssociatedWeight(hash))
+									.into(),
+							)
+						})?
 				};
 
-				let intermediate = block.take_intermediate::<BabeIntermediate<Block>>(
-					INTERMEDIATE_KEY
-				)?;
+				let intermediate =
+					block.take_intermediate::<BabeIntermediate<Block>>(INTERMEDIATE_KEY)?;
 
 				let epoch_descriptor = intermediate.epoch_descriptor;
 				let first_in_epoch = parent_slot < epoch_descriptor.start_slot();
@@ -1377,29 +1413,23 @@ impl<Block, Client, Inner> BlockImport<Block> for BabeBlockImport<Block, Client,
 				.map_err(|e| ConsensusError::ClientImport(e.to_string()))?;
 
 			match (first_in_epoch, next_epoch_digest.is_some(), next_config_digest.is_some()) {
-				(true, true, _) => {},
-				(false, false, false) => {},
+				(true, true, _) => {}
+				(false, false, false) => {}
 				(false, false, true) => {
-					return Err(
-						ConsensusError::ClientImport(
-							babe_err(Error::<Block>::UnexpectedConfigChange).into(),
-						)
-					)
-				},
+					return Err(ConsensusError::ClientImport(
+						babe_err(Error::<Block>::UnexpectedConfigChange).into(),
+					))
+				}
 				(true, false, _) => {
-					return Err(
-						ConsensusError::ClientImport(
-							babe_err(Error::<Block>::ExpectedEpochChange(hash, slot)).into(),
-						)
-					)
-				},
+					return Err(ConsensusError::ClientImport(
+						babe_err(Error::<Block>::ExpectedEpochChange(hash, slot)).into(),
+					))
+				}
 				(false, true, _) => {
-					return Err(
-						ConsensusError::ClientImport(
-							babe_err(Error::<Block>::UnexpectedEpochChange).into(),
-						)
-					)
-				},
+					return Err(ConsensusError::ClientImport(
+						babe_err(Error::<Block>::UnexpectedEpochChange).into(),
+					))
+				}
 			}
 
 			let info = self.client.info();
@@ -1407,16 +1437,15 @@ impl<Block, Client, Inner> BlockImport<Block> for BabeBlockImport<Block, Client,
 			if let Some(next_epoch_descriptor) = next_epoch_digest {
 				old_epoch_changes = Some((*epoch_changes).clone());
 
-				let viable_epoch = epoch_changes.viable_epoch(
-					&epoch_descriptor,
-					|slot| Epoch::genesis(&self.config, slot)
-				).ok_or_else(|| {
-					ConsensusError::ClientImport(Error::<Block>::FetchEpoch(parent_hash).into())
-				})?;
+				let viable_epoch = epoch_changes
+					.viable_epoch(&epoch_descriptor, |slot| Epoch::genesis(&self.config, slot))
+					.ok_or_else(|| {
+						ConsensusError::ClientImport(Error::<Block>::FetchEpoch(parent_hash).into())
+					})?;
 
-				let epoch_config = next_config_digest.map(Into::into).unwrap_or_else(
-					|| viable_epoch.as_ref().config.clone()
-				);
+				let epoch_config = next_config_digest
+					.map(Into::into)
+					.unwrap_or_else(|| viable_epoch.as_ref().config.clone());
 
 				// restrict info logging during initial sync to avoid spam
 				let log_level = if block.origin == BlockOrigin::NetworkInitialSync {
@@ -1450,43 +1479,40 @@ impl<Block, Client, Inner> BlockImport<Block> for BabeBlockImport<Block, Client,
 				// used by pruning may not know about the block that is being
 				// imported.
 				let prune_and_import = || {
-					prune_finalized(
-						self.client.clone(),
-						&mut epoch_changes,
-					)?;
+					prune_finalized(self.client.clone(), &mut epoch_changes)?;
 
-					epoch_changes.import(
-						descendent_query(&*self.client),
-						hash,
-						number,
-						*block.header.parent_hash(),
-						next_epoch,
-					).map_err(|e| ConsensusError::ClientImport(format!("{:?}", e)))?;
+					epoch_changes
+						.import(
+							descendent_query(&*self.client),
+							hash,
+							number,
+							*block.header.parent_hash(),
+							next_epoch,
+						)
+						.map_err(|e| ConsensusError::ClientImport(format!("{:?}", e)))?;
 
 					Ok(())
 				};
 
 				if let Err(e) = prune_and_import() {
 					debug!(target: "babe", "Failed to launch next epoch: {:?}", e);
-					*epoch_changes = old_epoch_changes.expect("set `Some` above and not taken; qed");
+					*epoch_changes =
+						old_epoch_changes.expect("set `Some` above and not taken; qed");
 					return Err(e);
 				}
 
-				crate::aux_schema::write_epoch_changes::<Block, _, _>(
-					&*epoch_changes,
-					|insert| block.auxiliary.extend(
-						insert.iter().map(|(k, v)| (k.to_vec(), Some(v.to_vec())))
-					)
-				);
+				crate::aux_schema::write_epoch_changes::<Block, _, _>(&*epoch_changes, |insert| {
+					block
+						.auxiliary
+						.extend(insert.iter().map(|(k, v)| (k.to_vec(), Some(v.to_vec()))))
+				});
 			}
 
-			aux_schema::write_block_weight(
-				hash,
-				total_weight,
-				|values| block.auxiliary.extend(
-					values.iter().map(|(k, v)| (k.to_vec(), Some(v.to_vec())))
-				),
-			);
+			aux_schema::write_block_weight(hash, total_weight, |values| {
+				block
+					.auxiliary
+					.extend(values.iter().map(|(k, v)| (k.to_vec(), Some(v.to_vec()))))
+			});
 
 			// The fork choice rule is that we pick the heaviest chain (i.e.
 			// more primary blocks), if there's a tie we go with the longest
@@ -1501,9 +1527,11 @@ impl<Block, Client, Inner> BlockImport<Block> for BabeBlockImport<Block, Client,
 				} else {
 					aux_schema::load_block_weight(&*self.client, last_best)
 						.map_err(|e| ConsensusError::ChainLookup(format!("{:?}", e)))?
-					.ok_or_else(
-						|| ConsensusError::ChainLookup("No block weight for parent header.".to_string())
-					)?
+						.ok_or_else(|| {
+							ConsensusError::ChainLookup(
+								"No block weight for parent header.".to_string(),
+							)
+						})?
 				};
 
 				Some(ForkChoiceStrategy::Custom(if total_weight > last_best_weight {
@@ -1544,30 +1572,38 @@ impl<Block, Client, Inner> BlockImport<Block> for BabeBlockImport<Block, Client,
 fn prune_finalized<Block, Client>(
 	client: Arc<Client>,
 	epoch_changes: &mut EpochChangesFor<Block, Epoch>,
-) -> Result<(), ConsensusError> where
+) -> Result<(), ConsensusError>
+where
 	Block: BlockT,
 	Client: HeaderBackend<Block> + HeaderMetadata<Block, Error = sp_blockchain::Error>,
 {
 	let info = client.info();
 
 	let finalized_slot = {
-		let finalized_header = client.header(BlockId::Hash(info.finalized_hash))
+		let finalized_header = client
+			.header(BlockId::Hash(info.finalized_hash))
 			.map_err(|e| ConsensusError::ClientImport(format!("{:?}", e)))?
-			.expect("best finalized hash was given by client; \
-				 finalized headers must exist in db; qed");
+			.expect(
+				"best finalized hash was given by client; \
+				 finalized headers must exist in db; qed",
+			);
 
 		find_pre_digest::<Block>(&finalized_header)
-			.expect("finalized header must be valid; \
-					 valid blocks have a pre-digest; qed")
+			.expect(
+				"finalized header must be valid; \
+					 valid blocks have a pre-digest; qed",
+			)
 			.slot()
 	};
 
-	epoch_changes.prune_finalized(
-		descendent_query(&*client),
-		&info.finalized_hash,
-		info.finalized_number,
-		finalized_slot,
-	).map_err(|e| ConsensusError::ClientImport(format!("{:?}", e)))?;
+	epoch_changes
+		.prune_finalized(
+			descendent_query(&*client),
+			&info.finalized_hash,
+			info.finalized_number,
+			finalized_slot,
+		)
+		.map_err(|e| ConsensusError::ClientImport(format!("{:?}", e)))?;
 
 	Ok(())
 }
@@ -1586,25 +1622,14 @@ where
 	Client: AuxStore + HeaderBackend<Block> + HeaderMetadata<Block, Error = sp_blockchain::Error>,
 {
 	let epoch_changes = aux_schema::load_epoch_changes::<Block, _>(&*client, &config)?;
-	let link = BabeLink {
-		epoch_changes: epoch_changes.clone(),
-		config: config.clone(),
-	};
+	let link = BabeLink { epoch_changes: epoch_changes.clone(), config: config.clone() };
 
 	// NOTE: this isn't entirely necessary, but since we didn't use to prune the
 	// epoch tree it is useful as a migration, so that nodes prune long trees on
 	// startup rather than waiting until importing the next epoch change block.
-	prune_finalized(
-		client.clone(),
-		&mut epoch_changes.shared_data(),
-	)?;
+	prune_finalized(client.clone(), &mut epoch_changes.shared_data())?;
 
-	let import = BabeBlockImport::new(
-		client,
-		epoch_changes,
-		wrapped_block_import,
-		config,
-	);
+	let import = BabeBlockImport::new(client, epoch_changes, wrapped_block_import, config);
 
 	Ok((import, link))
 }
@@ -1629,12 +1654,23 @@ pub fn import_queue<Block: BlockT, Client, SelectChain, Inner, CAW, CIDP>(
 	registry: Option<&Registry>,
 	can_author_with: CAW,
 	telemetry: Option<TelemetryHandle>,
-) -> ClientResult<DefaultImportQueue<Block, Client>> where
-	Inner: BlockImport<Block, Error = ConsensusError, Transaction = sp_api::TransactionFor<Client, Block>>
-		+ Send + Sync + 'static,
-	Client: ProvideRuntimeApi<Block> + ProvideCache<Block> + HeaderBackend<Block>
-		+ HeaderMetadata<Block, Error = sp_blockchain::Error> + AuxStore
-		+ Send + Sync + 'static,
+) -> ClientResult<DefaultImportQueue<Block, Client>>
+where
+	Inner: BlockImport<
+			Block,
+			Error = ConsensusError,
+			Transaction = sp_api::TransactionFor<Client, Block>,
+		> + Send
+		+ Sync
+		+ 'static,
+	Client: ProvideRuntimeApi<Block>
+		+ ProvideCache<Block>
+		+ HeaderBackend<Block>
+		+ HeaderMetadata<Block, Error = sp_blockchain::Error>
+		+ AuxStore
+		+ Send
+		+ Sync
+		+ 'static,
 	Client::Api: BlockBuilderApi<Block> + BabeApi<Block> + ApiExt<Block>,
 	SelectChain: sp_consensus::SelectChain<Block> + 'static,
 	CAW: CanAuthorWith<Block> + Send + Sync + 'static,
@@ -1651,11 +1687,5 @@ pub fn import_queue<Block: BlockT, Client, SelectChain, Inner, CAW, CIDP>(
 		client,
 	};
 
-	Ok(BasicQueue::new(
-		verifier,
-		Box::new(block_import),
-		justification_import,
-		spawner,
-		registry,
-	))
+	Ok(BasicQueue::new(verifier, Box::new(block_import), justification_import, spawner, registry))
 }

--- a/client/consensus/babe/src/migration.rs
+++ b/client/consensus/babe/src/migration.rs
@@ -16,13 +16,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use codec::{Encode, Decode};
+use codec::{Decode, Encode};
 use sc_consensus_epochs::Epoch as EpochT;
-use crate::{
-	Epoch, AuthorityId, BabeAuthorityWeight, BabeGenesisConfiguration,
-	BabeEpochConfiguration, VRF_OUTPUT_LENGTH, NextEpochDescriptor,
-};
 use sp_consensus_slots::Slot;
+
+use crate::{
+	AuthorityId, BabeAuthorityWeight, BabeEpochConfiguration, BabeGenesisConfiguration, Epoch,
+	NextEpochDescriptor, VRF_OUTPUT_LENGTH,
+};
 
 /// BABE epoch information, version 0.
 #[derive(Decode, Encode, PartialEq, Eq, Clone, Debug)]
@@ -43,10 +44,7 @@ impl EpochT for EpochV0 {
 	type NextEpochDescriptor = NextEpochDescriptor;
 	type Slot = Slot;
 
-	fn increment(
-		&self,
-		descriptor: NextEpochDescriptor
-	) -> EpochV0 {
+	fn increment(&self, descriptor: NextEpochDescriptor) -> EpochV0 {
 		EpochV0 {
 			epoch_index: self.epoch_index + 1,
 			start_slot: self.start_slot + self.duration,
@@ -74,10 +72,7 @@ impl EpochV0 {
 			duration: self.duration,
 			authorities: self.authorities,
 			randomness: self.randomness,
-			config: BabeEpochConfiguration {
-				c: config.c,
-				allowed_slots: config.allowed_slots,
-			},
+			config: BabeEpochConfiguration { c: config.c, allowed_slots: config.allowed_slots },
 		}
 	}
 }

--- a/client/consensus/babe/src/tests.rs
+++ b/client/consensus/babe/src/tests.rs
@@ -21,37 +21,37 @@
 // FIXME #2532: need to allow deprecated until refactor is done
 // https://github.com/paritytech/substrate/issues/2532
 #![allow(deprecated)]
-use super::*;
+use std::{cell::RefCell, task::Poll, time::Duration};
+
 use authorship::claim_slot;
-use sp_core::crypto::Pair;
-use sp_keystore::{
-	SyncCryptoStore,
-	vrf::make_transcript as transcript_from_data,
+use futures::executor::block_on;
+use log::debug;
+use rand::RngCore;
+use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
+use sc_block_builder::{BlockBuilder, BlockBuilderProvider};
+use sc_client_api::{backend::TransactionFor, BlockchainEvents};
+use sc_consensus_slots::BackoffAuthoringOnFinalizedHeadLagging;
+use sc_keystore::LocalKeystore;
+use sc_network::config::ProtocolConfig;
+use sc_network_test::{Block as TestBlock, *};
+use sp_application_crypto::key_types::BABE;
+use sp_consensus::{
+	import_queue::{BoxBlockImport, BoxJustificationImport},
+	AlwaysCanAuthor, DisableProofRecording, NoNetwork as DummyOracle, Proposal,
 };
 use sp_consensus_babe::{
-	AuthorityPair, Slot, AllowedSlots, make_transcript, make_transcript_data,
-	inherents::InherentDataProvider,
+	inherents::InherentDataProvider, make_transcript, make_transcript_data, AllowedSlots,
+	AuthorityPair, Slot,
 };
-use sc_consensus_slots::BackoffAuthoringOnFinalizedHeadLagging;
-use sc_block_builder::{BlockBuilder, BlockBuilderProvider};
-use sp_consensus::{
-	NoNetwork as DummyOracle, Proposal, DisableProofRecording, AlwaysCanAuthor,
-	import_queue::{BoxBlockImport, BoxJustificationImport},
+use sp_core::crypto::Pair;
+use sp_keystore::{vrf::make_transcript as transcript_from_data, SyncCryptoStore};
+use sp_runtime::{
+	generic::DigestItem,
+	traits::{Block as BlockT, DigestFor},
 };
-use sc_network_test::{Block as TestBlock, *};
-use sc_network::config::ProtocolConfig;
-use sp_runtime::{generic::DigestItem, traits::{Block as BlockT, DigestFor}};
-use sc_client_api::{BlockchainEvents, backend::TransactionFor};
-use log::debug;
-use std::{time::Duration, cell::RefCell, task::Poll};
-use rand::RngCore;
-use rand_chacha::{
-	rand_core::SeedableRng, ChaChaRng,
-};
-use sc_keystore::LocalKeystore;
-use sp_application_crypto::key_types::BABE;
-use futures::executor::block_on;
 use sp_timestamp::InherentDataProvider as TimestampInherentDataProvider;
+
+use super::*;
 
 type Item = DigestItem<Hash>;
 
@@ -92,13 +92,10 @@ struct DummyProposer {
 
 impl Environment<TestBlock> for DummyFactory {
 	type CreateProposer = future::Ready<Result<DummyProposer, Error>>;
-	type Proposer = DummyProposer;
 	type Error = Error;
+	type Proposer = DummyProposer;
 
-	fn init(&mut self, parent_header: &<TestBlock as BlockT>::Header)
-		-> Self::CreateProposer
-	{
-
+	fn init(&mut self, parent_header: &<TestBlock as BlockT>::Header) -> Self::CreateProposer {
 		let parent_slot = crate::find_pre_digest::<TestBlock>(parent_header)
 			.expect("parent header has a pre-digest")
 			.slot();
@@ -113,23 +110,24 @@ impl Environment<TestBlock> for DummyFactory {
 }
 
 impl DummyProposer {
-	fn propose_with(&mut self, pre_digests: DigestFor<TestBlock>)
-		-> future::Ready<
-			Result<
-				Proposal<
-					TestBlock,
-					sc_client_api::TransactionFor<substrate_test_runtime_client::Backend, TestBlock>,
-					()
-				>,
-				Error
-			>
-		>
-	{
-		let block_builder = self.factory.client.new_block_at(
-			&BlockId::Hash(self.parent_hash),
-			pre_digests,
-			false,
-		).unwrap();
+	fn propose_with(
+		&mut self,
+		pre_digests: DigestFor<TestBlock>,
+	) -> future::Ready<
+		Result<
+			Proposal<
+				TestBlock,
+				sc_client_api::TransactionFor<substrate_test_runtime_client::Backend, TestBlock>,
+				(),
+			>,
+			Error,
+		>,
+	> {
+		let block_builder = self
+			.factory
+			.client
+			.new_block_at(&BlockId::Hash(self.parent_hash), pre_digests, false)
+			.unwrap();
 
 		let mut block = match block_builder.build().map_err(|e| e.into()) {
 			Ok(b) => b.block,
@@ -143,13 +141,14 @@ impl DummyProposer {
 		// figure out if we should add a consensus digest, since the test runtime
 		// doesn't.
 		let epoch_changes = self.factory.epoch_changes.shared_data();
-		let epoch = epoch_changes.epoch_data_for_child_of(
-			descendent_query(&*self.factory.client),
-			&self.parent_hash,
-			self.parent_number,
-			this_slot,
-			|slot| Epoch::genesis(&self.factory.config, slot),
-		)
+		let epoch = epoch_changes
+			.epoch_data_for_child_of(
+				descendent_query(&*self.factory.client),
+				&self.parent_hash,
+				self.parent_number,
+				this_slot,
+				|slot| Epoch::genesis(&self.factory.config, slot),
+			)
 			.expect("client has data to find epoch")
 			.expect("can compute epoch for baked block");
 
@@ -162,7 +161,8 @@ impl DummyProposer {
 			let digest_data = ConsensusLog::NextEpochData(NextEpochDescriptor {
 				authorities: epoch.authorities.clone(),
 				randomness: epoch.randomness.clone(),
-			}).encode();
+			})
+			.encode();
 			let digest = DigestItem::Consensus(BABE_ENGINE_ID, digest_data);
 			block.header.digest_mut().push(digest)
 		}
@@ -176,10 +176,11 @@ impl DummyProposer {
 
 impl Proposer<TestBlock> for DummyProposer {
 	type Error = Error;
-	type Transaction = sc_client_api::TransactionFor<substrate_test_runtime_client::Backend, TestBlock>;
-	type Proposal = future::Ready<Result<Proposal<TestBlock, Self::Transaction, ()>, Error>>;
-	type ProofRecording = DisableProofRecording;
 	type Proof = ();
+	type ProofRecording = DisableProofRecording;
+	type Proposal = future::Ready<Result<Proposal<TestBlock, Self::Transaction, ()>, Error>>;
+	type Transaction =
+		sc_client_api::TransactionFor<substrate_test_runtime_client::Backend, TestBlock>;
 
 	fn propose(
 		mut self,
@@ -201,9 +202,9 @@ pub struct PanickingBlockImport<B>(B);
 
 #[async_trait::async_trait]
 impl<B: BlockImport<TestBlock>> BlockImport<TestBlock> for PanickingBlockImport<B>
-	where
-		B::Transaction: Send,
-		B: Send,
+where
+	B::Transaction: Send,
+	B: Send,
 {
 	type Error = B::Error;
 	type Transaction = B::Transaction;
@@ -233,10 +234,8 @@ pub struct BabeTestNet {
 type TestHeader = <TestBlock as BlockT>::Header;
 type TestExtrinsic = <TestBlock as BlockT>::Extrinsic;
 
-type TestSelectChain = substrate_test_runtime_client::LongestChain<
-	substrate_test_runtime_client::Backend,
-	TestBlock,
->;
+type TestSelectChain =
+	substrate_test_runtime_client::LongestChain<substrate_test_runtime_client::Backend, TestBlock>;
 
 pub struct TestVerifier {
 	inner: BabeVerifier<
@@ -244,11 +243,13 @@ pub struct TestVerifier {
 		PeersFullClient,
 		TestSelectChain,
 		AlwaysCanAuthor,
-		Box<dyn CreateInherentDataProviders<
-			TestBlock,
-			(),
-			InherentDataProviders = (TimestampInherentDataProvider, InherentDataProvider)
-		>>
+		Box<
+			dyn CreateInherentDataProviders<
+				TestBlock,
+				(),
+				InherentDataProviders = (TimestampInherentDataProvider, InherentDataProvider),
+			>,
+		>,
 	>,
 	mutator: Mutator,
 }
@@ -274,44 +275,44 @@ impl Verifier<TestBlock> for TestVerifier {
 pub struct PeerData {
 	link: BabeLink<TestBlock>,
 	block_import: Mutex<
-		Option<BoxBlockImport<TestBlock, TransactionFor<substrate_test_runtime_client::Backend, TestBlock>>>
+		Option<
+			BoxBlockImport<
+				TestBlock,
+				TransactionFor<substrate_test_runtime_client::Backend, TestBlock>,
+			>,
+		>,
 	>,
 }
 
 impl TestNetFactory for BabeTestNet {
-	type Verifier = TestVerifier;
-	type PeerData = Option<PeerData>;
 	type BlockImport = BabeBlockImport;
+	type PeerData = Option<PeerData>;
+	type Verifier = TestVerifier;
 
 	/// Create new test network with peers and given config.
 	fn from_config(_config: &ProtocolConfig) -> Self {
 		debug!(target: "babe", "Creating test network from config");
-		BabeTestNet {
-			peers: Vec::new(),
-		}
+		BabeTestNet { peers: Vec::new() }
 	}
 
-	fn make_block_import(&self, client: PeersClient)
-		-> (
-			BlockImportAdapter<Self::BlockImport>,
-			Option<BoxJustificationImport<Block>>,
-			Option<PeerData>,
-		)
-	{
+	fn make_block_import(
+		&self,
+		client: PeersClient,
+	) -> (
+		BlockImportAdapter<Self::BlockImport>,
+		Option<BoxJustificationImport<Block>>,
+		Option<PeerData>,
+	) {
 		let client = client.as_full().expect("only full clients are tested");
 
 		let config = Config::get_or_compute(&*client).expect("config available");
-		let (block_import, link) = crate::block_import(
-			config,
-			client.clone(),
-			client.clone(),
-		).expect("can initialize block-import");
+		let (block_import, link) = crate::block_import(config, client.clone(), client.clone())
+			.expect("can initialize block-import");
 
 		let block_import = PanickingBlockImport(block_import);
 
-		let data_block_import = Mutex::new(
-			Some(Box::new(block_import.clone()) as BoxBlockImport<_, _>)
-		);
+		let data_block_import =
+			Mutex::new(Some(Box::new(block_import.clone()) as BoxBlockImport<_, _>));
 		(
 			BlockImportAdapter::new(block_import),
 			None,
@@ -324,16 +325,16 @@ impl TestNetFactory for BabeTestNet {
 		client: PeersClient,
 		_cfg: &ProtocolConfig,
 		maybe_link: &Option<PeerData>,
-	)
-		-> Self::Verifier
-	{
+	) -> Self::Verifier {
 		use substrate_test_runtime_client::DefaultTestClientBuilderExt;
 
 		let client = client.as_full().expect("only full clients are used in test");
 		trace!(target: "babe", "Creating a verifier");
 
 		// ensure block import and verifier are linked correctly.
-		let data = maybe_link.as_ref().expect("babe link always provided to verifier instantiation");
+		let data = maybe_link
+			.as_ref()
+			.expect("babe link always provided to verifier instantiation");
 
 		let (_, longest_chain) = TestClientBuilder::new().build_with_longest_chain();
 
@@ -369,10 +370,7 @@ impl TestNetFactory for BabeTestNet {
 		&self.peers
 	}
 
-	fn mut_peers<F: FnOnce(&mut Vec<BabePeer>)>(
-		&mut self,
-		closure: F,
-	) {
+	fn mut_peers<F: FnOnce(&mut Vec<BabePeer>)>(&mut self, closure: F) {
 		closure(&mut self.peers);
 	}
 }
@@ -382,9 +380,7 @@ impl TestNetFactory for BabeTestNet {
 fn rejects_empty_block() {
 	sp_tracing::try_init_simple();
 	let mut net = BabeTestNet::new(3);
-	let block_builder = |builder: BlockBuilder<_, _, _>| {
-		builder.build().unwrap().block
-	};
+	let block_builder = |builder: BlockBuilder<_, _, _>| builder.build().unwrap().block;
 	net.mut_peers(|peer| {
 		peer[0].generate_blocks(1, BlockOrigin::NetworkInitialSync, block_builder);
 	})
@@ -397,11 +393,7 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
 	MUTATOR.with(|m| *m.borrow_mut() = mutator.clone());
 	let net = BabeTestNet::new(3);
 
-	let peers = &[
-		(0, "//Alice"),
-		(1, "//Bob"),
-		(2, "//Charlie"),
-	];
+	let peers = &[(0, "//Alice"), (1, "//Bob"), (2, "//Charlie")];
 
 	let net = Arc::new(Mutex::new(net));
 	let mut import_notifications = Vec::new();
@@ -415,9 +407,10 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
 		let select_chain = peer.select_chain().expect("Full client has select_chain");
 
 		let keystore_path = tempfile::tempdir().expect("Creates keystore path");
-		let keystore: SyncCryptoStorePtr = Arc::new(LocalKeystore::open(keystore_path.path(), None)
-			.expect("Creates keystore"));
-		SyncCryptoStore::sr25519_generate_new(&*keystore, BABE, Some(seed)).expect("Generates authority key");
+		let keystore: SyncCryptoStorePtr =
+			Arc::new(LocalKeystore::open(keystore_path.path(), None).expect("Creates keystore"));
+		SyncCryptoStore::sr25519_generate_new(&*keystore, BABE, Some(seed))
+			.expect("Generates authority key");
 		keystore_paths.push(keystore_path);
 
 		let mut got_own = false;
@@ -435,47 +428,54 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
 		import_notifications.push(
 			// run each future until we get one of our own blocks with number higher than 5
 			// that was produced locally.
-			client.import_notification_stream()
-				.take_while(move |n| future::ready(n.header.number() < &5 || {
-					if n.origin == BlockOrigin::Own {
-						got_own = true;
-					} else {
-						got_other = true;
-					}
+			client
+				.import_notification_stream()
+				.take_while(move |n| {
+					future::ready(
+						n.header.number() < &5 || {
+							if n.origin == BlockOrigin::Own {
+								got_own = true;
+							} else {
+								got_other = true;
+							}
 
-					// continue until we have at least one block of our own
-					// and one of another peer.
-					!(got_own && got_other)
-				}))
-				.for_each(|_| future::ready(()) )
+							// continue until we have at least one block of our own
+							// and one of another peer.
+							!(got_own && got_other)
+						},
+					)
+				})
+				.for_each(|_| future::ready(())),
 		);
 
+		babe_futures.push(
+			start_babe(BabeParams {
+				block_import: data.block_import.lock().take().expect("import set up during init"),
+				select_chain,
+				client,
+				env: environ,
+				sync_oracle: DummyOracle,
+				create_inherent_data_providers: Box::new(|_, _| async {
+					let timestamp = TimestampInherentDataProvider::from_system_time();
+					let slot = InherentDataProvider::from_timestamp_and_duration(
+						*timestamp,
+						Duration::from_secs(6),
+					);
 
-		babe_futures.push(start_babe(BabeParams {
-			block_import: data.block_import.lock().take().expect("import set up during init"),
-			select_chain,
-			client,
-			env: environ,
-			sync_oracle: DummyOracle,
-			create_inherent_data_providers: Box::new(|_, _| async {
-				let timestamp = TimestampInherentDataProvider::from_system_time();
-				let slot = InherentDataProvider::from_timestamp_and_duration(
-					*timestamp,
-					Duration::from_secs(6),
-				);
-
-				Ok((timestamp, slot))
-			}),
-			force_authoring: false,
-			backoff_authoring_blocks: Some(BackoffAuthoringOnFinalizedHeadLagging::default()),
-			babe_link: data.link.clone(),
-			keystore,
-			can_author_with: sp_consensus::AlwaysCanAuthor,
-			justification_sync_link: (),
-			block_proposal_slot_portion: SlotProportion::new(0.5),
-			max_block_proposal_slot_portion: None,
-			telemetry: None,
-		}).expect("Starts babe"));
+					Ok((timestamp, slot))
+				}),
+				force_authoring: false,
+				backoff_authoring_blocks: Some(BackoffAuthoringOnFinalizedHeadLagging::default()),
+				babe_link: data.link.clone(),
+				keystore,
+				can_author_with: sp_consensus::AlwaysCanAuthor,
+				justification_sync_link: (),
+				block_proposal_slot_portion: SlotProportion::new(0.5),
+				max_block_proposal_slot_portion: None,
+				telemetry: None,
+			})
+			.expect("Starts babe"),
+		);
 	}
 	block_on(future::select(
 		futures::future::poll_fn(move |cx| {
@@ -489,7 +489,7 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
 
 			Poll::<()>::Pending
 		}),
-		future::select(future::join_all(import_notifications), future::join_all(babe_futures))
+		future::select(future::join_all(import_notifications), future::join_all(babe_futures)),
 	));
 }
 
@@ -503,7 +503,8 @@ fn authoring_blocks() {
 fn rejects_missing_inherent_digest() {
 	run_one_test(|header: &mut TestHeader, stage| {
 		let v = std::mem::take(&mut header.digest_mut().logs);
-		header.digest_mut().logs = v.into_iter()
+		header.digest_mut().logs = v
+			.into_iter()
 			.filter(|v| stage == Stage::PostSeal || v.as_babe_pre_digest().is_none())
 			.collect()
 	})
@@ -514,7 +515,8 @@ fn rejects_missing_inherent_digest() {
 fn rejects_missing_seals() {
 	run_one_test(|header: &mut TestHeader, stage| {
 		let v = std::mem::take(&mut header.digest_mut().logs);
-		header.digest_mut().logs = v.into_iter()
+		header.digest_mut().logs = v
+			.into_iter()
 			.filter(|v| stage == Stage::PreSeal || v.as_babe_seal().is_none())
 			.collect()
 	})
@@ -525,7 +527,8 @@ fn rejects_missing_seals() {
 fn rejects_missing_consensus_digests() {
 	run_one_test(|header: &mut TestHeader, stage| {
 		let v = std::mem::take(&mut header.digest_mut().logs);
-		header.digest_mut().logs = v.into_iter()
+		header.digest_mut().logs = v
+			.into_iter()
 			.filter(|v| stage == Stage::PostSeal || v.as_next_epoch_descriptor().is_none())
 			.collect()
 	});
@@ -560,8 +563,8 @@ fn sig_is_not_pre_digest() {
 fn can_author_block() {
 	sp_tracing::try_init_simple();
 	let keystore_path = tempfile::tempdir().expect("Creates keystore path");
-	let keystore: SyncCryptoStorePtr = Arc::new(LocalKeystore::open(keystore_path.path(), None)
-		.expect("Creates keystore"));
+	let keystore: SyncCryptoStorePtr =
+		Arc::new(LocalKeystore::open(keystore_path.path(), None).expect("Creates keystore"));
 	let public = SyncCryptoStore::sr25519_generate_new(&*keystore, BABE, Some("//Alice"))
 		.expect("Generates authority pair");
 
@@ -622,26 +625,27 @@ fn propose_and_import_block<Transaction: Send + 'static>(
 	});
 
 	let pre_digest = sp_runtime::generic::Digest {
-		logs: vec![
-			Item::babe_pre_digest(
-				PreDigest::SecondaryPlain(SecondaryPlainPreDigest {
-					authority_index: 0,
-					slot,
-				}),
-			),
-		],
+		logs: vec![Item::babe_pre_digest(PreDigest::SecondaryPlain(SecondaryPlainPreDigest {
+			authority_index: 0,
+			slot,
+		}))],
 	};
 
 	let parent_hash = parent.hash();
 
 	let mut block = futures::executor::block_on(proposer.propose_with(pre_digest)).unwrap().block;
 
-	let epoch_descriptor = proposer_factory.epoch_changes.shared_data().epoch_descriptor_for_child_of(
-		descendent_query(&*proposer_factory.client),
-		&parent_hash,
-		*parent.number(),
-		slot,
-	).unwrap().unwrap();
+	let epoch_descriptor = proposer_factory
+		.epoch_changes
+		.shared_data()
+		.epoch_descriptor_for_child_of(
+			descendent_query(&*proposer_factory.client),
+			&parent_hash,
+			*parent.number(),
+			slot,
+		)
+		.unwrap()
+		.unwrap();
 
 	let seal = {
 		// sign the pre-sealed hash of the block and then
@@ -670,7 +674,7 @@ fn propose_and_import_block<Transaction: Send + 'static>(
 	let import_result = block_on(block_import.import_block(import, Default::default())).unwrap();
 
 	match import_result {
-		ImportResult::Imported(_) => {},
+		ImportResult::Imported(_) => {}
 		_ => panic!("expected block to be imported"),
 	}
 
@@ -706,13 +710,12 @@ fn importing_block_one_sets_genesis_epoch() {
 	let genesis_epoch = Epoch::genesis(&data.link.config, 999.into());
 
 	let epoch_changes = data.link.epoch_changes.shared_data();
-	let epoch_for_second_block = epoch_changes.epoch_data_for_child_of(
-		descendent_query(&*client),
-		&block_hash,
-		1,
-		1000.into(),
-		|slot| Epoch::genesis(&data.link.config, slot),
-	).unwrap().unwrap();
+	let epoch_for_second_block = epoch_changes
+		.epoch_data_for_child_of(descendent_query(&*client), &block_hash, 1, 1000.into(), |slot| {
+			Epoch::genesis(&data.link.config, slot)
+		})
+		.unwrap()
+		.unwrap();
 
 	assert_eq!(epoch_for_second_block, genesis_epoch);
 }
@@ -745,7 +748,7 @@ fn importing_epoch_change_block_prunes_tree() {
 		let mut hashes = Vec::new();
 		let mut parent_header = client.header(&parent_id).unwrap().unwrap();
 
-		for _ in 0..n {
+		for _ in 0 .. n {
 			let block_hash = propose_and_import_block(
 				&parent_header,
 				None,
@@ -779,16 +782,10 @@ fn importing_epoch_change_block_prunes_tree() {
 	let fork_3 = propose_and_import_blocks(BlockId::Hash(canon_hashes[18]), 10);
 
 	// We should be tracking a total of 9 epochs in the fork tree
-	assert_eq!(
-		epoch_changes.shared_data().tree().iter().count(),
-		9,
-	);
+	assert_eq!(epoch_changes.shared_data().tree().iter().count(), 9,);
 
 	// And only one root
-	assert_eq!(
-		epoch_changes.shared_data().tree().roots().count(),
-		1,
-	);
+	assert_eq!(epoch_changes.shared_data().tree().roots().count(), 1,);
 
 	// We finalize block #13 from the canon chain, so on the next epoch
 	// change the tree should be pruned, to not contain F (#7).
@@ -796,32 +793,47 @@ fn importing_epoch_change_block_prunes_tree() {
 	propose_and_import_blocks(BlockId::Hash(client.chain_info().best_hash), 7);
 
 	// at this point no hashes from the first fork must exist on the tree
-	assert!(
-		!epoch_changes.shared_data().tree().iter().map(|(h, _, _)| h).any(|h| fork_1.contains(h)),
-	);
+	assert!(!epoch_changes
+		.shared_data()
+		.tree()
+		.iter()
+		.map(|(h, _, _)| h)
+		.any(|h| fork_1.contains(h)),);
 
 	// but the epoch changes from the other forks must still exist
-	assert!(
-		epoch_changes.shared_data().tree().iter().map(|(h, _, _)| h).any(|h| fork_2.contains(h))
-	);
+	assert!(epoch_changes
+		.shared_data()
+		.tree()
+		.iter()
+		.map(|(h, _, _)| h)
+		.any(|h| fork_2.contains(h)));
 
-	assert!(
-		epoch_changes.shared_data().tree().iter().map(|(h, _, _)| h).any(|h| fork_3.contains(h)),
-	);
+	assert!(epoch_changes
+		.shared_data()
+		.tree()
+		.iter()
+		.map(|(h, _, _)| h)
+		.any(|h| fork_3.contains(h)),);
 
 	// finalizing block #25 from the canon chain should prune out the second fork
 	client.finalize_block(BlockId::Hash(canon_hashes[24]), None, false).unwrap();
 	propose_and_import_blocks(BlockId::Hash(client.chain_info().best_hash), 8);
 
 	// at this point no hashes from the second fork must exist on the tree
-	assert!(
-		!epoch_changes.shared_data().tree().iter().map(|(h, _, _)| h).any(|h| fork_2.contains(h)),
-	);
+	assert!(!epoch_changes
+		.shared_data()
+		.tree()
+		.iter()
+		.map(|(h, _, _)| h)
+		.any(|h| fork_2.contains(h)),);
 
 	// while epoch changes from the last fork should still exist
-	assert!(
-		epoch_changes.shared_data().tree().iter().map(|(h, _, _)| h).any(|h| fork_3.contains(h)),
-	);
+	assert!(epoch_changes
+		.shared_data()
+		.tree()
+		.iter()
+		.map(|(h, _, _)| h)
+		.any(|h| fork_3.contains(h)),);
 }
 
 #[test]
@@ -856,20 +868,15 @@ fn verify_slots_are_strictly_increasing() {
 
 	// we should fail to import this block since the slot number didn't increase.
 	// we will panic due to the `PanickingBlockImport` defined above.
-	propose_and_import_block(
-		&b1,
-		Some(999.into()),
-		&mut proposer_factory,
-		&mut block_import,
-	);
+	propose_and_import_block(&b1, Some(999.into()), &mut proposer_factory, &mut block_import);
 }
 
 #[test]
 fn babe_transcript_generation_match() {
 	sp_tracing::try_init_simple();
 	let keystore_path = tempfile::tempdir().expect("Creates keystore path");
-	let keystore: SyncCryptoStorePtr = Arc::new(LocalKeystore::open(keystore_path.path(), None)
-		.expect("Creates keystore"));
+	let keystore: SyncCryptoStorePtr =
+		Arc::new(LocalKeystore::open(keystore_path.path(), None).expect("Creates keystore"));
 	let public = SyncCryptoStore::sr25519_generate_new(&*keystore, BABE, Some("//Alice"))
 		.expect("Generates authority pair");
 
@@ -890,9 +897,7 @@ fn babe_transcript_generation_match() {
 
 	let test = |t: merlin::Transcript| -> [u8; 16] {
 		let mut b = [0u8; 16];
-		t.build_rng()
-			.finalize(&mut ChaChaRng::from_seed([0u8;32]))
-			.fill_bytes(&mut b);
+		t.build_rng().finalize(&mut ChaChaRng::from_seed([0u8; 32])).fill_bytes(&mut b);
 		b
 	};
 	debug_assert!(test(orig_transcript) == test(transcript_from_data(new_transcript)));

--- a/client/consensus/babe/src/verification.rs
+++ b/client/consensus/babe/src/verification.rs
@@ -17,18 +17,23 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Verification for BABE headers.
-use sp_runtime::{traits::Header, traits::DigestItemFor};
-use sp_core::{Pair, Public};
-use sp_consensus_babe::{make_transcript, AuthoritySignature, AuthorityPair, AuthorityId};
-use sp_consensus_babe::digests::{
-	PreDigest, PrimaryPreDigest, SecondaryPlainPreDigest, SecondaryVRFPreDigest,
-	CompatibleDigestItem
-};
-use sc_consensus_slots::CheckedHeader;
-use sp_consensus_slots::Slot;
 use log::{debug, trace};
-use super::{find_pre_digest, babe_err, Epoch, BlockT, Error};
-use super::authorship::{calculate_primary_threshold, check_primary_threshold, secondary_slot_author};
+use sc_consensus_slots::CheckedHeader;
+use sp_consensus_babe::{
+	digests::{
+		CompatibleDigestItem, PreDigest, PrimaryPreDigest, SecondaryPlainPreDigest,
+		SecondaryVRFPreDigest,
+	},
+	make_transcript, AuthorityId, AuthorityPair, AuthoritySignature,
+};
+use sp_consensus_slots::Slot;
+use sp_core::{Pair, Public};
+use sp_runtime::traits::{DigestItemFor, Header};
+
+use super::{
+	authorship::{calculate_primary_threshold, check_primary_threshold, secondary_slot_author},
+	babe_err, find_pre_digest, BlockT, Epoch, Error,
+};
 
 /// BABE verification parameters
 pub(super) struct VerificationParams<'a, B: 'a + BlockT> {
@@ -57,26 +62,24 @@ pub(super) struct VerificationParams<'a, B: 'a + BlockT> {
 /// with each having different validation logic.
 pub(super) fn check_header<B: BlockT + Sized>(
 	params: VerificationParams<B>,
-) -> Result<CheckedHeader<B::Header, VerifiedHeaderInfo<B>>, Error<B>> where
+) -> Result<CheckedHeader<B::Header, VerifiedHeaderInfo<B>>, Error<B>>
+where
 	DigestItemFor<B>: CompatibleDigestItem,
 {
-	let VerificationParams {
-		mut header,
-		pre_digest,
-		slot_now,
-		epoch,
-	} = params;
+	let VerificationParams { mut header, pre_digest, slot_now, epoch } = params;
 
 	let authorities = &epoch.authorities;
 	let pre_digest = pre_digest.map(Ok).unwrap_or_else(|| find_pre_digest::<B>(&header))?;
 
 	trace!(target: "babe", "Checking header");
-	let seal = header.digest_mut().pop()
+	let seal = header
+		.digest_mut()
+		.pop()
 		.ok_or_else(|| babe_err(Error::HeaderUnsealed(header.hash())))?;
 
-	let sig = seal.as_babe_seal().ok_or_else(|| {
-		babe_err(Error::HeaderBadSeal(header.hash()))
-	})?;
+	let sig = seal
+		.as_babe_seal()
+		.ok_or_else(|| babe_err(Error::HeaderBadSeal(header.hash())))?;
 
 	// the pre-hash of the header doesn't include the seal
 	// and that's what we sign
@@ -100,42 +103,30 @@ pub(super) fn check_header<B: BlockT + Sized>(
 				primary.slot,
 			);
 
-			check_primary_header::<B>(
-				pre_hash,
-				primary,
-				sig,
-				&epoch,
-				epoch.config.c,
-			)?;
-		},
-		PreDigest::SecondaryPlain(secondary) if epoch.config.allowed_slots.is_secondary_plain_slots_allowed() => {
+			check_primary_header::<B>(pre_hash, primary, sig, &epoch, epoch.config.c)?;
+		}
+		PreDigest::SecondaryPlain(secondary)
+			if epoch.config.allowed_slots.is_secondary_plain_slots_allowed() =>
+		{
 			debug!(target: "babe",
 				"Verifying secondary plain block #{} at slot: {}",
 				header.number(),
 				secondary.slot,
 			);
 
-			check_secondary_plain_header::<B>(
-				pre_hash,
-				secondary,
-				sig,
-				&epoch,
-			)?;
-		},
-		PreDigest::SecondaryVRF(secondary) if epoch.config.allowed_slots.is_secondary_vrf_slots_allowed() => {
+			check_secondary_plain_header::<B>(pre_hash, secondary, sig, &epoch)?;
+		}
+		PreDigest::SecondaryVRF(secondary)
+			if epoch.config.allowed_slots.is_secondary_vrf_slots_allowed() =>
+		{
 			debug!(target: "babe",
 				"Verifying secondary VRF block #{} at slot: {}",
 				header.number(),
 				secondary.slot,
 			);
 
-			check_secondary_vrf_header::<B>(
-				pre_hash,
-				secondary,
-				sig,
-				&epoch,
-			)?;
-		},
+			check_secondary_vrf_header::<B>(pre_hash, secondary, sig, &epoch)?;
+		}
 		_ => {
 			return Err(babe_err(Error::SecondarySlotAssignmentsDisabled));
 		}
@@ -170,24 +161,17 @@ fn check_primary_header<B: BlockT + Sized>(
 
 	if AuthorityPair::verify(&signature, pre_hash, &author) {
 		let (inout, _) = {
-			let transcript = make_transcript(
-				&epoch.randomness,
-				pre_digest.slot,
-				epoch.epoch_index,
-			);
+			let transcript = make_transcript(&epoch.randomness, pre_digest.slot, epoch.epoch_index);
 
-			schnorrkel::PublicKey::from_bytes(author.as_slice()).and_then(|p| {
-				p.vrf_verify(transcript, &pre_digest.vrf_output, &pre_digest.vrf_proof)
-			}).map_err(|s| {
-				babe_err(Error::VRFVerificationFailed(s))
-			})?
+			schnorrkel::PublicKey::from_bytes(author.as_slice())
+				.and_then(|p| {
+					p.vrf_verify(transcript, &pre_digest.vrf_output, &pre_digest.vrf_proof)
+				})
+				.map_err(|s| babe_err(Error::VRFVerificationFailed(s)))?
 		};
 
-		let threshold = calculate_primary_threshold(
-			c,
-			&epoch.authorities,
-			pre_digest.authority_index as usize,
-		);
+		let threshold =
+			calculate_primary_threshold(c, &epoch.authorities, pre_digest.authority_index as usize);
 
 		if !check_primary_threshold(&inout, threshold) {
 			return Err(babe_err(Error::VRFVerificationOfBlockFailed(author.clone(), threshold)));
@@ -211,11 +195,9 @@ fn check_secondary_plain_header<B: BlockT>(
 ) -> Result<(), Error<B>> {
 	// check the signature is valid under the expected authority and
 	// chain state.
-	let expected_author = secondary_slot_author(
-		pre_digest.slot,
-		&epoch.authorities,
-		epoch.randomness,
-	).ok_or_else(|| Error::NoSecondaryAuthorExpected)?;
+	let expected_author =
+		secondary_slot_author(pre_digest.slot, &epoch.authorities, epoch.randomness)
+			.ok_or_else(|| Error::NoSecondaryAuthorExpected)?;
 
 	let author = &epoch.authorities[pre_digest.authority_index as usize].0;
 
@@ -239,11 +221,9 @@ fn check_secondary_vrf_header<B: BlockT>(
 ) -> Result<(), Error<B>> {
 	// check the signature is valid under the expected authority and
 	// chain state.
-	let expected_author = secondary_slot_author(
-		pre_digest.slot,
-		&epoch.authorities,
-		epoch.randomness,
-	).ok_or_else(|| Error::NoSecondaryAuthorExpected)?;
+	let expected_author =
+		secondary_slot_author(pre_digest.slot, &epoch.authorities, epoch.randomness)
+			.ok_or_else(|| Error::NoSecondaryAuthorExpected)?;
 
 	let author = &epoch.authorities[pre_digest.authority_index as usize].0;
 
@@ -252,17 +232,11 @@ fn check_secondary_vrf_header<B: BlockT>(
 	}
 
 	if AuthorityPair::verify(&signature, pre_hash.as_ref(), author) {
-		let transcript = make_transcript(
-			&epoch.randomness,
-			pre_digest.slot,
-			epoch.epoch_index,
-		);
+		let transcript = make_transcript(&epoch.randomness, pre_digest.slot, epoch.epoch_index);
 
-		schnorrkel::PublicKey::from_bytes(author.as_slice()).and_then(|p| {
-			p.vrf_verify(transcript, &pre_digest.vrf_output, &pre_digest.vrf_proof)
-		}).map_err(|s| {
-			babe_err(Error::VRFVerificationFailed(s))
-		})?;
+		schnorrkel::PublicKey::from_bytes(author.as_slice())
+			.and_then(|p| p.vrf_verify(transcript, &pre_digest.vrf_output, &pre_digest.vrf_proof))
+			.map_err(|s| babe_err(Error::VRFVerificationFailed(s)))?;
 
 		Ok(())
 	} else {

--- a/client/consensus/common/src/longest_chain.rs
+++ b/client/consensus/common/src/longest_chain.rs
@@ -18,30 +18,27 @@
 
 //! Longest chain implementation
 
-use std::sync::Arc;
-use std::marker::PhantomData;
+use std::{marker::PhantomData, sync::Arc};
+
 use sc_client_api::backend;
-use sp_consensus::{SelectChain, Error as ConsensusError};
 use sp_blockchain::{Backend, HeaderBackend};
+use sp_consensus::{Error as ConsensusError, SelectChain};
 use sp_runtime::{
-	traits::{NumberFor, Block as BlockT},
 	generic::BlockId,
+	traits::{Block as BlockT, NumberFor},
 };
 
 /// Implement Longest Chain Select implementation
 /// where 'longest' is defined as the highest number of blocks
 pub struct LongestChain<B, Block> {
 	backend: Arc<B>,
-	_phantom: PhantomData<Block>
+	_phantom: PhantomData<Block>,
 }
 
 impl<B, Block> Clone for LongestChain<B, Block> {
 	fn clone(&self) -> Self {
 		let backend = self.backend.clone();
-		LongestChain {
-			backend,
-			_phantom: Default::default()
-		}
+		LongestChain { backend, _phantom: Default::default() }
 	}
 }
 
@@ -52,21 +49,22 @@ where
 {
 	/// Instantiate a new LongestChain for Backend B
 	pub fn new(backend: Arc<B>) -> Self {
-		LongestChain {
-			backend,
-			_phantom: Default::default(),
-		}
+		LongestChain { backend, _phantom: Default::default() }
 	}
 
 	fn best_block_header(&self) -> sp_blockchain::Result<<Block as BlockT>::Header> {
 		let info = self.backend.blockchain().info();
 		let import_lock = self.backend.get_import_lock();
-		let best_hash = self.backend
+		let best_hash = self
+			.backend
 			.blockchain()
 			.best_containing(info.best_hash, None, import_lock)?
 			.unwrap_or(info.best_hash);
 
-		Ok(self.backend.blockchain().header(BlockId::Hash(best_hash))?
+		Ok(self
+			.backend
+			.blockchain()
+			.header(BlockId::Hash(best_hash))?
 			.expect("given block hash was fetched from block in db; qed"))
 	}
 

--- a/client/consensus/common/src/shared_data.rs
+++ b/client/consensus/common/src/shared_data.rs
@@ -19,7 +19,8 @@
 //! Provides a generic wrapper around shared data. See [`SharedData`] for more information.
 
 use std::sync::Arc;
-use parking_lot::{Mutex, MappedMutexGuard, Condvar, MutexGuard};
+
+use parking_lot::{Condvar, MappedMutexGuard, Mutex, MutexGuard};
 
 /// Created by [`SharedDataLocked::release_mutex`].
 ///
@@ -75,8 +76,7 @@ impl<'a, T> SharedDataLocked<'a, T> {
 	/// Release the mutex, but keep the shared data locked.
 	pub fn release_mutex(mut self) -> SharedDataLockedUpgradable<T> {
 		SharedDataLockedUpgradable {
-			shared_data: self.shared_data.take()
-				.expect("`shared_data` is only taken on drop; qed"),
+			shared_data: self.shared_data.take().expect("`shared_data` is only taken on drop; qed"),
 		}
 	}
 }
@@ -132,7 +132,7 @@ struct SharedDataInner<T> {
 /// # Example
 ///
 /// ```
-///# use sc_consensus::shared_data::SharedData;
+/// # use sc_consensus::shared_data::SharedData;
 ///
 /// let shared_data = SharedData::new(String::from("hello world"));
 ///
@@ -174,10 +174,7 @@ pub struct SharedData<T> {
 
 impl<T> Clone for SharedData<T> {
 	fn clone(&self) -> Self {
-		Self {
-			inner: self.inner.clone(),
-			cond_var: self.cond_var.clone(),
-		}
+		Self { inner: self.inner.clone(), cond_var: self.cond_var.clone() }
 	}
 }
 
@@ -228,10 +225,7 @@ impl<T> SharedData<T> {
 		debug_assert!(!guard.locked);
 		guard.locked = true;
 
-		SharedDataLocked {
-			inner: guard,
-			shared_data: Some(self.clone()),
-		}
+		SharedDataLocked { inner: guard, shared_data: Some(self.clone()) }
 	}
 }
 
@@ -246,7 +240,7 @@ mod tests {
 
 		let lock = shared_data.shared_data_locked();
 
-		for i in 0..THREADS {
+		for i in 0 .. THREADS {
 			let data = shared_data.clone();
 			std::thread::spawn(move || {
 				if i % 2 == 1 {

--- a/client/consensus/epochs/src/lib.rs
+++ b/client/consensus/epochs/src/lib.rs
@@ -20,11 +20,16 @@
 
 pub mod migration;
 
-use std::{ops::Add, collections::BTreeMap, borrow::{Borrow, BorrowMut}};
-use codec::{Encode, Decode};
+use std::{
+	borrow::{Borrow, BorrowMut},
+	collections::BTreeMap,
+	ops::Add,
+};
+
+use codec::{Decode, Encode};
 use fork_tree::ForkTree;
 use sc_client_api::utils::is_descendent_of;
-use sp_blockchain::{HeaderMetadata, HeaderBackend, Error as ClientError};
+use sp_blockchain::{Error as ClientError, HeaderBackend, HeaderMetadata};
 use sp_runtime::traits::{Block as BlockT, NumberFor, One, Zero};
 
 /// A builder for `is_descendent_of` functions.
@@ -41,8 +46,7 @@ pub trait IsDescendentOfBuilder<Hash> {
 	/// details aren't yet stored, but its parent is.
 	///
 	/// The format of `current` when `Some` is `(current, current_parent)`.
-	fn build_is_descendent_of(&self, current: Option<(Hash, Hash)>)
-		-> Self::IsDescendentOf;
+	fn build_is_descendent_of(&self, current: Option<(Hash, Hash)>) -> Self::IsDescendentOf;
 }
 
 /// Produce a descendent query object given the client.
@@ -55,16 +59,18 @@ pub fn descendent_query<H, Block>(client: &H) -> HeaderBackendDescendentBuilder<
 pub struct HeaderBackendDescendentBuilder<H, Block>(H, std::marker::PhantomData<Block>);
 
 impl<'a, H, Block> IsDescendentOfBuilder<Block::Hash>
-	for HeaderBackendDescendentBuilder<&'a H, Block> where
-	H: HeaderBackend<Block> + HeaderMetadata<Block, Error=ClientError>,
+	for HeaderBackendDescendentBuilder<&'a H, Block>
+where
+	H: HeaderBackend<Block> + HeaderMetadata<Block, Error = ClientError>,
 	Block: BlockT,
 {
 	type Error = ClientError;
 	type IsDescendentOf = Box<dyn Fn(&Block::Hash, &Block::Hash) -> Result<bool, ClientError> + 'a>;
 
-	fn build_is_descendent_of(&self, current: Option<(Block::Hash, Block::Hash)>)
-		-> Self::IsDescendentOf
-	{
+	fn build_is_descendent_of(
+		&self,
+		current: Option<(Block::Hash, Block::Hash)>,
+	) -> Self::IsDescendentOf {
 		Box::new(is_descendent_of(self.0, current))
 	}
 }
@@ -90,10 +96,7 @@ pub trait Epoch {
 
 impl<'a, E: Epoch> From<&'a E> for EpochHeader<E> {
 	fn from(epoch: &'a E) -> EpochHeader<E> {
-		Self {
-			start_slot: epoch.start_slot(),
-			end_slot: epoch.end_slot(),
-		}
+		Self { start_slot: epoch.start_slot(), end_slot: epoch.end_slot() }
 	}
 }
 
@@ -109,10 +112,7 @@ pub struct EpochHeader<E: Epoch> {
 
 impl<E: Epoch> Clone for EpochHeader<E> {
 	fn clone(&self) -> Self {
-		Self {
-			start_slot: self.start_slot,
-			end_slot: self.end_slot,
-		}
+		Self { start_slot: self.start_slot, end_slot: self.end_slot }
 	}
 }
 
@@ -149,7 +149,8 @@ pub enum ViableEpoch<E, ERef = E> {
 	Signaled(ERef),
 }
 
-impl<E, ERef> AsRef<E> for ViableEpoch<E, ERef> where
+impl<E, ERef> AsRef<E> for ViableEpoch<E, ERef>
+where
 	ERef: Borrow<E>,
 {
 	fn as_ref(&self) -> &E {
@@ -160,7 +161,8 @@ impl<E, ERef> AsRef<E> for ViableEpoch<E, ERef> where
 	}
 }
 
-impl<E, ERef> AsMut<E> for ViableEpoch<E, ERef> where
+impl<E, ERef> AsMut<E> for ViableEpoch<E, ERef>
+where
 	ERef: BorrowMut<E>,
 {
 	fn as_mut(&mut self) -> &mut E {
@@ -171,7 +173,8 @@ impl<E, ERef> AsMut<E> for ViableEpoch<E, ERef> where
 	}
 }
 
-impl<E, ERef> ViableEpoch<E, ERef> where
+impl<E, ERef> ViableEpoch<E, ERef>
+where
 	E: Epoch + Clone,
 	ERef: Borrow<E>,
 {
@@ -187,22 +190,19 @@ impl<E, ERef> ViableEpoch<E, ERef> where
 	/// Get cloned value for the viable epoch.
 	pub fn into_cloned(self) -> ViableEpoch<E, E> {
 		match self {
-			ViableEpoch::UnimportedGenesis(e) =>
-				ViableEpoch::UnimportedGenesis(e),
+			ViableEpoch::UnimportedGenesis(e) => ViableEpoch::UnimportedGenesis(e),
 			ViableEpoch::Signaled(e) => ViableEpoch::Signaled(e.borrow().clone()),
 		}
 	}
 
 	/// Increment the epoch, yielding an `IncrementedEpoch` to be imported
 	/// into the fork-tree.
-	pub fn increment(
-		&self,
-		next_descriptor: E::NextEpochDescriptor
-	) -> IncrementedEpoch<E> {
+	pub fn increment(&self, next_descriptor: E::NextEpochDescriptor) -> IncrementedEpoch<E> {
 		let next = self.as_ref().increment(next_descriptor);
 		let to_persist = match *self {
-			ViableEpoch::UnimportedGenesis(ref epoch_0) =>
-				PersistedEpoch::Genesis(epoch_0.clone(), next),
+			ViableEpoch::UnimportedGenesis(ref epoch_0) => {
+				PersistedEpoch::Genesis(epoch_0.clone(), next)
+			}
 			ViableEpoch::Signaled(_) => PersistedEpoch::Regular(next),
 		};
 
@@ -216,7 +216,7 @@ pub enum ViableEpochDescriptor<Hash, Number, E: Epoch> {
 	/// The epoch is an unimported genesis, with given start slot number.
 	UnimportedGenesis(E::Slot),
 	/// The epoch is signaled and has been imported, with given identifier and header.
-	Signaled(EpochIdentifier<Hash, Number>, EpochHeader<E>)
+	Signaled(EpochIdentifier<Hash, Number>, EpochHeader<E>),
 }
 
 impl<Hash, Number, E: Epoch> ViableEpochDescriptor<Hash, Number, E> {
@@ -241,10 +241,10 @@ pub enum PersistedEpoch<E: Epoch> {
 impl<'a, E: Epoch> From<&'a PersistedEpoch<E>> for PersistedEpochHeader<E> {
 	fn from(epoch: &'a PersistedEpoch<E>) -> Self {
 		match epoch {
-			PersistedEpoch::Genesis(ref epoch_0, ref epoch_1) =>
-				PersistedEpochHeader::Genesis(epoch_0.into(), epoch_1.into()),
-			PersistedEpoch::Regular(ref epoch_n) =>
-				PersistedEpochHeader::Regular(epoch_n.into()),
+			PersistedEpoch::Genesis(ref epoch_0, ref epoch_1) => {
+				PersistedEpochHeader::Genesis(epoch_0.into(), epoch_1.into())
+			}
+			PersistedEpoch::Regular(ref epoch_n) => PersistedEpochHeader::Regular(epoch_n.into()),
 		}
 	}
 }
@@ -312,7 +312,8 @@ fn fake_head_hash<H: AsRef<[u8]> + AsMut<[u8]> + Clone>(parent_hash: &H) -> H {
 	h
 }
 
-impl<Hash, Number, E: Epoch> Default for EpochChanges<Hash, Number, E> where
+impl<Hash, Number, E: Epoch> Default for EpochChanges<Hash, Number, E>
+where
 	Hash: PartialEq + Ord,
 	Number: Ord,
 {
@@ -321,9 +322,10 @@ impl<Hash, Number, E: Epoch> Default for EpochChanges<Hash, Number, E> where
 	}
 }
 
-impl<Hash, Number, E: Epoch> EpochChanges<Hash, Number, E> where
+impl<Hash, Number, E: Epoch> EpochChanges<Hash, Number, E>
+where
 	Hash: PartialEq + Ord + AsRef<[u8]> + AsMut<[u8]> + Copy,
-	Number: Ord + One + Zero + Add<Output=Number> + Copy,
+	Number: Ord + One + Zero + Add<Output = Number> + Copy,
 {
 	/// Create a new epoch change.
 	pub fn new() -> Self {
@@ -337,51 +339,40 @@ impl<Hash, Number, E: Epoch> EpochChanges<Hash, Number, E> where
 	}
 
 	/// Map the epoch changes from one storing data to a different one.
-	pub fn map<B, F>(self, mut f: F) -> EpochChanges<Hash, Number, B> where
-		B: Epoch<Slot=E::Slot>,
+	pub fn map<B, F>(self, mut f: F) -> EpochChanges<Hash, Number, B>
+	where
+		B: Epoch<Slot = E::Slot>,
 		F: FnMut(&Hash, &Number, E) -> B,
 	{
 		EpochChanges {
-			inner: self.inner.map(&mut |_, _, header| {
-				match header {
-					PersistedEpochHeader::Genesis(epoch_0, epoch_1) => {
-						PersistedEpochHeader::Genesis(
-							EpochHeader {
-								start_slot: epoch_0.start_slot,
-								end_slot: epoch_0.end_slot,
-							},
-							EpochHeader {
-								start_slot: epoch_1.start_slot,
-								end_slot: epoch_1.end_slot,
-							},
-						)
-					},
-					PersistedEpochHeader::Regular(epoch_n) => {
-						PersistedEpochHeader::Regular(
-							EpochHeader {
-								start_slot: epoch_n.start_slot,
-								end_slot: epoch_n.end_slot,
-							},
-						)
-					},
+			inner: self.inner.map(&mut |_, _, header| match header {
+				PersistedEpochHeader::Genesis(epoch_0, epoch_1) => PersistedEpochHeader::Genesis(
+					EpochHeader { start_slot: epoch_0.start_slot, end_slot: epoch_0.end_slot },
+					EpochHeader { start_slot: epoch_1.start_slot, end_slot: epoch_1.end_slot },
+				),
+				PersistedEpochHeader::Regular(epoch_n) => {
+					PersistedEpochHeader::Regular(EpochHeader {
+						start_slot: epoch_n.start_slot,
+						end_slot: epoch_n.end_slot,
+					})
 				}
 			}),
-			epochs: self.epochs.into_iter().map(|((hash, number), epoch)| {
-				let bepoch = match epoch {
-					PersistedEpoch::Genesis(epoch_0, epoch_1) => {
-						PersistedEpoch::Genesis(
+			epochs: self
+				.epochs
+				.into_iter()
+				.map(|((hash, number), epoch)| {
+					let bepoch = match epoch {
+						PersistedEpoch::Genesis(epoch_0, epoch_1) => PersistedEpoch::Genesis(
 							f(&hash, &number, epoch_0),
 							f(&hash, &number, epoch_1),
-						)
-					},
-					PersistedEpoch::Regular(epoch_n) => {
-						PersistedEpoch::Regular(
-							f(&hash, &number, epoch_n)
-						)
-					},
-				};
-				((hash, number), bepoch)
-			}).collect(),
+						),
+						PersistedEpoch::Regular(epoch_n) => {
+							PersistedEpoch::Regular(f(&hash, &number, epoch_n))
+						}
+					};
+					((hash, number), bepoch)
+				})
+				.collect(),
 		}
 	}
 
@@ -395,25 +386,17 @@ impl<Hash, Number, E: Epoch> EpochChanges<Hash, Number, E> where
 		number: Number,
 		slot: E::Slot,
 	) -> Result<(), fork_tree::Error<D::Error>> {
-		let is_descendent_of = descendent_of_builder
-			.build_is_descendent_of(None);
+		let is_descendent_of = descendent_of_builder.build_is_descendent_of(None);
 
 		let predicate = |epoch: &PersistedEpochHeader<E>| match *epoch {
-			PersistedEpochHeader::Genesis(_, ref epoch_1) =>
-				slot >= epoch_1.end_slot,
-			PersistedEpochHeader::Regular(ref epoch_n) =>
-				slot >= epoch_n.end_slot,
+			PersistedEpochHeader::Genesis(_, ref epoch_1) => slot >= epoch_1.end_slot,
+			PersistedEpochHeader::Regular(ref epoch_n) => slot >= epoch_n.end_slot,
 		};
 
 		// prune any epochs which could not be _live_ as of the children of the
 		// finalized block, i.e. re-root the fork tree to the oldest ancestor of
 		// (hash, number) where epoch.end_slot() >= finalized_slot
-		let removed = self.inner.prune(
-			hash,
-			&number,
-			&is_descendent_of,
-			&predicate,
-		)?;
+		let removed = self.inner.prune(hash, &number, &is_descendent_of, &predicate)?;
 
 		for (hash, number, _) in removed {
 			self.epochs.remove(&(hash, number));
@@ -424,18 +407,24 @@ impl<Hash, Number, E: Epoch> EpochChanges<Hash, Number, E> where
 
 	/// Get a reference to an epoch with given identifier.
 	pub fn epoch(&self, id: &EpochIdentifier<Hash, Number>) -> Option<&E> {
-		self.epochs.get(&(id.hash, id.number))
-			.and_then(|v| {
-				match v {
-					PersistedEpoch::Genesis(ref epoch_0, _)
-						if id.position == EpochIdentifierPosition::Genesis0 => Some(epoch_0),
-					PersistedEpoch::Genesis(_, ref epoch_1)
-						if id.position == EpochIdentifierPosition::Genesis1 => Some(epoch_1),
-					PersistedEpoch::Regular(ref epoch_n)
-						if id.position == EpochIdentifierPosition::Regular => Some(epoch_n),
-					_ => None,
-				}
-			})
+		self.epochs.get(&(id.hash, id.number)).and_then(|v| match v {
+			PersistedEpoch::Genesis(ref epoch_0, _)
+				if id.position == EpochIdentifierPosition::Genesis0 =>
+			{
+				Some(epoch_0)
+			}
+			PersistedEpoch::Genesis(_, ref epoch_1)
+				if id.position == EpochIdentifierPosition::Genesis1 =>
+			{
+				Some(epoch_1)
+			}
+			PersistedEpoch::Regular(ref epoch_n)
+				if id.position == EpochIdentifierPosition::Regular =>
+			{
+				Some(epoch_n)
+			}
+			_ => None,
+		})
 	}
 
 	/// Get a reference to a viable epoch with given descriptor.
@@ -443,33 +432,40 @@ impl<Hash, Number, E: Epoch> EpochChanges<Hash, Number, E> where
 		&self,
 		descriptor: &ViableEpochDescriptor<Hash, Number, E>,
 		make_genesis: G,
-	) -> Option<ViableEpoch<E, &E>> where
-		G: FnOnce(E::Slot) -> E
+	) -> Option<ViableEpoch<E, &E>>
+	where
+		G: FnOnce(E::Slot) -> E,
 	{
 		match descriptor {
 			ViableEpochDescriptor::UnimportedGenesis(slot) => {
 				Some(ViableEpoch::UnimportedGenesis(make_genesis(*slot)))
-			},
+			}
 			ViableEpochDescriptor::Signaled(identifier, _) => {
 				self.epoch(&identifier).map(ViableEpoch::Signaled)
-			},
+			}
 		}
 	}
 
 	/// Get a mutable reference to an epoch with given identifier.
 	pub fn epoch_mut(&mut self, id: &EpochIdentifier<Hash, Number>) -> Option<&mut E> {
-		self.epochs.get_mut(&(id.hash, id.number))
-			.and_then(|v| {
-				match v {
-					PersistedEpoch::Genesis(ref mut epoch_0, _)
-						if id.position == EpochIdentifierPosition::Genesis0 => Some(epoch_0),
-					PersistedEpoch::Genesis(_, ref mut epoch_1)
-						if id.position == EpochIdentifierPosition::Genesis1 => Some(epoch_1),
-					PersistedEpoch::Regular(ref mut epoch_n)
-						if id.position == EpochIdentifierPosition::Regular => Some(epoch_n),
-					_ => None,
-				}
-			})
+		self.epochs.get_mut(&(id.hash, id.number)).and_then(|v| match v {
+			PersistedEpoch::Genesis(ref mut epoch_0, _)
+				if id.position == EpochIdentifierPosition::Genesis0 =>
+			{
+				Some(epoch_0)
+			}
+			PersistedEpoch::Genesis(_, ref mut epoch_1)
+				if id.position == EpochIdentifierPosition::Genesis1 =>
+			{
+				Some(epoch_1)
+			}
+			PersistedEpoch::Regular(ref mut epoch_n)
+				if id.position == EpochIdentifierPosition::Regular =>
+			{
+				Some(epoch_n)
+			}
+			_ => None,
+		})
 	}
 
 	/// Get a mutable reference to a viable epoch with given descriptor.
@@ -477,16 +473,17 @@ impl<Hash, Number, E: Epoch> EpochChanges<Hash, Number, E> where
 		&mut self,
 		descriptor: &ViableEpochDescriptor<Hash, Number, E>,
 		make_genesis: G,
-	) -> Option<ViableEpoch<E, &mut E>> where
-		G: FnOnce(E::Slot) -> E
+	) -> Option<ViableEpoch<E, &mut E>>
+	where
+		G: FnOnce(E::Slot) -> E,
 	{
 		match descriptor {
 			ViableEpochDescriptor::UnimportedGenesis(slot) => {
 				Some(ViableEpoch::UnimportedGenesis(make_genesis(*slot)))
-			},
+			}
 			ViableEpochDescriptor::Signaled(identifier, _) => {
 				self.epoch_mut(&identifier).map(ViableEpoch::Signaled)
-			},
+			}
 		}
 	}
 
@@ -497,18 +494,15 @@ impl<Hash, Number, E: Epoch> EpochChanges<Hash, Number, E> where
 	pub fn epoch_data<G>(
 		&self,
 		descriptor: &ViableEpochDescriptor<Hash, Number, E>,
-		make_genesis: G
-	) -> Option<E> where
+		make_genesis: G,
+	) -> Option<E>
+	where
 		G: FnOnce(E::Slot) -> E,
 		E: Clone,
 	{
 		match descriptor {
-			ViableEpochDescriptor::UnimportedGenesis(slot) => {
-				Some(make_genesis(*slot))
-			},
-			ViableEpochDescriptor::Signaled(identifier, _) => {
-				self.epoch(&identifier).cloned()
-			},
+			ViableEpochDescriptor::UnimportedGenesis(slot) => Some(make_genesis(*slot)),
+			ViableEpochDescriptor::Signaled(identifier, _) => self.epoch(&identifier).cloned(),
 		}
 	}
 
@@ -524,7 +518,8 @@ impl<Hash, Number, E: Epoch> EpochChanges<Hash, Number, E> where
 		parent_number: Number,
 		slot: E::Slot,
 		make_genesis: G,
-	) -> Result<Option<E>, fork_tree::Error<D::Error>> where
+	) -> Result<Option<E>, fork_tree::Error<D::Error>>
+	where
 		G: FnOnce(E::Slot) -> E,
 		E: Clone,
 	{
@@ -532,7 +527,7 @@ impl<Hash, Number, E: Epoch> EpochChanges<Hash, Number, E> where
 			descendent_of_builder,
 			parent_hash,
 			parent_number,
-			slot
+			slot,
 		)?;
 
 		Ok(descriptor.and_then(|des| self.epoch_data(&des, make_genesis)))
@@ -555,12 +550,12 @@ impl<Hash, Number, E: Epoch> EpochChanges<Hash, Number, E> where
 		// "descends" from our parent-hash.
 		let fake_head_hash = fake_head_hash(parent_hash);
 
-		let is_descendent_of = descendent_of_builder
-			.build_is_descendent_of(Some((fake_head_hash, *parent_hash)));
+		let is_descendent_of =
+			descendent_of_builder.build_is_descendent_of(Some((fake_head_hash, *parent_hash)));
 
 		if parent_number == Zero::zero() {
 			// need to insert the genesis epoch.
-			return Ok(Some(ViableEpochDescriptor::UnimportedGenesis(slot)))
+			return Ok(Some(ViableEpochDescriptor::UnimportedGenesis(slot)));
 		}
 
 		// We want to find the deepest node in the tree which is an ancestor
@@ -569,37 +564,43 @@ impl<Hash, Number, E: Epoch> EpochChanges<Hash, Number, E> where
 		// at epoch_1 -- all we're doing here is figuring out which node
 		// we need.
 		let predicate = |epoch: &PersistedEpochHeader<E>| match *epoch {
-			PersistedEpochHeader::Genesis(ref epoch_0, _) =>
-				epoch_0.start_slot <= slot,
-			PersistedEpochHeader::Regular(ref epoch_n) =>
-				epoch_n.start_slot <= slot,
+			PersistedEpochHeader::Genesis(ref epoch_0, _) => epoch_0.start_slot <= slot,
+			PersistedEpochHeader::Regular(ref epoch_n) => epoch_n.start_slot <= slot,
 		};
 
-		self.inner.find_node_where(
-			&fake_head_hash,
-			&(parent_number + One::one()),
-			&is_descendent_of,
-			&predicate,
-		)
+		self.inner
+			.find_node_where(
+				&fake_head_hash,
+				&(parent_number + One::one()),
+				&is_descendent_of,
+				&predicate,
+			)
 			.map(|n| {
-				n.map(|node| (match node.data {
-					// Ok, we found our node.
-					// and here we figure out which of the internal epochs
-					// of a genesis node to use based on their start slot.
-					PersistedEpochHeader::Genesis(ref epoch_0, ref epoch_1) =>
-						if epoch_1.start_slot <= slot {
-							(EpochIdentifierPosition::Genesis1, epoch_1.clone())
-						} else {
-							(EpochIdentifierPosition::Genesis0, epoch_0.clone())
+				n.map(|node| {
+					(
+						match node.data {
+							// Ok, we found our node.
+							// and here we figure out which of the internal epochs
+							// of a genesis node to use based on their start slot.
+							PersistedEpochHeader::Genesis(ref epoch_0, ref epoch_1) => {
+								if epoch_1.start_slot <= slot {
+									(EpochIdentifierPosition::Genesis1, epoch_1.clone())
+								} else {
+									(EpochIdentifierPosition::Genesis0, epoch_0.clone())
+								}
+							}
+							PersistedEpochHeader::Regular(ref epoch_n) => {
+								(EpochIdentifierPosition::Regular, epoch_n.clone())
+							}
 						},
-					PersistedEpochHeader::Regular(ref epoch_n) =>
-						(EpochIdentifierPosition::Regular, epoch_n.clone()),
-				}, node)).map(|((position, header), node)| {
-					ViableEpochDescriptor::Signaled(EpochIdentifier {
-						position,
-						hash: node.hash,
-						number: node.number
-					}, header)
+						node,
+					)
+				})
+				.map(|((position, header), node)| {
+					ViableEpochDescriptor::Signaled(
+						EpochIdentifier { position, hash: node.hash, number: node.number },
+						header,
+					)
 				})
 			})
 	}
@@ -617,22 +618,17 @@ impl<Hash, Number, E: Epoch> EpochChanges<Hash, Number, E> where
 		parent_hash: Hash,
 		epoch: IncrementedEpoch<E>,
 	) -> Result<(), fork_tree::Error<D::Error>> {
-		let is_descendent_of = descendent_of_builder
-			.build_is_descendent_of(Some((hash, parent_hash)));
+		let is_descendent_of =
+			descendent_of_builder.build_is_descendent_of(Some((hash, parent_hash)));
 		let header = PersistedEpochHeader::<E>::from(&epoch.0);
 
-		let res = self.inner.import(
-			hash,
-			number,
-			header,
-			&is_descendent_of,
-		);
+		let res = self.inner.import(hash, number, header, &is_descendent_of);
 
 		match res {
 			Ok(_) | Err(fork_tree::Error::Duplicate) => {
 				self.epochs.insert((hash, number), epoch.0);
 				Ok(())
-			},
+			}
 			Err(e) => Err(e),
 		}
 	}
@@ -653,8 +649,7 @@ pub type SharedEpochChanges<Block, Epoch> =
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use super::Epoch as EpochT;
+	use super::{Epoch as EpochT, *};
 
 	#[derive(Debug, PartialEq)]
 	pub struct TestError;
@@ -667,15 +662,14 @@ mod tests {
 
 	impl std::error::Error for TestError {}
 
-	impl<'a, F: 'a , H: 'a + PartialEq + std::fmt::Debug> IsDescendentOfBuilder<H> for &'a F
-		where F: Fn(&H, &H) -> Result<bool, TestError>
+	impl<'a, F: 'a, H: 'a + PartialEq + std::fmt::Debug> IsDescendentOfBuilder<H> for &'a F
+	where
+		F: Fn(&H, &H) -> Result<bool, TestError>,
 	{
 		type Error = TestError;
 		type IsDescendentOf = Box<dyn Fn(&H, &H) -> Result<bool, TestError> + 'a>;
 
-		fn build_is_descendent_of(&self, current: Option<(H, H)>)
-			-> Self::IsDescendentOf
-		{
+		fn build_is_descendent_of(&self, current: Option<(H, H)>) -> Self::IsDescendentOf {
 			let f = *self;
 			Box::new(move |base, head| {
 				let mut head = head;
@@ -709,10 +703,7 @@ mod tests {
 		type Slot = Slot;
 
 		fn increment(&self, _: ()) -> Self {
-			Epoch {
-				start_slot: self.start_slot + self.duration,
-				duration: self.duration,
-			}
+			Epoch { start_slot: self.start_slot + self.duration, duration: self.duration }
 		}
 
 		fn end_slot(&self) -> Slot {
@@ -726,7 +717,6 @@ mod tests {
 
 	#[test]
 	fn genesis_epoch_is_created_but_not_imported() {
-		//
 		// A - B
 		//  \
 		//   — C
@@ -741,38 +731,33 @@ mod tests {
 		};
 
 		let epoch_changes = EpochChanges::<_, _, Epoch>::new();
-		let genesis_epoch = epoch_changes.epoch_descriptor_for_child_of(
-			&is_descendent_of,
-			b"0",
-			0,
-			10101,
-		).unwrap().unwrap();
+		let genesis_epoch = epoch_changes
+			.epoch_descriptor_for_child_of(&is_descendent_of, b"0", 0, 10101)
+			.unwrap()
+			.unwrap();
 
 		match genesis_epoch {
 			ViableEpochDescriptor::UnimportedGenesis(slot) => {
 				assert_eq!(slot, 10101u64);
-			},
+			}
 			_ => panic!("should be unimported genesis"),
 		};
 
-		let genesis_epoch_2 = epoch_changes.epoch_descriptor_for_child_of(
-			&is_descendent_of,
-			b"0",
-			0,
-			10102,
-		).unwrap().unwrap();
+		let genesis_epoch_2 = epoch_changes
+			.epoch_descriptor_for_child_of(&is_descendent_of, b"0", 0, 10102)
+			.unwrap()
+			.unwrap();
 
 		match genesis_epoch_2 {
 			ViableEpochDescriptor::UnimportedGenesis(slot) => {
 				assert_eq!(slot, 10102u64);
-			},
+			}
 			_ => panic!("should be unimported genesis"),
 		};
 	}
 
 	#[test]
 	fn epoch_changes_between_blocks() {
-		//
 		// A - B
 		//  \
 		//   — C
@@ -786,34 +771,23 @@ mod tests {
 			}
 		};
 
-		let make_genesis = |slot| Epoch {
-			start_slot: slot,
-			duration: 100,
-		};
+		let make_genesis = |slot| Epoch { start_slot: slot, duration: 100 };
 
 		let mut epoch_changes = EpochChanges::<_, _, Epoch>::new();
-		let genesis_epoch = epoch_changes.epoch_descriptor_for_child_of(
-			&is_descendent_of,
-			b"0",
-			0,
-			100,
-		).unwrap().unwrap();
+		let genesis_epoch = epoch_changes
+			.epoch_descriptor_for_child_of(&is_descendent_of, b"0", 0, 100)
+			.unwrap()
+			.unwrap();
 
 		assert_eq!(genesis_epoch, ViableEpochDescriptor::UnimportedGenesis(100));
 
-		let import_epoch_1 = epoch_changes
-			.viable_epoch(&genesis_epoch, &make_genesis)
-			.unwrap()
-			.increment(());
+		let import_epoch_1 =
+			epoch_changes.viable_epoch(&genesis_epoch, &make_genesis).unwrap().increment(());
 		let epoch_1 = import_epoch_1.as_ref().clone();
 
-		epoch_changes.import(
-			&is_descendent_of,
-			*b"A",
-			1,
-			*b"0",
-			import_epoch_1,
-		).unwrap();
+		epoch_changes
+			.import(&is_descendent_of, *b"A", 1, *b"0", import_epoch_1)
+			.unwrap();
 		let genesis_epoch = epoch_changes.epoch_data(&genesis_epoch, &make_genesis).unwrap();
 
 		assert!(is_descendent_of(b"0", b"A").unwrap());
@@ -823,13 +797,10 @@ mod tests {
 
 		{
 			// x is still within the genesis epoch.
-			let x = epoch_changes.epoch_data_for_child_of(
-				&is_descendent_of,
-				b"A",
-				1,
-				end_slot - 1,
-				&make_genesis,
-			).unwrap().unwrap();
+			let x = epoch_changes
+				.epoch_data_for_child_of(&is_descendent_of, b"A", 1, end_slot - 1, &make_genesis)
+				.unwrap()
+				.unwrap();
 
 			assert_eq!(x, genesis_epoch);
 		}
@@ -837,13 +808,10 @@ mod tests {
 		{
 			// x is now at the next epoch, because the block is now at the
 			// start slot of epoch 1.
-			let x = epoch_changes.epoch_data_for_child_of(
-				&is_descendent_of,
-				b"A",
-				1,
-				end_slot,
-				&make_genesis,
-			).unwrap().unwrap();
+			let x = epoch_changes
+				.epoch_data_for_child_of(&is_descendent_of, b"A", 1, end_slot, &make_genesis)
+				.unwrap()
+				.unwrap();
 
 			assert_eq!(x, epoch_1);
 		}
@@ -851,13 +819,16 @@ mod tests {
 		{
 			// x is now at the next epoch, because the block is now after
 			// start slot of epoch 1.
-			let x = epoch_changes.epoch_data_for_child_of(
-				&is_descendent_of,
-				b"A",
-				1,
-				epoch_1.end_slot() - 1,
-				&make_genesis,
-			).unwrap().unwrap();
+			let x = epoch_changes
+				.epoch_data_for_child_of(
+					&is_descendent_of,
+					b"A",
+					1,
+					epoch_1.end_slot() - 1,
+					&make_genesis,
+				)
+				.unwrap()
+				.unwrap();
 
 			assert_eq!(x, epoch_1);
 		}
@@ -880,90 +851,65 @@ mod tests {
 
 		let duration = 100;
 
-		let make_genesis = |slot| Epoch {
-			start_slot: slot,
-			duration,
-		};
+		let make_genesis = |slot| Epoch { start_slot: slot, duration };
 
 		let mut epoch_changes = EpochChanges::new();
 		let next_descriptor = ();
 
 		// insert genesis epoch for A
 		{
-			let genesis_epoch_a_descriptor = epoch_changes.epoch_descriptor_for_child_of(
-				&is_descendent_of,
-				b"0",
-				0,
-				100,
-			).unwrap().unwrap();
+			let genesis_epoch_a_descriptor = epoch_changes
+				.epoch_descriptor_for_child_of(&is_descendent_of, b"0", 0, 100)
+				.unwrap()
+				.unwrap();
 
 			let incremented_epoch = epoch_changes
 				.viable_epoch(&genesis_epoch_a_descriptor, &make_genesis)
 				.unwrap()
 				.increment(next_descriptor.clone());
 
-			epoch_changes.import(
-				&is_descendent_of,
-				*b"A",
-				1,
-				*b"0",
-				incremented_epoch,
-			).unwrap();
+			epoch_changes
+				.import(&is_descendent_of, *b"A", 1, *b"0", incremented_epoch)
+				.unwrap();
 		}
 
 		// insert genesis epoch for X
 		{
-			let genesis_epoch_x_descriptor = epoch_changes.epoch_descriptor_for_child_of(
-				&is_descendent_of,
-				b"0",
-				0,
-				1000,
-			).unwrap().unwrap();
+			let genesis_epoch_x_descriptor = epoch_changes
+				.epoch_descriptor_for_child_of(&is_descendent_of, b"0", 0, 1000)
+				.unwrap()
+				.unwrap();
 
 			let incremented_epoch = epoch_changes
 				.viable_epoch(&genesis_epoch_x_descriptor, &make_genesis)
 				.unwrap()
 				.increment(next_descriptor.clone());
 
-			epoch_changes.import(
-				&is_descendent_of,
-				*b"X",
-				1,
-				*b"0",
-				incremented_epoch,
-			).unwrap();
+			epoch_changes
+				.import(&is_descendent_of, *b"X", 1, *b"0", incremented_epoch)
+				.unwrap();
 		}
 
 		// now check that the genesis epochs for our respective block 1s
 		// respect the chain structure.
 		{
-			let epoch_for_a_child = epoch_changes.epoch_data_for_child_of(
-				&is_descendent_of,
-				b"A",
-				1,
-				101,
-				&make_genesis,
-			).unwrap().unwrap();
+			let epoch_for_a_child = epoch_changes
+				.epoch_data_for_child_of(&is_descendent_of, b"A", 1, 101, &make_genesis)
+				.unwrap()
+				.unwrap();
 
 			assert_eq!(epoch_for_a_child, make_genesis(100));
 
-			let epoch_for_x_child = epoch_changes.epoch_data_for_child_of(
-				&is_descendent_of,
-				b"X",
-				1,
-				1001,
-				&make_genesis,
-			).unwrap().unwrap();
+			let epoch_for_x_child = epoch_changes
+				.epoch_data_for_child_of(&is_descendent_of, b"X", 1, 1001, &make_genesis)
+				.unwrap()
+				.unwrap();
 
 			assert_eq!(epoch_for_x_child, make_genesis(1000));
 
-			let epoch_for_x_child_before_genesis = epoch_changes.epoch_data_for_child_of(
-				&is_descendent_of,
-				b"X",
-				1,
-				101,
-				&make_genesis,
-			).unwrap();
+			let epoch_for_x_child_before_genesis = epoch_changes
+				.epoch_data_for_child_of(&is_descendent_of, b"X", 1, 101, &make_genesis)
+				.unwrap();
 
 			// even though there is a genesis epoch at that slot, it's not in
 			// this chain.

--- a/client/consensus/epochs/src/migration.rs
+++ b/client/consensus/epochs/src/migration.rs
@@ -19,9 +19,11 @@
 //! Migration types for epoch changes.
 
 use std::collections::BTreeMap;
-use codec::{Encode, Decode};
+
+use codec::{Decode, Encode};
 use fork_tree::ForkTree;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
+
 use crate::{Epoch, EpochChanges, PersistedEpoch, PersistedEpochHeader};
 
 /// Legacy definition of epoch changes.
@@ -31,9 +33,11 @@ pub struct EpochChangesV0<Hash, Number, E: Epoch> {
 }
 
 /// Type alias for legacy definition of epoch changes.
-pub type EpochChangesForV0<Block, Epoch> = EpochChangesV0<<Block as BlockT>::Hash, NumberFor<Block>, Epoch>;
+pub type EpochChangesForV0<Block, Epoch> =
+	EpochChangesV0<<Block as BlockT>::Hash, NumberFor<Block>, Epoch>;
 
-impl<Hash, Number, E: Epoch> EpochChangesV0<Hash, Number, E> where
+impl<Hash, Number, E: Epoch> EpochChangesV0<Hash, Number, E>
+where
 	Hash: PartialEq + Ord + Copy,
 	Number: Ord + Copy,
 {

--- a/client/consensus/manual-seal/src/consensus.rs
+++ b/client/consensus/manual-seal/src/consensus.rs
@@ -17,28 +17,32 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Extensions for manual seal to produce blocks valid for any runtime.
-use super::Error;
-
-use sp_runtime::traits::{Block as BlockT, DigestFor};
-use sp_inherents::InherentData;
 use sp_consensus::BlockImportParams;
+use sp_inherents::InherentData;
+use sp_runtime::traits::{Block as BlockT, DigestFor};
+
+use super::Error;
 
 pub mod babe;
 
-/// Consensus data provider, manual seal uses this trait object for authoring blocks valid 
+/// Consensus data provider, manual seal uses this trait object for authoring blocks valid
 /// for any runtime.
 pub trait ConsensusDataProvider<B: BlockT>: Send + Sync {
 	/// Block import transaction type
 	type Transaction;
 
 	/// Attempt to create a consensus digest.
-	fn create_digest(&self, parent: &B::Header, inherents: &InherentData) -> Result<DigestFor<B>, Error>;
+	fn create_digest(
+		&self,
+		parent: &B::Header,
+		inherents: &InherentData,
+	) -> Result<DigestFor<B>, Error>;
 
 	/// set up the neccessary import params.
 	fn append_block_import(
 		&self,
 		parent: &B::Header,
 		params: &mut BlockImportParams<B, Self::Transaction>,
-		inherents: &InherentData
+		inherents: &InherentData,
 	) -> Result<(), Error>;
 }

--- a/client/consensus/manual-seal/src/error.rs
+++ b/client/consensus/manual-seal/src/error.rs
@@ -19,10 +19,10 @@
 //! A manual sealing engine: the engine listens for rpc calls to seal blocks and create forks.
 //! This is suitable for a testing environment.
 
-use sp_consensus::{Error as ConsensusError, ImportResult};
+use futures::channel::{mpsc::SendError, oneshot};
 use sp_blockchain::Error as BlockchainError;
+use sp_consensus::{Error as ConsensusError, ImportResult};
 use sp_inherents::Error as InherentsError;
-use futures::channel::{oneshot, mpsc::SendError};
 
 /// Error code for rpc
 mod codes {
@@ -63,14 +63,14 @@ pub enum Error {
 	#[display(fmt = "{}", _0)]
 	#[from(ignore)]
 	StringError(String),
-	///send error
+	/// send error
 	#[display(fmt = "Consensus process is terminating")]
 	Canceled(oneshot::Canceled),
-	///send error
+	/// send error
 	#[display(fmt = "Consensus process is terminating")]
 	SendError(SendError),
 	/// Some other error.
-	#[display(fmt="Other error: {}", _0)]
+	#[display(fmt = "Other error: {}", _0)]
 	Other(Box<dyn std::error::Error + Send>),
 }
 
@@ -85,7 +85,7 @@ impl Error {
 			InherentError(_) => codes::INHERENTS_ERROR,
 			BlockchainError(_) => codes::BLOCKCHAIN_ERROR,
 			SendError(_) | Canceled(_) => codes::SERVER_SHUTTING_DOWN,
-			_ => codes::UNKNOWN_ERROR
+			_ => codes::UNKNOWN_ERROR,
 		}
 	}
 }
@@ -95,7 +95,7 @@ impl std::convert::From<Error> for jsonrpc_core::Error {
 		jsonrpc_core::Error {
 			code: jsonrpc_core::ErrorCode::ServerError(error.to_code()),
 			message: format!("{}", error),
-			data: None
+			data: None,
 		}
 	}
 }

--- a/client/consensus/manual-seal/src/finalize_block.rs
+++ b/client/consensus/manual-seal/src/finalize_block.rs
@@ -18,15 +18,12 @@
 
 //! Block finalization utilities
 
-use crate::rpc;
-use sp_runtime::{
-	Justification,
-	traits::Block as BlockT,
-	generic::BlockId,
-};
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
+
 use sc_client_api::backend::{Backend as ClientBackend, Finalizer};
-use std::marker::PhantomData;
+use sp_runtime::{generic::BlockId, traits::Block as BlockT, Justification};
+
+use crate::rpc;
 
 /// params for block finalization.
 pub struct FinalizeBlockParams<B: BlockT, F, CB> {
@@ -42,21 +39,14 @@ pub struct FinalizeBlockParams<B: BlockT, F, CB> {
 	pub _phantom: PhantomData<CB>,
 }
 
-
 /// finalizes a block in the backend with the given params.
 pub async fn finalize_block<B, F, CB>(params: FinalizeBlockParams<B, F, CB>)
-	where
-		B: BlockT,
-		F: Finalizer<B, CB>,
-		CB: ClientBackend<B>,
+where
+	B: BlockT,
+	F: Finalizer<B, CB>,
+	CB: ClientBackend<B>,
 {
-	let FinalizeBlockParams {
-		hash,
-		mut sender,
-		justification,
-		finalizer,
-		..
-	} = params;
+	let FinalizeBlockParams { hash, mut sender, justification, finalizer, .. } = params;
 
 	match finalizer.finalize_block(BlockId::Hash(hash), justification, true) {
 		Err(e) => {

--- a/client/consensus/manual-seal/src/lib.rs
+++ b/client/consensus/manual-seal/src/lib.rs
@@ -19,18 +19,19 @@
 //! A manual sealing engine: the engine listens for rpc calls to seal blocks and create forks.
 //! This is suitable for a testing environment.
 
+use std::{marker::PhantomData, sync::Arc};
+
 use futures::prelude::*;
-use sp_consensus::{
-	Environment, Proposer, SelectChain, BlockImport,
-	ForkChoiceStrategy, BlockImportParams, BlockOrigin,
-	import_queue::{Verifier, BasicQueue, CacheKeyId, BoxBlockImport},
-};
-use sp_blockchain::HeaderBackend;
-use sp_inherents::CreateInherentDataProviders;
-use sp_runtime::{traits::Block as BlockT, Justifications, ConsensusEngineId};
-use sc_client_api::backend::{Backend as ClientBackend, Finalizer};
-use std::{sync::Arc, marker::PhantomData};
 use prometheus_endpoint::Registry;
+use sc_client_api::backend::{Backend as ClientBackend, Finalizer};
+use sp_blockchain::HeaderBackend;
+use sp_consensus::{
+	import_queue::{BasicQueue, BoxBlockImport, CacheKeyId, Verifier},
+	BlockImport, BlockImportParams, BlockOrigin, Environment, ForkChoiceStrategy, Proposer,
+	SelectChain,
+};
+use sp_inherents::CreateInherentDataProviders;
+use sp_runtime::{traits::Block as BlockT, ConsensusEngineId, Justifications};
 
 mod error;
 mod finalize_block;
@@ -39,15 +40,16 @@ mod seal_block;
 pub mod consensus;
 pub mod rpc;
 
-pub use self::{
-	error::Error,
-	consensus::ConsensusDataProvider,
-	finalize_block::{finalize_block, FinalizeBlockParams},
-	seal_block::{SealBlockParams, seal_block, MAX_PROPOSAL_DURATION},
-	rpc::{EngineCommand, CreatedBlock},
-};
-use sp_api::{ProvideRuntimeApi, TransactionFor};
 use sc_transaction_pool_api::TransactionPool;
+use sp_api::{ProvideRuntimeApi, TransactionFor};
+
+pub use self::{
+	consensus::ConsensusDataProvider,
+	error::Error,
+	finalize_block::{finalize_block, FinalizeBlockParams},
+	rpc::{CreatedBlock, EngineCommand},
+	seal_block::{seal_block, SealBlockParams, MAX_PROPOSAL_DURATION},
+};
 
 /// The `ConsensusEngineId` of Manual Seal.
 pub const MANUAL_SEAL_ENGINE_ID: ConsensusEngineId = [b'm', b'a', b'n', b'l'];
@@ -80,17 +82,11 @@ pub fn import_queue<Block, Transaction>(
 	spawner: &impl sp_core::traits::SpawnEssentialNamed,
 	registry: Option<&Registry>,
 ) -> BasicQueue<Block, Transaction>
-	where
-		Block: BlockT,
-		Transaction: Send + Sync + 'static,
+where
+	Block: BlockT,
+	Transaction: Send + Sync + 'static,
 {
-	BasicQueue::new(
-		ManualSealVerifier,
-		block_import,
-		None,
-		spawner,
-		registry,
-	)
+	BasicQueue::new(ManualSealVerifier, block_import, None, spawner, registry)
 }
 
 /// Params required to start the instant sealing authorship task.
@@ -115,7 +111,8 @@ pub struct ManualSealParams<B: BlockT, BI, E, C: ProvideRuntimeApi<B>, TP, SC, C
 	pub select_chain: SC,
 
 	/// Digest provider for inclusion in blocks.
-	pub consensus_data_provider: Option<Box<dyn ConsensusDataProvider<B, Transaction = TransactionFor<C, B>>>>,
+	pub consensus_data_provider:
+		Option<Box<dyn ConsensusDataProvider<B, Transaction = TransactionFor<C, B>>>>,
 
 	/// Something that can create the inherent data providers.
 	pub create_inherent_data_providers: CIDP,
@@ -139,7 +136,8 @@ pub struct InstantSealParams<B: BlockT, BI, E, C: ProvideRuntimeApi<B>, TP, SC, 
 	pub select_chain: SC,
 
 	/// Digest provider for inclusion in blocks.
-	pub consensus_data_provider: Option<Box<dyn ConsensusDataProvider<B, Transaction = TransactionFor<C, B>>>>,
+	pub consensus_data_provider:
+		Option<Box<dyn ConsensusDataProvider<B, Transaction = TransactionFor<C, B>>>>,
 
 	/// Something that can create the inherent data providers.
 	pub create_inherent_data_providers: CIDP,
@@ -156,57 +154,51 @@ pub async fn run_manual_seal<B, BI, CB, E, C, TP, SC, CS, CIDP>(
 		select_chain,
 		consensus_data_provider,
 		create_inherent_data_providers,
-	}: ManualSealParams<B, BI, E, C, TP, SC, CS, CIDP>
-)
-	where
-		B: BlockT + 'static,
-		BI: BlockImport<B, Error = sp_consensus::Error, Transaction = sp_api::TransactionFor<C, B>>
-			+ Send + Sync + 'static,
-		C: HeaderBackend<B> + Finalizer<B, CB> + ProvideRuntimeApi<B> + 'static,
-		CB: ClientBackend<B> + 'static,
-		E: Environment<B> + 'static,
-		E::Proposer: Proposer<B, Transaction = TransactionFor<C, B>>,
-		CS: Stream<Item=EngineCommand<<B as BlockT>::Hash>> + Unpin + 'static,
-		SC: SelectChain<B> + 'static,
-		TransactionFor<C, B>: 'static,
-		TP: TransactionPool<Block = B>,
-		CIDP: CreateInherentDataProviders<B, ()>,
+	}: ManualSealParams<B, BI, E, C, TP, SC, CS, CIDP>,
+) where
+	B: BlockT + 'static,
+	BI: BlockImport<B, Error = sp_consensus::Error, Transaction = sp_api::TransactionFor<C, B>>
+		+ Send
+		+ Sync
+		+ 'static,
+	C: HeaderBackend<B> + Finalizer<B, CB> + ProvideRuntimeApi<B> + 'static,
+	CB: ClientBackend<B> + 'static,
+	E: Environment<B> + 'static,
+	E::Proposer: Proposer<B, Transaction = TransactionFor<C, B>>,
+	CS: Stream<Item = EngineCommand<<B as BlockT>::Hash>> + Unpin + 'static,
+	SC: SelectChain<B> + 'static,
+	TransactionFor<C, B>: 'static,
+	TP: TransactionPool<Block = B>,
+	CIDP: CreateInherentDataProviders<B, ()>,
 {
 	while let Some(command) = commands_stream.next().await {
 		match command {
-			EngineCommand::SealNewBlock {
-				create_empty,
-				finalize,
-				parent_hash,
-				sender,
-			} => {
-				seal_block(
-					SealBlockParams {
-						sender,
-						parent_hash,
-						finalize,
-						create_empty,
-						env: &mut env,
-						select_chain: &select_chain,
-						block_import: &mut block_import,
-						consensus_data_provider: consensus_data_provider.as_ref().map(|p| &**p),
-						pool: pool.clone(),
-						client: client.clone(),
-						create_inherent_data_providers: &create_inherent_data_providers,
-					}
-				).await;
+			EngineCommand::SealNewBlock { create_empty, finalize, parent_hash, sender } => {
+				seal_block(SealBlockParams {
+					sender,
+					parent_hash,
+					finalize,
+					create_empty,
+					env: &mut env,
+					select_chain: &select_chain,
+					block_import: &mut block_import,
+					consensus_data_provider: consensus_data_provider.as_ref().map(|p| &**p),
+					pool: pool.clone(),
+					client: client.clone(),
+					create_inherent_data_providers: &create_inherent_data_providers,
+				})
+				.await;
 			}
 			EngineCommand::FinalizeBlock { hash, sender, justification } => {
 				let justification = justification.map(|j| (MANUAL_SEAL_ENGINE_ID, j));
-				finalize_block(
-					FinalizeBlockParams {
-						hash,
-						sender,
-						justification,
-						finalizer: client.clone(),
-						_phantom: PhantomData,
-					}
-				).await
+				finalize_block(FinalizeBlockParams {
+					hash,
+					sender,
+					justification,
+					finalizer: client.clone(),
+					_phantom: PhantomData,
+				})
+				.await
 			}
 		}
 	}
@@ -224,63 +216,58 @@ pub async fn run_instant_seal<B, BI, CB, E, C, TP, SC, CIDP>(
 		select_chain,
 		consensus_data_provider,
 		create_inherent_data_providers,
-	}: InstantSealParams<B, BI, E, C, TP, SC, CIDP>
-)
-	where
-		B: BlockT + 'static,
-		BI: BlockImport<B, Error = sp_consensus::Error, Transaction = sp_api::TransactionFor<C, B>>
-			+ Send + Sync + 'static,
-		C: HeaderBackend<B> + Finalizer<B, CB> + ProvideRuntimeApi<B> + 'static,
-		CB: ClientBackend<B> + 'static,
-		E: Environment<B> + 'static,
-		E::Proposer: Proposer<B, Transaction = TransactionFor<C, B>>,
-		SC: SelectChain<B> + 'static,
-		TransactionFor<C, B>: 'static,
-		TP: TransactionPool<Block = B>,
-		CIDP: CreateInherentDataProviders<B, ()>,
+	}: InstantSealParams<B, BI, E, C, TP, SC, CIDP>,
+) where
+	B: BlockT + 'static,
+	BI: BlockImport<B, Error = sp_consensus::Error, Transaction = sp_api::TransactionFor<C, B>>
+		+ Send
+		+ Sync
+		+ 'static,
+	C: HeaderBackend<B> + Finalizer<B, CB> + ProvideRuntimeApi<B> + 'static,
+	CB: ClientBackend<B> + 'static,
+	E: Environment<B> + 'static,
+	E::Proposer: Proposer<B, Transaction = TransactionFor<C, B>>,
+	SC: SelectChain<B> + 'static,
+	TransactionFor<C, B>: 'static,
+	TP: TransactionPool<Block = B>,
+	CIDP: CreateInherentDataProviders<B, ()>,
 {
 	// instant-seal creates blocks as soon as transactions are imported
 	// into the transaction pool.
-	let commands_stream = pool.import_notification_stream()
-		.map(|_| {
-			EngineCommand::SealNewBlock {
-				create_empty: false,
-				finalize: false,
-				parent_hash: None,
-				sender: None,
-			}
-		});
+	let commands_stream = pool.import_notification_stream().map(|_| EngineCommand::SealNewBlock {
+		create_empty: false,
+		finalize: false,
+		parent_hash: None,
+		sender: None,
+	});
 
-	run_manual_seal(
-		ManualSealParams {
-			block_import,
-			env,
-			client,
-			pool,
-			commands_stream,
-			select_chain,
-			consensus_data_provider,
-			create_inherent_data_providers,
-		}
-	).await
+	run_manual_seal(ManualSealParams {
+		block_import,
+		env,
+		client,
+		pool,
+		commands_stream,
+		select_chain,
+		consensus_data_provider,
+		create_inherent_data_providers,
+	})
+	.await
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use substrate_test_runtime_client::{
-		DefaultTestClientBuilderExt,
-		TestClientBuilderExt,
-		AccountKeyring::*,
-		TestClientBuilder,
-	};
-	use sc_transaction_pool::{BasicPool, RevalidationType, Options};
-	use substrate_test_runtime_transaction_pool::{TestApi, uxt};
-	use sc_transaction_pool_api::{TransactionPool, MaintainedTransactionPool, TransactionSource};
-	use sp_runtime::generic::BlockId;
-	use sp_consensus::ImportedAux;
 	use sc_basic_authorship::ProposerFactory;
 	use sc_client_api::BlockBackend;
+	use sc_transaction_pool::{BasicPool, Options, RevalidationType};
+	use sc_transaction_pool_api::{MaintainedTransactionPool, TransactionPool, TransactionSource};
+	use sp_consensus::ImportedAux;
+	use sp_runtime::generic::BlockId;
+	use substrate_test_runtime_client::{
+		AccountKeyring::*, DefaultTestClientBuilderExt, TestClientBuilder, TestClientBuilderExt,
+	};
+	use substrate_test_runtime_transaction_pool::{uxt, TestApi};
+
+	use super::*;
 
 	fn api() -> Arc<TestApi> {
 		Arc::new(TestApi::empty())
@@ -303,40 +290,32 @@ mod tests {
 			spawner.clone(),
 			0,
 		));
-		let env = ProposerFactory::new(
-			spawner.clone(),
-			client.clone(),
-			pool.clone(),
-			None,
-			None,
-		);
+		let env = ProposerFactory::new(spawner.clone(), client.clone(), pool.clone(), None, None);
 		// this test checks that blocks are created as soon as transactions are imported into the pool.
 		let (sender, receiver) = futures::channel::oneshot::channel();
 		let mut sender = Arc::new(Some(sender));
-		let commands_stream = pool.pool().validated_pool().import_notification_stream()
-			.map(move |_| {
+		let commands_stream =
+			pool.pool().validated_pool().import_notification_stream().map(move |_| {
 				// we're only going to submit one tx so this fn will only be called once.
-				let mut_sender =  Arc::get_mut(&mut sender).unwrap();
+				let mut_sender = Arc::get_mut(&mut sender).unwrap();
 				let sender = std::mem::take(mut_sender);
 				EngineCommand::SealNewBlock {
 					create_empty: false,
 					finalize: true,
 					parent_hash: None,
-					sender
+					sender,
 				}
 			});
-		let future = run_manual_seal(
-			ManualSealParams {
-				block_import: client.clone(),
-				env,
-				client: client.clone(),
-				pool: pool.clone(),
-				commands_stream,
-				select_chain,
-				create_inherent_data_providers: |_, _| async { Ok(()) },
-				consensus_data_provider: None,
-			}
-		);
+		let future = run_manual_seal(ManualSealParams {
+			block_import: client.clone(),
+			env,
+			client: client.clone(),
+			pool: pool.clone(),
+			commands_stream,
+			select_chain,
+			create_inherent_data_providers: |_, _| async { Ok(()) },
+			consensus_data_provider: None,
+		});
 		std::thread::spawn(|| {
 			let mut rt = tokio::runtime::Runtime::new().unwrap();
 			// spawn the background authorship task
@@ -380,27 +359,19 @@ mod tests {
 			spawner.clone(),
 			0,
 		));
-		let env = ProposerFactory::new(
-			spawner.clone(),
-			client.clone(),
-			pool.clone(),
-			None,
-			None,
-		);
+		let env = ProposerFactory::new(spawner.clone(), client.clone(), pool.clone(), None, None);
 		// this test checks that blocks are created as soon as an engine command is sent over the stream.
 		let (mut sink, commands_stream) = futures::channel::mpsc::channel(1024);
-		let future = run_manual_seal(
-			ManualSealParams {
-				block_import: client.clone(),
-				env,
-				client: client.clone(),
-				pool: pool.clone(),
-				commands_stream,
-				select_chain,
-				consensus_data_provider: None,
-				create_inherent_data_providers: |_, _| async { Ok(()) },
-			}
-		);
+		let future = run_manual_seal(ManualSealParams {
+			block_import: client.clone(),
+			env,
+			client: client.clone(),
+			pool: pool.clone(),
+			commands_stream,
+			select_chain,
+			consensus_data_provider: None,
+			create_inherent_data_providers: |_, _| async { Ok(()) },
+		});
 		std::thread::spawn(|| {
 			let mut rt = tokio::runtime::Runtime::new().unwrap();
 			// spawn the background authorship task
@@ -416,7 +387,9 @@ mod tests {
 			sender: Some(tx),
 			create_empty: false,
 			finalize: false,
-		}).await.unwrap();
+		})
+		.await
+		.unwrap();
 		let created_block = rx.await.unwrap().unwrap();
 
 		// assert that the background task returns ok
@@ -439,8 +412,10 @@ mod tests {
 		sink.send(EngineCommand::FinalizeBlock {
 			sender: Some(tx),
 			hash: header.hash(),
-			justification: None
-		}).await.unwrap();
+			justification: None,
+		})
+		.await
+		.unwrap();
 		// assert that the background task returns ok
 		assert_eq!(rx.await.unwrap().unwrap(), ());
 	}
@@ -461,27 +436,19 @@ mod tests {
 			spawner.clone(),
 			0,
 		));
-		let env = ProposerFactory::new(
-			spawner.clone(),
-			client.clone(),
-			pool.clone(),
-			None,
-			None,
-		);
+		let env = ProposerFactory::new(spawner.clone(), client.clone(), pool.clone(), None, None);
 		// this test checks that blocks are created as soon as an engine command is sent over the stream.
 		let (mut sink, commands_stream) = futures::channel::mpsc::channel(1024);
-		let future = run_manual_seal(
-			ManualSealParams {
-				block_import: client.clone(),
-				env,
-				client: client.clone(),
-				pool: pool.clone(),
-				commands_stream,
-				select_chain,
-				consensus_data_provider: None,
-				create_inherent_data_providers: |_, _| async { Ok(()) },
-			}
-		);
+		let future = run_manual_seal(ManualSealParams {
+			block_import: client.clone(),
+			env,
+			client: client.clone(),
+			pool: pool.clone(),
+			commands_stream,
+			select_chain,
+			consensus_data_provider: None,
+			create_inherent_data_providers: |_, _| async { Ok(()) },
+		});
 		std::thread::spawn(|| {
 			let mut rt = tokio::runtime::Runtime::new().unwrap();
 			// spawn the background authorship task
@@ -498,7 +465,9 @@ mod tests {
 			sender: Some(tx),
 			create_empty: false,
 			finalize: false,
-		}).await.unwrap();
+		})
+		.await
+		.unwrap();
 		let created_block = rx.await.unwrap().unwrap();
 		pool_api.increment_nonce(Alice.into());
 
@@ -524,31 +493,35 @@ mod tests {
 		pool.maintain(sc_transaction_pool_api::ChainEvent::NewBestBlock {
 			hash: header.hash(),
 			tree_route: None,
-		}).await;
+		})
+		.await;
 
 		let (tx1, rx1) = futures::channel::oneshot::channel();
-		assert!(sink.send(EngineCommand::SealNewBlock {
-			parent_hash: Some(created_block.hash),
-			sender: Some(tx1),
-			create_empty: false,
-			finalize: false,
-		}).await.is_ok());
-		assert_matches::assert_matches!(
-			rx1.await.expect("should be no error receiving"),
-			Ok(_)
-		);
+		assert!(sink
+			.send(EngineCommand::SealNewBlock {
+				parent_hash: Some(created_block.hash),
+				sender: Some(tx1),
+				create_empty: false,
+				finalize: false,
+			})
+			.await
+			.is_ok());
+		assert_matches::assert_matches!(rx1.await.expect("should be no error receiving"), Ok(_));
 		let block = client.block(&BlockId::Number(2)).unwrap().unwrap().block;
 		pool_api.add_block(block, true);
 		pool_api.increment_nonce(Alice.into());
 
 		assert!(pool.submit_one(&BlockId::Number(1), SOURCE, uxt(Bob, 0)).await.is_ok());
 		let (tx2, rx2) = futures::channel::oneshot::channel();
-		assert!(sink.send(EngineCommand::SealNewBlock {
-			parent_hash: Some(created_block.hash),
-			sender: Some(tx2),
-			create_empty: false,
-			finalize: false,
-		}).await.is_ok());
+		assert!(sink
+			.send(EngineCommand::SealNewBlock {
+				parent_hash: Some(created_block.hash),
+				sender: Some(tx2),
+				create_empty: false,
+				finalize: false,
+			})
+			.await
+			.is_ok());
 		let imported = rx2.await.unwrap().unwrap();
 		// assert that fork block is in the db
 		assert!(client.header(&BlockId::Hash(imported.hash)).unwrap().is_some())

--- a/client/consensus/manual-seal/src/rpc.rs
+++ b/client/consensus/manual-seal/src/rpc.rs
@@ -18,17 +18,16 @@
 
 //! RPC interface for the `ManualSeal` Engine.
 
-use sp_consensus::ImportedAux;
-use jsonrpc_core::Error;
-use jsonrpc_derive::rpc;
 use futures::{
 	channel::{mpsc, oneshot},
-	TryFutureExt,
-	FutureExt,
-	SinkExt
+	FutureExt, SinkExt, TryFutureExt,
 };
+use jsonrpc_core::Error;
+use jsonrpc_derive::rpc;
 use serde::{Deserialize, Serialize};
+use sp_consensus::ImportedAux;
 use sp_runtime::EncodedJustification;
+
 pub use self::gen_client::Client as ManualSealClient;
 
 /// Future's type for jsonrpc
@@ -63,7 +62,7 @@ pub enum EngineCommand<Hash> {
 		sender: Sender<()>,
 		/// finalization justification
 		justification: Option<EncodedJustification>,
-	}
+	},
 }
 
 /// RPC trait that provides methods for interacting with the manual-seal authorship task over rpc.
@@ -75,7 +74,7 @@ pub trait ManualSealApi<Hash> {
 		&self,
 		create_empty: bool,
 		finalize: bool,
-		parent_hash: Option<Hash>
+		parent_hash: Option<Hash>,
 	) -> FutureResult<CreatedBlock<Hash>>;
 
 	/// Instructs the manual-seal authorship task to finalize a block
@@ -83,7 +82,7 @@ pub trait ManualSealApi<Hash> {
 	fn finalize_block(
 		&self,
 		hash: Hash,
-		justification: Option<EncodedJustification>
+		justification: Option<EncodedJustification>,
 	) -> FutureResult<bool>;
 }
 
@@ -98,7 +97,7 @@ pub struct CreatedBlock<Hash> {
 	/// hash of the created block.
 	pub hash: Hash,
 	/// some extra details about the import operation
-	pub aux: ImportedAux
+	pub aux: ImportedAux,
 }
 
 impl<Hash> ManualSeal<Hash> {
@@ -113,7 +112,7 @@ impl<Hash: Send + 'static> ManualSealApi<Hash> for ManualSeal<Hash> {
 		&self,
 		create_empty: bool,
 		finalize: bool,
-		parent_hash: Option<Hash>
+		parent_hash: Option<Hash>,
 	) -> FutureResult<CreatedBlock<Hash>> {
 		let mut sink = self.import_block_channel.clone();
 		let future = async move {
@@ -126,18 +125,22 @@ impl<Hash: Send + 'static> ManualSealApi<Hash> for ManualSeal<Hash> {
 			};
 			sink.send(command).await?;
 			receiver.await?
-		}.boxed();
+		}
+		.boxed();
 
 		Box::new(future.map_err(Error::from).compat())
 	}
 
-	fn finalize_block(&self, hash: Hash, justification: Option<EncodedJustification>) -> FutureResult<bool> {
+	fn finalize_block(
+		&self,
+		hash: Hash,
+		justification: Option<EncodedJustification>,
+	) -> FutureResult<bool> {
 		let mut sink = self.import_block_channel.clone();
 		let future = async move {
 			let (sender, receiver) = oneshot::channel();
-			sink.send(
-				EngineCommand::FinalizeBlock { hash, sender: Some(sender), justification }
-			).await?;
+			sink.send(EngineCommand::FinalizeBlock { hash, sender: Some(sender), justification })
+				.await?;
 
 			receiver.await?.map(|_| true)
 		};
@@ -150,7 +153,7 @@ impl<Hash: Send + 'static> ManualSealApi<Hash> for ManualSeal<Hash> {
 /// to the rpc
 pub fn send_result<T: std::fmt::Debug>(
 	sender: &mut Sender<T>,
-	result: std::result::Result<T, crate::Error>
+	result: std::result::Result<T, crate::Error>,
 ) {
 	if let Some(sender) = sender.take() {
 		if let Err(err) = sender.send(result) {
@@ -160,7 +163,7 @@ pub fn send_result<T: std::fmt::Debug>(
 		// instant seal doesn't report errors over rpc, simply log them.
 		match result {
 			Ok(r) => log::info!("Instant Seal success: {:?}", r),
-			Err(e) => log::error!("Instant Seal encountered an error: {}", e)
+			Err(e) => log::error!("Instant Seal encountered an error: {}", e),
 		}
 	}
 }

--- a/client/consensus/slots/src/aux_schema.rs
+++ b/client/consensus/slots/src/aux_schema.rs
@@ -18,9 +18,9 @@
 
 //! Schema for slots in the aux-db.
 
-use codec::{Encode, Decode};
+use codec::{Decode, Encode};
 use sc_client_api::backend::AuxStore;
-use sp_blockchain::{Result as ClientResult, Error as ClientError};
+use sp_blockchain::{Error as ClientError, Result as ClientResult};
 use sp_consensus_slots::{EquivocationProof, Slot};
 use sp_runtime::traits::Header;
 
@@ -33,17 +33,17 @@ pub const MAX_SLOT_CAPACITY: u64 = 1000;
 pub const PRUNING_BOUND: u64 = 2 * MAX_SLOT_CAPACITY;
 
 fn load_decode<C, T>(backend: &C, key: &[u8]) -> ClientResult<Option<T>>
-	where
-		C: AuxStore,
-		T: Decode,
+where
+	C: AuxStore,
+	T: Decode,
 {
 	match backend.get_aux(key)? {
 		None => Ok(None),
 		Some(t) => T::decode(&mut &t[..])
-			.map_err(
-				|e| ClientError::Backend(format!("Slots DB is corrupted. Decode error: {}", e)),
-			)
-			.map(Some)
+			.map_err(|e| {
+				ClientError::Backend(format!("Slots DB is corrupted. Decode error: {}", e))
+			})
+			.map(Some),
 	}
 }
 
@@ -57,10 +57,10 @@ pub fn check_equivocation<C, H, P>(
 	header: &H,
 	signer: &P,
 ) -> ClientResult<Option<EquivocationProof<H, P>>>
-	where
-		H: Header,
-		C: AuxStore,
-		P: Clone + Encode + Decode + PartialEq,
+where
+	H: Header,
+	C: AuxStore,
+	P: Clone + Encode + Decode + PartialEq,
 {
 	// We don't check equivocations for old headers out of our capacity.
 	if slot_now.saturating_sub(*slot) > Slot::from(MAX_SLOT_CAPACITY) {
@@ -72,13 +72,12 @@ pub fn check_equivocation<C, H, P>(
 	slot.using_encoded(|s| curr_slot_key.extend(s));
 
 	// Get headers of this slot.
-	let mut headers_with_sig = load_decode::<_, Vec<(H, P)>>(backend, &curr_slot_key[..])?
-		.unwrap_or_else(Vec::new);
+	let mut headers_with_sig =
+		load_decode::<_, Vec<(H, P)>>(backend, &curr_slot_key[..])?.unwrap_or_else(Vec::new);
 
 	// Get first slot saved.
 	let slot_header_start = SLOT_HEADER_START.to_vec();
-	let first_saved_slot = load_decode::<_, Slot>(backend, &slot_header_start[..])?
-		.unwrap_or(slot);
+	let first_saved_slot = load_decode::<_, Slot>(backend, &slot_header_start[..])?.unwrap_or(slot);
 
 	if slot_now < first_saved_slot {
 		// The code below assumes that slots will be visited sequentially.
@@ -101,7 +100,7 @@ pub fn check_equivocation<C, H, P>(
 				// We don't need to continue in case of duplicated header,
 				// since it's already saved and a possible equivocation
 				// would have been detected before.
-				return Ok(None)
+				return Ok(None);
 			}
 		}
 	}
@@ -113,7 +112,7 @@ pub fn check_equivocation<C, H, P>(
 		let prefix = SLOT_HEADER_MAP_KEY.to_vec();
 		new_first_saved_slot = slot_now.saturating_sub(MAX_SLOT_CAPACITY);
 
-		for s in u64::from(first_saved_slot)..new_first_saved_slot.into() {
+		for s in u64::from(first_saved_slot) .. new_first_saved_slot.into() {
 			let mut p = prefix.clone();
 			s.using_encoded(|s| p.extend(s));
 			keys_to_delete.push(p);
@@ -135,12 +134,11 @@ pub fn check_equivocation<C, H, P>(
 
 #[cfg(test)]
 mod test {
-	use sp_core::{sr25519, Pair};
-	use sp_core::hash::H256;
-	use sp_runtime::testing::{Header as HeaderTest, Digest as DigestTest};
+	use sp_core::{hash::H256, sr25519, Pair};
+	use sp_runtime::testing::{Digest as DigestTest, Header as HeaderTest};
 	use substrate_test_runtime_client;
 
-	use super::{MAX_SLOT_CAPACITY, PRUNING_BOUND, check_equivocation};
+	use super::{check_equivocation, MAX_SLOT_CAPACITY, PRUNING_BOUND};
 
 	fn create_header(number: u64) -> HeaderTest {
 		// so that different headers for the same number get different hashes
@@ -151,7 +149,7 @@ mod test {
 			number,
 			state_root: Default::default(),
 			extrinsics_root: Default::default(),
-			digest: DigestTest { logs: vec![], },
+			digest: DigestTest { logs: vec![] },
 		};
 
 		header
@@ -171,79 +169,55 @@ mod test {
 		let header6 = create_header(3); // @ slot 4
 
 		// It's ok to sign same headers.
-		assert!(
-			check_equivocation(
-				&client,
-				2.into(),
-				2.into(),
-				&header1,
-				&public,
-			).unwrap().is_none(),
-		);
+		assert!(check_equivocation(&client, 2.into(), 2.into(), &header1, &public,)
+			.unwrap()
+			.is_none(),);
 
-		assert!(
-			check_equivocation(
-				&client,
-				3.into(),
-				2.into(),
-				&header1,
-				&public,
-			).unwrap().is_none(),
-		);
+		assert!(check_equivocation(&client, 3.into(), 2.into(), &header1, &public,)
+			.unwrap()
+			.is_none(),);
 
 		// But not two different headers at the same slot.
-		assert!(
-			check_equivocation(
-				&client,
-				4.into(),
-				2.into(),
-				&header2,
-				&public,
-			).unwrap().is_some(),
-		);
+		assert!(check_equivocation(&client, 4.into(), 2.into(), &header2, &public,)
+			.unwrap()
+			.is_some(),);
 
 		// Different slot is ok.
-		assert!(
-			check_equivocation(
-				&client,
-				5.into(),
-				4.into(),
-				&header3,
-				&public,
-			).unwrap().is_none(),
-		);
+		assert!(check_equivocation(&client, 5.into(), 4.into(), &header3, &public,)
+			.unwrap()
+			.is_none(),);
 
 		// Here we trigger pruning and save header 4.
-		assert!(
-			check_equivocation(
-				&client,
-				(PRUNING_BOUND + 2).into(),
-				(MAX_SLOT_CAPACITY + 4).into(),
-				&header4,
-				&public,
-			).unwrap().is_none(),
-		);
+		assert!(check_equivocation(
+			&client,
+			(PRUNING_BOUND + 2).into(),
+			(MAX_SLOT_CAPACITY + 4).into(),
+			&header4,
+			&public,
+		)
+		.unwrap()
+		.is_none(),);
 
 		// This fails because header 5 is an equivocation of header 4.
-		assert!(
-			check_equivocation(
-				&client,
-				(PRUNING_BOUND + 3).into(),
-				(MAX_SLOT_CAPACITY + 4).into(),
-				&header5,
-				&public,
-			).unwrap().is_some(),
-		);
+		assert!(check_equivocation(
+			&client,
+			(PRUNING_BOUND + 3).into(),
+			(MAX_SLOT_CAPACITY + 4).into(),
+			&header5,
+			&public,
+		)
+		.unwrap()
+		.is_some(),);
 
 		// This is ok because we pruned the corresponding header. Shows that we are pruning.
-		assert!(
-			check_equivocation(
-				&client,
-				(PRUNING_BOUND + 4).into(),
-				4.into(),
-				&header6,
-				&public,
-			).unwrap().is_none(),
-		);
+		assert!(check_equivocation(
+			&client,
+			(PRUNING_BOUND + 4).into(),
+			4.into(),
+			&header6,
+			&public,
+		)
+		.unwrap()
+		.is_none(),);
 	}
 }

--- a/client/consensus/uncles/src/lib.rs
+++ b/client/consensus/uncles/src/lib.rs
@@ -19,7 +19,7 @@
 //! Uncles functionality for Substrate.
 
 use sc_client_api::ProvideUncles;
-use sp_runtime::{traits::Block as BlockT, generic::BlockId};
+use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error<B: BlockT> {
@@ -34,7 +34,8 @@ const MAX_UNCLE_GENERATIONS: u32 = 8;
 pub fn create_uncles_inherent_data_provider<B, C>(
 	client: &C,
 	parent: B::Hash,
-) -> Result<sp_authorship::InherentDataProvider<B::Header>, sc_client_api::blockchain::Error> where
+) -> Result<sp_authorship::InherentDataProvider<B::Header>, sc_client_api::blockchain::Error>
+where
 	B: BlockT,
 	C: ProvideUncles<B>,
 {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,19 @@
+# Basic
+hard_tabs = true
+max_width = 100
+use_small_heuristics = "Max"
+# Imports
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+reorder_imports = true
+# Consistency
+newline_style = "Unix"
+normalize_comments = true
+normalize_doc_attributes = true
+# Misc
+chain_width = 80
+spaces_around_ranges = true
+binop_separator = "Back"
+reorder_impl_items = true
+use_field_init_shorthand = true
+


### PR DESCRIPTION
A corrollary to https://github.com/paritytech/substrate/pull/8982

Here we show the effects of the rustfmt.toml rules on consensus which has some truly meaty `where` clauses. I thought rustfmt would struggle with them but if anything it seems to have improved on our by-hand formatting making them a little clearer and more consistent.

On the whole I'm pretty impressed. (Interestingly there's 100 lines less in the formatted code.)

There's no big whoppers (that I can see) where I'd want to go in and manually add in a skip. It might not be to everyone's taste but taste can change once you've got used to something being a certain way.