### PR TITLE
Run `cargo fmt` on infrequently updated source files

### DIFF
--- a/bin/utils/chain-spec-builder/src/main.rs
+++ b/bin/utils/chain-spec-builder/src/main.rs
@@ -16,19 +16,23 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{fs, path::{Path, PathBuf}, sync::Arc};
+use std::{
+	fs,
+	path::{Path, PathBuf},
+	sync::Arc,
+};
 
 use ansi_term::Style;
-use rand::{Rng, distributions::Alphanumeric, rngs::OsRng};
+use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
 use structopt::StructOpt;
 
-use sc_keystore::LocalKeystore;
 use node_cli::chain_spec::{self, AccountId};
+use sc_keystore::LocalKeystore;
 use sp_core::{
-	sr25519,
 	crypto::{Public, Ss58Codec},
+	sr25519,
 };
-use sp_keystore::{SyncCryptoStorePtr, SyncCryptoStore};
+use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
 
 /// A utility to easily create a testnet chain spec definition with a given set
 /// of authorities and endowed accounts and/or generate random accounts.
@@ -86,10 +90,8 @@ impl ChainSpecBuilder {
 	/// Returns the path where the chain spec should be saved.
 	fn chain_spec_path(&self) -> &Path {
 		match self {
-			ChainSpecBuilder::New { chain_spec_path, .. } =>
-				chain_spec_path.as_path(),
-			ChainSpecBuilder::Generate { chain_spec_path, .. } =>
-				chain_spec_path.as_path(),
+			ChainSpecBuilder::New { chain_spec_path, .. } => chain_spec_path.as_path(),
+			ChainSpecBuilder::Generate { chain_spec_path, .. } => chain_spec_path.as_path(),
 		}
 	}
 }
@@ -125,11 +127,15 @@ fn generate_chain_spec(
 			.map_err(|err| format!("Failed to parse account address: {:?}", err))
 	};
 
-	let nominator_accounts =
-		nominator_accounts.into_iter().map(parse_account).collect::<Result<Vec<_>, String>>()?;
+	let nominator_accounts = nominator_accounts
+		.into_iter()
+		.map(parse_account)
+		.collect::<Result<Vec<_>, String>>()?;
 
-	let endowed_accounts =
-		endowed_accounts.into_iter().map(parse_account).collect::<Result<Vec<_>, String>>()?;
+	let endowed_accounts = endowed_accounts
+		.into_iter()
+		.map(parse_account)
+		.collect::<Result<Vec<_>, String>>()?;
 
 	let sudo_account = parse_account(sudo_account)?;
 
