### PR TITLE
`kill_stash` should check unclaimed rewards

### DIFF
--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -77,7 +77,7 @@ fn kill_stash_works() {
 }
 
 #[test]
-fn kill_stash_spots_unclaimed_payouts() {
+fn kill_stash_detects_unclaimed_payouts() {
 	ExtBuilder::default().has_stakers(false).build_and_execute(|| {
 		let balance = 1000;
 		// Create a validator:

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -77,6 +77,26 @@ fn kill_stash_works() {
 }
 
 #[test]
+fn kill_stash_spots_unclaimed_payouts() {
+	ExtBuilder::default().has_stakers(false).build_and_execute(|| {
+		let balance = 1000;
+		// Create a validator:
+		bond_validator(11, 10, balance); // Default(64)
+
+		mock::start_active_era(1);
+		Staking::reward_by_ids(vec![(11, 1)]);
+
+		// compute and ensure the reward amount is greater than zero.
+		let _ = current_total_payout_for_duration(reward_time_per_era());
+
+		mock::start_active_era(2);
+
+		assert_noop!(Staking::kill_stash(&11, 0), Error::<Test>::UnclaimedRewards);
+		assert_ok!(Staking::payout_stakers(Origin::signed(1337), 11, 1));
+	});
+}
+
+#[test]
 fn basic_setup_works() {
 	// Verifies initial conditions of mock
 	ExtBuilder::default().build_and_execute(|| {


### PR DESCRIPTION
In the current implementation, executing `kill_stash` deletes all associated data of the stash account, even if unclaimed rewards are available. Therefore, if a validator decides to unbond their funds and the `BondingDuration` has been reached (currently 28 Eras), the execution of `withdraw_unbonded` can kill all associated data about the validator on specific conditions (`ledger.unlocking.is_empty() && ledger.active < T::Currency::minimum_balance()`). Any attempts to claim rewards results in a dispatch error since the runtime code cannot find the corresponding controller:

```rust
let controller = Self::bonded(&validator_stash).ok_or(
	Error::<T>::NotStash.with_weight(T::WeightInfo::payout_stakers_alive_staked(0))
)?;
```

This is demonstrated by the following test:

```rust
#[test]
fn kill_stash_prevents_payouts() {
	ExtBuilder::default().has_stakers(false).build_and_execute(|| {
		let balance = 1000;
		// Create a validator:
		bond_validator(11, 10, balance); // Default(64)

		mock::start_active_era(1);
		Staking::reward_by_ids(vec![(11, 1)]);

		// compute and ensure the reward amount is greater than zero.
		let _ = current_total_payout_for_duration(reward_time_per_era());

		mock::start_active_era(2);

		assert_ok!(Staking::kill_stash(&11, 0));
		assert_ok!(Staking::payout_stakers(Origin::signed(1337), 11, 1));  // <-- ERROR
	});
}
```

Which results in:

```
---- tests::kill_stash_prevents_payouts stdout ----
thread 'tests::kill_stash_prevents_payouts' panicked at 'Expected Ok(_). Got Err(
    DispatchErrorWithPostInfo {
        post_info: PostDispatchInfo {
            actual_weight: Some(
                731788000,
            ),
            pays_fee: Pays::Yes,
        },
        error: Module {
            index: 4,
            error: 1,
            message: Some(
                "NotStash",
            ),
        },
    },
)', frame/staking/src/tests.rs:95:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

One might argue that it's in the validators best interest not to do so. Regardless, nominators lose potential rewards.

## Proposal

This proposal adds a check to `kill_stash` which prevents the killing if any unclaimed Eras are detected. This proposal might be controversial since there's an increase of performance cost. Do note that the new logic first limits the Eras that must be checked as much as possible by taking advantage of the ledger. Then, it will check the storage for the first sign of an unclaimed Era and return an error immediatly.

## TODO

* Someone with more runtime experience than me should determine whether this is a good idea to begin with.
  * Performance cost?
  * Potential side-issues regarding backwards-compatibility?
* Additional weight should be added. One can consider adding extra weight for each Era that must be checked (`let to_check = ...`).
* More/better tests are probably required here, especially regarding point one.