### PR TITLE
Remove `IncRefError`, `DecRefError` and `StoredMapError`

### DIFF
--- a/frame/assets/src/impl_stored_map.rs
+++ b/frame/assets/src/impl_stored_map.rs
@@ -29,7 +29,7 @@ impl<T: Config<I>, I: 'static> StoredMap<(T::AssetId, T::AccountId), T::Extra> f
 		}
 	}
 
-	fn try_mutate_exists<R, E: From<StoredMapError>>(
+	fn try_mutate_exists<R, E: From<DispatchError>>(
 		id_who: &(T::AssetId, T::AccountId),
 		f: impl FnOnce(&mut Option<T::Extra>) -> Result<R, E>,
 	) -> Result<R, E> {
@@ -46,11 +46,11 @@ impl<T: Config<I>, I: 'static> StoredMap<(T::AssetId, T::AccountId), T::Extra> f
 				if let Some(ref mut account) = maybe_account {
 					account.extra = extra;
 				} else {
-					Err(StoredMapError::NoProviders)?;
+					Err(DispatchError::NoProviders)?;
 				}
 			} else {
 				// They want to delete it. Let this pass if the item never existed anyway.
-				ensure!(maybe_account.is_none(), StoredMapError::ConsumerRemaining);
+				ensure!(maybe_account.is_none(), DispatchError::ConsumerRemaining);
 			}
 			Ok(r)
 		})

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -141,10 +141,7 @@ pub use types::*;
 use sp_std::{prelude::*, borrow::Borrow, convert::TryInto};
 use sp_runtime::{
 	TokenError, ArithmeticError,
-	traits::{
-		AtLeast32BitUnsigned, Zero, StaticLookup, Saturating, CheckedSub, CheckedAdd, Bounded,
-		StoredMapError,
-	}
+	traits::{AtLeast32BitUnsigned, Zero, StaticLookup, Saturating, CheckedSub, CheckedAdd, Bounded}
 };
 use codec::HasCompact;
 use frame_support::{ensure, dispatch::{DispatchError, DispatchResult}};

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -175,7 +175,7 @@ use sp_runtime::{
 	RuntimeDebug, DispatchResult, DispatchError, ArithmeticError,
 	traits::{
 		Zero, AtLeast32BitUnsigned, StaticLookup, CheckedAdd, CheckedSub,
-		MaybeSerializeDeserialize, Saturating, Bounded, StoredMapError,
+		MaybeSerializeDeserialize, Saturating, Bounded,
 	},
 };
 use frame_system as system;
@@ -830,8 +830,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	pub fn mutate_account<R>(
 		who: &T::AccountId,
 		f: impl FnOnce(&mut AccountData<T::Balance>) -> R,
-	) -> Result<R, StoredMapError> {
-		Self::try_mutate_account(who, |a, _| -> Result<R, StoredMapError> { Ok(f(a)) })
+	) -> Result<R, DispatchError> {
+		Self::try_mutate_account(who, |a, _| -> Result<R, DispatchError> { Ok(f(a)) })
 	}
 
 	/// Mutate an account to some new value, or delete it entirely with `None`. Will enforce
@@ -843,7 +843,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// NOTE: LOW-LEVEL: This will not attempt to maintain total issuance. It is expected that
 	/// the caller will do this.