@@ -137,7 +143,14 @@ fn generate_chain_spec(
 		"Custom",
 		"custom",
 		sc_chain_spec::ChainType::Live,
-		move || genesis_constructor(&authority_seeds, &nominator_accounts, &endowed_accounts, &sudo_account),
+		move || {
+			genesis_constructor(
+				&authority_seeds,
+				&nominator_accounts,
+				&endowed_accounts,
+				&sudo_account,
+			)
+		},
 		vec![],
 		None,
 		None,
@@ -148,42 +161,26 @@ fn generate_chain_spec(
 	chain_spec.as_json(false).map_err(|err| err)
 }
 
-fn generate_authority_keys_and_store(
-	seeds: &[String],
-	keystore_path: &Path,
-) -> Result<(), String> {
+fn generate_authority_keys_and_store(seeds: &[String], keystore_path: &Path) -> Result<(), String> {
 	for (n, seed) in seeds.into_iter().enumerate() {
-		let keystore: SyncCryptoStorePtr = Arc::new(LocalKeystore::open(
-			keystore_path.join(format!("auth-{}", n)),
-			None,
-		).map_err(|err| err.to_string())?);
+		let keystore: SyncCryptoStorePtr = Arc::new(
+			LocalKeystore::open(keystore_path.join(format!("auth-{}", n)), None)
+				.map_err(|err| err.to_string())?,
+		);
 
 		let (_, _, grandpa, babe, im_online, authority_discovery) =
 			chain_spec::authority_keys_from_seed(seed);
 
 		let insert_key = |key_type, public| {
-			SyncCryptoStore::insert_unknown(
-				&*keystore,
-				key_type,
-				&format!("//{}", seed),
-				public,
-			).map_err(|_| format!("Failed to insert key: {}", grandpa))
+			SyncCryptoStore::insert_unknown(&*keystore, key_type, &format!("//{}", seed), public)
+				.map_err(|_| format!("Failed to insert key: {}", grandpa))
 		};
 
-		insert_key(
-			sp_core::crypto::key_types::BABE,
-			babe.as_slice(),
-		)?;
+		insert_key(sp_core::crypto::key_types::BABE, babe.as_slice())?;
 
-		insert_key(
-			sp_core::crypto::key_types::GRANDPA,
-			grandpa.as_slice(),
-		)?;
+		insert_key(sp_core::crypto::key_types::GRANDPA, grandpa.as_slice())?;
 
-		insert_key(
-			sp_core::crypto::key_types::IM_ONLINE,
-			im_online.as_slice(),
-		)?;
+		insert_key(sp_core::crypto::key_types::IM_ONLINE, im_online.as_slice())?;
 
 		insert_key(
 			sp_core::crypto::key_types::AUTHORITY_DISCOVERY,
@@ -206,10 +203,7 @@ fn print_seeds(
 	println!("{}", header.paint("Authority seeds"));
 
 	for (n, seed) in authority_seeds.iter().enumerate() {
-		println!("{} //{}",
-			entry.paint(format!("auth-{}:", n)),
-			seed,
-		);
+		println!("{} //{}", entry.paint(format!("auth-{}:", n)), seed,);
 	}
 
 	println!("{}", header.paint("Nominator seeds"));
@@ -223,10 +217,7 @@ fn print_seeds(
 	if !endowed_seeds.is_empty() {
 		println!("{}", header.paint("Endowed seeds"));
 		for (n, seed) in endowed_seeds.iter().enumerate() {
-			println!("{} //{}",
-				entry.paint(format!("endowed-{}:", n)),
-				seed,
-			);
+			println!("{} //{}", entry.paint(format!("endowed-{}:", n)), seed,);
 		}
 
 		println!();
@@ -260,10 +251,7 @@ fn main() -> Result<(), String> {
 			print_seeds(&authority_seeds, &nominator_seeds, &endowed_seeds, &sudo_seed);
 
 			if let Some(keystore_path) = keystore_path {
-				generate_authority_keys_and_store(
-					&authority_seeds,
-					&keystore_path,
-				)?;
+				generate_authority_keys_and_store(&authority_seeds, &keystore_path)?;
 			}
 
 			let nominator_accounts = nominator_seeds
@@ -284,7 +272,7 @@ fn main() -> Result<(), String> {
 				chain_spec::get_account_id_from_seed::<sr25519::Public>(&sudo_seed).to_ss58check();
 
 			(authority_seeds, nominator_accounts, endowed_accounts, sudo_account)
-		}
+		},
 		ChainSpecBuilder::New {
 			authority_seeds,
 			nominator_accounts,
@@ -294,12 +282,8 @@ fn main() -> Result<(), String> {
 		} => (authority_seeds, nominator_accounts, endowed_accounts, sudo_account),
 	};
 
-	let json = generate_chain_spec(
-		authority_seeds,
-		nominator_accounts,
-		endowed_accounts,
-		sudo_account,
-	)?;
+	let json =
+		generate_chain_spec(authority_seeds, nominator_accounts, endowed_accounts, sudo_account)?;
 
 	fs::write(chain_spec_path, json).map_err(|err| err.to_string())
 }

--- a/bin/utils/subkey/src/lib.rs
+++ b/bin/utils/subkey/src/lib.rs
@@ -16,17 +16,17 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use structopt::StructOpt;
 use sc_cli::{
-	Error, VanityCmd, SignCmd, VerifyCmd, GenerateNodeKeyCmd, GenerateCmd, InspectKeyCmd,
-	InspectNodeKeyCmd
+	Error, GenerateCmd, GenerateNodeKeyCmd, InspectKeyCmd, InspectNodeKeyCmd, SignCmd, VanityCmd,
+	VerifyCmd,
 };
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 #[structopt(
 	name = "subkey",
 	author = "Parity Team <admin@parity.io>",
-	about = "Utility for generating and restoring with Substrate keys",
+	about = "Utility for generating and restoring with Substrate keys"
 )]
 pub enum Subkey {
 	/// Generate a random node libp2p key, save it to file or print it to stdout

--- a/client/proposer-metrics/src/lib.rs
+++ b/client/proposer-metrics/src/lib.rs
@@ -18,7 +18,9 @@
 
 //! Prometheus basic proposer metrics.
 
-use prometheus_endpoint::{register, PrometheusError, Registry, Histogram, HistogramOpts, Gauge, U64};
+use prometheus_endpoint::{
+	register, Gauge, Histogram, HistogramOpts, PrometheusError, Registry, U64,
+};
 
 /// Optional shareable link to basic authorship metrics.
 #[derive(Clone, Default)]
@@ -26,13 +28,13 @@ pub struct MetricsLink(Option<Metrics>);
 
 impl MetricsLink {
 	pub fn new(registry: Option<&Registry>) -> Self {
-		Self(
-			registry.and_then(|registry|
-				Metrics::register(registry)
-					.map_err(|err| log::warn!("Failed to register proposer prometheus metrics: {}", err))
-					.ok()
-			)
-		)
+		Self(registry.and_then(|registry| {
+			Metrics::register(registry)
+				.map_err(|err| {
+					log::warn!("Failed to register proposer prometheus metrics: {}", err)
+				})
+				.ok()
+		}))
 	}
 
 	pub fn report<O>(&self, do_this: impl FnOnce(&Metrics) -> O) -> Option<O> {

--- a/primitives/debug-derive/src/lib.rs
+++ b/primitives/debug-derive/src/lib.rs
@@ -38,6 +38,5 @@ use proc_macro::TokenStream;
 
 #[proc_macro_derive(RuntimeDebug)]
 pub fn debug_derive(input: TokenStream) -> TokenStream {
-   impls::debug_derive(syn::parse_macro_input!(input))
+	impls::debug_derive(syn::parse_macro_input!(input))
 }
-

--- a/primitives/debug-derive/tests/tests.rs
+++ b/primitives/debug-derive/tests/tests.rs
@@ -30,33 +30,17 @@ struct Named {
 enum EnumLongName<A> {
 	A,
 	B(A, String),
-	VariantLongName {
-		a: A,
-		b: String,
-	},
+	VariantLongName { a: A, b: String },
 }
-
 
 #[test]
 fn should_display_proper_debug() {
 	use self::EnumLongName as Enum;
 
-	assert_eq!(
-		format!("{:?}", Unnamed(1, "abc".into())),
-		"Unnamed(1, \"abc\")"
-	);
-	assert_eq!(
-		format!("{:?}", Named { a: 1, b: "abc".into() }),
-		"Named { a: 1, b: \"abc\" }"
-	);
-	assert_eq!(
-		format!("{:?}", Enum::<u64>::A),
-		"EnumLongName::A"
-	);
-	assert_eq!(
-		format!("{:?}", Enum::B(1, "abc".into())),
-		"EnumLongName::B(1, \"abc\")"
-	);
+	assert_eq!(format!("{:?}", Unnamed(1, "abc".into())), "Unnamed(1, \"abc\")");
+	assert_eq!(format!("{:?}", Named { a: 1, b: "abc".into() }), "Named { a: 1, b: \"abc\" }");
+	assert_eq!(format!("{:?}", Enum::<u64>::A), "EnumLongName::A");
+	assert_eq!(format!("{:?}", Enum::B(1, "abc".into())), "EnumLongName::B(1, \"abc\")");
 	assert_eq!(
 		format!("{:?}", Enum::VariantLongName { a: 1, b: "abc".into() }),
 		"EnumLongName::VariantLongName { a: 1, b: \"abc\" }"

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -24,7 +24,7 @@ pub use futures;
 ///
 /// # Requirements
 ///
-///	You must have tokio in the `[dev-dependencies]` of your crate to use this macro.
+/// 	You must have tokio in the `[dev-dependencies]` of your crate to use this macro.
 ///
 /// # Example
 ///
@@ -64,7 +64,7 @@ macro_rules! assert_eq_uvec {
 	( $x:expr, $y:expr $(,)? ) => {
 		$crate::__assert_eq_uvec!($x, $y);
 		$crate::__assert_eq_uvec!($y, $x);
-	}
+	};
 }
 
 #[macro_export]
@@ -72,7 +72,9 @@ macro_rules! assert_eq_uvec {
 macro_rules! __assert_eq_uvec {
 	( $x:expr, $y:expr ) => {
 		$x.iter().for_each(|e| {
-			if !$y.contains(e) { panic!("vectors not equal: {:?} != {:?}", $x, $y); }
+			if !$y.contains(e) {
+				panic!("vectors not equal: {:?} != {:?}", $x, $y);
+			}
 		});
-	}
+	};
 }

--- a/utils/build-script-utils/src/git.rs
+++ b/utils/build-script-utils/src/git.rs
@@ -33,16 +33,16 @@ pub fn rerun_if_git_head_changed() {
 			Err(err) => {
 				eprintln!("cargo:warning=Unable to read the Git repository: {}", err);
 
-				return;
-			}
-			Ok(None) => {}
+				return
+			},
+			Ok(None) => {},
 			Ok(Some(paths)) => {
 				for p in paths {
 					println!("cargo:rerun-if-changed={}", p.display());
 				}
 
-				return;
-			}
+				return
+			},
 		}
 
 		manifest_dir.pop();

--- a/utils/build-script-utils/src/lib.rs
+++ b/utils/build-script-utils/src/lib.rs
@@ -17,8 +17,8 @@
 
 //! Crate with utility functions for `build.rs` scripts.
 
-mod version;
 mod git;
+mod version;
 
 pub use git::*;
 pub use version::*;

--- a/utils/build-script-utils/src/version.rs
+++ b/utils/build-script-utils/src/version.rs
@@ -20,15 +20,13 @@ use std::{borrow::Cow, process::Command};
 
 /// Generate the `cargo:` key output
 pub fn generate_cargo_keys() {
-	let output = Command::new("git")
-		.args(&["rev-parse", "--short", "HEAD"])
-		.output();
+	let output = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output();
 
 	let commit = match output {
 		Ok(o) if o.status.success() => {
 			let sha = String::from_utf8_lossy(&o.stdout).trim().to_owned();
 			Cow::from(sha)
-		}
+		},
 		Ok(o) => {
 			println!("cargo:warning=Git command failed with status: {}", o.status);
 			Cow::from("unknown")

--- a/utils/fork-tree/src/lib.rs
+++ b/utils/fork-tree/src/lib.rs
@@ -20,9 +20,8 @@
 
 #![warn(missing_docs)]
 
-use std::cmp::Reverse;
-use std::fmt;
 use codec::{Decode, Encode};
+use std::{cmp::Reverse, fmt};
 
 /// Error occurred when iterating with the tree.
 #[derive(Clone, Debug, PartialEq)]
@@ -83,7 +82,8 @@ pub struct ForkTree<H, N, V> {
 	best_finalized_number: Option<N>,
 }
 
-impl<H, N, V> ForkTree<H, N, V> where
+impl<H, N, V> ForkTree<H, N, V>
+where
 	H: PartialEq + Clone,
 	N: Ord + Clone,
 	V: Clone,
@@ -102,17 +102,14 @@ impl<H, N, V> ForkTree<H, N, V> where
 		number: &N,
 		is_descendent_of: &F,
 		predicate: &P,
-	) -> Result<impl Iterator<Item=(H, N, V)>, Error<E>>
-		where E: std::error::Error,
-			  F: Fn(&H, &H) -> Result<bool, E>,
-			  P: Fn(&V) -> bool,
+	) -> Result<impl Iterator<Item = (H, N, V)>, Error<E>>
+	where
+		E: std::error::Error,
+		F: Fn(&H, &H) -> Result<bool, E>,
+		P: Fn(&V) -> bool,
 	{
-		let new_root_index = self.find_node_index_where(
-			hash,
-			number,
-			is_descendent_of,
-			predicate,
-		)?;
+		let new_root_index =
+			self.find_node_index_where(hash, number, is_descendent_of, predicate)?;
 
 		let removed = if let Some(mut root_index) = new_root_index {
 			let mut old_roots = std::mem::take(&mut self.roots);
@@ -130,9 +127,10 @@ impl<H, N, V> ForkTree<H, N, V> where
 				}
 			}
 
-			let mut root = root
-				.expect("find_node_index_where will return array with at least one index; \
-						 this results in at least one item in removed; qed");
+			let mut root = root.expect(
+				"find_node_index_where will return array with at least one index; \
+						 this results in at least one item in removed; qed",
+			);
 
 			let mut removed = old_roots;
 
@@ -144,7 +142,7 @@ impl<H, N, V> ForkTree<H, N, V> where
 			for child in root_children {
 				if is_first &&
 					(child.number == *number && child.hash == *hash ||
-					 child.number < *number && is_descendent_of(&child.hash, hash)?)
+						child.number < *number && is_descendent_of(&child.hash, hash)?)
 				{
 					root.children.push(child);
 					// assuming that the tree is well formed only one child should pass this requirement
@@ -168,16 +166,14 @@ impl<H, N, V> ForkTree<H, N, V> where
 	}
 }
 
-impl<H, N, V> ForkTree<H, N, V> where
+impl<H, N, V> ForkTree<H, N, V>
+where
 	H: PartialEq,
 	N: Ord,
 {
 	/// Create a new empty tree.
 	pub fn new() -> ForkTree<H, N, V> {
-		ForkTree {
-			roots: Vec::new(),
-			best_finalized_number: None,
-		}
+		ForkTree { roots: Vec::new(), best_finalized_number: None }
 	}
 
 	/// Rebalance the tree, i.e. sort child nodes by max branch depth
@@ -209,18 +205,19 @@ impl<H, N, V> ForkTree<H, N, V> where
 		mut data: V,
 		is_descendent_of: &F,
 	) -> Result<bool, Error<E>>
-		where E: std::error::Error,
-			  F: Fn(&H, &H) -> Result<bool, E>,
+	where
+		E: std::error::Error,
+		F: Fn(&H, &H) -> Result<bool, E>,
 	{
 		if let Some(ref best_finalized_number) = self.best_finalized_number {
 			if number <= *best_finalized_number {
-				return Err(Error::Revert);
+				return Err(Error::Revert)
 			}
 		}
 
 		for root in self.roots.iter_mut() {
 			if root.hash == hash {
-				return Err(Error::Duplicate);
+				return Err(Error::Duplicate)
 			}
 
 			match root.import(hash, number, data, is_descendent_of)? {
@@ -231,17 +228,12 @@ impl<H, N, V> ForkTree<H, N, V> where
 				},
 				None => {
 					self.rebalance();
-					return Ok(false);
+					return Ok(false)
 				},
 			}
 		}
 
-		self.roots.push(Node {
-			data,
-			hash: hash,
-			number: number,
-			children: Vec::new(),
-		});
+		self.roots.push(Node { data, hash, number, children: Vec::new() });
 
 		self.rebalance();
 
@@ -249,18 +241,18 @@ impl<H, N, V> ForkTree<H, N, V> where
 	}
 
 	/// Iterates over the existing roots in the tree.
-	pub fn roots(&self) -> impl Iterator<Item=(&H, &N, &V)> {
+	pub fn roots(&self) -> impl Iterator<Item = (&H, &N, &V)> {
 		self.roots.iter().map(|node| (&node.hash, &node.number, &node.data))
 	}
 
-	fn node_iter(&self) -> impl Iterator<Item=&Node<H, N, V>> {
+	fn node_iter(&self) -> impl Iterator<Item = &Node<H, N, V>> {
 		// we need to reverse the order of roots to maintain the expected
 		// ordering since the iterator uses a stack to track state.
 		ForkTreeIterator { stack: self.roots.iter().rev().collect() }
 	}
 
 	/// Iterates the nodes in the tree in pre-order.
-	pub fn iter(&self) -> impl Iterator<Item=(&H, &N, &V)> {
+	pub fn iter(&self) -> impl Iterator<Item = (&H, &N, &V)> {
 		self.node_iter().map(|node| (&node.hash, &node.number, &node.data))
 	}
 
@@ -274,7 +266,8 @@ impl<H, N, V> ForkTree<H, N, V> where
 		number: &N,
 		is_descendent_of: &F,
 		predicate: &P,
-	) -> Result<Option<&Node<H, N, V>>, Error<E>> where
+	) -> Result<Option<&Node<H, N, V>>, Error<E>>
+	where
 		E: std::error::Error,
 		F: Fn(&H, &H) -> Result<bool, E>,
 		P: Fn(&V) -> bool,
@@ -285,7 +278,7 @@ impl<H, N, V> ForkTree<H, N, V> where
 
 			// found the node, early exit
 			if let FindOutcome::Found(node) = node {
-				return Ok(Some(node));
+				return Ok(Some(node))
 			}
 		}
 
@@ -293,23 +286,13 @@ impl<H, N, V> ForkTree<H, N, V> where
 	}
 
 	/// Map fork tree into values of new types.
-	pub fn map<VT, F>(
-		self,
-		f: &mut F,
-	) -> ForkTree<H, N, VT> where
+	pub fn map<VT, F>(self, f: &mut F) -> ForkTree<H, N, VT>
+	where
 		F: FnMut(&H, &N, V) -> VT,
 	{
-		let roots = self.roots
-			.into_iter()
-			.map(|root| {
-				root.map(f)
-			})
-			.collect();
+		let roots = self.roots.into_iter().map(|root| root.map(f)).collect();
 
-		ForkTree {
-			roots,
-			best_finalized_number: self.best_finalized_number,
-		}
+		ForkTree { roots, best_finalized_number: self.best_finalized_number }
 	}
 
 	/// Same as [`find_node_where`](ForkTree::find_node_where), but returns mutable reference.
@@ -319,7 +302,8 @@ impl<H, N, V> ForkTree<H, N, V> where
 		number: &N,
 		is_descendent_of: &F,
 		predicate: &P,
-	) -> Result<Option<&mut Node<H, N, V>>, Error<E>> where
+	) -> Result<Option<&mut Node<H, N, V>>, Error<E>>
+	where
 		E: std::error::Error,
 		F: Fn(&H, &H) -> Result<bool, E>,
 		P: Fn(&V) -> bool,
@@ -330,7 +314,7 @@ impl<H, N, V> ForkTree<H, N, V> where
 
 			// found the node, early exit
 			if let FindOutcome::Found(node) = node {
-				return Ok(Some(node));
+				return Ok(Some(node))
 			}
 		}
 
@@ -344,7 +328,8 @@ impl<H, N, V> ForkTree<H, N, V> where
 		number: &N,
 		is_descendent_of: &F,
 		predicate: &P,
-	) -> Result<Option<Vec<usize>>, Error<E>> where
+	) -> Result<Option<Vec<usize>>, Error<E>>
+	where
 		E: std::error::Error,
 		F: Fn(&H, &H) -> Result<bool, E>,
 		P: Fn(&V) -> bool,
