### PR TITLE
RUSTSEC-2021-0076 bump libsecp256k1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,6 +2450,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array 0.14.4",
+ "hmac 0.8.1",
+]
+
+[[package]]
 name = "honggfuzz"
 version = "0.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3173,7 +3184,7 @@ dependencies = [
  "futures 0.3.16",
  "futures-timer 3.0.2",
  "lazy_static",
- "libsecp256k1",
+ "libsecp256k1 0.3.5",
  "log 0.4.14",
  "multihash",
  "multistream-select",
@@ -3575,11 +3586,59 @@ dependencies = [
  "arrayref",
  "crunchy",
  "digest 0.8.1",
- "hmac-drbg",
+ "hmac-drbg 0.2.0",
  "rand 0.7.3",
  "sha2 0.8.2",
  "subtle 2.4.0",
  "typenum",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
+dependencies = [
+ "arrayref",
+ "base64 0.12.3",
+ "digest 0.9.0",
+ "hmac-drbg 0.3.0",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.3",
+ "typenum",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle 2.4.0",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
+dependencies = [
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -7511,7 +7570,7 @@ version = "0.10.0-dev"
 dependencies = [
  "hex-literal",
  "lazy_static",
- "libsecp256k1",
+ "libsecp256k1 0.3.5",
  "log 0.4.14",
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -8856,7 +8915,7 @@ dependencies = [
  "hex-literal",
  "impl-serde",
  "lazy_static",
- "libsecp256k1",
+ "libsecp256k1 0.6.0",
  "log 0.4.14",
  "merlin",
  "num-traits",
@@ -8949,7 +9008,7 @@ version = "4.0.0-dev"
 dependencies = [
  "futures 0.3.16",
  "hash-db",
- "libsecp256k1",
+ "libsecp256k1 0.3.5",
  "log 0.4.14",
  "parity-scale-codec",
  "parking_lot 0.11.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,17 +2426,6 @@ dependencies = [
 
 [[package]]
 name = "hmac-drbg"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
-dependencies = [
- "digest 0.8.1",
- "generic-array 0.12.4",
- "hmac 0.7.1",
-]
-
-[[package]]
-name = "hmac-drbg"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
@@ -3119,26 +3108,6 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08053fbef67cd777049ef7a95ebaca2ece370b4ed7712c3fa404d69a88cb741b"
-dependencies = [
- "atomic",
- "bytes 1.0.1",
- "futures 0.3.16",
- "lazy_static",
- "libp2p-core 0.28.3",
- "libp2p-swarm 0.29.0",
- "libp2p-swarm-derive 0.23.0",
- "parity-multiaddr",
- "parking_lot 0.11.1",
- "pin-project 1.0.5",
- "smallvec 1.6.1",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p"
 version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9004c06878ef8f3b4b4067e69a140d87ed20bf777287f82223e49713b36ee433"
@@ -3147,7 +3116,7 @@ dependencies = [
  "bytes 1.0.1",
  "futures 0.3.16",
  "lazy_static",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "libp2p-deflate",
  "libp2p-dns",
  "libp2p-floodsub",
@@ -3162,8 +3131,8 @@ dependencies = [
  "libp2p-pnet",
  "libp2p-relay",
  "libp2p-request-response",
- "libp2p-swarm 0.30.0",
- "libp2p-swarm-derive 0.24.0",
+ "libp2p-swarm",
+ "libp2p-swarm-derive",
  "libp2p-tcp",
  "libp2p-uds",
  "libp2p-wasm-ext",
@@ -3174,40 +3143,6 @@ dependencies = [
  "pin-project 1.0.5",
  "smallvec 1.6.1",
  "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "554d3e7e9e65f939d66b75fd6a4c67f258fe250da61b91f46c545fc4a89b51d9"
-dependencies = [
- "asn1_der",
- "bs58",
- "ed25519-dalek",
- "either",
- "fnv",
- "futures 0.3.16",
- "futures-timer 3.0.2",
- "lazy_static",
- "libsecp256k1 0.3.5",
- "log 0.4.14",
- "multihash 0.13.2",
- "multistream-select",
- "parity-multiaddr",
- "parking_lot 0.11.1",
- "pin-project 1.0.5",
- "prost 0.7.0",
- "prost-build 0.7.0",
- "rand 0.7.3",
- "ring",
- "rw-stream-sink",
- "sha2 0.9.3",
- "smallvec 1.6.1",
- "thiserror",
- "unsigned-varint 0.7.0",
- "void",
- "zeroize",
 ]
 
 [[package]]
@@ -3252,7 +3187,7 @@ checksum = "66097fccc0b7f8579f90a03ea76ba6196332ea049fd07fd969490a06819dcdc8"
 dependencies = [
  "flate2",
  "futures 0.3.16",
- "libp2p-core 0.29.0",
+ "libp2p-core",
 ]
 
 [[package]]
@@ -3263,7 +3198,7 @@ checksum = "58ff08b3196b85a17f202d80589e93b1660a574af67275706657fdc762e42c32"
 dependencies = [
  "async-std-resolver",
  "futures 0.3.16",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log 0.4.14",
  "smallvec 1.6.1",
  "trust-dns-resolver",
@@ -3278,8 +3213,8 @@ dependencies = [
  "cuckoofilter",
  "fnv",
  "futures 0.3.16",
- "libp2p-core 0.29.0",
- "libp2p-swarm 0.30.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log 0.4.14",
  "prost 0.8.0",
  "prost-build 0.8.0",
@@ -3300,8 +3235,8 @@ dependencies = [
  "fnv",
  "futures 0.3.16",
  "hex_fmt",
- "libp2p-core 0.29.0",
- "libp2p-swarm 0.30.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log 0.4.14",
  "prost 0.8.0",
  "prost-build 0.8.0",
@@ -3320,8 +3255,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7b61f6cf07664fb97016c318c4d4512b3dd4cc07238607f3f0163245f99008e"
 dependencies = [
  "futures 0.3.16",
- "libp2p-core 0.29.0",
- "libp2p-swarm 0.30.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log 0.4.14",
  "prost 0.8.0",
  "prost-build 0.8.0",
@@ -3341,8 +3276,8 @@ dependencies = [
  "either",
  "fnv",
  "futures 0.3.16",
- "libp2p-core 0.29.0",
- "libp2p-swarm 0.30.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log 0.4.14",
  "prost 0.8.0",
  "prost-build 0.8.0",
@@ -3367,8 +3302,8 @@ dependencies = [
  "futures 0.3.16",
  "if-watch",
  "lazy_static",
- "libp2p-core 0.29.0",
- "libp2p-swarm 0.30.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log 0.4.14",
  "rand 0.8.4",
  "smallvec 1.6.1",
@@ -3385,7 +3320,7 @@ dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.0.1",
  "futures 0.3.16",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log 0.4.14",
  "nohash-hasher",
  "parking_lot 0.11.1",
@@ -3404,7 +3339,7 @@ dependencies = [
  "curve25519-dalek 3.0.2",
  "futures 0.3.16",
  "lazy_static",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log 0.4.14",
  "prost 0.8.0",
  "prost-build 0.8.0",
@@ -3423,8 +3358,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2482cfd9eb0b7a0baaf3e7b329dc4f2785181a161b1a47b7192f8d758f54a439"
 dependencies = [
  "futures 0.3.16",
- "libp2p-core 0.29.0",
- "libp2p-swarm 0.30.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log 0.4.14",
  "rand 0.7.3",
  "void",
@@ -3440,7 +3375,7 @@ dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.0.1",
  "futures 0.3.16",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log 0.4.14",
  "prost 0.8.0",
  "prost-build 0.8.0",
@@ -3472,8 +3407,8 @@ dependencies = [
  "bytes 1.0.1",
  "futures 0.3.16",
  "futures-timer 3.0.2",
- "libp2p-core 0.29.0",
- "libp2p-swarm 0.30.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log 0.4.14",
  "pin-project 1.0.5",
  "prost 0.8.0",
@@ -3494,8 +3429,8 @@ dependencies = [
  "async-trait",
  "bytes 1.0.1",
  "futures 0.3.16",
- "libp2p-core 0.29.0",
- "libp2p-swarm 0.30.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log 0.4.14",
  "lru",
  "minicbor",
@@ -3507,44 +3442,18 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e04d8e1eef675029ec728ba14e8d0da7975d84b6679b699b4ae91a1de9c3a92"
-dependencies = [
- "either",
- "futures 0.3.16",
- "libp2p-core 0.28.3",
- "log 0.4.14",
- "rand 0.7.3",
- "smallvec 1.6.1",
- "void",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-swarm"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7083861341e1555467863b4cd802bea1e8c4787c0f7b5110097d0f1f3248f9a9"
 dependencies = [
  "either",
  "futures 0.3.16",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log 0.4.14",
  "rand 0.7.3",
  "smallvec 1.6.1",
  "void",
  "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-swarm-derive"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365b0a699fea5168676840567582a012ea297b1ca02eee467e58301b9c9c5eed"
-dependencies = [
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3569,7 +3478,7 @@ dependencies = [
  "if-watch",
  "ipnet",
  "libc",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log 0.4.14",
  "socket2 0.4.0",
 ]
@@ -3582,7 +3491,7 @@ checksum = "280e793440dd4e9f273d714f4497325c72cddb0fe85a49f9a03c88f41dd20182"
 dependencies = [
  "async-std",
  "futures 0.3.16",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log 0.4.14",
 ]
 
@@ -3594,7 +3503,7 @@ checksum = "f553b7140fad3d7a76f50497b0ea591e26737d9607428a75509fc191e4d1b1f6"
 dependencies = [
  "futures 0.3.16",
  "js-sys",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "parity-send-wrapper",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3609,7 +3518,7 @@ dependencies = [
  "either",
  "futures 0.3.16",
  "futures-rustls",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "log 0.4.14",
  "quicksink",
  "rw-stream-sink",
@@ -3625,7 +3534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "214cc0dd9c37cbed27f0bb1eba0c41bbafdb93a8be5e9d6ae1e6b4b42cd044bf"
 dependencies = [
  "futures 0.3.16",
- "libp2p-core 0.29.0",
+ "libp2p-core",
  "parking_lot 0.11.1",
  "thiserror",
  "yamux",
@@ -3645,22 +3554,6 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
-dependencies = [
- "arrayref",
- "crunchy",
- "digest 0.8.1",
- "hmac-drbg 0.2.0",
- "rand 0.7.3",
- "sha2 0.8.2",
- "subtle 2.4.0",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
@@ -3668,7 +3561,7 @@ dependencies = [
  "arrayref",
  "base64 0.12.3",
  "digest 0.9.0",
- "hmac-drbg 0.3.0",
+ "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
@@ -3687,7 +3580,7 @@ dependencies = [
  "arrayref",
  "base64 0.12.3",
  "digest 0.9.0",
- "hmac-drbg 0.3.0",
+ "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
@@ -4325,7 +4218,7 @@ version = "3.0.0-dev"
 dependencies = [
  "futures-timer 3.0.2",
  "jsonrpc-core",
- "libp2p 0.39.1",
+ "libp2p",
  "node-cli",
  "parking_lot 0.11.1",
  "serde",
@@ -5886,24 +5779,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-multiaddr"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58341485071825827b7f03cf7efd1cb21e6a709bea778fb50227fd45d2f361b4"
-dependencies = [
- "arrayref",
- "bs58",
- "byteorder",
- "data-encoding",
- "multihash 0.13.2",
- "percent-encoding 2.1.0",
- "serde",
- "static_assertions",
- "unsigned-varint 0.7.0",
- "url 2.2.1",
-]
-
-[[package]]
 name = "parity-scale-codec"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7311,7 +7186,7 @@ dependencies = [
  "futures 0.3.16",
  "futures-timer 3.0.2",
  "ip_network",
- "libp2p 0.39.1",
+ "libp2p",
  "log 0.4.14",
  "parity-scale-codec",
  "prost 0.7.0",
@@ -7405,7 +7280,7 @@ dependencies = [
  "fdlimit",
  "futures 0.3.16",
  "hex",
- "libp2p 0.39.1",
+ "libp2p",
  "log 0.4.14",
  "names",
  "parity-scale-codec",
@@ -7500,7 +7375,7 @@ dependencies = [
  "async-trait",
  "futures 0.3.16",
  "futures-timer 3.0.2",
- "libp2p 0.37.1",
+ "libp2p",
  "log 0.4.14",
  "parking_lot 0.11.1",
  "sc-client-api",
@@ -7971,7 +7846,7 @@ dependencies = [
  "futures-timer 3.0.2",
  "hex",
  "ip_network",
- "libp2p 0.39.1",
+ "libp2p",
  "linked-hash-map",
  "linked_hash_set",
  "log 0.4.14",
@@ -8017,7 +7892,7 @@ dependencies = [
  "async-std",
  "futures 0.3.16",
  "futures-timer 3.0.2",
- "libp2p 0.39.1",
+ "libp2p",
  "log 0.4.14",
  "lru",
  "quickcheck",
@@ -8037,7 +7912,7 @@ dependencies = [
  "async-trait",
  "futures 0.3.16",
  "futures-timer 3.0.2",
- "libp2p 0.39.1",
+ "libp2p",
  "log 0.4.14",
  "parking_lot 0.11.1",
  "rand 0.7.3",
@@ -8096,7 +7971,7 @@ name = "sc-peerset"
 version = "4.0.0-dev"
 dependencies = [
  "futures 0.3.16",
- "libp2p 0.39.1",
+ "libp2p",
  "log 0.4.14",
  "rand 0.7.3",
  "serde_json",
@@ -8346,7 +8221,7 @@ version = "4.0.0-dev"
 dependencies = [
  "chrono",
  "futures 0.3.16",
- "libp2p 0.39.1",
+ "libp2p",
  "log 0.4.14",
  "parking_lot 0.11.1",
  "pin-project 1.0.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4216,9 +4216,7 @@ dependencies = [
 name = "node-browser-testing"
 version = "3.0.0-dev"
 dependencies = [
- "futures-timer 3.0.2",
  "jsonrpc-core",
- "libp2p",
  "node-cli",
  "parking_lot 0.11.1",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,56 +38,37 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
-version = "0.3.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+checksum = "6e3e798aa0c8239776f54415bc06f3d74b1850f3f830b45c35cfc80556973f70"
 dependencies = [
  "generic-array 0.14.4",
 ]
 
 [[package]]
 name = "aes"
-version = "0.5.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2bc6d3f370b5666245ff421e231cba4353df936e26986d2918e61a8fd6aef6"
+checksum = "495ee669413bfbe9e8cace80f4d3d78e6d8c8d99579f97fb93bde351b185f2d4"
 dependencies = [
- "aes-soft",
- "aesni",
- "block-cipher",
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.7.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0301c9e9c443494d970a07885e8cf3e587bae8356a1d5abd0999068413f7205f"
+checksum = "b2a930fd487faaa92a30afa92cc9dd1526a5cff67124abbbb1c617ce070f4dcf"
 dependencies = [
  "aead",
  "aes",
- "block-cipher",
+ "cipher",
+ "ctr",
  "ghash",
  "subtle 2.4.0",
-]
-
-[[package]]
-name = "aes-soft"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
-dependencies = [
- "block-cipher",
- "byteorder",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "aesni"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6fe808308bb07d393e2ea47780043ec47683fcf19cf5efc8ca51c50cc8c68a"
-dependencies = [
- "block-cipher",
- "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -657,15 +638,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-cipher"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
-dependencies = [
- "generic-array 0.14.4",
-]
-
-[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,7 +783,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -846,24 +818,26 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.5.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244fbce0d47e97e8ef2f63b81d5e05882cb518c68531eb33194990d7b7e85845"
+checksum = "fee7ad89dc1128635074c268ee661f90c3f7e83d9fd12910608c36b47d6c3412"
 dependencies = [
- "stream-cipher",
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures",
  "zeroize",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf18d374d66df0c05cdddd528a7db98f78c28e2519b120855c4f84c5027b1f5"
+checksum = "1580317203210c517b6d44794abfbe600698276db18127e37ad3e69bf5e848e5"
 dependencies = [
  "aead",
  "chacha20",
+ "cipher",
  "poly1305",
- "stream-cipher",
  "zeroize",
 ]
 
@@ -903,15 +877,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff0e3bc0b6446b3f9663c1a6aba6ef06c5aeaa1bc92bd18077be337198ab9768"
 dependencies = [
  "multibase",
- "multihash",
+ "multihash 0.13.2",
  "unsigned-varint 0.5.1",
 ]
 
 [[package]]
 name = "cipher"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array 0.14.4",
 ]
@@ -1012,16 +986,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
-
-[[package]]
-name = "cpuid-bool"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "cranelift-bforest"
@@ -1320,6 +1297,15 @@ checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ctr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -2272,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.3.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
+checksum = "b442c439366184de619215247d24e908912b175e824a530253845ac4c251a5c1"
 dependencies = [
  "opaque-debug 0.3.0",
  "polyval",
@@ -3141,7 +3127,27 @@ dependencies = [
  "bytes 1.0.1",
  "futures 0.3.16",
  "lazy_static",
- "libp2p-core",
+ "libp2p-core 0.28.3",
+ "libp2p-swarm 0.29.0",
+ "libp2p-swarm-derive 0.23.0",
+ "parity-multiaddr",
+ "parking_lot 0.11.1",
+ "pin-project 1.0.5",
+ "smallvec 1.6.1",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9004c06878ef8f3b4b4067e69a140d87ed20bf777287f82223e49713b36ee433"
+dependencies = [
+ "atomic",
+ "bytes 1.0.1",
+ "futures 0.3.16",
+ "lazy_static",
+ "libp2p-core 0.29.0",
  "libp2p-deflate",
  "libp2p-dns",
  "libp2p-floodsub",
@@ -3156,14 +3162,14 @@ dependencies = [
  "libp2p-pnet",
  "libp2p-relay",
  "libp2p-request-response",
- "libp2p-swarm",
- "libp2p-swarm-derive",
+ "libp2p-swarm 0.30.0",
+ "libp2p-swarm-derive 0.24.0",
  "libp2p-tcp",
  "libp2p-uds",
  "libp2p-wasm-ext",
  "libp2p-websocket",
  "libp2p-yamux",
- "parity-multiaddr",
+ "multiaddr",
  "parking_lot 0.11.1",
  "pin-project 1.0.5",
  "smallvec 1.6.1",
@@ -3172,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71dd51b562e14846e65bad00e5808d0644376e6588668c490d3c48e1dfeb4a9a"
+checksum = "554d3e7e9e65f939d66b75fd6a4c67f258fe250da61b91f46c545fc4a89b51d9"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -3186,13 +3192,47 @@ dependencies = [
  "lazy_static",
  "libsecp256k1 0.3.5",
  "log 0.4.14",
- "multihash",
+ "multihash 0.13.2",
  "multistream-select",
  "parity-multiaddr",
  "parking_lot 0.11.1",
  "pin-project 1.0.5",
- "prost",
- "prost-build",
+ "prost 0.7.0",
+ "prost-build 0.7.0",
+ "rand 0.7.3",
+ "ring",
+ "rw-stream-sink",
+ "sha2 0.9.3",
+ "smallvec 1.6.1",
+ "thiserror",
+ "unsigned-varint 0.7.0",
+ "void",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9b4abdeaa420593a297c8592f63fad4234f4b88dc9343b8fd8e736c35faa59"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "either",
+ "fnv",
+ "futures 0.3.16",
+ "futures-timer 3.0.2",
+ "lazy_static",
+ "libsecp256k1 0.5.0",
+ "log 0.4.14",
+ "multiaddr",
+ "multihash 0.14.0",
+ "multistream-select",
+ "parking_lot 0.11.1",
+ "pin-project 1.0.5",
+ "prost 0.8.0",
+ "prost-build 0.8.0",
  "rand 0.7.3",
  "ring",
  "rw-stream-sink",
@@ -3206,24 +3246,24 @@ dependencies = [
 
 [[package]]
 name = "libp2p-deflate"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2181a641cd15f9b6ba71b1335800f309012a0a97a29ffaabbbf40e9d3d58f08"
+checksum = "66097fccc0b7f8579f90a03ea76ba6196332ea049fd07fd969490a06819dcdc8"
 dependencies = [
  "flate2",
  "futures 0.3.16",
- "libp2p-core",
+ "libp2p-core 0.29.0",
 ]
 
 [[package]]
 name = "libp2p-dns"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e63dab8b5ff35e0c101a3e51e843ba782c07bbb1682f5fd827622e0d02b98b"
+checksum = "58ff08b3196b85a17f202d80589e93b1660a574af67275706657fdc762e42c32"
 dependencies = [
  "async-std-resolver",
  "futures 0.3.16",
- "libp2p-core",
+ "libp2p-core 0.29.0",
  "log 0.4.14",
  "smallvec 1.6.1",
  "trust-dns-resolver",
@@ -3231,27 +3271,27 @@ dependencies = [
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48a9b570f6766301d9c4aa00fce3554cad1598e2f466debbc4dde909028417cf"
+checksum = "404eca8720967179dac7a5b4275eb91f904a53859c69ca8d018560ad6beb214f"
 dependencies = [
  "cuckoofilter",
  "fnv",
  "futures 0.3.16",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.29.0",
+ "libp2p-swarm 0.30.0",
  "log 0.4.14",
- "prost",
- "prost-build",
+ "prost 0.8.0",
+ "prost-build 0.8.0",
  "rand 0.7.3",
  "smallvec 1.6.1",
 ]
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cb9a89a301afde1e588c73f7e9131e12a5388725f290a9047b878862db1b53"
+checksum = "b1cc48709bcbc3a3321f08a73560b4bbb4166a7d56f6fdb615bc775f4f91058e"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "base64 0.13.0",
@@ -3260,11 +3300,11 @@ dependencies = [
  "fnv",
  "futures 0.3.16",
  "hex_fmt",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.29.0",
+ "libp2p-swarm 0.30.0",
  "log 0.4.14",
- "prost",
- "prost-build",
+ "prost 0.8.0",
+ "prost-build 0.8.0",
  "rand 0.7.3",
  "regex",
  "sha2 0.9.3",
@@ -3275,25 +3315,25 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f668f00efd9883e8b7bcc582eaf0164615792608f886f6577da18bcbeea0a46"
+checksum = "a7b61f6cf07664fb97016c318c4d4512b3dd4cc07238607f3f0163245f99008e"
 dependencies = [
  "futures 0.3.16",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.29.0",
+ "libp2p-swarm 0.30.0",
  "log 0.4.14",
- "prost",
- "prost-build",
+ "prost 0.8.0",
+ "prost-build 0.8.0",
  "smallvec 1.6.1",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-kad"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07312ebe5ee4fd2404447a0609814574df55c65d4e20838b957bbd34907d820"
+checksum = "50ed78489c87924235665a0ab345b298ee34dff0f7ad62c0ba6608b2144fb75e"
 dependencies = [
  "arrayvec 0.5.2",
  "asynchronous-codec 0.6.0",
@@ -3301,11 +3341,11 @@ dependencies = [
  "either",
  "fnv",
  "futures 0.3.16",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.29.0",
+ "libp2p-swarm 0.30.0",
  "log 0.4.14",
- "prost",
- "prost-build",
+ "prost 0.8.0",
+ "prost-build 0.8.0",
  "rand 0.7.3",
  "sha2 0.9.3",
  "smallvec 1.6.1",
@@ -3317,9 +3357,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c221897b3fd7f215de7ecfec215c5eba598e5b61c605b5f8b56fe8a4fb507724"
+checksum = "a29e6cbc2a24b8471b6567e580a0e8e7b70a6d0f0ea2be0844d1e842d7d4fa33"
 dependencies = [
  "async-io",
  "data-encoding",
@@ -3327,8 +3367,8 @@ dependencies = [
  "futures 0.3.16",
  "if-watch",
  "lazy_static",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.29.0",
+ "libp2p-swarm 0.30.0",
  "log 0.4.14",
  "rand 0.8.4",
  "smallvec 1.6.1",
@@ -3338,14 +3378,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e9b544335d1ed30af71daa96edbefadef6f19c7a55f078b9fc92c87163105d"
+checksum = "313d9ea526c68df4425f580024e67a9d3ffd49f2c33de5154b1f5019816f7a99"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.0.1",
  "futures 0.3.16",
- "libp2p-core",
+ "libp2p-core 0.29.0",
  "log 0.4.14",
  "nohash-hasher",
  "parking_lot 0.11.1",
@@ -3356,19 +3396,19 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36db0f0db3b0433f5b9463f1c0cd9eadc0a3734a9170439ce501ff99733a88bd"
+checksum = "3f1db7212f342b6ba7c981cc40e31f76e9e56cb48e65fa4c142ecaca5839523e"
 dependencies = [
  "bytes 1.0.1",
  "curve25519-dalek 3.0.2",
  "futures 0.3.16",
  "lazy_static",
- "libp2p-core",
+ "libp2p-core 0.29.0",
  "log 0.4.14",
- "prost",
- "prost-build",
- "rand 0.7.3",
+ "prost 0.8.0",
+ "prost-build 0.8.0",
+ "rand 0.8.4",
  "sha2 0.9.3",
  "snow",
  "static_assertions",
@@ -3378,13 +3418,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4bfaffac63bf3c7ec11ed9d8879d455966ddea7e78ee14737f0b6dce0d1cd1"
+checksum = "2482cfd9eb0b7a0baaf3e7b329dc4f2785181a161b1a47b7192f8d758f54a439"
 dependencies = [
  "futures 0.3.16",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.29.0",
+ "libp2p-swarm 0.30.0",
  "log 0.4.14",
  "rand 0.7.3",
  "void",
@@ -3393,26 +3433,26 @@ dependencies = [
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8c37b4d2a075b4be8442760a5f8c037180f0c8dd5b5734b9978ab868b3aa11"
+checksum = "13b4783e5423870b9a5c199f65a7a3bc66d86ab56b2b9beebf3c338d889cf8e4"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.0.1",
  "futures 0.3.16",
- "libp2p-core",
+ "libp2p-core 0.29.0",
  "log 0.4.14",
- "prost",
- "prost-build",
+ "prost 0.8.0",
+ "prost-build 0.8.0",
  "unsigned-varint 0.7.0",
  "void",
 ]
 
 [[package]]
 name = "libp2p-pnet"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce3374f3b28162db9d3442c9347c4f14cb01e8290052615c7d341d40eae0599"
+checksum = "07cb4dd4b917e5b40ddefe49b96b07adcd8d342e0317011d175b7b2bb1dcc974"
 dependencies = [
  "futures 0.3.16",
  "log 0.4.14",
@@ -3424,20 +3464,20 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8786aca3f18671d8776289706a5521f6c9124a820f69e358de214b9939440d"
+checksum = "0133f6cfd81cdc16e716de2982e012c62e6b9d4f12e41967b3ee361051c622aa"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.0.1",
  "futures 0.3.16",
  "futures-timer 3.0.2",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.29.0",
+ "libp2p-swarm 0.30.0",
  "log 0.4.14",
  "pin-project 1.0.5",
- "prost",
- "prost-build",
+ "prost 0.8.0",
+ "prost-build 0.8.0",
  "rand 0.7.3",
  "smallvec 1.6.1",
  "unsigned-varint 0.7.0",
@@ -3447,15 +3487,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cdbe172f08e6d0f95fa8634e273d4c4268c4063de2e33e7435194b0130c62e3"
+checksum = "06cdae44b6821466123af93cbcdec7c9e6ba9534a8af9cdc296446d39416d241"
 dependencies = [
  "async-trait",
  "bytes 1.0.1",
  "futures 0.3.16",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.29.0",
+ "libp2p-swarm 0.30.0",
  "log 0.4.14",
  "lru",
  "minicbor",
@@ -3473,7 +3513,23 @@ checksum = "1e04d8e1eef675029ec728ba14e8d0da7975d84b6679b699b4ae91a1de9c3a92"
 dependencies = [
  "either",
  "futures 0.3.16",
- "libp2p-core",
+ "libp2p-core 0.28.3",
+ "log 0.4.14",
+ "rand 0.7.3",
+ "smallvec 1.6.1",
+ "void",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-swarm"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7083861341e1555467863b4cd802bea1e8c4787c0f7b5110097d0f1f3248f9a9"
+dependencies = [
+ "either",
+ "futures 0.3.16",
+ "libp2p-core 0.29.0",
  "log 0.4.14",
  "rand 0.7.3",
  "smallvec 1.6.1",
@@ -3492,10 +3548,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-tcp"
-version = "0.28.0"
+name = "libp2p-swarm-derive"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b1a27d21c477951799e99d5c105d78868258502ce092988040a808d5a19bbd9"
+checksum = "ab8cb308d4fc854869f5abb54fdab0833d2cf670d407c745849dc47e6e08d79c"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "libp2p-tcp"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79edd26b6b4bb5feee210dcda562dca186940dfecb0024b979c3f50824b3bf28"
 dependencies = [
  "async-io",
  "futures 0.3.16",
@@ -3503,32 +3569,32 @@ dependencies = [
  "if-watch",
  "ipnet",
  "libc",
- "libp2p-core",
+ "libp2p-core 0.29.0",
  "log 0.4.14",
  "socket2 0.4.0",
 ]
 
 [[package]]
 name = "libp2p-uds"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd6564bb3b7ff203661ccbb69003c2b551e34cef974f2d6c6a28306a12170b5"
+checksum = "280e793440dd4e9f273d714f4497325c72cddb0fe85a49f9a03c88f41dd20182"
 dependencies = [
  "async-std",
  "futures 0.3.16",
- "libp2p-core",
+ "libp2p-core 0.29.0",
  "log 0.4.14",
 ]
 
 [[package]]
 name = "libp2p-wasm-ext"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef45d61e43c313531b5e903e4e8415212ff6338e0c54c47da5b9b412b5760de"
+checksum = "f553b7140fad3d7a76f50497b0ea591e26737d9607428a75509fc191e4d1b1f6"
 dependencies = [
  "futures 0.3.16",
  "js-sys",
- "libp2p-core",
+ "libp2p-core 0.29.0",
  "parity-send-wrapper",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3536,14 +3602,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cace60995ef6f637e4752cccbb2590f6bc358e8741a0d066307636c69a4b3a74"
+checksum = "ddf99dcbf5063e9d59087f61b1e85c686ceab2f5abedb472d32288065c0e5e27"
 dependencies = [
  "either",
  "futures 0.3.16",
  "futures-rustls",
- "libp2p-core",
+ "libp2p-core 0.29.0",
  "log 0.4.14",
  "quicksink",
  "rw-stream-sink",
@@ -3554,12 +3620,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f35da42cfc6d5cb0dcf3ad6881bc68d146cdf38f98655e09e33fbba4d13eabc4"
+checksum = "214cc0dd9c37cbed27f0bb1eba0c41bbafdb93a8be5e9d6ae1e6b4b42cd044bf"
 dependencies = [
  "futures 0.3.16",
- "libp2p-core",
+ "libp2p-core 0.29.0",
  "parking_lot 0.11.1",
  "thiserror",
  "yamux",
@@ -3590,6 +3656,25 @@ dependencies = [
  "rand 0.7.3",
  "sha2 0.8.2",
  "subtle 2.4.0",
+ "typenum",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
+dependencies = [
+ "arrayref",
+ "base64 0.12.3",
+ "digest 0.9.0",
+ "hmac-drbg 0.3.0",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.3",
  "typenum",
 ]
 
@@ -4016,6 +4101,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
+name = "multiaddr"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ee4ea82141951ac6379f964f71b20876d43712bea8faf6dd1a375e08a46499"
+dependencies = [
+ "arrayref",
+ "bs58",
+ "byteorder",
+ "data-encoding",
+ "multihash 0.14.0",
+ "percent-encoding 2.1.0",
+ "serde",
+ "static_assertions",
+ "unsigned-varint 0.7.0",
+ "url 2.2.1",
+]
+
+[[package]]
 name = "multibase"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4044,12 +4147,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "multihash-derive"
-version = "0.7.1"
+name = "multihash"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ee3c48cb9d9b275ad967a0e96715badc13c6029adb92f34fa17b9ff28fd81f"
+checksum = "752a61cd890ff691b4411423d23816d5866dd5621e4d1c5687a53b94b5a979d8"
 dependencies = [
- "proc-macro-crate 0.1.5",
+ "digest 0.9.0",
+ "generic-array 0.14.4",
+ "multihash-derive",
+ "sha2 0.9.3",
+ "unsigned-varint 0.7.0",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424f6e86263cd5294cbd7f1e95746b95aca0e0d66bff31e5a40d6baa87b4aa99"
+dependencies = [
+ "proc-macro-crate 1.0.0",
  "proc-macro-error 1.0.4",
  "proc-macro2",
  "quote",
@@ -4207,7 +4323,9 @@ dependencies = [
 name = "node-browser-testing"
 version = "3.0.0-dev"
 dependencies = [
+ "futures-timer 3.0.2",
  "jsonrpc-core",
+ "libp2p 0.39.1",
  "node-cli",
  "parking_lot 0.11.1",
  "serde",
@@ -5777,7 +5895,7 @@ dependencies = [
  "bs58",
  "byteorder",
  "data-encoding",
- "multihash",
+ "multihash 0.13.2",
  "percent-encoding 2.1.0",
  "serde",
  "static_assertions",
@@ -5905,7 +6023,7 @@ checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
  "lock_api 0.3.4",
  "parking_lot_core 0.6.2",
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -5939,7 +6057,7 @@ dependencies = [
  "cloudabi",
  "libc",
  "redox_syscall 0.1.57",
- "rustc_version",
+ "rustc_version 0.2.3",
  "smallvec 0.6.14",
  "winapi 0.3.9",
 ]
@@ -6200,21 +6318,23 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7456bc1ad2d4cf82b3a016be4c2ac48daf11bf990c1603ebd447fe6f30fca8"
+checksum = "9fcffab1f78ebbdf4b93b68c1ffebc24037eedf271edaca795732b24e5e4e349"
 dependencies = [
- "cpuid-bool 0.2.0",
+ "cpufeatures",
+ "opaque-debug 0.3.0",
  "universal-hash",
 ]
 
 [[package]]
 name = "polyval"
-version = "0.4.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
+checksum = "a6ba6a405ef63530d6cb12802014b22f9c5751bd17cdcddbe9e46d5c8ae83287"
 dependencies = [
- "cpuid-bool 0.2.0",
+ "cfg-if 1.0.0",
+ "cpufeatures",
  "opaque-debug 0.3.0",
  "universal-hash",
 ]
@@ -6398,7 +6518,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
  "bytes 1.0.1",
- "prost-derive",
+ "prost-derive 0.7.0",
+]
+
+[[package]]
+name = "prost"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
+dependencies = [
+ "bytes 1.0.1",
+ "prost-derive 0.8.0",
 ]
 
 [[package]]
@@ -6413,8 +6543,26 @@ dependencies = [
  "log 0.4.14",
  "multimap",
  "petgraph",
- "prost",
- "prost-types",
+ "prost 0.7.0",
+ "prost-types 0.7.0",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
+dependencies = [
+ "bytes 1.0.1",
+ "heck",
+ "itertools 0.10.0",
+ "log 0.4.14",
+ "multimap",
+ "petgraph",
+ "prost 0.8.0",
+ "prost-types 0.8.0",
  "tempfile",
  "which",
 ]
@@ -6433,13 +6581,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
  "bytes 1.0.1",
- "prost",
+ "prost 0.7.0",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
+dependencies = [
+ "bytes 1.0.1",
+ "prost 0.8.0",
 ]
 
 [[package]]
@@ -7022,6 +7193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7085,7 +7265,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d3d055a2582e6b00ed7a31c1524040aa391092bf636328350813f3a0605215c"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -7096,9 +7276,9 @@ checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "salsa20"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399f290ffc409596022fce5ea5d4138184be4784f2b28c62c59f0d8389059a15"
+checksum = "ecbd2eb639fd7cab5804a0837fe373cc2172d15437e804c054a9fb885cb923b0"
 dependencies = [
  "cipher",
 ]
@@ -7131,11 +7311,11 @@ dependencies = [
  "futures 0.3.16",
  "futures-timer 3.0.2",
  "ip_network",
- "libp2p",
+ "libp2p 0.39.1",
  "log 0.4.14",
  "parity-scale-codec",
- "prost",
- "prost-build",
+ "prost 0.7.0",
+ "prost-build 0.7.0",
  "quickcheck",
  "rand 0.7.3",
  "sc-client-api",
@@ -7225,7 +7405,7 @@ dependencies = [
  "fdlimit",
  "futures 0.3.16",
  "hex",
- "libp2p",
+ "libp2p 0.39.1",
  "log 0.4.14",
  "names",
  "parity-scale-codec",
@@ -7320,7 +7500,7 @@ dependencies = [
  "async-trait",
  "futures 0.3.16",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.37.1",
  "log 0.4.14",
  "parking_lot 0.11.1",
  "sc-client-api",
@@ -7570,7 +7750,7 @@ version = "0.10.0-dev"
 dependencies = [
  "hex-literal",
  "lazy_static",
- "libsecp256k1 0.3.5",
+ "libsecp256k1 0.6.0",
  "log 0.4.14",
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -7791,7 +7971,7 @@ dependencies = [
  "futures-timer 3.0.2",
  "hex",
  "ip_network",
- "libp2p",
+ "libp2p 0.39.1",
  "linked-hash-map",
  "linked_hash_set",
  "log 0.4.14",
@@ -7799,8 +7979,8 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.1",
  "pin-project 1.0.5",
- "prost",
- "prost-build",
+ "prost 0.7.0",
+ "prost-build 0.7.0",
  "quickcheck",
  "rand 0.7.3",
  "sc-block-builder",
@@ -7837,7 +8017,7 @@ dependencies = [
  "async-std",
  "futures 0.3.16",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.39.1",
  "log 0.4.14",
  "lru",
  "quickcheck",
@@ -7857,7 +8037,7 @@ dependencies = [
  "async-trait",
  "futures 0.3.16",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.39.1",
  "log 0.4.14",
  "parking_lot 0.11.1",
  "rand 0.7.3",
@@ -7916,7 +8096,7 @@ name = "sc-peerset"
 version = "4.0.0-dev"
 dependencies = [
  "futures 0.3.16",
- "libp2p",
+ "libp2p 0.39.1",
  "log 0.4.14",
  "rand 0.7.3",
  "serde_json",
@@ -8166,7 +8346,7 @@ version = "4.0.0-dev"
 dependencies = [
  "chrono",
  "futures 0.3.16",
- "libp2p",
+ "libp2p 0.39.1",
  "log 0.4.14",
  "parking_lot 0.11.1",
  "pin-project 1.0.5",
@@ -8457,7 +8637,7 @@ checksum = "dfebf75d25bd900fd1e7d11501efab59bc846dbc76196839663e6637bba9f25f"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpuid-bool 0.1.2",
+ "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -8488,7 +8668,7 @@ checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpuid-bool 0.1.2",
+ "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -8595,17 +8775,17 @@ checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "snow"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795dd7aeeee24468e5a32661f6d27f7b5cbed802031b2d7640c7b10f8fb2dd50"
+checksum = "6142f7c25e94f6fd25a32c3348ec230df9109b463f59c8c7acc4bd34936babb7"
 dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.4",
+ "rand_core 0.6.2",
  "ring",
- "rustc_version",
+ "rustc_version 0.3.3",
  "sha2 0.9.3",
  "subtle 2.4.0",
  "x25519-dalek",
@@ -9008,7 +9188,7 @@ version = "4.0.0-dev"
 dependencies = [
  "futures 0.3.16",
  "hash-db",
- "libsecp256k1 0.3.5",
+ "libsecp256k1 0.6.0",
  "log 0.4.14",
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -9481,16 +9661,6 @@ dependencies = [
  "nalgebra",
  "num-traits",
  "rand 0.8.4",
-]
-
-[[package]]
-name = "stream-cipher"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80e15f898d8d8f25db24c253ea615cc14acf418ff307822995814e7d42cfa89"
-dependencies = [
- "block-cipher",
- "generic-array 0.14.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,8 +221,6 @@ members = [
 #
 # This list is ordered alphabetically.
 [profile.dev.package]
-aes-soft = { opt-level = 3 }
-aesni = { opt-level = 3 }
 blake2 = { opt-level = 3 }
 blake2-rfc = { opt-level = 3 }
 blake2b_simd = { opt-level = 3 }

--- a/bin/node/browser-testing/Cargo.toml
+++ b/bin/node/browser-testing/Cargo.toml
@@ -8,6 +8,8 @@ license = "Apache-2.0"
 
 [dependencies]
 jsonrpc-core = "18.0.0"
+futures-timer = "3.0.2"
+libp2p = { version = "0.39.1", default-features = false }
 serde = "1.0.126"
 serde_json = "1.0.48"
 wasm-bindgen = { version = "=0.2.73", features = ["serde-serialize"] }

--- a/bin/node/browser-testing/Cargo.toml
+++ b/bin/node/browser-testing/Cargo.toml
@@ -8,8 +8,6 @@ license = "Apache-2.0"
 
 [dependencies]
 jsonrpc-core = "18.0.0"
-futures-timer = "3.0.2"
-libp2p = { version = "0.39.1", default-features = false }
 serde = "1.0.126"
 serde_json = "1.0.48"
 wasm-bindgen = { version = "=0.2.73", features = ["serde-serialize"] }

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -95,10 +95,8 @@ try-runtime-cli = { version = "0.10.0-dev", optional = true, path = "../../../ut
 # WASM-specific dependencies
 wasm-bindgen = { version = "0.2.73", optional = true }
 wasm-bindgen-futures = { version = "0.4.18", optional = true }
-browser-utils = { package = "substrate-browser-utils", path = "../../../utils/browser", optional = true, version = "0.10.0-dev" }
-libp2p-wasm-ext = { version = "0.28", features = [
-	"websocket",
-], optional = true }
+browser-utils = { package = "substrate-browser-utils", path = "../../../utils/browser", optional = true, version = "0.10.0-dev"}
+libp2p-wasm-ext = { version = "0.29", features = ["websocket"], optional = true }
 
 [target.'cfg(target_arch="x86_64")'.dependencies]
 node-executor = { version = "3.0.0-dev", path = "../executor", features = [

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -23,7 +23,7 @@ derive_more = "0.99.2"
 futures = "0.3.9"
 futures-timer = "3.0.1"
 ip_network = "0.4.0"
-libp2p = { version = "0.37.1", default-features = false, features = ["kad"] }
+libp2p = { version = "0.39.1", default-features = false, features = ["kad"] }
 log = "0.4.8"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.9.0" }
 prost = "0.7"

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -18,7 +18,7 @@ regex = "1.4.2"
 tokio = { version = "0.2.21", features = [ "signal", "rt-core", "rt-threaded", "blocking" ] }
 futures = "0.3.9"
 fdlimit = "0.2.1"
-libp2p = "0.37.1"
+libp2p = "0.39.1"
 parity-scale-codec = "2.0.0"
 hex = "0.4.2"
 rand = "0.7.3"

--- a/client/consensus/common/Cargo.toml
+++ b/client/consensus/common/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 thiserror = "1.0.21"
-libp2p = { version = "0.37.1", default-features = false }
+libp2p = { version = "0.39.1", default-features = false }
 log = "0.4.8"
 futures = { version = "0.3.1", features = ["thread-pool"] }
 futures-timer = "3.0.1"

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -32,7 +32,7 @@ sc-executor-wasmi = { version = "0.10.0-dev", path = "wasmi" }
 sc-executor-wasmtime = { version = "0.10.0-dev", path = "wasmtime", optional = true }
 parking_lot = "0.11.1"
 log = "0.4.8"
-libsecp256k1 = "0.3.4"
+libsecp256k1 = "0.6"
 
 [dev-dependencies]
 wat = "1.0"

--- a/client/network-gossip/Cargo.toml
+++ b/client/network-gossip/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 futures = "0.3.9"
 futures-timer = "3.0.1"
-libp2p = { version = "0.37.1", default-features = false }
+libp2p = { version = "0.39.1", default-features = false }
 log = "0.4.8"
 lru = "0.6.5"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.9.0", path = "../../utils/prometheus" }

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -67,10 +67,10 @@ wasm-timer = "0.2"
 zeroize = "1.2.0"
 
 [dependencies.libp2p]
-version = "0.37.1"
+version = "0.39.1"
 
 [target.'cfg(target_os = "unknown")'.dependencies.libp2p]
-version = "0.37.1"
+version = "0.39.1"
 default-features = false
 features = [
     "identify",
@@ -88,7 +88,7 @@ features = [
 
 [dev-dependencies]
 assert_matches = "1.3"
-libp2p = { version = "0.37.1", default-features = false }
+libp2p = { version = "0.39.1", default-features = false }
 quickcheck = "1.0.3"
 rand = "0.7.2"
 sp-test-primitives = { version = "2.0.0", path = "../../primitives/test-primitives" }

--- a/client/network/src/bitswap.rs
+++ b/client/network/src/bitswap.rs
@@ -94,7 +94,7 @@ where
 
 	fn upgrade_inbound(self, mut socket: TSocket, _info: Self::Info) -> Self::Future {
 		Box::pin(async move {
-			let packet = upgrade::read_one(&mut socket, MAX_PACKET_SIZE).await?;
+			let packet = upgrade::read_length_prefixed(&mut socket, MAX_PACKET_SIZE).await?;
 			let message: BitswapMessage = Message::decode(packet.as_slice())?;
 			Ok(message)
 		})
@@ -122,7 +122,7 @@ where
 		Box::pin(async move {
 			let mut data = Vec::with_capacity(self.encoded_len());
 			self.encode(&mut data)?;
-			upgrade::write_one(&mut socket, data).await
+			upgrade::write_length_prefixed(&mut socket, data).await
 		})
 	}
 }
@@ -328,7 +328,7 @@ pub enum BitswapError {
 	/// Error parsing CID
 	BadCid(cid::Error),
 	/// Packet read error.
-	Read(upgrade::ReadOneError),
+	Read(io::Error),
 	/// Error sending response.
 	#[display(fmt = "Failed to send response.")]
 	SendResponse,

--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -722,7 +722,7 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 						KademliaEvent::PendingRoutablePeer { .. } => {
 							// We are not interested in this event at the moment.
 						},
-						KademliaEvent::QueryResult {
+						KademliaEvent::OutboundQueryCompleted {
 							result: QueryResult::GetClosestPeers(res),
 							..
 						} => match res {
@@ -741,7 +741,7 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 								}
 							},
 						},
-						KademliaEvent::QueryResult {
+						KademliaEvent::OutboundQueryCompleted {
 							result: QueryResult::GetRecord(res),
 							stats,
 							..
@@ -778,7 +778,7 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 							};
 							return Poll::Ready(NetworkBehaviourAction::GenerateEvent(ev))
 						},
-						KademliaEvent::QueryResult {
+						KademliaEvent::OutboundQueryCompleted {
 							result: QueryResult::PutRecord(res),
 							stats,
 							..
@@ -799,7 +799,7 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 							};
 							return Poll::Ready(NetworkBehaviourAction::GenerateEvent(ev))
 						},
-						KademliaEvent::QueryResult {
+						KademliaEvent::OutboundQueryCompleted {
 							result: QueryResult::RepublishRecord(res),
 							..
 						} => match res {
@@ -829,6 +829,11 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 						return Poll::Ready(NetworkBehaviourAction::ReportObservedAddr {
 							address,
 							score,
+						}),
+					NetworkBehaviourAction::CloseConnection { peer_id, connection } =>
+						return Poll::Ready(NetworkBehaviourAction::CloseConnection {
+							peer_id,
+							connection,
 						}),
 				}
 			}
@@ -861,6 +866,11 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 					return Poll::Ready(NetworkBehaviourAction::ReportObservedAddr {
 						address,
 						score,
+					}),
+				NetworkBehaviourAction::CloseConnection { peer_id, connection } =>
+					return Poll::Ready(NetworkBehaviourAction::CloseConnection {
+						peer_id,
+						connection,
 					}),
 			}
 		}

--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -941,7 +941,7 @@ mod tests {
 		},
 		identity::Keypair,
 		noise,
-		swarm::Swarm,
+		swarm::{Swarm, SwarmEvent},
 		yamux, Multiaddr, PeerId,
 	};
 	use std::{collections::HashSet, task::Poll};
@@ -1010,8 +1010,8 @@ mod tests {
 					match swarms[swarm_n].0.poll_next_unpin(cx) {
 						Poll::Ready(Some(e)) => {
 							match e {
-								DiscoveryOut::UnroutablePeer(other) |
-								DiscoveryOut::Discovered(other) => {
+								SwarmEvent::Behaviour(DiscoveryOut::UnroutablePeer(other)) |
+								SwarmEvent::Behaviour(DiscoveryOut::Discovered(other)) => {
 									// Call `add_self_reported_address` to simulate identify
 									// happening.
 									let addr = swarms
@@ -1032,7 +1032,7 @@ mod tests {
 
 									to_discover[swarm_n].remove(&other);
 								},
-								DiscoveryOut::RandomKademliaStarted(_) => {},
+								SwarmEvent::Behaviour(DiscoveryOut::RandomKademliaStarted(_)) => {},
 								e => {
 									panic!("Unexpected event: {:?}", e)
 								},

--- a/client/network/src/peer_info.rs
+++ b/client/network/src/peer_info.rs
@@ -340,6 +340,11 @@ impl NetworkBehaviour for PeerInfoBehaviour {
 						address,
 						score,
 					}),
+				Poll::Ready(NetworkBehaviourAction::CloseConnection { peer_id, connection }) =>
+					return Poll::Ready(NetworkBehaviourAction::CloseConnection {
+						peer_id,
+						connection,
+					}),
 			}
 		}
 
@@ -372,6 +377,11 @@ impl NetworkBehaviour for PeerInfoBehaviour {
 					return Poll::Ready(NetworkBehaviourAction::ReportObservedAddr {
 						address,
 						score,
+					}),
+				Poll::Ready(NetworkBehaviourAction::CloseConnection { peer_id, connection }) =>
+					return Poll::Ready(NetworkBehaviourAction::CloseConnection {
+						peer_id,
+						connection,
 					}),
 			}
 		}

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -1575,6 +1575,8 @@ impl<B: BlockT> NetworkBehaviour for Protocol<B> {
 				}),
 			Poll::Ready(NetworkBehaviourAction::ReportObservedAddr { address, score }) =>
 				return Poll::Ready(NetworkBehaviourAction::ReportObservedAddr { address, score }),
+			Poll::Ready(NetworkBehaviourAction::CloseConnection { peer_id, connection }) =>
+				return Poll::Ready(NetworkBehaviourAction::CloseConnection { peer_id, connection }),
 		};
 
 		let outcome = match event {

--- a/client/network/src/protocol/notifications/tests.rs
+++ b/client/network/src/protocol/notifications/tests.rs
@@ -30,7 +30,7 @@ use libp2p::{
 	identity, noise,
 	swarm::{
 		IntoProtocolsHandler, NetworkBehaviour, NetworkBehaviourAction, PollParameters,
-		ProtocolsHandler, Swarm,
+		ProtocolsHandler, Swarm, SwarmEvent,
 	},
 	yamux, Multiaddr, PeerId, Transport,
 };
@@ -262,8 +262,8 @@ fn reconnect_after_disconnect() {
 		loop {
 			// Grab next event from services.
 			let event = {
-				let s1 = service1.next();
-				let s2 = service2.next();
+				let s1 = service1.select_next_some();
+				let s2 = service2.select_next_some();
 				futures::pin_mut!(s1, s2);
 				match future::select(s1, s2).await {
 					future::Either::Left((ev, _)) => future::Either::Left(ev),
@@ -272,48 +272,52 @@ fn reconnect_after_disconnect() {
 			};
 
 			match event {
-				future::Either::Left(NotificationsOut::CustomProtocolOpen { .. }) =>
-					match service1_state {
-						ServiceState::NotConnected => {
-							service1_state = ServiceState::FirstConnec;
-							if service2_state == ServiceState::FirstConnec {
-								service1.behaviour_mut().disconnect_peer(
-									Swarm::local_peer_id(&service2),
-									sc_peerset::SetId::from(0),
-								);
-							}
-						},
-						ServiceState::Disconnected => service1_state = ServiceState::ConnectedAgain,
-						ServiceState::FirstConnec | ServiceState::ConnectedAgain => panic!(),
+				future::Either::Left(SwarmEvent::Behaviour(
+					NotificationsOut::CustomProtocolOpen { .. },
+				)) => match service1_state {
+					ServiceState::NotConnected => {
+						service1_state = ServiceState::FirstConnec;
+						if service2_state == ServiceState::FirstConnec {
+							service1.behaviour_mut().disconnect_peer(
+								Swarm::local_peer_id(&service2),
+								sc_peerset::SetId::from(0),
+							);
+						}
 					},
-				future::Either::Left(NotificationsOut::CustomProtocolClosed { .. }) =>
-					match service1_state {
-						ServiceState::FirstConnec => service1_state = ServiceState::Disconnected,
-						ServiceState::ConnectedAgain |
-						ServiceState::NotConnected |
-						ServiceState::Disconnected => panic!(),
+					ServiceState::Disconnected => service1_state = ServiceState::ConnectedAgain,
+					ServiceState::FirstConnec | ServiceState::ConnectedAgain => panic!(),
+				},
+				future::Either::Left(SwarmEvent::Behaviour(
+					NotificationsOut::CustomProtocolClosed { .. },
+				)) => match service1_state {
+					ServiceState::FirstConnec => service1_state = ServiceState::Disconnected,
+					ServiceState::ConnectedAgain |
+					ServiceState::NotConnected |
+					ServiceState::Disconnected => panic!(),
+				},
+				future::Either::Right(SwarmEvent::Behaviour(
+					NotificationsOut::CustomProtocolOpen { .. },
+				)) => match service2_state {
+					ServiceState::NotConnected => {
+						service2_state = ServiceState::FirstConnec;
+						if service1_state == ServiceState::FirstConnec {
+							service1.behaviour_mut().disconnect_peer(
+								Swarm::local_peer_id(&service2),
+								sc_peerset::SetId::from(0),
+							);
+						}
 					},
-				future::Either::Right(NotificationsOut::CustomProtocolOpen { .. }) =>
-					match service2_state {
-						ServiceState::NotConnected => {
-							service2_state = ServiceState::FirstConnec;
-							if service1_state == ServiceState::FirstConnec {
-								service1.behaviour_mut().disconnect_peer(
-									Swarm::local_peer_id(&service2),
-									sc_peerset::SetId::from(0),
-								);
-							}
-						},
-						ServiceState::Disconnected => service2_state = ServiceState::ConnectedAgain,
-						ServiceState::FirstConnec | ServiceState::ConnectedAgain => panic!(),
-					},
-				future::Either::Right(NotificationsOut::CustomProtocolClosed { .. }) =>
-					match service2_state {
-						ServiceState::FirstConnec => service2_state = ServiceState::Disconnected,
-						ServiceState::ConnectedAgain |
-						ServiceState::NotConnected |
-						ServiceState::Disconnected => panic!(),
-					},
+					ServiceState::Disconnected => service2_state = ServiceState::ConnectedAgain,
+					ServiceState::FirstConnec | ServiceState::ConnectedAgain => panic!(),
+				},
+				future::Either::Right(SwarmEvent::Behaviour(
+					NotificationsOut::CustomProtocolClosed { .. },
+				)) => match service2_state {
+					ServiceState::FirstConnec => service2_state = ServiceState::Disconnected,
+					ServiceState::ConnectedAgain |
+					ServiceState::NotConnected |
+					ServiceState::Disconnected => panic!(),
+				},
 				_ => {},
 			}
 
@@ -331,8 +335,8 @@ fn reconnect_after_disconnect() {
 		loop {
 			// Grab next event from services.
 			let event = {
-				let s1 = service1.next();
-				let s2 = service2.next();
+				let s1 = service1.select_next_some();
+				let s2 = service2.select_next_some();
 				futures::pin_mut!(s1, s2);
 				match future::select(future::select(s1, s2), &mut delay).await {
 					future::Either::Right(_) => break, // success
@@ -342,8 +346,8 @@ fn reconnect_after_disconnect() {
 			};
 
 			match event {
-				NotificationsOut::CustomProtocolOpen { .. } |
-				NotificationsOut::CustomProtocolClosed { .. } => panic!(),
+				SwarmEvent::Behaviour(NotificationsOut::CustomProtocolOpen { .. }) |
+				SwarmEvent::Behaviour(NotificationsOut::CustomProtocolClosed { .. }) => panic!(),
 				_ => {},
 			}
 		}

--- a/client/network/src/protocol/notifications/upgrade/notifications.rs
+++ b/client/network/src/protocol/notifications/upgrade/notifications.rs
@@ -385,7 +385,7 @@ where
 
 	fn upgrade_outbound(self, mut socket: TSubstream, negotiated_name: Self::Info) -> Self::Future {
 		Box::pin(async move {
-			upgrade::write_with_len_prefix(&mut socket, &self.initial_message).await?;
+			upgrade::write_length_prefixed(&mut socket, &self.initial_message).await?;
 
 			// Reading handshake.
 			let handshake_len = unsigned_varint::aio::read_usize(&mut socket).await?;

--- a/client/network/src/request_responses.rs
+++ b/client/network/src/request_responses.rs
@@ -1014,7 +1014,7 @@ mod tests {
 				let (mut swarm, _) = swarms.remove(0);
 				async move {
 					loop {
-						match swarm.next_event().await {
+						match swarm.select_next_some().await {
 							SwarmEvent::Behaviour(Event::InboundRequest { result, .. }) => {
 								result.unwrap();
 							},
@@ -1033,7 +1033,7 @@ mod tests {
 			let mut response_receiver = None;
 
 			loop {
-				match swarm.next_event().await {
+				match swarm.select_next_some().await {
 					SwarmEvent::ConnectionEstablished { peer_id, .. } => {
 						let (sender, receiver) = oneshot::channel();
 						swarm.behaviour_mut().send_request(
@@ -1111,7 +1111,7 @@ mod tests {
 				let (mut swarm, _) = swarms.remove(0);
 				async move {
 					loop {
-						match swarm.next_event().await {
+						match swarm.select_next_some().await {
 							SwarmEvent::Behaviour(Event::InboundRequest { result, .. }) => {
 								assert!(result.is_ok());
 								break
@@ -1131,7 +1131,7 @@ mod tests {
 			let mut response_receiver = None;
 
 			loop {
-				match swarm.next_event().await {
+				match swarm.select_next_some().await {
 					SwarmEvent::ConnectionEstablished { peer_id, .. } => {
 						let (sender, receiver) = oneshot::channel();
 						swarm.behaviour_mut().send_request(
@@ -1231,7 +1231,7 @@ mod tests {
 			.spawn_obj(
 				async move {
 					loop {
-						match swarm_2.next_event().await {
+						match swarm_2.select_next_some().await {
 							SwarmEvent::Behaviour(Event::InboundRequest { result, .. }) => {
 								result.unwrap();
 							},
@@ -1284,7 +1284,7 @@ mod tests {
 			let mut num_responses = 0;
 
 			loop {
-				match swarm_1.next_event().await {
+				match swarm_1.select_next_some().await {
 					SwarmEvent::ConnectionEstablished { peer_id, .. } => {
 						let (sender_1, receiver_1) = oneshot::channel();
 						let (sender_2, receiver_2) = oneshot::channel();

--- a/client/network/src/request_responses.rs
+++ b/client/network/src/request_responses.rs
@@ -567,6 +567,11 @@ impl NetworkBehaviour for RequestResponsesBehaviour {
 								address,
 								score,
 							}),
+						NetworkBehaviourAction::CloseConnection { peer_id, connection } =>
+							return Poll::Ready(NetworkBehaviourAction::CloseConnection {
+								peer_id,
+								connection,
+							}),
 					};
 
 					match ev {

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -1631,7 +1631,7 @@ impl<B: BlockT + 'static, H: ExHashT> Future for NetworkWorker<B, H> {
 			}
 
 			// Process the next action coming from the network.
-			let next_event = this.network_service.next_event();
+			let next_event = this.network_service.select_next_some();
 			futures::pin_mut!(next_event);
 			let poll_value = next_event.poll_unpin(cx);
 
@@ -1919,14 +1919,14 @@ impl<B: BlockT + 'static, H: ExHashT> Future for NetworkWorker<B, H> {
 						}
 					}
 				},
-				Poll::Ready(SwarmEvent::NewListenAddr(addr)) => {
-					trace!(target: "sub-libp2p", "Libp2p => NewListenAddr({})", addr);
+				Poll::Ready(SwarmEvent::NewListenAddr { address, .. }) => {
+					trace!(target: "sub-libp2p", "Libp2p => NewListenAddr({})", address);
 					if let Some(metrics) = this.metrics.as_ref() {
 						metrics.listeners_local_addresses.inc();
 					}
 				},
-				Poll::Ready(SwarmEvent::ExpiredListenAddr(addr)) => {
-					info!(target: "sub-libp2p", "📪 No longer listening on {}", addr);
+				Poll::Ready(SwarmEvent::ExpiredListenAddr { address, .. }) => {
+					info!(target: "sub-libp2p", "📪 No longer listening on {}", address);
 					if let Some(metrics) = this.metrics.as_ref() {
 						metrics.listeners_local_addresses.dec();
 					}
@@ -2008,11 +2008,9 @@ impl<B: BlockT + 'static, H: ExHashT> Future for NetworkWorker<B, H> {
 							.inc();
 					}
 				},
-				Poll::Ready(SwarmEvent::UnknownPeerUnreachableAddr { address, error }) => {
-					trace!(target: "sub-libp2p", "Libp2p => UnknownPeerUnreachableAddr({}): {}",
-						address, error)
-				},
-				Poll::Ready(SwarmEvent::ListenerClosed { reason, addresses }) => {
+				Poll::Ready(SwarmEvent::UnknownPeerUnreachableAddr { address, error }) =>
+					trace!(target: "sub-libp2p", "Libp2p => UnknownPeerUnreachableAddr({}): {}", address, error),
+				Poll::Ready(SwarmEvent::ListenerClosed { reason, addresses, .. }) => {
 					if let Some(metrics) = this.metrics.as_ref() {
 						metrics.listeners_local_addresses.sub(addresses.len() as u64);
 					}
@@ -2031,7 +2029,7 @@ impl<B: BlockT + 'static, H: ExHashT> Future for NetworkWorker<B, H> {
 						),
 					}
 				},
-				Poll::Ready(SwarmEvent::ListenerError { error }) => {
+				Poll::Ready(SwarmEvent::ListenerError { error, .. }) => {
 					debug!(target: "sub-libp2p", "Libp2p => ListenerError: {}", error);
 					if let Some(metrics) = this.metrics.as_ref() {
 						metrics.listeners_errors_total.inc();

--- a/client/network/test/Cargo.toml
+++ b/client/network/test/Cargo.toml
@@ -20,7 +20,7 @@ parking_lot = "0.11.1"
 futures = "0.3.9"
 futures-timer = "3.0.1"
 rand = "0.7.2"
-libp2p = { version = "0.37.1", default-features = false }
+libp2p = { version = "0.39.1", default-features = false }
 sp-consensus = { version = "0.10.0-dev", path = "../../../primitives/consensus/common" }
 sc-consensus = { version = "0.10.0-dev", path = "../../consensus/common" }
 sc-client-api = { version = "4.0.0-dev", path = "../../api" }

--- a/client/peerset/Cargo.toml
+++ b/client/peerset/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 futures = "0.3.9"
-libp2p = { version = "0.37.1", default-features = false }
+libp2p = { version = "0.39.1", default-features = false }
 sp-utils = { version = "4.0.0-dev", path = "../../primitives/utils"}
 log = "0.4.8"
 serde_json = "1.0.41"

--- a/client/telemetry/Cargo.toml
+++ b/client/telemetry/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 parking_lot = "0.11.1"
 futures = "0.3.9"
 wasm-timer = "0.2.5"
-libp2p = { version = "0.37.1", default-features = false, features = ["dns-async-std", "tcp-async-io", "wasm-ext", "websocket"] }
+libp2p = { version = "0.39.1", default-features = false, features = ["dns-async-std", "tcp-async-io", "wasm-ext", "websocket"] }
 log = "0.4.8"
 pin-project = "1.0.4"
 rand = "0.7.2"

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -62,9 +62,7 @@ schnorrkel = { version = "0.9.1", features = [
 sha2 = { version = "0.9.2", default-features = false, optional = true }
 hex = { version = "0.4", default-features = false, optional = true }
 twox-hash = { version = "1.5.0", default-features = false, optional = true }
-libsecp256k1 = { version = "0.3.2", default-features = false, features = [
-	"hmac",
-], optional = true }
+libsecp256k1 = { version = "0.6", default-features = false, features = ["hmac", "static-context"], optional = true }
 merlin = { version = "2.0", default-features = false, optional = true }
 
 sp-runtime-interface = { version = "4.0.0-dev", default-features = false, path = "../runtime-interface" }

--- a/primitives/core/src/ecdsa.rs
+++ b/primitives/core/src/ecdsa.rs
@@ -606,7 +606,7 @@ impl Pair {
 fn parse_signature_standard(
 	x: &[u8],
 ) -> Result<(libsecp256k1::Signature, libsecp256k1::RecoveryId), libsecp256k1::Error> {
-	let sig = libsecp256k1::Signature::parse_standard_slice(&x[0..64])?;
+	let sig = libsecp256k1::Signature::parse_standard_slice(&x[..64])?;
 	let ri = libsecp256k1::RecoveryId::parse(x[64])?;
 	Ok((sig, ri))
 }

--- a/primitives/core/src/ecdsa.rs
+++ b/primitives/core/src/ecdsa.rs
@@ -593,6 +593,7 @@ impl Pair {
 	}
 }
 
+#[cfg(feature = "full_crypto")]
 fn parse_signature(
     x: &[u8],
 ) -> Result<(libsecp256k1::Signature, libsecp256k1::RecoveryId), libsecp256k1::Error> {
@@ -601,6 +602,7 @@ fn parse_signature(
     Ok((sig, ri))
 }
 
+#[cfg(feature = "full_crypto")]
 fn parse_signature_deprecated(
     x: &[u8],
 ) -> Result<(libsecp256k1::Signature, libsecp256k1::RecoveryId), libsecp256k1::Error> {

--- a/primitives/core/src/ecdsa.rs
+++ b/primitives/core/src/ecdsa.rs
@@ -19,10 +19,8 @@
 //! Simple ECDSA API.
 // end::description[]
 
-#[cfg(feature = "full_crypto")]
-use sp_std::vec::Vec;
-
 use codec::{Decode, Encode, MaxEncodedLen};
+use sp_runtime_interface::pass_by::PassByInner;
 use sp_std::cmp::Ordering;
 
 #[cfg(feature = "std")]
@@ -41,6 +39,10 @@ use bip39::{Language, Mnemonic, MnemonicType};
 use core::convert::{TryFrom, TryInto};
 #[cfg(feature = "full_crypto")]
 use libsecp256k1::{PublicKey, SecretKey};
+#[cfg(feature = "std")]
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+#[cfg(feature = "full_crypto")]
+use sp_std::vec::Vec;
 
 /// An identifier used to match public keys against ecdsa keys
 pub const CRYPTO_ID: CryptoTypeId = CryptoTypeId(*b"ecds");
@@ -449,7 +451,7 @@ impl TraitPair for Pair {
 		phrase: &str,
 		password: Option<&str>,
 	) -> Result<(Pair, Seed), SecretStringError> {
-		let big_seed = seed_from_entropy(
+		let big_seed = substrate_bip39::seed_from_entropy(
 			Mnemonic::from_phrase(phrase, Language::English)
 				.map_err(|_| SecretStringError::InvalidPhrase)?
 				.entropy(),

--- a/primitives/core/src/ecdsa.rs
+++ b/primitives/core/src/ecdsa.rs
@@ -394,7 +394,7 @@ impl<'a> TryFrom<&'a Signature> for (libsecp256k1::Signature, libsecp256k1::Reco
 	type Error = ();
 	fn try_from(x: &'a Signature) -> Result<(libsecp256k1::Signature, libsecp256k1::RecoveryId), Self::Error> {
 		Ok((
-			libsecp256k1::Signature::parse_standard_slice(&x.0[0..64]).expect("hardcoded to 64 bytes; qed"),
+			libsecp256k1::Signature::parse_overflowing_slice(&x.0[0..64]).expect("hardcoded to 64 bytes; qed"),
 			libsecp256k1::RecoveryId::parse(x.0[64]).map_err(|_| ())?,
 		))
 	}
@@ -525,7 +525,7 @@ impl TraitPair for Pair {
 		let message = libsecp256k1::Message::parse(&blake2_256(message.as_ref()));
 		if sig.len() != 65 { return false }
 		let ri = match libsecp256k1::RecoveryId::parse(sig[64]) { Ok(x) => x, _ => return false };
-		let sig = match libsecp256k1::Signature::parse_standard_slice(&sig[0..64]) { Ok(x) => x, _ => return false };
+		let sig = match libsecp256k1::Signature::parse_overflowing_slice(&sig[0..64]) { Ok(x) => x, _ => return false };
 		match libsecp256k1::recover(&message, &sig, &ri) {
 			Ok(actual) => pubkey.as_ref() == &actual.serialize()[1..],
 			_ => false,

--- a/primitives/core/src/ecdsa.rs
+++ b/primitives/core/src/ecdsa.rs
@@ -615,7 +615,7 @@ fn parse_signature_standard(
 fn parse_signature_overflowing(
 	x: &[u8],
 ) -> Result<(libsecp256k1::Signature, libsecp256k1::RecoveryId), libsecp256k1::Error> {
-	let sig = libsecp256k1::Signature::parse_overflowing_slice(&x[0..64])?;
+	let sig = libsecp256k1::Signature::parse_overflowing_slice(&x[..64])?;
 	let ri = libsecp256k1::RecoveryId::parse(x[64])?;
 	Ok((sig, ri))
 }

--- a/primitives/core/src/ecdsa.rs
+++ b/primitives/core/src/ecdsa.rs
@@ -40,12 +40,7 @@ use bip39::{Language, Mnemonic, MnemonicType};
 #[cfg(feature = "full_crypto")]
 use core::convert::{TryFrom, TryInto};
 #[cfg(feature = "full_crypto")]
-use secp256k1::{PublicKey, SecretKey};
-#[cfg(feature = "std")]
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-use sp_runtime_interface::pass_by::PassByInner;
-#[cfg(feature = "std")]
-use substrate_bip39::seed_from_entropy;
+use libsecp256k1::{PublicKey, SecretKey};
 
 /// An identifier used to match public keys against ecdsa keys
 pub const CRYPTO_ID: CryptoTypeId = CryptoTypeId(*b"ecds");
@@ -108,7 +103,7 @@ impl Public {
 	/// This will convert the full public key into the compressed format.
 	#[cfg(feature = "std")]
 	pub fn from_full(full: &[u8]) -> Result<Self, ()> {
-		secp256k1::PublicKey::parse_slice(full, None)
+		libsecp256k1::PublicKey::parse_slice(full, None)
 			.map(|k| k.serialize_compressed())
 			.map(Self)
 			.map_err(|_| ())
@@ -364,9 +359,9 @@ impl Signature {
 	/// Recover the public key from this signature and a message.
 	#[cfg(feature = "full_crypto")]
 	pub fn recover<M: AsRef<[u8]>>(&self, message: M) -> Option<Public> {
-		let message = secp256k1::Message::parse(&blake2_256(message.as_ref()));
+		let message = libsecp256k1::Message::parse(&blake2_256(message.as_ref()));
 		let sig: (_, _) = self.try_into().ok()?;
-		secp256k1::recover(&message, &sig.0, &sig.1)
+		libsecp256k1::recover(&message, &sig.0, &sig.1)
 			.ok()
 			.map(|recovered| Public(recovered.serialize_compressed()))
 	}
@@ -374,19 +369,19 @@ impl Signature {
 	/// Recover the public key from this signature and a pre-hashed message.
 	#[cfg(feature = "full_crypto")]
 	pub fn recover_prehashed(&self, message: &[u8; 32]) -> Option<Public> {
-		let message = secp256k1::Message::parse(message);
+		let message = libsecp256k1::Message::parse(message);
 
 		let sig: (_, _) = self.try_into().ok()?;
 
-		secp256k1::recover(&message, &sig.0, &sig.1)
+		libsecp256k1::recover(&message, &sig.0, &sig.1)
 			.ok()
 			.map(|key| Public(key.serialize_compressed()))
 	}
 }
 
 #[cfg(feature = "full_crypto")]
-impl From<(secp256k1::Signature, secp256k1::RecoveryId)> for Signature {
-	fn from(x: (secp256k1::Signature, secp256k1::RecoveryId)) -> Signature {
+impl From<(libsecp256k1::Signature, libsecp256k1::RecoveryId)> for Signature {
+	fn from(x: (libsecp256k1::Signature, libsecp256k1::RecoveryId)) -> Signature {
 		let mut r = Self::default();
 		r.0[0..64].copy_from_slice(&x.0.serialize()[..]);
 		r.0[64] = x.1.serialize();
@@ -395,14 +390,12 @@ impl From<(secp256k1::Signature, secp256k1::RecoveryId)> for Signature {
 }
 
 #[cfg(feature = "full_crypto")]
-impl<'a> TryFrom<&'a Signature> for (secp256k1::Signature, secp256k1::RecoveryId) {
+impl<'a> TryFrom<&'a Signature> for (libsecp256k1::Signature, libsecp256k1::RecoveryId) {
 	type Error = ();
-	fn try_from(
-		x: &'a Signature,
-	) -> Result<(secp256k1::Signature, secp256k1::RecoveryId), Self::Error> {
+	fn try_from(x: &'a Signature) -> Result<(libsecp256k1::Signature, libsecp256k1::RecoveryId), Self::Error> {
 		Ok((
-			secp256k1::Signature::parse_slice(&x.0[0..64]).expect("hardcoded to 64 bytes; qed"),
-			secp256k1::RecoveryId::parse(x.0[64]).map_err(|_| ())?,
+			libsecp256k1::Signature::parse_standard_slice(&x.0[0..64]).expect("hardcoded to 64 bytes; qed"),
+			libsecp256k1::RecoveryId::parse(x.0[64]).map_err(|_| ())?,
 		))
 	}
 }
@@ -510,18 +503,15 @@ impl TraitPair for Pair {
 
 	/// Sign a message.
 	fn sign(&self, message: &[u8]) -> Signature {
-		let message = secp256k1::Message::parse(&blake2_256(message));
-		secp256k1::sign(&message, &self.secret).into()
+		let message = libsecp256k1::Message::parse(&blake2_256(message));
+		libsecp256k1::sign(&message, &self.secret).into()
 	}
 
 	/// Verify a signature on a message. Returns true if the signature is good.
 	fn verify<M: AsRef<[u8]>>(sig: &Self::Signature, message: M, pubkey: &Self::Public) -> bool {
-		let message = secp256k1::Message::parse(&blake2_256(message.as_ref()));
-		let sig: (_, _) = match sig.try_into() {
-			Ok(x) => x,
-			_ => return false,
-		};
-		match secp256k1::recover(&message, &sig.0, &sig.1) {
+		let message = libsecp256k1::Message::parse(&blake2_256(message.as_ref()));
+		let sig: (_, _) = match sig.try_into() { Ok(x) => x, _ => return false };
+		match libsecp256k1::recover(&message, &sig.0, &sig.1) {
 			Ok(actual) => pubkey.0[..] == actual.serialize_compressed()[..],
 			_ => false,
 		}
@@ -532,19 +522,11 @@ impl TraitPair for Pair {
 	/// This doesn't use the type system to ensure that `sig` and `pubkey` are the correct
 	/// size. Use it only if you're coming from byte buffers and need the speed.
 	fn verify_weak<P: AsRef<[u8]>, M: AsRef<[u8]>>(sig: &[u8], message: M, pubkey: P) -> bool {
-		let message = secp256k1::Message::parse(&blake2_256(message.as_ref()));
-		if sig.len() != 65 {
-			return false
-		}
-		let ri = match secp256k1::RecoveryId::parse(sig[64]) {
-			Ok(x) => x,
-			_ => return false,
-		};
-		let sig = match secp256k1::Signature::parse_slice(&sig[0..64]) {
-			Ok(x) => x,
-			_ => return false,
-		};
-		match secp256k1::recover(&message, &sig, &ri) {
+		let message = libsecp256k1::Message::parse(&blake2_256(message.as_ref()));
+		if sig.len() != 65 { return false }
+		let ri = match libsecp256k1::RecoveryId::parse(sig[64]) { Ok(x) => x, _ => return false };
+		let sig = match libsecp256k1::Signature::parse_standard_slice(&sig[0..64]) { Ok(x) => x, _ => return false };
+		match libsecp256k1::recover(&message, &sig, &ri) {
 			Ok(actual) => pubkey.as_ref() == &actual.serialize()[1..],
 			_ => false,
 		}
@@ -577,21 +559,21 @@ impl Pair {
 
 	/// Sign a pre-hashed message
 	pub fn sign_prehashed(&self, message: &[u8; 32]) -> Signature {
-		let message = secp256k1::Message::parse(message);
-		secp256k1::sign(&message, &self.secret).into()
+		let message = libsecp256k1::Message::parse(message);
+		libsecp256k1::sign(&message, &self.secret).into()
 	}
 
 	/// Verify a signature on a pre-hashed message. Return `true` if the signature is valid
 	/// and thus matches the given `public` key.
 	pub fn verify_prehashed(sig: &Signature, message: &[u8; 32], public: &Public) -> bool {
-		let message = secp256k1::Message::parse(message);
+		let message = libsecp256k1::Message::parse(message);
 
 		let sig: (_, _) = match sig.try_into() {
 			Ok(x) => x,
 			_ => return false,
 		};
 
-		match secp256k1::recover(&message, &sig.0, &sig.1) {
+		match libsecp256k1::recover(&message, &sig.0, &sig.1) {
 			Ok(actual) => public.0[..] == actual.serialize_compressed()[..],
 			_ => false,
 		}
@@ -839,8 +821,7 @@ mod test {
 		// `msg` shouldn't be mangled
 		let msg = [0u8; 32];
 		let sig1 = pair.sign_prehashed(&msg);
-		let sig2: Signature =
-			secp256k1::sign(&secp256k1::Message::parse(&msg), &pair.secret).into();
+		let sig2: Signature = libsecp256k1::sign(&libsecp256k1::Message::parse(&msg), &pair.secret).into();
 
 		assert_eq!(sig1, sig2);
 
@@ -852,8 +833,7 @@ mod test {
 		// using pre-hashed `msg` works
 		let msg = keccak_256(b"this should be hashed");
 		let sig1 = pair.sign_prehashed(&msg);
-		let sig2: Signature =
-			secp256k1::sign(&secp256k1::Message::parse(&msg), &pair.secret).into();
+		let sig2: Signature = libsecp256k1::sign(&libsecp256k1::Message::parse(&msg), &pair.secret).into();
 
 		assert_eq!(sig1, sig2);
 	}

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -20,7 +20,7 @@ hash-db = { version = "0.15.2", default-features = false }
 sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }
 sp-keystore = { version = "0.10.0-dev", default-features = false, optional = true, path = "../keystore" }
 sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
-libsecp256k1 = { version = "0.3.4", optional = true }
+libsecp256k1 = { version = "0.6", optional = true }
 sp-state-machine = { version = "0.10.0-dev", optional = true, path = "../state-machine" }
 sp-wasm-interface = { version = "4.0.0-dev", path = "../wasm-interface", default-features = false }
 sp-runtime-interface = { version = "4.0.0-dev", default-features = false, path = "../runtime-interface" }

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -760,12 +760,13 @@ pub trait Crypto {
 		sig: &[u8; 65],
 		msg: &[u8; 32],
 	) -> Result<[u8; 64], EcdsaVerifyError> {
-		let rs =
-			secp256k1::Signature::parse_slice(&sig[0..64]).map_err(|_| EcdsaVerifyError::BadRS)?;
-		let v =
-			secp256k1::RecoveryId::parse(if sig[64] > 26 { sig[64] - 27 } else { sig[64] } as u8)
-				.map_err(|_| EcdsaVerifyError::BadV)?;
-		let pubkey = secp256k1::recover(&secp256k1::Message::parse(msg), &rs, &v)
+		let rs = libsecp256k1::Signature::parse_standard_slice(&sig[0..64])
+			.map_err(|_| EcdsaVerifyError::BadRS)?;
+		let v = libsecp256k1::RecoveryId::parse(
+			if sig[64] > 26 { sig[64] - 27 } else { sig[64] } as u8
+		)
+		.map_err(|_| EcdsaVerifyError::BadV)?;
+		let pubkey = libsecp256k1::recover(&libsecp256k1::Message::parse(msg), &rs, &v)
 			.map_err(|_| EcdsaVerifyError::BadSignature)?;
 		let mut res = [0u8; 64];
 		res.copy_from_slice(&pubkey.serialize()[1..65]);
@@ -782,12 +783,13 @@ pub trait Crypto {
 		sig: &[u8; 65],
 		msg: &[u8; 32],
 	) -> Result<[u8; 33], EcdsaVerifyError> {
-		let rs =
-			secp256k1::Signature::parse_slice(&sig[0..64]).map_err(|_| EcdsaVerifyError::BadRS)?;
-		let v =
-			secp256k1::RecoveryId::parse(if sig[64] > 26 { sig[64] - 27 } else { sig[64] } as u8)
-				.map_err(|_| EcdsaVerifyError::BadV)?;
-		let pubkey = secp256k1::recover(&secp256k1::Message::parse(msg), &rs, &v)
+		let rs = libsecp256k1::Signature::parse_standard_slice(&sig[0..64])
+			.map_err(|_| EcdsaVerifyError::BadRS)?;
+		let v = libsecp256k1::RecoveryId::parse(
+			if sig[64] > 26 { sig[64] - 27 } else { sig[64] } as u8
+		)
+		.map_err(|_| EcdsaVerifyError::BadV)?;
+		let pubkey = libsecp256k1::recover(&libsecp256k1::Message::parse(msg), &rs, &v)
 			.map_err(|_| EcdsaVerifyError::BadSignature)?;
 		Ok(pubkey.serialize_compressed())
 	}

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -760,6 +760,31 @@ pub trait Crypto {
 		sig: &[u8; 65],
 		msg: &[u8; 32],
 	) -> Result<[u8; 64], EcdsaVerifyError> {
+		let rs = libsecp256k1::Signature::parse_overflowing_slice(&sig[0..64])
+			.map_err(|_| EcdsaVerifyError::BadRS)?;
+		let v = libsecp256k1::RecoveryId::parse(
+			if sig[64] > 26 { sig[64] - 27 } else { sig[64] } as u8
+		)
+		.map_err(|_| EcdsaVerifyError::BadV)?;
+		let pubkey = libsecp256k1::recover(&libsecp256k1::Message::parse(msg), &rs, &v)
+			.map_err(|_| EcdsaVerifyError::BadSignature)?;
+		let mut res = [0u8; 64];
+		res.copy_from_slice(&pubkey.serialize()[1..65]);
+		Ok(res)
+	}
+
+	/// Verify and recover a SECP256k1 ECDSA signature.
+	///
+	/// - `sig` is passed in RSV format. V should be either `0/1` or `27/28`.
+	/// - `msg` is the blake2-256 hash of the message.
+	///
+	/// Returns `Err` if the signature is bad, otherwise the 64-byte pubkey
+	/// (doesn't include the 0x04 prefix).
+	#[version(2)]
+	fn secp256k1_ecdsa_recover(
+		sig: &[u8; 65],
+		msg: &[u8; 32],
+	) -> Result<[u8; 64], EcdsaVerifyError> {
 		let rs = libsecp256k1::Signature::parse_standard_slice(&sig[0..64])
 			.map_err(|_| EcdsaVerifyError::BadRS)?;
 		let v = libsecp256k1::RecoveryId::parse(
@@ -779,6 +804,28 @@ pub trait Crypto {
 	/// - `msg` is the blake2-256 hash of the message.
 	///
 	/// Returns `Err` if the signature is bad, otherwise the 33-byte compressed pubkey.
+	fn secp256k1_ecdsa_recover_compressed(
+		sig: &[u8; 65],
+		msg: &[u8; 32],
+	) -> Result<[u8; 33], EcdsaVerifyError> {
+		let rs = libsecp256k1::Signature::parse_overflowing_slice(&sig[0..64])
+			.map_err(|_| EcdsaVerifyError::BadRS)?;
+		let v = libsecp256k1::RecoveryId::parse(
+			if sig[64] > 26 { sig[64] - 27 } else { sig[64] } as u8
+		)
+		.map_err(|_| EcdsaVerifyError::BadV)?;
+		let pubkey = libsecp256k1::recover(&libsecp256k1::Message::parse(msg), &rs, &v)
+			.map_err(|_| EcdsaVerifyError::BadSignature)?;
+		Ok(pubkey.serialize_compressed())
+	}
+
+	/// Verify and recover a SECP256k1 ECDSA signature.
+	///
+	/// - `sig` is passed in RSV format. V should be either `0/1` or `27/28`.
+	/// - `msg` is the blake2-256 hash of the message.
+	///
+	/// Returns `Err` if the signature is bad, otherwise the 33-byte compressed pubkey.
+	#[version(2)]
 	fn secp256k1_ecdsa_recover_compressed(
 		sig: &[u8; 65],
 		msg: &[u8; 32],

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -718,7 +718,23 @@ pub trait Crypto {
 	/// Verify `ecdsa` signature.
 	///
 	/// Returns `true` when the verification was successful.
-	fn ecdsa_verify(sig: &ecdsa::Signature, msg: &[u8], pub_key: &ecdsa::Public) -> bool {
+	fn ecdsa_verify(
+		sig: &ecdsa::Signature,
+		msg: &[u8],
+		pub_key: &ecdsa::Public,
+	) -> bool {
+		ecdsa::Pair::verify_deprecated(sig, msg, pub_key)
+	}
+
+	/// Verify `ecdsa` signature.
+	///
+	/// Returns `true` when the verification was successful.
+	#[version(2)]
+	fn ecdsa_verify(
+		sig: &ecdsa::Signature,
+		msg: &[u8],
+		pub_key: &ecdsa::Public,
+	) -> bool {
 		ecdsa::Pair::verify(sig, msg, pub_key)
 	}
 

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -718,11 +718,7 @@ pub trait Crypto {
 	/// Verify `ecdsa` signature.
 	///
 	/// Returns `true` when the verification was successful.
-	fn ecdsa_verify(
-		sig: &ecdsa::Signature,
-		msg: &[u8],
-		pub_key: &ecdsa::Public,
-	) -> bool {
+	fn ecdsa_verify(sig: &ecdsa::Signature, msg: &[u8], pub_key: &ecdsa::Public) -> bool {
 		ecdsa::Pair::verify_deprecated(sig, msg, pub_key)
 	}
 
@@ -730,11 +726,7 @@ pub trait Crypto {
 	///
 	/// Returns `true` when the verification was successful.
 	#[version(2)]
-	fn ecdsa_verify(
-		sig: &ecdsa::Signature,
-		msg: &[u8],
-		pub_key: &ecdsa::Public,
-	) -> bool {
+	fn ecdsa_verify(sig: &ecdsa::Signature, msg: &[u8], pub_key: &ecdsa::Public) -> bool {
 		ecdsa::Pair::verify(sig, msg, pub_key)
 	}
 

--- a/test-utils/test-runner/src/host_functions.rs
+++ b/test-utils/test-runner/src/host_functions.rs
@@ -77,6 +77,8 @@ impl sp_wasm_interface::HostFunctions for SignatureVerificationOverride {
 		override_host_functions!(
 			"ext_crypto_ecdsa_verify_version_1",
 			EcdsaVerify,
+			"ext_crypto_ecdsa_verify_version_2",
+			EcdsaVerifyV2,
 			"ext_crypto_ed25519_verify_version_1",
 			Ed25519Verify,
 			"ext_crypto_sr25519_verify_version_1",

--- a/utils/browser/Cargo.toml
+++ b/utils/browser/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 futures = "0.3.16"
 log = "0.4.8"
-libp2p-wasm-ext = { version = "0.28.1", features = ["websocket"] }
+libp2p-wasm-ext = { version = "0.29", features = ["websocket"] }
 console_error_panic_hook = "0.1.6"
 js-sys = "0.3.34"
 wasm-bindgen = "0.2.73"


### PR DESCRIPTION
libsecp256k1 allows overflowing signatures
https://rustsec.org/advisories/RUSTSEC-2021-0076

Changes were made to conform to libsecp256k1 version differences.

Closes #9356