-	fn try_mutate_account<R, E: From<StoredMapError>>(
+	fn try_mutate_account<R, E: From<DispatchError>>(
 		who: &T::AccountId,
 		f: impl FnOnce(&mut AccountData<T::Balance>, bool) -> Result<R, E>,
 	) -> Result<R, E> {
@@ -867,7 +867,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// NOTE: LOW-LEVEL: This will not attempt to maintain total issuance. It is expected that
 	/// the caller will do this.
-	fn try_mutate_account_with_dust<R, E: From<StoredMapError>>(
+	fn try_mutate_account_with_dust<R, E: From<DispatchError>>(
 		who: &T::AccountId,
 		f: impl FnOnce(&mut AccountData<T::Balance>, bool) -> Result<R, E>,
 	) -> Result<(R, DustCleaner<T, I>), E> {
@@ -1449,7 +1449,7 @@ impl<T: Config<I>, I: 'static> Currency<T::AccountId> for Pallet<T, I> where
 
 		for attempt in 0..2 {
 			match Self::try_mutate_account(who,
-				|account, _is_new| -> Result<(Self::NegativeImbalance, Self::Balance), StoredMapError> {
+				|account, _is_new| -> Result<(Self::NegativeImbalance, Self::Balance), DispatchError> {
 					// Best value is the most amount we can slash following liveness rules.
 					let best_value = match attempt {
 						// First attempt we try to slash the full amount, and see if liveness issues happen.

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -17,7 +17,7 @@
 
 //! Smaller traits used in FRAME which don't need their own file.
 
-use sp_runtime::traits::{StoredMapError, Block as BlockT};
+use sp_runtime::{traits::Block as BlockT, DispatchError};
 use sp_arithmetic::traits::AtLeast32Bit;
 use crate::dispatch::Parameter;
 
@@ -157,10 +157,10 @@ pub trait OnKilledAccount<AccountId> {
 /// A simple, generic one-parameter event notifier/handler.
 pub trait HandleLifetime<T> {
 	/// An account was created.
-	fn created(_t: &T) -> Result<(), StoredMapError> { Ok(()) }
+	fn created(_t: &T) -> Result<(), DispatchError> { Ok(()) }
 
 	/// An account was killed.
-	fn killed(_t: &T) -> Result<(), StoredMapError> { Ok(()) }
+	fn killed(_t: &T) -> Result<(), DispatchError> { Ok(()) }
 }
 
 impl<T> HandleLifetime<T> for () {}

--- a/frame/system/src/tests.rs
+++ b/frame/system/src/tests.rs
@@ -121,18 +121,18 @@ fn sufficient_cannot_support_consumer() {
 		assert_eq!(System::inc_sufficients(&0), IncRefStatus::Created);
 		System::inc_account_nonce(&0);
 		assert_eq!(System::account_nonce(&0), 1);
-		assert_noop!(System::inc_consumers(&0), IncRefError::NoProviders);
+		assert_noop!(System::inc_consumers(&0), DispatchError::NoProviders);
 
 		assert_eq!(System::inc_providers(&0), IncRefStatus::Existed);
 		assert_ok!(System::inc_consumers(&0));
-		assert_noop!(System::dec_providers(&0), DecRefError::ConsumerRemaining);
+		assert_noop!(System::dec_providers(&0), DispatchError::ConsumerRemaining);
 	});
 }
 
 #[test]
 fn provider_required_to_support_consumer() {
 	new_test_ext().execute_with(|| {
-		assert_noop!(System::inc_consumers(&0), IncRefError::NoProviders);
+		assert_noop!(System::inc_consumers(&0), DispatchError::NoProviders);
 
 		assert_eq!(System::inc_providers(&0), IncRefStatus::Created);
 		System::inc_account_nonce(&0);
@@ -143,7 +143,7 @@ fn provider_required_to_support_consumer() {
 		assert_eq!(System::account_nonce(&0), 1);
 
 		assert_ok!(System::inc_consumers(&0));
-		assert_noop!(System::dec_providers(&0), DecRefError::ConsumerRemaining);
+		assert_noop!(System::dec_providers(&0), DispatchError::ConsumerRemaining);
 
 		System::dec_consumers(&0);
 		assert_eq!(System::dec_providers(&0).unwrap(), DecRefStatus::Reaped);

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -516,15 +516,6 @@ impl From<crate::traits::BadOrigin> for DispatchError {
 	}
 }
 
-impl From<crate::traits::StoredMapError> for DispatchError {
-	fn from(e: crate::traits::StoredMapError) -> Self {
-		match e {
-			crate::traits::StoredMapError::ConsumerRemaining => Self::ConsumerRemaining,
-			crate::traits::StoredMapError::NoProviders => Self::NoProviders,
-		}
-	}
-}
-
 /// Description of what went wrong when trying to complete an operation on a token.
 #[derive(Eq, PartialEq, Clone, Copy, Encode, Decode, Debug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -152,25 +152,6 @@ impl From<BadOrigin> for &'static str {
 	}
 }
 
-/// Error that can be returned by our impl of `StoredMap`.
-#[derive(Encode, Decode, RuntimeDebug)]
-pub enum StoredMapError {
-	/// Attempt to create map value when it is a consumer and there are no providers in place.
-	NoProviders,
-	/// Attempt to anull/remove value when it is the last provider and there is still at
-	/// least one consumer left.
-	ConsumerRemaining,
-}
-
-impl From<StoredMapError> for &'static str {
-	fn from(e: StoredMapError) -> &'static str {
-		match e {
-			StoredMapError::NoProviders => "No providers",
-			StoredMapError::ConsumerRemaining => "Consumer remaining",
-		}
-	}
-}
-
 /// An error that indicates that a lookup failed.
 #[derive(Encode, Decode, RuntimeDebug)]
 pub struct LookupError;


### PR DESCRIPTION
All of them are a subset of `DispatchError` anyway, no need to have
special errors IMHO.

Fixes: https://github.com/paritytech/substrate/issues/8709