@@ -356,7 +341,7 @@ impl<H, N, V> ForkTree<H, N, V> where
 			// found the node, early exit
 			if let FindOutcome::Found(mut node) = node {
 				node.push(index);
-				return Ok(Some(node));
+				return Ok(Some(node))
 			}
 		}
 
@@ -367,7 +352,9 @@ impl<H, N, V> ForkTree<H, N, V> where
 	/// with the given hash exists. All other roots are pruned, and the children
 	/// of the finalized node become the new roots.
 	pub fn finalize_root(&mut self, hash: &H) -> Option<V> {
-		self.roots.iter().position(|node| node.hash == *hash)
+		self.roots
+			.iter()
+			.position(|node| node.hash == *hash)
 			.map(|position| self.finalize_root_at(position))
 	}
 
@@ -376,7 +363,7 @@ impl<H, N, V> ForkTree<H, N, V> where
 		let node = self.roots.swap_remove(position);
 		self.roots = node.children;
 		self.best_finalized_number = Some(node.number);
-		return node.data;
+		return node.data
 	}
 
 	/// Finalize a node in the tree. This method will make sure that the node
@@ -390,24 +377,25 @@ impl<H, N, V> ForkTree<H, N, V> where
 		number: N,
 		is_descendent_of: &F,
 	) -> Result<FinalizationResult<V>, Error<E>>
