### PR TITLE
`unset` all defaults in .editorconfig for `*.rs`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,16 @@ trim_trailing_whitespace=true
 max_line_length=100
 insert_final_newline=true
 
+[*.rs]
+indent_style=unset
+indent_size=unset
+tab_width=unset
+end_of_line=unset
+charset=unset
+trim_trailing_whitespace=unset
+max_line_length=unset
+insert_final_newline=unset
+
 [*.md]
 max_line_length=80
 indent_style=space

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ trim_trailing_whitespace=true
 max_line_length=100
 insert_final_newline=true
 
+# rust files ignored, instead use `rustfmt.toml` with `cargo +nightly fmt` 
 [*.rs]
 indent_style=unset
 indent_size=unset


### PR DESCRIPTION
Opts to use `rustfmt.toml` behavior for rust files by ignoring in .editorconfig based on #8982 

https://editorconfig.org/#supported-properties
[Node.js canonical usage example](https://github.com/nodejs/node/pull/28440/files)