### PR TITLE
Replace DB assertion with error

### DIFF
--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -1306,8 +1306,13 @@ impl<Block: BlockT> Backend<Block> {
 				sc_client_api::blockchain::HeaderBackend::hash(
 					&self.blockchain,
 					new_canonical.saturated_into(),
-				)?.expect("existence of block with number `new_canonical` \
-					implies existence of blocks with all numbers before it; qed")
+				)?
+				.ok_or_else(|| sp_blockchain::Error::Backend(format!(
+					"Can't canonicalize missing block number #{} when importing {:?} (#{})",
+					new_canonical,
+					hash,
+					number,
+				)))?
 			};
 			if !sc_client_api::Backend::have_state_at(self, &hash, new_canonical.saturated_into()) {
 				return Ok(())

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -1306,8 +1306,7 @@ impl<Block: BlockT> Backend<Block> {
 				sc_client_api::blockchain::HeaderBackend::hash(
 					&self.blockchain,
 					new_canonical.saturated_into(),
-				)?
-				.ok_or_else(|| sp_blockchain::Error::Backend(format!(
+				)?.ok_or_else(|| sp_blockchain::Error::Backend(format!(
 					"Can't canonicalize missing block number #{} when importing {:?} (#{})",
 					new_canonical,
 					hash,


### PR DESCRIPTION
Produce proper error when trying to canonicalize block with missing parents.
See https://github.com/PureStake/moonbeam/issues/541