-		where E: std::error::Error,
-			  F: Fn(&H, &H) -> Result<bool, E>
+	where
+		E: std::error::Error,
+		F: Fn(&H, &H) -> Result<bool, E>,
 	{
 		if let Some(ref best_finalized_number) = self.best_finalized_number {
 			if number <= *best_finalized_number {
-				return Err(Error::Revert);
+				return Err(Error::Revert)
 			}
 		}
 
 		// check if one of the current roots is being finalized
 		if let Some(root) = self.finalize_root(hash) {
-			return Ok(FinalizationResult::Changed(Some(root)));
+			return Ok(FinalizationResult::Changed(Some(root)))
 		}
 
 		// make sure we're not finalizing a descendent of any root
 		for root in self.roots.iter() {
 			if number > root.number && is_descendent_of(&root.hash, hash)? {
-				return Err(Error::UnfinalizedAncestor);
+				return Err(Error::UnfinalizedAncestor)
 			}
 		}
 
@@ -443,18 +431,19 @@ impl<H, N, V> ForkTree<H, N, V> where
 		number: N,
 		is_descendent_of: &F,
 	) -> Result<FinalizationResult<V>, Error<E>>
-		where E: std::error::Error,
-				F: Fn(&H, &H) -> Result<bool, E>
+	where
+		E: std::error::Error,
+		F: Fn(&H, &H) -> Result<bool, E>,
 	{
 		if let Some(ref best_finalized_number) = self.best_finalized_number {
 			if number <= *best_finalized_number {
-				return Err(Error::Revert);
+				return Err(Error::Revert)
 			}
 		}
 
 		// check if one of the current roots is being finalized
 		if let Some(root) = self.finalize_root(hash) {
-			return Ok(FinalizationResult::Changed(Some(root)));
+			return Ok(FinalizationResult::Changed(Some(root)))
 		}
 
 		// we need to:
@@ -469,23 +458,21 @@ impl<H, N, V> ForkTree<H, N, V> where
 				let is_finalized = root.hash == *hash;
 				let is_descendant =
 					!is_finalized && root.number > number && is_descendent_of(hash, &root.hash)?;
-				let is_ancestor = !is_finalized
-					&& !is_descendant && root.number < number
-					&& is_descendent_of(&root.hash, hash)?;
+				let is_ancestor = !is_finalized &&
+					!is_descendant && root.number < number &&
+					is_descendent_of(&root.hash, hash)?;
 				(is_finalized, is_descendant, is_ancestor)
 			};
 
 			// if we have met finalized root - open it and return
 			if is_finalized {
-				return Ok(FinalizationResult::Changed(Some(
-					self.finalize_root_at(idx),
-				)));
+				return Ok(FinalizationResult::Changed(Some(self.finalize_root_at(idx))))
 			}
 
 			// if node is descendant of finalized block - just leave it as is
 			if is_descendant {
 				idx += 1;
-				continue;
+				continue
 			}
 
 			// if node is ancestor of finalized block - remove it and continue with children
@@ -493,7 +480,7 @@ impl<H, N, V> ForkTree<H, N, V> where
 				let root = self.roots.swap_remove(idx);
 				self.roots.extend(root.children);
 				changed = true;
-				continue;
+				continue
 			}
 
 			// if node is neither ancestor, nor descendant of the finalized block - remove it
@@ -526,13 +513,14 @@ impl<H, N, V> ForkTree<H, N, V> where
 		is_descendent_of: &F,
 		predicate: P,
 	) -> Result<Option<bool>, Error<E>>
-		where E: std::error::Error,
-			  F: Fn(&H, &H) -> Result<bool, E>,
-			  P: Fn(&V) -> bool,
+	where
+		E: std::error::Error,
+		F: Fn(&H, &H) -> Result<bool, E>,
+		P: Fn(&V) -> bool,
 	{
 		if let Some(ref best_finalized_number) = self.best_finalized_number {
 			if number <= *best_finalized_number {
-				return Err(Error::Revert);
+				return Err(Error::Revert)
 			}
 		}
 
@@ -544,11 +532,11 @@ impl<H, N, V> ForkTree<H, N, V> where
 				if node.hash == *hash || is_descendent_of(&node.hash, hash)? {
 					for node in node.children.iter() {
 						if node.number <= number && is_descendent_of(&node.hash, &hash)? {
-							return Err(Error::UnfinalizedAncestor);
+							return Err(Error::UnfinalizedAncestor)
 						}
 					}
 
-					return Ok(Some(self.roots.iter().any(|root| root.hash == node.hash)));
+					return Ok(Some(self.roots.iter().any(|root| root.hash == node.hash)))
 				}
 			}
 		}
@@ -570,13 +558,14 @@ impl<H, N, V> ForkTree<H, N, V> where
 		is_descendent_of: &F,
 		predicate: P,
 	) -> Result<FinalizationResult<V>, Error<E>>
-		where E: std::error::Error,
-			  F: Fn(&H, &H) -> Result<bool, E>,
-			  P: Fn(&V) -> bool,
+	where
+		E: std::error::Error,
+		F: Fn(&H, &H) -> Result<bool, E>,
+		P: Fn(&V) -> bool,
 	{
 		if let Some(ref best_finalized_number) = self.best_finalized_number {
 			if number <= *best_finalized_number {
-				return Err(Error::Revert);
+				return Err(Error::Revert)
 			}
 		}
 
@@ -589,12 +578,12 @@ impl<H, N, V> ForkTree<H, N, V> where
 				if root.hash == *hash || is_descendent_of(&root.hash, hash)? {
 					for node in root.children.iter() {
 						if node.number <= number && is_descendent_of(&node.hash, &hash)? {
-							return Err(Error::UnfinalizedAncestor);
+							return Err(Error::UnfinalizedAncestor)
 						}
 					}
 
 					position = Some(i);
-					break;
+					break
 				}
 			}
 		}
@@ -616,9 +605,9 @@ impl<H, N, V> ForkTree<H, N, V> where
 		let roots = std::mem::take(&mut self.roots);
 
 		for root in roots {
-			let retain = root.number > number && is_descendent_of(hash, &root.hash)?
-				|| root.number == number && root.hash == *hash
-				|| is_descendent_of(&root.hash, hash)?;
+			let retain = root.number > number && is_descendent_of(hash, &root.hash)? ||
+				root.number == number && root.hash == *hash ||
+				is_descendent_of(&root.hash, hash)?;
 
 			if retain {
 				self.roots.push(root);
@@ -681,26 +670,14 @@ mod node_implementation {
 		}
 
 		/// Map node data into values of new types.
-		pub fn map<VT, F>(
-			self,
-			f: &mut F,
-		) -> Node<H, N, VT> where
+		pub fn map<VT, F>(self, f: &mut F) -> Node<H, N, VT>
+		where
 			F: FnMut(&H, &N, V) -> VT,
 		{
-			let children = self.children
-				.into_iter()
-				.map(|node| {
-					node.map(f)
-				})
-				.collect();
+			let children = self.children.into_iter().map(|node| node.map(f)).collect();
 
 			let vt = f(&self.hash, &self.number, self.data);
-			Node {
-				hash: self.hash,
-				number: self.number,
-				data: vt,
-				children,
-			}
+			Node { hash: self.hash, number: self.number, data: vt, children }
 		}
 
 		pub fn import<F, E: std::error::Error>(
@@ -710,14 +687,17 @@ mod node_implementation {
 			mut data: V,
 			is_descendent_of: &F,
 		) -> Result<Option<(H, N, V)>, Error<E>>
-			where E: fmt::Debug,
-				  F: Fn(&H, &H) -> Result<bool, E>,
+		where
+			E: fmt::Debug,
+			F: Fn(&H, &H) -> Result<bool, E>,
 		{
 			if self.hash == hash {
-				return Err(Error::Duplicate);
+				return Err(Error::Duplicate)
 			};
 
-			if number <= self.number { return Ok(Some((hash, number, data))); }
+			if number <= self.number {
+				return Ok(Some((hash, number, data)))
+			}
 
 			for node in self.children.iter_mut() {
 				match node.import(hash, number, data, is_descendent_of)? {
@@ -731,12 +711,7 @@ mod node_implementation {
 			}
 
 			if is_descendent_of(&self.hash, &hash)? {
-				self.children.push(Node {
-					data,
-					hash: hash,
-					number: number,
-					children: Vec::new(),
-				});
+				self.children.push(Node { data, hash, number, children: Vec::new() });
 
 				Ok(None)
 			} else {
@@ -760,13 +735,14 @@ mod node_implementation {
 			is_descendent_of: &F,
 			predicate: &P,
 		) -> Result<FindOutcome<Vec<usize>>, Error<E>>
-			where E: std::error::Error,
-				  F: Fn(&H, &H) -> Result<bool, E>,
-				  P: Fn(&V) -> bool,
+		where
+			E: std::error::Error,
+			F: Fn(&H, &H) -> Result<bool, E>,
+			P: Fn(&V) -> bool,
 		{
 			// stop searching this branch
 			if *number < self.number {
-				return Ok(FindOutcome::Failure(false));
+				return Ok(FindOutcome::Failure(false))
 			}
 
 			let mut known_descendent_of = false;
@@ -785,7 +761,7 @@ mod node_implementation {
 						// then it cannot be a descendent of any others,
 						// so we don't search them.
 						known_descendent_of = true;
-						break;
+						break
 					},
 					FindOutcome::Failure(false) => {},
 				}
@@ -799,7 +775,7 @@ mod node_implementation {
 			if is_descendent_of {
 				// if the predicate passes we return the node
 				if predicate(&self.data) {
-					return Ok(FindOutcome::Found(Vec::new()));
+					return Ok(FindOutcome::Found(Vec::new()))
 				}
 			}
 
@@ -820,9 +796,10 @@ mod node_implementation {
 			is_descendent_of: &F,
 			predicate: &P,
 		) -> Result<FindOutcome<&Node<H, N, V>>, Error<E>>
-			where E: std::error::Error,
-				  F: Fn(&H, &H) -> Result<bool, E>,
-				  P: Fn(&V) -> bool,
+		where
+			E: std::error::Error,
+			F: Fn(&H, &H) -> Result<bool, E>,
+			P: Fn(&V) -> bool,
 		{
 			let outcome = self.find_node_index_where(hash, number, is_descendent_of, predicate)?;
 
@@ -852,9 +829,10 @@ mod node_implementation {
 			is_descendent_of: &F,
 			predicate: &P,
 		) -> Result<FindOutcome<&mut Node<H, N, V>>, Error<E>>
-			where E: std::error::Error,
-				  F: Fn(&H, &H) -> Result<bool, E>,
-				  P: Fn(&V) -> bool,
+		where
+			E: std::error::Error,
+			F: Fn(&H, &H) -> Result<bool, E>,
+			P: Fn(&V) -> bool,
 		{
 			let outcome = self.find_node_index_where(hash, number, is_descendent_of, predicate)?;
 
@@ -875,7 +853,7 @@ mod node_implementation {
 }
 
 // Workaround for: https://github.com/rust-lang/rust/issues/34537
-use node_implementation::{Node, FindOutcome};
+use node_implementation::{FindOutcome, Node};
 
 struct ForkTreeIterator<'a, H, N, V> {
 	stack: Vec<&'a Node<H, N, V>>,
@@ -917,7 +895,7 @@ impl<H, N, V> Iterator for RemovedIterator<H, N, V> {
 
 #[cfg(test)]
 mod test {
-	use super::{FinalizationResult, ForkTree, Error};
+	use super::{Error, FinalizationResult, ForkTree};
 
 	#[derive(Debug, PartialEq)]
 	struct TestError;
@@ -930,10 +908,10 @@ mod test {
 
 	impl std::error::Error for TestError {}
 
-	fn test_fork_tree<'a>() -> (ForkTree<&'a str, u64, ()>, impl Fn(&&str, &&str) -> Result<bool, TestError>)  {
+	fn test_fork_tree<'a>(
+	) -> (ForkTree<&'a str, u64, ()>, impl Fn(&&str, &&str) -> Result<bool, TestError>) {
 		let mut tree = ForkTree::new();
 
-		//
 		//     - B - C - D - E
 		//    /
 		//   /   - G
@@ -959,7 +937,8 @@ mod test {
 				("C", b) => Ok(b == "D" || b == "E"),
 				("D", b) => Ok(b == "E"),
 				("E", _) => Ok(false),
-				("F", b) => Ok(b == "G" || b == "H" || b == "I" || b == "L" || b == "M" || b == "O"),
+				("F", b) =>
+					Ok(b == "G" || b == "H" || b == "I" || b == "L" || b == "M" || b == "O"),
 				("G", _) => Ok(false),
 				("H", b) => Ok(b == "I" || b == "L" || b == "M" || b == "O"),
 				("I", _) => Ok(false),
@@ -1001,40 +980,22 @@ mod test {
 
 		tree.finalize_root(&"A");
 
-		assert_eq!(
-			tree.best_finalized_number,
-			Some(1),
-		);
+		assert_eq!(tree.best_finalized_number, Some(1),);
 
-		assert_eq!(
-			tree.import("A", 1, (), &is_descendent_of),
-			Err(Error::Revert),
-		);
+		assert_eq!(tree.import("A", 1, (), &is_descendent_of), Err(Error::Revert),);
 	}
 
 	#[test]
 	fn import_doesnt_add_duplicates() {
 		let (mut tree, is_descendent_of) = test_fork_tree();
 
-		assert_eq!(
-			tree.import("A", 1, (), &is_descendent_of),
-			Err(Error::Duplicate),
-		);
+		assert_eq!(tree.import("A", 1, (), &is_descendent_of), Err(Error::Duplicate),);
 
-		assert_eq!(
-			tree.import("I", 4, (), &is_descendent_of),
-			Err(Error::Duplicate),
-		);
+		assert_eq!(tree.import("I", 4, (), &is_descendent_of), Err(Error::Duplicate),);
 
-		assert_eq!(
-			tree.import("G", 3, (), &is_descendent_of),
-			Err(Error::Duplicate),
-		);
+		assert_eq!(tree.import("G", 3, (), &is_descendent_of), Err(Error::Duplicate),);
 
-		assert_eq!(
-			tree.import("K", 3, (), &is_descendent_of),
-			Err(Error::Duplicate),
-		);
+		assert_eq!(tree.import("K", 3, (), &is_descendent_of), Err(Error::Duplicate),);
 	}
 
 	#[test]
@@ -1096,10 +1057,7 @@ mod test {
 		let original_roots = tree.roots.clone();
 
 		// finalizing a block prior to any in the node doesn't change the tree
-		assert_eq!(
-			tree.finalize(&"0", 0, &is_descendent_of),
-			Ok(FinalizationResult::Unchanged),
-		);
+		assert_eq!(tree.finalize(&"0", 0, &is_descendent_of), Ok(FinalizationResult::Unchanged),);
 
 		assert_eq!(tree.roots, original_roots);
 
@@ -1115,21 +1073,12 @@ mod test {
 		);
 
 		// finalizing anything lower than what we observed will fail
-		assert_eq!(
-			tree.best_finalized_number,
-			Some(1),
-		);
+		assert_eq!(tree.best_finalized_number, Some(1),);
 
-		assert_eq!(
-			tree.finalize(&"Z", 1, &is_descendent_of),
-			Err(Error::Revert),
-		);
+		assert_eq!(tree.finalize(&"Z", 1, &is_descendent_of), Err(Error::Revert),);
 
 		// trying to finalize a node without finalizing its ancestors first will fail
-		assert_eq!(
-			tree.finalize(&"H", 3, &is_descendent_of),
-			Err(Error::UnfinalizedAncestor),
-		);
+		assert_eq!(tree.finalize(&"H", 3, &is_descendent_of), Err(Error::UnfinalizedAncestor),);
 
 		// after finalizing "F" we can finalize "H"
 		assert_eq!(
@@ -1195,10 +1144,7 @@ mod test {
 			vec![("L", 4), ("I", 4)],
 		);
 
-		assert_eq!(
-			tree.best_finalized_number,
-			Some(3),
-		);
+		assert_eq!(tree.best_finalized_number, Some(3),);
 
 		// finalizing N (which is not a part of the tree):
 		// 1) removes roots that are not ancestors/descendants of N (I)
@@ -1215,23 +1161,20 @@ mod test {
 			vec![],
 		);
 
-		assert_eq!(
-			tree.best_finalized_number,
-			Some(6),
-		);
+		assert_eq!(tree.best_finalized_number, Some(6),);
 	}
 
 	#[test]
 	fn finalize_with_descendent_works() {
 		#[derive(Debug, PartialEq)]
-		struct Change { effective: u64 }
+		struct Change {
+			effective: u64,
+		}
 
 		let (mut tree, is_descendent_of) = {
 			let mut tree = ForkTree::new();
 
 			let is_descendent_of = |base: &&str, block: &&str| -> Result<bool, TestError> {
-
-				//
 				// A0 #1 - (B #2) - (C #5) - D #10 - E #15 - (F #100)
 				//                            \
 				//                             - (G #100)
@@ -1270,24 +1213,15 @@ mod test {
 		// finalizing "D" will finalize a block from the tree, but it can't be applied yet
 		// since it is not a root change
 		assert_eq!(
-			tree.finalizes_any_with_descendent_if(
-				&"D",
-				10,
-				&is_descendent_of,
-				|c| c.effective == 10,
-			),
+			tree.finalizes_any_with_descendent_if(&"D", 10, &is_descendent_of, |c| c.effective ==
+				10,),
 			Ok(Some(false)),
 		);
 
 		// finalizing "B" doesn't finalize "A0" since the predicate doesn't pass,
 		// although it will clear out "A1" from the tree
 		assert_eq!(
-			tree.finalize_with_descendent_if(
-				&"B",
-				2,
-				&is_descendent_of,
-				|c| c.effective <= 2,
-			),
+			tree.finalize_with_descendent_if(&"B", 2, &is_descendent_of, |c| c.effective <= 2,),
 			Ok(FinalizationResult::Changed(None)),
 		);
 
@@ -1308,12 +1242,7 @@ mod test {
 		);
 
 		assert_eq!(
-			tree.finalize_with_descendent_if(
-				&"C",
-				5,
-				&is_descendent_of,
-				|c| c.effective <= 5,
-			),
+			tree.finalize_with_descendent_if(&"C", 5, &is_descendent_of, |c| c.effective <= 5,),
 			Ok(FinalizationResult::Changed(Some(Change { effective: 5 }))),
 		);
 
@@ -1324,33 +1253,20 @@ mod test {
 
 		// finalizing "F" will fail since it would finalize past "E" without finalizing "D" first
 		assert_eq!(
-			tree.finalizes_any_with_descendent_if(
-				&"F",
-				100,
-				&is_descendent_of,
-				|c| c.effective <= 100,
-			),
+			tree.finalizes_any_with_descendent_if(&"F", 100, &is_descendent_of, |c| c.effective <=
+				100,),
 			Err(Error::UnfinalizedAncestor),
 		);
 
 		// it will work with "G" though since it is not in the same branch as "E"
 		assert_eq!(
-			tree.finalizes_any_with_descendent_if(
-				&"G",
-				100,
-				&is_descendent_of,
-				|c| c.effective <= 100,
-			),
+			tree.finalizes_any_with_descendent_if(&"G", 100, &is_descendent_of, |c| c.effective <=
+				100,),
 			Ok(Some(true)),
 		);
 
 		assert_eq!(
-			tree.finalize_with_descendent_if(
-				&"G",
-				100,
-				&is_descendent_of,
-				|c| c.effective <= 100,
-			),
+			tree.finalize_with_descendent_if(&"G", 100, &is_descendent_of, |c| c.effective <= 100,),
 			Ok(FinalizationResult::Changed(Some(Change { effective: 10 }))),
 		);
 
@@ -1365,12 +1281,19 @@ mod test {
 			tree.iter().map(|(h, n, _)| (h.clone(), n.clone())).collect::<Vec<_>>(),
 			vec![
 				("A", 1),
-				("B", 2), ("C", 3), ("D", 4), ("E", 5),
-				("F", 2), ("H", 3), ("L", 4), ("M", 5),
+				("B", 2),
+				("C", 3),
+				("D", 4),
+				("E", 5),
+				("F", 2),
+				("H", 3),
+				("L", 4),
+				("M", 5),
 				("O", 5),
 				("I", 4),
 				("G", 3),
-				("J", 2), ("K", 3),
+				("J", 2),
+				("K", 3),
 			],
 		);
 	}
@@ -1400,19 +1323,11 @@ mod test {
 			// "L" is a descendent of "K", but the predicate will only pass for "K",
 			// therefore only one call to `is_descendent_of` should be made
 			assert_eq!(
-				tree.finalizes_any_with_descendent_if(
-					&"L",
-					11,
-					&is_descendent_of,
-					|i| *i == 10,
-				),
+				tree.finalizes_any_with_descendent_if(&"L", 11, &is_descendent_of, |i| *i == 10,),
 				Ok(Some(false)),
 			);
 
-			assert_eq!(
-				n_is_descendent_of_calls.load(Ordering::SeqCst),
-				1,
-			);
+			assert_eq!(n_is_descendent_of_calls.load(Ordering::SeqCst), 1,);
 		}
 
 		n_is_descendent_of_calls.store(0, Ordering::SeqCst);
@@ -1431,19 +1346,11 @@ mod test {
 			// "L" is a descendent of "K", but the predicate will only pass for "K",
 			// therefore only one call to `is_descendent_of` should be made
 			assert_eq!(
-				tree.finalize_with_descendent_if(
-					&"L",
-					11,
-					&is_descendent_of,
-					|i| *i == 10,
-				),
+				tree.finalize_with_descendent_if(&"L", 11, &is_descendent_of, |i| *i == 10,),
 				Ok(FinalizationResult::Changed(Some(10))),
 			);
 
-			assert_eq!(
-				n_is_descendent_of_calls.load(Ordering::SeqCst),
-				1,
-			);
+			assert_eq!(n_is_descendent_of_calls.load(Ordering::SeqCst), 1,);
 		}
 	}
 
@@ -1451,12 +1358,7 @@ mod test {
 	fn find_node_works() {
 		let (tree, is_descendent_of) = test_fork_tree();
 
-		let node = tree.find_node_where(
-			&"D",
-			&4,
-			&is_descendent_of,
-			&|_| true,
-		).unwrap().unwrap();
+		let node = tree.find_node_where(&"D", &4, &is_descendent_of, &|_| true).unwrap().unwrap();
 
 		assert_eq!(node.hash, "C");
 		assert_eq!(node.number, 3);
@@ -1473,17 +1375,9 @@ mod test {
 	fn prune_works() {
 		let (mut tree, is_descendent_of) = test_fork_tree();
 
-		let removed = tree.prune(
-			&"C",
-			&3,
-			&is_descendent_of,
-			&|_| true,
-		).unwrap();
+		let removed = tree.prune(&"C", &3, &is_descendent_of, &|_| true).unwrap();
 
-		assert_eq!(
-			tree.roots.iter().map(|node| node.hash).collect::<Vec<_>>(),
-			vec!["B"],
-		);
+		assert_eq!(tree.roots.iter().map(|node| node.hash).collect::<Vec<_>>(), vec!["B"],);
 
 		assert_eq!(
 			tree.iter().map(|(hash, _, _)| *hash).collect::<Vec<_>>(),
@@ -1495,34 +1389,19 @@ mod test {
 			vec!["A", "F", "H", "L", "M", "O", "I", "G", "J", "K"]
 		);
 
-		let removed = tree.prune(
-			&"E",
-			&5,
-			&is_descendent_of,
-			&|_| true,
-		).unwrap();
+		let removed = tree.prune(&"E", &5, &is_descendent_of, &|_| true).unwrap();
 
-		assert_eq!(
-			tree.roots.iter().map(|node| node.hash).collect::<Vec<_>>(),
-			vec!["D"],
-		);
+		assert_eq!(tree.roots.iter().map(|node| node.hash).collect::<Vec<_>>(), vec!["D"],);
 
-		assert_eq!(
-			tree.iter().map(|(hash, _, _)| *hash).collect::<Vec<_>>(),
-			vec!["D", "E"],
-		);
+		assert_eq!(tree.iter().map(|(hash, _, _)| *hash).collect::<Vec<_>>(), vec!["D", "E"],);
 
-		assert_eq!(
-			removed.map(|(hash, _, _)| hash).collect::<Vec<_>>(),
-			vec!["B", "C"]
-		);
+		assert_eq!(removed.map(|(hash, _, _)| hash).collect::<Vec<_>>(), vec!["B", "C"]);
 	}
 
 	#[test]
 	fn find_node_backtracks_after_finding_highest_descending_node() {
 		let mut tree = ForkTree::new();
 
-		//
 		// A - B
 		//  \
 		//   — C
@@ -1543,12 +1422,7 @@ mod test {
 		// when searching the tree we reach node `C`, but the
 		// predicate doesn't pass. we should backtrack to `B`, but not to `A`,
 		// since "B" fulfills the predicate.
-		let node = tree.find_node_where(
-			&"D",
-			&3,
-			&is_descendent_of,
-			&|data| *data < 3,
-		).unwrap();
+		let node = tree.find_node_where(&"D", &3, &is_descendent_of, &|data| *data < 3).unwrap();
 
 		assert_eq!(node.unwrap().hash, "B");
 	}

--- a/utils/prometheus/src/lib.rs
+++ b/utils/prometheus/src/lib.rs
@@ -15,33 +15,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures_util::{FutureExt, future::Future};
+use futures_util::{future::Future, FutureExt};
 pub use prometheus::{
 	self,
-	Registry, Error as PrometheusError, Opts,
-	Histogram, HistogramOpts, HistogramVec,
-	exponential_buckets,
 	core::{
-		GenericGauge as Gauge, GenericCounter as Counter,
-		GenericGaugeVec as GaugeVec, GenericCounterVec as CounterVec,
-		AtomicF64 as F64, AtomicI64 as I64, AtomicU64 as U64,
-	}
+		AtomicF64 as F64, AtomicI64 as I64, AtomicU64 as U64, GenericCounter as Counter,
+		GenericCounterVec as CounterVec, GenericGauge as Gauge, GenericGaugeVec as GaugeVec,
+	},
+	exponential_buckets, Error as PrometheusError, Histogram, HistogramOpts, HistogramVec, Opts,
+	Registry,
 };
-use prometheus::{Encoder, TextEncoder, core::Collector};
+use prometheus::{core::Collector, Encoder, TextEncoder};
 use std::net::SocketAddr;
 
 #[cfg(not(target_os = "unknown"))]
 mod networking;
 mod sourced;
 
-pub use sourced::{SourcedCounter, SourcedGauge, MetricSource, SourcedMetric};
+pub use sourced::{MetricSource, SourcedCounter, SourcedGauge, SourcedMetric};
 
-#[cfg(target_os = "unknown")]
-pub use unknown_os::init_prometheus;
 #[cfg(not(target_os = "unknown"))]
 pub use known_os::init_prometheus;
+#[cfg(target_os = "unknown")]
+pub use unknown_os::init_prometheus;
 
-pub fn register<T: Clone + Collector + 'static>(metric: T, registry: &Registry) -> Result<T, PrometheusError> {
+pub fn register<T: Clone + Collector + 'static>(
+	metric: T,
+	registry: &Registry,
+) -> Result<T, PrometheusError> {
 	registry.register(Box::new(metric.clone()))?;
 	Ok(metric)
 }
@@ -61,8 +62,11 @@ mod unknown_os {
 #[cfg(not(target_os = "unknown"))]
 mod known_os {
 	use super::*;
-	use hyper::http::StatusCode;
-	use hyper::{Server, Body, Request, Response, service::{service_fn, make_service_fn}};
+	use hyper::{
+		http::StatusCode,
+		service::{make_service_fn, service_fn},
+		Body, Request, Response, Server,
+	};
 
 	#[derive(Debug, derive_more::Display, derive_more::From)]
 	pub enum Error {
@@ -73,7 +77,7 @@ mod known_os {
 		/// i/o error.
 		Io(std::io::Error),
 		#[display(fmt = "Prometheus port {} already in use.", _0)]
-		PortInUse(SocketAddr)
+		PortInUse(SocketAddr),
 	}
 
 	impl std::error::Error for Error {
@@ -82,28 +86,32 @@ mod known_os {
 				Error::Hyper(error) => Some(error),
 				Error::Http(error) => Some(error),
 				Error::Io(error) => Some(error),
-				Error::PortInUse(_) => None
+				Error::PortInUse(_) => None,
 			}
 		}
 	}
 
-	async fn request_metrics(req: Request<Body>, registry: Registry) -> Result<Response<Body>, Error> {
+	async fn request_metrics(
+		req: Request<Body>,
+		registry: Registry,
+	) -> Result<Response<Body>, Error> {
 		if req.uri().path() == "/metrics" {
 			let metric_families = registry.gather();
 			let mut buffer = vec![];
 			let encoder = TextEncoder::new();
 			encoder.encode(&metric_families, &mut buffer).unwrap();
 
-			Response::builder().status(StatusCode::OK)
+			Response::builder()
+				.status(StatusCode::OK)
 				.header("Content-Type", encoder.format_type())
 				.body(Body::from(buffer))
 				.map_err(Error::Http)
 		} else {
-			Response::builder().status(StatusCode::NOT_FOUND)
+			Response::builder()
+				.status(StatusCode::NOT_FOUND)
 				.body(Body::from("Not found."))
 				.map_err(Error::Http)
 		}
-
 	}
 
 	#[derive(Clone)]
@@ -121,7 +129,10 @@ mod known_os {
 
 	/// Initializes the metrics context, and starts an HTTP server
 	/// to serve metrics.
-	pub async fn init_prometheus(prometheus_addr: SocketAddr, registry: Registry) -> Result<(), Error>{
+	pub async fn init_prometheus(
+		prometheus_addr: SocketAddr,
+		registry: Registry,
+	) -> Result<(), Error> {
 		use networking::Incoming;
 		let listener = async_std::net::TcpListener::bind(&prometheus_addr)
 			.await

--- a/utils/prometheus/src/networking.rs
+++ b/utils/prometheus/src/networking.rs
@@ -16,8 +16,11 @@
 // limitations under the License.
 
 use async_std::pin::Pin;
-use std::task::{Poll, Context};
-use futures_util::{stream::Stream, io::{AsyncRead, AsyncWrite}};
+use futures_util::{
+	io::{AsyncRead, AsyncWrite},
+	stream::Stream,
+};
+use std::task::{Context, Poll};
 
 pub struct Incoming<'a>(pub async_std::net::Incoming<'a>);
 
@@ -25,7 +28,10 @@ impl hyper::server::accept::Accept for Incoming<'_> {
 	type Conn = TcpStream;
 	type Error = async_std::io::Error;
 
-	fn poll_accept(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
+	fn poll_accept(
+		self: Pin<&mut Self>,
+		cx: &mut Context,
+	) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
 		Pin::new(&mut Pin::into_inner(self).0)
 			.poll_next(cx)
 			.map(|opt| opt.map(|res| res.map(TcpStream)))
@@ -38,10 +44,9 @@ impl tokio::io::AsyncRead for TcpStream {
 	fn poll_read(
 		self: Pin<&mut Self>,
 		cx: &mut Context,
-		buf: &mut [u8]
+		buf: &mut [u8],
 	) -> Poll<Result<usize, std::io::Error>> {
-		Pin::new(&mut Pin::into_inner(self).0)
-			.poll_read(cx, buf)
+		Pin::new(&mut Pin::into_inner(self).0).poll_read(cx, buf)
 	}
 }
 
@@ -49,19 +54,16 @@ impl tokio::io::AsyncWrite for TcpStream {
 	fn poll_write(
 		self: Pin<&mut Self>,
 		cx: &mut Context,
-		buf: &[u8]
+		buf: &[u8],
 	) -> Poll<Result<usize, std::io::Error>> {
-		Pin::new(&mut Pin::into_inner(self).0)
-			.poll_write(cx, buf)
+		Pin::new(&mut Pin::into_inner(self).0).poll_write(cx, buf)
 	}
 
 	fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), std::io::Error>> {
-		Pin::new(&mut Pin::into_inner(self).0)
-			.poll_flush(cx)
+		Pin::new(&mut Pin::into_inner(self).0).poll_flush(cx)
 	}
 
 	fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), std::io::Error>> {
-		Pin::new(&mut Pin::into_inner(self).0)
-			.poll_close(cx)
+		Pin::new(&mut Pin::into_inner(self).0).poll_close(cx)
 	}
 }

--- a/utils/prometheus/src/sourced.rs
+++ b/utils/prometheus/src/sourced.rs
@@ -17,8 +17,10 @@
 
 //! Metrics that are collected from existing sources.
 
-use prometheus::core::{Collector, Desc, Describer, Number, Opts};
-use prometheus::proto;
+use prometheus::{
+	core::{Collector, Desc, Describer, Number, Opts},
+	proto,
+};
 use std::{cmp::Ordering, marker::PhantomData};
 
 /// A counter whose values are obtained from an existing source.
@@ -80,15 +82,15 @@ impl<T: SourcedType, S: MetricSource> Collector for SourcedMetric<T, S> {
 					let mut c = proto::Counter::default();
 					c.set_value(value.into_f64());
 					m.set_counter(c);
-				}
+				},
 				proto::MetricType::GAUGE => {
 					let mut g = proto::Gauge::default();
 					g.set_value(value.into_f64());
 					m.set_gauge(g);
-				}
+				},
 				t => {
 					log::error!("Unsupported sourced metric type: {:?}", t);
-				}
+				},
 			}
 
 			debug_assert_eq!(self.desc.variable_labels.len(), label_values.len());
@@ -97,18 +99,23 @@ impl<T: SourcedType, S: MetricSource> Collector for SourcedMetric<T, S> {
 					log::warn!("Missing label values for sourced metric {}", self.desc.fq_name),
 				Ordering::Less =>
 					log::warn!("Too many label values for sourced metric {}", self.desc.fq_name),
-				Ordering::Equal => {}
+				Ordering::Equal => {},
 			}
 
-			m.set_label(self.desc.variable_labels.iter().zip(label_values)
-				.map(|(l_name, l_value)| {
-					let mut l = proto::LabelPair::default();
-					l.set_name(l_name.to_string());
-					l.set_value(l_value.to_string());
-					l
-				})
-				.chain(self.desc.const_label_pairs.iter().cloned())
-				.collect::<Vec<_>>());
+			m.set_label(
+				self.desc
+					.variable_labels
+					.iter()
+					.zip(label_values)
+					.map(|(l_name, l_value)| {
+						let mut l = proto::LabelPair::default();
+						l.set_name(l_name.to_string());
+						l.set_value(l_value.to_string());
+						l
+					})
+					.chain(self.desc.const_label_pairs.iter().cloned())
+					.collect::<Vec<_>>(),
+			);
 
 			counters.push(m);
 		});
@@ -130,11 +137,15 @@ pub trait SourcedType: private::Sealed + Sync + Send {
 }
 
 impl SourcedType for Counter {
-	fn proto() -> proto::MetricType { proto::MetricType::COUNTER }
+	fn proto() -> proto::MetricType {
+		proto::MetricType::COUNTER
+	}
 }
 
 impl SourcedType for Gauge {
-	fn proto() -> proto::MetricType { proto::MetricType::GAUGE }
+	fn proto() -> proto::MetricType {
+		proto::MetricType::GAUGE
+	}
 }
 
 mod private {


### PR DESCRIPTION
After https://github.com/paritytech/substrate/pull/8982, we can start running `cargo fmt` on the source code. In order to be less disruptive to PRs that are currently underway, I figured that we could start with source files that aren't updated very frequently (or at least, ones that were last updated more than 14 days ago).

This PR contains no logic changes and is just the result of me running `cargo +nightly fmt`.