### PR TITLE
Remove extra commas made redundent after rustfmt

### DIFF
--- a/bin/node/executor/tests/basic.rs
+++ b/bin/node/executor/tests/basic.rs
@@ -427,7 +427,7 @@ fn full_native_block_import_works() {
 			Balances::total_balance(&alice()),
 			alice_last_known_balance - 10 * DOLLARS - fees,
 		);
-		assert_eq!(Balances::total_balance(&bob()), 179 * DOLLARS - fees,);
+		assert_eq!(Balances::total_balance(&bob()), 179 * DOLLARS - fees);
 		let events = vec![
 			EventRecord {
 				phase: Phase::ApplyExtrinsic(0),
@@ -529,7 +529,7 @@ fn full_wasm_block_import_works() {
 			Balances::total_balance(&alice()),
 			alice_last_known_balance - 10 * DOLLARS - fees,
 		);
-		assert_eq!(Balances::total_balance(&bob()), 179 * DOLLARS - 1 * fees,);
+		assert_eq!(Balances::total_balance(&bob()), 179 * DOLLARS - 1 * fees);
 	});
 }
 

--- a/bin/utils/chain-spec-builder/src/main.rs
+++ b/bin/utils/chain-spec-builder/src/main.rs
@@ -203,7 +203,7 @@ fn print_seeds(
 	println!("{}", header.paint("Authority seeds"));
 
 	for (n, seed) in authority_seeds.iter().enumerate() {
-		println!("{} //{}", entry.paint(format!("auth-{}:", n)), seed,);
+		println!("{} //{}", entry.paint(format!("auth-{}:", n)), seed);
 	}
 
 	println!("{}", header.paint("Nominator seeds"));
@@ -217,7 +217,7 @@ fn print_seeds(
 	if !endowed_seeds.is_empty() {
 		println!("{}", header.paint("Endowed seeds"));
 		for (n, seed) in endowed_seeds.iter().enumerate() {
-			println!("{} //{}", entry.paint(format!("endowed-{}:", n)), seed,);
+			println!("{} //{}", entry.paint(format!("endowed-{}:", n)), seed);
 		}
 
 		println!();

--- a/client/authority-discovery/src/worker.rs
+++ b/client/authority-discovery/src/worker.rs
@@ -421,7 +421,7 @@ where
 
 				if log_enabled!(log::Level::Debug) {
 					let hashes: Vec<_> = v.iter().map(|(hash, _value)| hash.clone()).collect();
-					debug!(target: LOG_TARGET, "Value for hash '{:?}' found on Dht.", hashes,);
+					debug!(target: LOG_TARGET, "Value for hash '{:?}' found on Dht.", hashes);
 				}
 
 				if let Err(e) = self.handle_dht_value_found_event(v) {
@@ -429,7 +429,7 @@ where
 						metrics.handle_value_found_event_failure.inc();
 					}
 
-					debug!(target: LOG_TARGET, "Failed to handle Dht value found event: {:?}", e,);
+					debug!(target: LOG_TARGET, "Failed to handle Dht value found event: {:?}", e);
 				}
 			},
 			DhtEvent::ValueNotFound(hash) => {
@@ -456,7 +456,7 @@ where
 					metrics.dht_event_received.with_label_values(&["value_put"]).inc();
 				}
 
-				debug!(target: LOG_TARGET, "Successfully put hash '{:?}' on Dht.", hash,)
+				debug!(target: LOG_TARGET, "Successfully put hash '{:?}' on Dht.", hash)
 			},
 			DhtEvent::ValuePutFailed(hash) => {
 				if let Some(metrics) = &self.metrics {

--- a/client/cli/src/params/mod.rs
+++ b/client/cli/src/params/mod.rs
@@ -49,7 +49,7 @@ impl FromStr for GenericNumber {
 
 	fn from_str(block_number: &str) -> Result<Self, Self::Err> {
 		if let Some(pos) = block_number.chars().position(|d| !d.is_digit(10)) {
-			Err(format!("Expected block number, found illegal digit at position: {}", pos,))
+			Err(format!("Expected block number, found illegal digit at position: {}", pos))
 		} else {
 			Ok(Self(block_number.to_owned()))
 		}

--- a/client/cli/src/runner.rs
+++ b/client/cli/src/runner.rs
@@ -206,7 +206,7 @@ impl<C: SubstrateCli> Runner<C> {
 pub fn print_node_infos<C: SubstrateCli>(config: &Configuration) {
 	info!("{}", C::impl_name());
 	info!("✌️  version {}", C::impl_version());
-	info!("❤️  by {}, {}-{}", C::author(), C::copyright_start_year(), Local::today().year(),);
+	info!("❤️  by {}, {}-{}", C::author(), C::copyright_start_year(), Local::today().year());
 	info!("📋 Chain specification: {}", config.chain_spec.name());
 	info!("🏷 Node name: {}", config.network.node_name);
 	info!("👤 Role: {}", config.display_role());

--- a/client/consensus/babe/src/aux_schema.rs
+++ b/client/consensus/babe/src/aux_schema.rs
@@ -170,7 +170,7 @@ mod test {
 			)
 			.unwrap();
 
-		assert_eq!(load_decode::<_, u32>(&client, BABE_EPOCH_CHANGES_VERSION).unwrap(), None,);
+		assert_eq!(load_decode::<_, u32>(&client, BABE_EPOCH_CHANGES_VERSION).unwrap(), None);
 
 		let epoch_changes = load_epoch_changes::<TestBlock, _>(
 			&client,
@@ -202,6 +202,6 @@ mod test {
 			client.insert_aux(values, &[]).unwrap();
 		});
 
-		assert_eq!(load_decode::<_, u32>(&client, BABE_EPOCH_CHANGES_VERSION).unwrap(), Some(2),);
+		assert_eq!(load_decode::<_, u32>(&client, BABE_EPOCH_CHANGES_VERSION).unwrap(), Some(2));
 	}
 }

--- a/client/consensus/babe/src/tests.rs
+++ b/client/consensus/babe/src/tests.rs
@@ -780,10 +780,10 @@ fn importing_epoch_change_block_prunes_tree() {
 	let fork_3 = propose_and_import_blocks(BlockId::Hash(canon_hashes[18]), 10);
 
 	// We should be tracking a total of 9 epochs in the fork tree
-	assert_eq!(epoch_changes.shared_data().tree().iter().count(), 9,);
+	assert_eq!(epoch_changes.shared_data().tree().iter().count(), 9);
 
 	// And only one root
-	assert_eq!(epoch_changes.shared_data().tree().roots().count(), 1,);
+	assert_eq!(epoch_changes.shared_data().tree().roots().count(), 1);
 
 	// We finalize block #13 from the canon chain, so on the next epoch
 	// change the tree should be pruned, to not contain F (#7).

--- a/client/consensus/slots/src/aux_schema.rs
+++ b/client/consensus/slots/src/aux_schema.rs
@@ -169,21 +169,21 @@ mod test {
 		let header6 = create_header(3); // @ slot 4
 
 		// It's ok to sign same headers.
-		assert!(check_equivocation(&client, 2.into(), 2.into(), &header1, &public,)
+		assert!(check_equivocation(&client, 2.into(), 2.into(), &header1, &public)
 			.unwrap()
 			.is_none(),);
 
-		assert!(check_equivocation(&client, 3.into(), 2.into(), &header1, &public,)
+		assert!(check_equivocation(&client, 3.into(), 2.into(), &header1, &public)
 			.unwrap()
 			.is_none(),);
 
 		// But not two different headers at the same slot.
-		assert!(check_equivocation(&client, 4.into(), 2.into(), &header2, &public,)
+		assert!(check_equivocation(&client, 4.into(), 2.into(), &header2, &public)
 			.unwrap()
 			.is_some(),);
 
 		// Different slot is ok.
-		assert!(check_equivocation(&client, 5.into(), 4.into(), &header3, &public,)
+		assert!(check_equivocation(&client, 5.into(), 4.into(), &header3, &public)
 			.unwrap()
 			.is_none(),);
 

--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -318,7 +318,7 @@ pub trait SimpleSlotWorker<B: BlockT> {
 		let proposal = match futures::future::select(proposing, proposing_remaining).await {
 			Either::Left((Ok(p), _)) => p,
 			Either::Left((Err(err), _)) => {
-				warn!(target: logging_target, "Proposing failed: {:?}", err,);
+				warn!(target: logging_target, "Proposing failed: {:?}", err);
 
 				return None
 			},
@@ -363,7 +363,7 @@ pub trait SimpleSlotWorker<B: BlockT> {
 		) {
 			Ok(bi) => bi,
 			Err(err) => {
-				warn!(target: logging_target, "Failed to create block import params: {:?}", err,);
+				warn!(target: logging_target, "Failed to create block import params: {:?}", err);
 
 				return None
 			},
@@ -922,7 +922,7 @@ mod test {
 		}
 
 		// but we cap it to a maximum of 20 slots
-		assert_eq!(super::slot_lenience_linear(1u64.into(), &slot(23)), Some(SLOT_DURATION * 20),);
+		assert_eq!(super::slot_lenience_linear(1u64.into(), &slot(23)), Some(SLOT_DURATION * 20));
 	}
 
 	#[test]

--- a/client/consensus/slots/src/slots.rs
+++ b/client/consensus/slots/src/slots.rs
@@ -33,7 +33,7 @@ pub fn duration_now() -> Duration {
 	use std::time::SystemTime;
 	let now = SystemTime::now();
 	now.duration_since(SystemTime::UNIX_EPOCH).unwrap_or_else(|e| {
-		panic!("Current time {:?} is before unix epoch. Something is wrong: {:?}", now, e,)
+		panic!("Current time {:?} is before unix epoch. Something is wrong: {:?}", now, e)
 	})
 }
 

--- a/client/db/src/light.rs
+++ b/client/db/src/light.rs
@@ -1155,23 +1155,23 @@ pub(crate) mod tests {
 
 			let hash7 =
 				insert_block(&db, make_authorities(vec![auth3()]), || default_header(&hash6, 7));
-			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6)), Some(vec![auth1(), auth2()]),);
+			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6)), Some(vec![auth1(), auth2()]));
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash7)), Some(vec![auth3()]));
 			let hash8 =
 				insert_block(&db, make_authorities(vec![auth3()]), || default_header(&hash7, 8));
-			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6)), Some(vec![auth1(), auth2()]),);
+			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6)), Some(vec![auth1(), auth2()]));
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash7)), Some(vec![auth3()]));
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash8)), Some(vec![auth3()]));
 			let hash6_1 =
 				insert_block(&db, make_authorities(vec![auth4()]), || default_header(&hash6, 7));
-			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6)), Some(vec![auth1(), auth2()]),);
+			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6)), Some(vec![auth1(), auth2()]));
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash7)), Some(vec![auth3()]));
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash8)), Some(vec![auth3()]));
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6_1)), Some(vec![auth4()]));
 			let hash6_1_1 = insert_non_best_block(&db, make_authorities(vec![auth5()]), || {
 				default_header(&hash6_1, 8)
 			});
-			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6)), Some(vec![auth1(), auth2()]),);
+			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6)), Some(vec![auth1(), auth2()]));
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash7)), Some(vec![auth3()]));
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash8)), Some(vec![auth3()]));
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6_1)), Some(vec![auth4()]));
@@ -1179,7 +1179,7 @@ pub(crate) mod tests {
 			let hash6_1_2 = insert_non_best_block(&db, make_authorities(vec![auth6()]), || {
 				default_header(&hash6_1, 8)
 			});
-			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6)), Some(vec![auth1(), auth2()]),);
+			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6)), Some(vec![auth1(), auth2()]));
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash7)), Some(vec![auth3()]));
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash8)), Some(vec![auth3()]));
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6_1)), Some(vec![auth4()]));
@@ -1187,7 +1187,7 @@ pub(crate) mod tests {
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6_1_2)), Some(vec![auth6()]));
 			let hash6_2 =
 				insert_block(&db, make_authorities(vec![auth4()]), || default_header(&hash6_1, 8));
-			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6)), Some(vec![auth1(), auth2()]),);
+			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6)), Some(vec![auth1(), auth2()]));
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash7)), Some(vec![auth3()]));
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash8)), Some(vec![auth3()]));
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6_1)), Some(vec![auth4()]));
@@ -1201,7 +1201,7 @@ pub(crate) mod tests {
 		{
 			// finalize block hash6_1
 			db.finalize_header(BlockId::Hash(hash6_1)).unwrap();
-			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6)), Some(vec![auth1(), auth2()]),);
+			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6)), Some(vec![auth1(), auth2()]));
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash7)), None);
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash8)), None);
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6_1)), Some(vec![auth4()]));
@@ -1210,7 +1210,7 @@ pub(crate) mod tests {
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6_2)), Some(vec![auth4()]));
 			// finalize block hash6_2
 			db.finalize_header(BlockId::Hash(hash6_2)).unwrap();
-			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6)), Some(vec![auth1(), auth2()]),);
+			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6)), Some(vec![auth1(), auth2()]));
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash7)), None);
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash8)), None);
 			assert_eq!(authorities(db.cache(), BlockId::Hash(hash6_1)), Some(vec![auth4()]));

--- a/client/executor/src/integration_tests/sandbox.rs
+++ b/client/executor/src/integration_tests/sandbox.rs
@@ -51,7 +51,7 @@ fn sandbox_should_work(wasm_method: WasmExecutionMethod) {
 	.unwrap()
 	.encode();
 
-	assert_eq!(call_in_wasm("test_sandbox", &code, wasm_method, &mut ext,).unwrap(), true.encode(),);
+	assert_eq!(call_in_wasm("test_sandbox", &code, wasm_method, &mut ext).unwrap(), true.encode());
 }
 
 test_wasm_execution!(sandbox_trap);
@@ -72,7 +72,7 @@ fn sandbox_trap(wasm_method: WasmExecutionMethod) {
 	)
 	.unwrap();
 
-	assert_eq!(call_in_wasm("test_sandbox", &code, wasm_method, &mut ext,).unwrap(), vec![0],);
+	assert_eq!(call_in_wasm("test_sandbox", &code, wasm_method, &mut ext).unwrap(), vec![0]);
 }
 
 test_wasm_execution!(start_called);
@@ -111,7 +111,7 @@ fn start_called(wasm_method: WasmExecutionMethod) {
 	.unwrap()
 	.encode();
 
-	assert_eq!(call_in_wasm("test_sandbox", &code, wasm_method, &mut ext,).unwrap(), true.encode(),);
+	assert_eq!(call_in_wasm("test_sandbox", &code, wasm_method, &mut ext).unwrap(), true.encode());
 }
 
 test_wasm_execution!(invoke_args);

--- a/client/executor/src/native_executor.rs
+++ b/client/executor/src/native_executor.rs
@@ -658,7 +658,7 @@ mod tests {
 	fn native_executor_registers_custom_interface() {
 		let executor = NativeExecutor::<MyExecutor>::new(WasmExecutionMethod::Interpreted, None, 8);
 		my_interface::HostFunctions::host_functions().iter().for_each(|function| {
-			assert_eq!(executor.wasm.host_functions.iter().filter(|f| f == &function).count(), 2,);
+			assert_eq!(executor.wasm.host_functions.iter().filter(|f| f == &function).count(), 2);
 		});
 
 		my_interface::say_hello_world("hey");

--- a/client/executor/wasmtime/src/instance_wrapper.rs
+++ b/client/executor/wasmtime/src/instance_wrapper.rs
@@ -176,7 +176,7 @@ impl InstanceWrapper {
 					.ok_or_else(|| Error::from(format!("Export {} is not a function", method)))?
 					.clone();
 				EntryPoint::direct(func).map_err(|_| {
-					Error::from(format!("Exported function '{}' has invalid signature.", method,))
+					Error::from(format!("Exported function '{}' has invalid signature.", method))
 				})?
 			},
 			InvokeMethod::Table(func_ref) => {

--- a/client/finality-grandpa/src/authorities.rs
+++ b/client/finality-grandpa/src/authorities.rs
@@ -780,13 +780,13 @@ mod tests {
 		authorities.add_pending_change(change(1), &is_descendent_of).unwrap();
 		authorities.add_pending_change(change(2), &is_descendent_of).unwrap();
 
-		assert_eq!(authorities.current_limit(0), Some(1),);
+		assert_eq!(authorities.current_limit(0), Some(1));
 
-		assert_eq!(authorities.current_limit(1), Some(1),);
+		assert_eq!(authorities.current_limit(1), Some(1));
 
-		assert_eq!(authorities.current_limit(2), Some(2),);
+		assert_eq!(authorities.current_limit(2), Some(2));
 
-		assert_eq!(authorities.current_limit(3), None,);
+		assert_eq!(authorities.current_limit(3), None);
 	}
 
 	#[test]
@@ -910,7 +910,7 @@ mod tests {
 			.add_pending_change(change_b.clone(), &static_is_descendent_of(true))
 			.unwrap();
 
-		assert_eq!(authorities.pending_changes().collect::<Vec<_>>(), vec![&change_a, &change_b],);
+		assert_eq!(authorities.pending_changes().collect::<Vec<_>>(), vec![&change_a, &change_b]);
 
 		// finalizing "hash_c" won't enact the change signaled at "hash_a" but it will prune out "hash_b"
 		let status = authorities
@@ -929,7 +929,7 @@ mod tests {
 
 		assert!(status.changed);
 		assert_eq!(status.new_set_block, None);
-		assert_eq!(authorities.pending_changes().collect::<Vec<_>>(), vec![&change_a],);
+		assert_eq!(authorities.pending_changes().collect::<Vec<_>>(), vec![&change_a]);
 		assert_eq!(authorities.authority_set_changes, AuthoritySetChanges::empty());
 
 		// finalizing "hash_d" will enact the change signaled at "hash_a"
@@ -1444,7 +1444,7 @@ mod tests {
 		);
 
 		// there's no longer any pending change at `best_b` fork
-		assert_eq!(authorities.next_change(&"best_b", &is_descendent_of).unwrap(), None,);
+		assert_eq!(authorities.next_change(&"best_b", &is_descendent_of).unwrap(), None);
 
 		// we a forced change at A10 (#8)
 		let change_a10 = PendingChange {
@@ -1666,7 +1666,7 @@ mod tests {
 		authority_set_changes.append(2, 81);
 
 		// we are missing the data for the first set, therefore we should return `None`
-		assert_eq!(None, authority_set_changes.iter_from(40).map(|it| it.collect::<Vec<_>>()),);
+		assert_eq!(None, authority_set_changes.iter_from(40).map(|it| it.collect::<Vec<_>>()));
 
 		// after adding the data for the first set the same query should work
 		let mut authority_set_changes = AuthoritySetChanges::empty();
@@ -1685,8 +1685,8 @@ mod tests {
 			authority_set_changes.iter_from(41).map(|it| it.cloned().collect::<Vec<_>>()),
 		);
 
-		assert_eq!(0, authority_set_changes.iter_from(121).unwrap().count(),);
+		assert_eq!(0, authority_set_changes.iter_from(121).unwrap().count());
 
-		assert_eq!(0, authority_set_changes.iter_from(200).unwrap().count(),);
+		assert_eq!(0, authority_set_changes.iter_from(200).unwrap().count());
 	}
 }

--- a/client/finality-grandpa/src/aux_schema.rs
+++ b/client/finality-grandpa/src/aux_schema.rs
@@ -536,7 +536,7 @@ mod test {
 				.unwrap();
 		}
 
-		assert_eq!(load_decode::<_, u32>(&client, VERSION_KEY).unwrap(), None,);
+		assert_eq!(load_decode::<_, u32>(&client, VERSION_KEY).unwrap(), None);
 
 		// should perform the migration
 		load_persistent::<substrate_test_runtime_client::runtime::Block, _, _>(
@@ -547,7 +547,7 @@ mod test {
 		)
 		.unwrap();
 
-		assert_eq!(load_decode::<_, u32>(&client, VERSION_KEY).unwrap(), Some(3),);
+		assert_eq!(load_decode::<_, u32>(&client, VERSION_KEY).unwrap(), Some(3));
 
 		let PersistentData { authority_set, set_state, .. } =
 			load_persistent::<substrate_test_runtime_client::runtime::Block, _, _>(
@@ -629,7 +629,7 @@ mod test {
 				.unwrap();
 		}
 
-		assert_eq!(load_decode::<_, u32>(&client, VERSION_KEY).unwrap(), Some(1),);
+		assert_eq!(load_decode::<_, u32>(&client, VERSION_KEY).unwrap(), Some(1));
 
 		// should perform the migration
 		load_persistent::<substrate_test_runtime_client::runtime::Block, _, _>(
@@ -640,7 +640,7 @@ mod test {
 		)
 		.unwrap();
 
-		assert_eq!(load_decode::<_, u32>(&client, VERSION_KEY).unwrap(), Some(3),);
+		assert_eq!(load_decode::<_, u32>(&client, VERSION_KEY).unwrap(), Some(3));
 
 		let PersistentData { authority_set, set_state, .. } =
 			load_persistent::<substrate_test_runtime_client::runtime::Block, _, _>(
@@ -719,7 +719,7 @@ mod test {
 				.unwrap();
 		}
 
-		assert_eq!(load_decode::<_, u32>(&client, VERSION_KEY).unwrap(), Some(2),);
+		assert_eq!(load_decode::<_, u32>(&client, VERSION_KEY).unwrap(), Some(2));
 
 		// should perform the migration
 		load_persistent::<substrate_test_runtime_client::runtime::Block, _, _>(
@@ -730,7 +730,7 @@ mod test {
 		)
 		.unwrap();
 
-		assert_eq!(load_decode::<_, u32>(&client, VERSION_KEY).unwrap(), Some(3),);
+		assert_eq!(load_decode::<_, u32>(&client, VERSION_KEY).unwrap(), Some(3));
 
 		let PersistentData { authority_set, .. } = load_persistent::<
 			substrate_test_runtime_client::runtime::Block,

--- a/client/finality-grandpa/src/communication/gossip.rs
+++ b/client/finality-grandpa/src/communication/gossip.rs
@@ -2258,7 +2258,7 @@ mod tests {
 		// we accept messages from rounds 9, 10 and 11
 		// therefore neither of those should be considered expired
 		for round in &[9, 10, 11] {
-			assert!(!is_expired(crate::communication::round_topic::<Block>(*round, 1), &[],))
+			assert!(!is_expired(crate::communication::round_topic::<Block>(*round, 1), &[]))
 		}
 	}
 
@@ -2533,10 +2533,10 @@ mod tests {
 		);
 
 		// it should be expired if it is for a lower block
-		assert!(message_expired(crate::communication::global_topic::<Block>(1), &commit(1, 1, 1),));
+		assert!(message_expired(crate::communication::global_topic::<Block>(1), &commit(1, 1, 1)));
 
 		// or the same block height but from the previous round
-		assert!(message_expired(crate::communication::global_topic::<Block>(1), &commit(0, 1, 2),));
+		assert!(message_expired(crate::communication::global_topic::<Block>(1), &commit(0, 1, 2)));
 	}
 
 	#[test]

--- a/client/finality-grandpa/src/communication/tests.rs
+++ b/client/finality-grandpa/src/communication/tests.rs
@@ -512,7 +512,7 @@ fn peer_with_higher_view_leads_to_catch_up_request() {
 			tester
 				.filter_network_events(move |event| match event {
 					Event::WriteNotification(peer, message) => {
-						assert_eq!(peer, id,);
+						assert_eq!(peer, id);
 
 						assert_eq!(
 							message,

--- a/client/finality-grandpa/src/environment.rs
+++ b/client/finality-grandpa/src/environment.rs
@@ -1376,7 +1376,7 @@ where
 					set_ref.len(),
 				);
 			} else {
-				afg_log!(initial_sync, "👴 Applying GRANDPA set change to new set {:?}", set_ref,);
+				afg_log!(initial_sync, "👴 Applying GRANDPA set change to new set {:?}", set_ref);
 			}
 
 			telemetry!(

--- a/client/finality-grandpa/src/finality_proof.rs
+++ b/client/finality-grandpa/src/finality_proof.rs
@@ -512,7 +512,7 @@ pub(crate) mod tests {
 		let mut authority_set_changes = AuthoritySetChanges::empty();
 		authority_set_changes.append(0, 5);
 
-		assert!(matches!(prove_finality(&*backend, authority_set_changes, 6), Ok(None),));
+		assert!(matches!(prove_finality(&*backend, authority_set_changes, 6), Ok(None)));
 	}
 
 	#[test]

--- a/client/finality-grandpa/src/tests.rs
+++ b/client/finality-grandpa/src/tests.rs
@@ -1631,7 +1631,7 @@ fn imports_justification_for_regular_blocks_on_import() {
 	);
 
 	// the justification should be imported and available from the client
-	assert!(client.justifications(&BlockId::Hash(block_hash)).unwrap().is_some(),);
+	assert!(client.justifications(&BlockId::Hash(block_hash)).unwrap().is_some());
 }
 
 #[test]

--- a/client/finality-grandpa/src/until_imported.rs
+++ b/client/finality-grandpa/src/until_imported.rs
@@ -759,7 +759,7 @@ mod tests {
 			chain_state.import_header(h3);
 		});
 
-		assert_eq!(unapply_commit(res), unapply_commit(unknown_commit()),);
+		assert_eq!(unapply_commit(res), unapply_commit(unknown_commit()));
 	}
 
 	#[test]
@@ -787,7 +787,7 @@ mod tests {
 			chain_state.import_header(h3);
 		});
 
-		assert_eq!(unapply_commit(res), unapply_commit(known_commit()),);
+		assert_eq!(unapply_commit(res), unapply_commit(known_commit()));
 	}
 
 	#[test]
@@ -835,7 +835,7 @@ mod tests {
 			chain_state.import_header(h3);
 		});
 
-		assert_eq!(unapply_catch_up(res), unapply_catch_up(unknown_catch_up()),);
+		assert_eq!(unapply_catch_up(res), unapply_catch_up(unknown_catch_up()));
 	}
 
 	#[test]
@@ -883,7 +883,7 @@ mod tests {
 			chain_state.import_header(h3);
 		});
 
-		assert_eq!(unapply_catch_up(res), unapply_catch_up(unknown_catch_up()),);
+		assert_eq!(unapply_catch_up(res), unapply_catch_up(unknown_catch_up()));
 	}
 
 	#[test]

--- a/client/keystore/src/local.rs
+++ b/client/keystore/src/local.rs
@@ -709,7 +709,7 @@ mod tests {
 		let file_name = temp_dir.path().join(hex::encode(&SR25519.0[..2]));
 		fs::write(file_name, "test").expect("Invalid file is written");
 
-		assert!(SyncCryptoStore::sr25519_public_keys(&store, SR25519).is_empty(),);
+		assert!(SyncCryptoStore::sr25519_public_keys(&store, SR25519).is_empty());
 	}
 
 	#[test]

--- a/client/network-gossip/src/bridge.rs
+++ b/client/network-gossip/src/bridge.rs
@@ -264,7 +264,7 @@ impl<B: BlockT> Future for GossipEngine<B> {
 						match sink.start_send(notification.clone()) {
 							Ok(()) => {},
 							Err(e) if e.is_full() =>
-								unreachable!("Previously ensured that all sinks are ready; qed.",),
+								unreachable!("Previously ensured that all sinks are ready; qed."),
 							// Receiver got dropped. Will be removed in next iteration (See (1)).
 							Err(_) => {},
 						}
@@ -624,7 +624,7 @@ mod tests {
 									.or_insert(1);
 							},
 							Poll::Ready(None) =>
-								unreachable!("Sender side of channel is never dropped",),
+								unreachable!("Sender side of channel is never dropped"),
 							Poll::Pending => {},
 						}
 					}

--- a/client/network/src/bitswap.rs
+++ b/client/network/src/bitswap.rs
@@ -230,7 +230,7 @@ impl<B: BlockT> NetworkBehaviour for Bitswap<B> {
 		let wantlist = match request.wantlist {
 			Some(wantlist) => wantlist,
 			None => {
-				debug!(target: LOG_TARGET, "Unexpected bitswap message from {}", peer,);
+				debug!(target: LOG_TARGET, "Unexpected bitswap message from {}", peer);
 				return
 			},
 		};

--- a/client/network/src/light_client_requests/sender.rs
+++ b/client/network/src/light_client_requests/sender.rs
@@ -902,7 +902,7 @@ mod tests {
 
 		let OutEvent::SendRequest { target, pending_response, .. } =
 			block_on(sender.next()).unwrap();
-		assert!(target == peer0 || target == peer1, "Expect request to originate from known peer.",);
+		assert!(target == peer0 || target == peer1, "Expect request to originate from known peer.");
 
 		// And we should have one busy peer.
 		assert!({

--- a/client/network/src/protocol/sync.rs
+++ b/client/network/src/protocol/sync.rs
@@ -2272,7 +2272,7 @@ mod test {
 			.any(|(who, request)| { who == peer_id && request.from == FromBlock::Hash(a1_hash) }));
 
 		// there are no extra pending requests
-		assert_eq!(sync.extra_justifications.pending_requests().count(), 0,);
+		assert_eq!(sync.extra_justifications.pending_requests().count(), 0);
 
 		// there's one in-flight extra request to the expected peer
 		assert!(sync.extra_justifications.active_requests().any(|(who, (hash, number))| {
@@ -2290,7 +2290,7 @@ mod test {
 		);
 
 		// there should be no in-flight requests
-		assert_eq!(sync.extra_justifications.active_requests().count(), 0,);
+		assert_eq!(sync.extra_justifications.active_requests().count(), 0);
 
 		// and the request should now be pending again, waiting for reschedule
 		assert!(sync

--- a/client/rpc/src/state/tests.rs
+++ b/client/rpc/src/state/tests.rs
@@ -127,7 +127,7 @@ fn should_return_child_storage() {
 			.map(|x| x.is_some()),
 		Ok(true)
 	);
-	assert_matches!(child.storage_size(child_key.clone(), key.clone(), None,).wait(), Ok(Some(1)));
+	assert_matches!(child.storage_size(child_key.clone(), key.clone(), None).wait(), Ok(Some(1)));
 }
 
 #[test]

--- a/client/rpc/src/system/tests.rs
+++ b/client/rpc/src/system/tests.rs
@@ -145,27 +145,27 @@ fn wait_receiver<T>(rx: Receiver<T>) -> T {
 
 #[test]
 fn system_name_works() {
-	assert_eq!(api(None).system_name().unwrap(), "testclient".to_owned(),);
+	assert_eq!(api(None).system_name().unwrap(), "testclient".to_owned());
 }
 
 #[test]
 fn system_version_works() {
-	assert_eq!(api(None).system_version().unwrap(), "0.2.0".to_owned(),);
+	assert_eq!(api(None).system_version().unwrap(), "0.2.0".to_owned());
 }
 
 #[test]
 fn system_chain_works() {
-	assert_eq!(api(None).system_chain().unwrap(), "testchain".to_owned(),);
+	assert_eq!(api(None).system_chain().unwrap(), "testchain".to_owned());
 }
 
 #[test]
 fn system_properties_works() {
-	assert_eq!(api(None).system_properties().unwrap(), serde_json::map::Map::new(),);
+	assert_eq!(api(None).system_properties().unwrap(), serde_json::map::Map::new());
 }
 
 #[test]
 fn system_type_works() {
-	assert_eq!(api(None).system_type().unwrap(), Default::default(),);
+	assert_eq!(api(None).system_type().unwrap(), Default::default());
 }
 
 #[test]

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -1913,7 +1913,7 @@ where
 		// (i.e. fork blocks and bad blocks respectively)
 		match self.block_rules.lookup(number, &hash) {
 			BlockLookupResult::KnownBad => {
-				trace!("Rejecting known bad block: #{} {:?}", number, hash,);
+				trace!("Rejecting known bad block: #{} {:?}", number, hash);
 				return Ok(ImportResult::KnownBad)
 			},
 			BlockLookupResult::Expected(expected_hash) => {

--- a/client/service/test/src/client/mod.rs
+++ b/client/service/test/src/client/mod.rs
@@ -1220,13 +1220,13 @@ fn import_with_justification() {
 		.block;
 	block_on(client.import_justified(BlockOrigin::Own, a3.clone(), justification.clone())).unwrap();
 
-	assert_eq!(client.chain_info().finalized_hash, a3.hash(),);
+	assert_eq!(client.chain_info().finalized_hash, a3.hash());
 
-	assert_eq!(client.justifications(&BlockId::Hash(a3.hash())).unwrap(), Some(justification),);
+	assert_eq!(client.justifications(&BlockId::Hash(a3.hash())).unwrap(), Some(justification));
 
-	assert_eq!(client.justifications(&BlockId::Hash(a1.hash())).unwrap(), None,);
+	assert_eq!(client.justifications(&BlockId::Hash(a1.hash())).unwrap(), None);
 
-	assert_eq!(client.justifications(&BlockId::Hash(a2.hash())).unwrap(), None,);
+	assert_eq!(client.justifications(&BlockId::Hash(a2.hash())).unwrap(), None);
 }
 
 #[test]
@@ -1265,15 +1265,15 @@ fn importing_diverged_finalized_block_should_trigger_reorg() {
 	let b1 = b1.build().unwrap().block;
 
 	// A2 is the current best since it's the longest chain
-	assert_eq!(client.chain_info().best_hash, a2.hash(),);
+	assert_eq!(client.chain_info().best_hash, a2.hash());
 
 	// importing B1 as finalized should trigger a re-org and set it as new best
 	let justification = Justifications::from((TEST_ENGINE_ID, vec![1, 2, 3]));
 	block_on(client.import_justified(BlockOrigin::Own, b1.clone(), justification)).unwrap();
 
-	assert_eq!(client.chain_info().best_hash, b1.hash(),);
+	assert_eq!(client.chain_info().best_hash, b1.hash());
 
-	assert_eq!(client.chain_info().finalized_hash, b1.hash(),);
+	assert_eq!(client.chain_info().finalized_hash, b1.hash());
 }
 
 #[test]
@@ -1320,21 +1320,21 @@ fn finalizing_diverged_block_should_trigger_reorg() {
 	block_on(client.import(BlockOrigin::Own, b2.clone())).unwrap();
 
 	// A2 is the current best since it's the longest chain
-	assert_eq!(client.chain_info().best_hash, a2.hash(),);
+	assert_eq!(client.chain_info().best_hash, a2.hash());
 
 	// we finalize block B1 which is on a different branch from current best
 	// which should trigger a re-org.
 	ClientExt::finalize_block(&client, BlockId::Hash(b1.hash()), None).unwrap();
 
 	// B1 should now be the latest finalized
-	assert_eq!(client.chain_info().finalized_hash, b1.hash(),);
+	assert_eq!(client.chain_info().finalized_hash, b1.hash());
 
 	// and B1 should be the new best block (`finalize_block` as no way of
 	// knowing about B2)
-	assert_eq!(client.chain_info().best_hash, b1.hash(),);
+	assert_eq!(client.chain_info().best_hash, b1.hash());
 
 	// `SelectChain` should report B2 as best block though
-	assert_eq!(block_on(select_chain.best_chain()).unwrap().hash(), b2.hash(),);
+	assert_eq!(block_on(select_chain.best_chain()).unwrap().hash(), b2.hash());
 
 	// after we build B3 on top of B2 and import it
 	// it should be the new best block,
@@ -1346,7 +1346,7 @@ fn finalizing_diverged_block_should_trigger_reorg() {
 		.block;
 	block_on(client.import(BlockOrigin::Own, b3.clone())).unwrap();
 
-	assert_eq!(client.chain_info().best_hash, b3.hash(),);
+	assert_eq!(client.chain_info().best_hash, b3.hash());
 }
 
 #[test]
@@ -1505,7 +1505,7 @@ fn doesnt_import_blocks_that_revert_finality() {
 		.to_string(),
 	);
 
-	assert_eq!(import_err.to_string(), expected_err.to_string(),);
+	assert_eq!(import_err.to_string(), expected_err.to_string());
 
 	// adding a C1 block which is lower than the last finalized should also
 	// fail (with a cheaper check that doesn't require checking ancestry).
@@ -1525,7 +1525,7 @@ fn doesnt_import_blocks_that_revert_finality() {
 	let expected_err =
 		ConsensusError::ClientImport(sp_blockchain::Error::NotInFinalizedChain.to_string());
 
-	assert_eq!(import_err.to_string(), expected_err.to_string(),);
+	assert_eq!(import_err.to_string(), expected_err.to_string());
 }
 
 #[test]

--- a/client/tracing/src/block/mod.rs
+++ b/client/tracing/src/block/mod.rs
@@ -246,7 +246,7 @@ where
 			);
 			let _guard = dispatcher_span.enter();
 			if let Err(e) = dispatcher::with_default(&dispatch, || {
-				let span = tracing::info_span!(target: TRACE_TARGET, "trace_block",);
+				let span = tracing::info_span!(target: TRACE_TARGET, "trace_block");
 				let _enter = span.enter();
 				self.client.runtime_api().execute_block(&parent_id, block)
 			}) {

--- a/client/tracing/src/logging/mod.rs
+++ b/client/tracing/src/logging/mod.rs
@@ -403,7 +403,7 @@ mod tests {
 			.unwrap();
 
 		let output = String::from_utf8(output.stderr).unwrap();
-		assert!(re.is_match(output.trim()), "Expected:\n{}\nGot:\n{}", re, output,);
+		assert!(re.is_match(output.trim()), "Expected:\n{}\nGot:\n{}", re, output);
 	}
 
 	/// This is not an actual test, it is used by the `prefix_in_log_lines` test.
@@ -448,7 +448,7 @@ mod tests {
 			.unwrap();
 
 		let output = String::from_utf8(output.stderr).unwrap();
-		assert!(re.is_match(output.trim()), "Expected:\n{}\nGot:\n{}", re, output,);
+		assert!(re.is_match(output.trim()), "Expected:\n{}\nGot:\n{}", re, output);
 	}
 
 	#[test]

--- a/frame/atomic-swap/src/lib.rs
+++ b/frame/atomic-swap/src/lib.rs
@@ -289,7 +289,7 @@ pub mod pallet {
 			proof: Vec<u8>,
 			action: T::SwapAction,
 		) -> DispatchResult {
-			ensure!(proof.len() <= T::ProofLimit::get() as usize, Error::<T>::ProofTooLarge,);
+			ensure!(proof.len() <= T::ProofLimit::get() as usize, Error::<T>::ProofTooLarge);
 
 			let target = ensure_signed(origin)?;
 			let hashed_proof = blake2_256(&proof);
@@ -322,7 +322,7 @@ pub mod pallet {
 			let source = ensure_signed(origin)?;
 
 			let swap = PendingSwaps::<T>::get(&target, hashed_proof).ok_or(Error::<T>::NotExist)?;
-			ensure!(swap.source == source, Error::<T>::SourceMismatch,);
+			ensure!(swap.source == source, Error::<T>::SourceMismatch);
 			ensure!(
 				frame_system::Pallet::<T>::block_number() >= swap.end_block,
 				Error::<T>::DurationNotPassed,

--- a/frame/babe/src/tests.rs
+++ b/frame/babe/src/tests.rs
@@ -323,7 +323,7 @@ fn can_fetch_current_and_next_epoch_data() {
 		});
 
 		// genesis authorities should be used for the first and second epoch
-		assert_eq!(Babe::current_epoch().authorities, Babe::next_epoch().authorities,);
+		assert_eq!(Babe::current_epoch().authorities, Babe::next_epoch().authorities);
 		// 1 era = 3 epochs
 		// 1 epoch = 3 slots
 		// Eras start from 0.

--- a/frame/bounties/src/benchmarking.rs
+++ b/frame/bounties/src/benchmarking.rs
@@ -211,4 +211,4 @@ benchmarks! {
 	}
 }
 
-impl_benchmark_test_suite!(Bounties, crate::tests::new_test_ext(), crate::tests::Test,);
+impl_benchmark_test_suite!(Bounties, crate::tests::new_test_ext(), crate::tests::Test);

--- a/frame/collective/src/benchmarking.rs
+++ b/frame/collective/src/benchmarking.rs
@@ -635,4 +635,4 @@ benchmarks_instance! {
 	}
 }
 
-impl_benchmark_test_suite!(Collective, crate::tests::new_test_ext(), crate::tests::Test,);
+impl_benchmark_test_suite!(Collective, crate::tests::new_test_ext(), crate::tests::Test);

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -2468,7 +2468,7 @@ mod tests {
 			let forbidden_call = Call::Balances(BalanceCall::transfer(CHARLIE, 22));
 
 			// simple cases: direct call
-			assert_err!(ctx.ext.call_runtime(forbidden_call.clone()), BadOrigin,);
+			assert_err!(ctx.ext.call_runtime(forbidden_call.clone()), BadOrigin);
 
 			// as part of a patch: return is OK (but it interrupted the batch)
 			assert_ok!(ctx.ext.call_runtime(Call::Utility(UtilCall::batch(vec![

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -639,7 +639,7 @@ fn storage_size() {
 		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
 		let bob_contract = ContractInfoOf::<Test>::get(&addr).unwrap().get_alive().unwrap();
 		assert_eq!(bob_contract.storage_size, 4);
-		assert_eq!(bob_contract.pair_count, 1,);
+		assert_eq!(bob_contract.pair_count, 1);
 
 		assert_ok!(Contracts::call(
 			Origin::signed(ALICE),
@@ -650,7 +650,7 @@ fn storage_size() {
 		));
 		let bob_contract = ContractInfoOf::<Test>::get(&addr).unwrap().get_alive().unwrap();
 		assert_eq!(bob_contract.storage_size, 4 + 4);
-		assert_eq!(bob_contract.pair_count, 2,);
+		assert_eq!(bob_contract.pair_count, 2);
 
 		assert_ok!(Contracts::call(
 			Origin::signed(ALICE),
@@ -661,7 +661,7 @@ fn storage_size() {
 		));
 		let bob_contract = ContractInfoOf::<Test>::get(&addr).unwrap().get_alive().unwrap();
 		assert_eq!(bob_contract.storage_size, 4);
-		assert_eq!(bob_contract.pair_count, 1,);
+		assert_eq!(bob_contract.pair_count, 1);
 	});
 }
 
@@ -682,8 +682,8 @@ fn empty_kv_pairs() {
 		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
 		let bob_contract = ContractInfoOf::<Test>::get(&addr).unwrap().get_alive().unwrap();
 
-		assert_eq!(bob_contract.storage_size, 0,);
-		assert_eq!(bob_contract.pair_count, 1,);
+		assert_eq!(bob_contract.storage_size, 0);
+		assert_eq!(bob_contract.pair_count, 1);
 	});
 }
 
@@ -993,7 +993,7 @@ fn removals(trigger_call: impl Fn(AccountIdOf<Test>) -> bool) {
 			ContractInfoOf::<Test>::get(&addr).unwrap().get_alive().unwrap().rent_allowance,
 			allowance,
 		);
-		assert_eq!(Balances::free_balance(&addr), balance,);
+		assert_eq!(Balances::free_balance(&addr), balance);
 
 		// Make contract have exactly the subsistence threshold
 		Balances::make_free_balance_be(&addr, subsistence_threshold);
@@ -1357,14 +1357,14 @@ fn restoration(
 			assert_eq!(django_contract.storage_size, 8);
 			assert_eq!(django_contract.trie_id, django_trie_id);
 			assert_eq!(django_contract.deduct_block, System::block_number());
-			assert_eq!(Storage::<Test>::read(&django_trie_id, &delta_key), Some(vec![40, 0, 0, 0]),);
+			assert_eq!(Storage::<Test>::read(&django_trie_id, &delta_key), Some(vec![40, 0, 0, 0]));
 			match (test_different_storage, test_restore_to_with_dirty_storage, test_code_evicted) {
 				(true, false, false) => {
-					assert_err_ignore_postinfo!(result, Error::<Test>::InvalidTombstone,);
+					assert_err_ignore_postinfo!(result, Error::<Test>::InvalidTombstone);
 					assert_eq!(System::events(), vec![]);
 				},
 				(_, true, false) => {
-					assert_err_ignore_postinfo!(result, Error::<Test>::InvalidContractOrigin,);
+					assert_err_ignore_postinfo!(result, Error::<Test>::InvalidContractOrigin);
 					assert_eq!(
 						System::events(),
 						vec![
@@ -1428,7 +1428,7 @@ fn restoration(
 					);
 				},
 				(false, false, true) => {
-					assert_err_ignore_postinfo!(result, Error::<Test>::CodeNotFound,);
+					assert_err_ignore_postinfo!(result, Error::<Test>::CodeNotFound);
 					assert_refcount!(set_rent_code_hash, 0);
 					assert_eq!(System::events(), vec![]);
 				},
@@ -1576,7 +1576,7 @@ fn cannot_self_destruct_through_draning() {
 
 		// Call BOB which makes it send all funds to the zero address
 		// The contract code asserts that the correct error value is returned.
-		assert_ok!(Contracts::call(Origin::signed(ALICE), addr, 0, GAS_LIMIT, vec![],));
+		assert_ok!(Contracts::call(Origin::signed(ALICE), addr, 0, GAS_LIMIT, vec![]));
 	});
 }
 
@@ -2155,7 +2155,7 @@ fn lazy_removal_works() {
 		child::put(trie, &[99], &42);
 
 		// Terminate the contract
-		assert_ok!(Contracts::call(Origin::signed(ALICE), addr.clone(), 0, GAS_LIMIT, vec![],));
+		assert_ok!(Contracts::call(Origin::signed(ALICE), addr.clone(), 0, GAS_LIMIT, vec![]));
 
 		// Contract info should be gone
 		assert!(!<ContractInfoOf::<Test>>::contains_key(&addr));
@@ -2209,7 +2209,7 @@ fn lazy_removal_partial_remove_works() {
 		<ContractInfoOf<Test>>::insert(&addr, ContractInfo::Alive(info.clone()));
 
 		// Terminate the contract
-		assert_ok!(Contracts::call(Origin::signed(ALICE), addr.clone(), 0, GAS_LIMIT, vec![],));
+		assert_ok!(Contracts::call(Origin::signed(ALICE), addr.clone(), 0, GAS_LIMIT, vec![]));
 
 		// Contract info should be gone
 		assert!(!<ContractInfoOf::<Test>>::contains_key(&addr));
@@ -2286,7 +2286,7 @@ fn lazy_removal_does_no_run_on_full_block() {
 		<ContractInfoOf<Test>>::insert(&addr, ContractInfo::Alive(info.clone()));
 
 		// Terminate the contract
-		assert_ok!(Contracts::call(Origin::signed(ALICE), addr.clone(), 0, GAS_LIMIT, vec![],));
+		assert_ok!(Contracts::call(Origin::signed(ALICE), addr.clone(), 0, GAS_LIMIT, vec![]));
 
 		// Contract info should be gone
 		assert!(!<ContractInfoOf::<Test>>::contains_key(&addr));
@@ -2359,7 +2359,7 @@ fn lazy_removal_does_not_use_all_weight() {
 		<ContractInfoOf<Test>>::insert(&addr, ContractInfo::Alive(info.clone()));
 
 		// Terminate the contract
-		assert_ok!(Contracts::call(Origin::signed(ALICE), addr.clone(), 0, GAS_LIMIT, vec![],));
+		assert_ok!(Contracts::call(Origin::signed(ALICE), addr.clone(), 0, GAS_LIMIT, vec![]));
 
 		// Contract info should be gone
 		assert!(!<ContractInfoOf::<Test>>::contains_key(&addr));
@@ -2543,7 +2543,7 @@ fn refcounter() {
 		let addr2 = Contracts::contract_address(&ALICE, &code_hash, &[2]);
 
 		// Terminating one contract should decrement the refcount
-		assert_ok!(Contracts::call(Origin::signed(ALICE), addr0, 0, GAS_LIMIT, vec![],));
+		assert_ok!(Contracts::call(Origin::signed(ALICE), addr0, 0, GAS_LIMIT, vec![]));
 		assert_refcount!(code_hash, 2);
 
 		// make remaining contracts eligible for eviction
@@ -2657,7 +2657,7 @@ fn debug_message_logging_disabled() {
 		let result = Contracts::bare_call(ALICE, addr.clone(), 0, GAS_LIMIT, vec![], false);
 		assert_matches!(result.result, Ok(_));
 		// the dispatchables always run without debugging
-		assert_ok!(Contracts::call(Origin::signed(ALICE), addr, 0, GAS_LIMIT, vec![],));
+		assert_ok!(Contracts::call(Origin::signed(ALICE), addr, 0, GAS_LIMIT, vec![]));
 		assert!(result.debug_message.is_empty());
 	});
 }

--- a/frame/contracts/src/wasm/env_def/macros.rs
+++ b/frame/contracts/src/wasm/env_def/macros.rs
@@ -341,7 +341,7 @@ mod tests {
 
 	#[test]
 	fn macro_gen_signature() {
-		assert_eq!(gen_signature!((i32)), FunctionType::new(vec![ValueType::I32], vec![]),);
+		assert_eq!(gen_signature!((i32)), FunctionType::new(vec![ValueType::I32], vec![]));
 
 		assert_eq!(
 			gen_signature!( (i32, u32) -> u32 ),

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -507,7 +507,7 @@ mod tests {
 	#[test]
 	fn contract_transfer() {
 		let mut mock_ext = MockExt::default();
-		assert_ok!(execute(CODE_TRANSFER, vec![], &mut mock_ext,));
+		assert_ok!(execute(CODE_TRANSFER, vec![], &mut mock_ext));
 
 		assert_eq!(&mock_ext.transfers, &[TransferEntry { to: ALICE, value: 153 }]);
 	}
@@ -561,7 +561,7 @@ mod tests {
 	#[test]
 	fn contract_call() {
 		let mut mock_ext = MockExt::default();
-		assert_ok!(execute(CODE_CALL, vec![], &mut mock_ext,));
+		assert_ok!(execute(CODE_CALL, vec![], &mut mock_ext));
 
 		assert_eq!(
 			&mock_ext.calls,
@@ -787,7 +787,7 @@ mod tests {
 	#[test]
 	fn contract_instantiate() {
 		let mut mock_ext = MockExt::default();
-		assert_ok!(execute(CODE_INSTANTIATE, vec![], &mut mock_ext,));
+		assert_ok!(execute(CODE_INSTANTIATE, vec![], &mut mock_ext));
 
 		assert_matches!(
 			&mock_ext.instantiates[..],
@@ -884,7 +884,7 @@ mod tests {
 	#[test]
 	fn contract_call_limited_gas() {
 		let mut mock_ext = MockExt::default();
-		assert_ok!(execute(&CODE_TRANSFER_LIMITED_GAS, vec![], &mut mock_ext,));
+		assert_ok!(execute(&CODE_TRANSFER_LIMITED_GAS, vec![], &mut mock_ext));
 
 		assert_eq!(
 			&mock_ext.calls,
@@ -1014,7 +1014,7 @@ mod tests {
 
 	#[test]
 	fn caller() {
-		assert_ok!(execute(CODE_CALLER, vec![], MockExt::default(),));
+		assert_ok!(execute(CODE_CALLER, vec![], MockExt::default()));
 	}
 
 	/// calls `seal_address` and compares the result with the constant 69.
@@ -1062,7 +1062,7 @@ mod tests {
 
 	#[test]
 	fn address() {
-		assert_ok!(execute(CODE_ADDRESS, vec![], MockExt::default(),));
+		assert_ok!(execute(CODE_ADDRESS, vec![], MockExt::default()));
 	}
 
 	const CODE_BALANCE: &str = r#"
@@ -1108,7 +1108,7 @@ mod tests {
 
 	#[test]
 	fn balance() {
-		assert_ok!(execute(CODE_BALANCE, vec![], MockExt::default(),));
+		assert_ok!(execute(CODE_BALANCE, vec![], MockExt::default()));
 	}
 
 	const CODE_GAS_PRICE: &str = r#"
@@ -1154,7 +1154,7 @@ mod tests {
 
 	#[test]
 	fn gas_price() {
-		assert_ok!(execute(CODE_GAS_PRICE, vec![], MockExt::default(),));
+		assert_ok!(execute(CODE_GAS_PRICE, vec![], MockExt::default()));
 	}
 
 	const CODE_GAS_LEFT: &str = r#"
@@ -1252,7 +1252,7 @@ mod tests {
 
 	#[test]
 	fn value_transferred() {
-		assert_ok!(execute(CODE_VALUE_TRANSFERRED, vec![], MockExt::default(),));
+		assert_ok!(execute(CODE_VALUE_TRANSFERRED, vec![], MockExt::default()));
 	}
 
 	const CODE_RETURN_FROM_START_FN: &str = r#"
@@ -1332,7 +1332,7 @@ mod tests {
 
 	#[test]
 	fn now() {
-		assert_ok!(execute(CODE_TIMESTAMP_NOW, vec![], MockExt::default(),));
+		assert_ok!(execute(CODE_TIMESTAMP_NOW, vec![], MockExt::default()));
 	}
 
 	const CODE_MINIMUM_BALANCE: &str = r#"
@@ -1377,7 +1377,7 @@ mod tests {
 
 	#[test]
 	fn minimum_balance() {
-		assert_ok!(execute(CODE_MINIMUM_BALANCE, vec![], MockExt::default(),));
+		assert_ok!(execute(CODE_MINIMUM_BALANCE, vec![], MockExt::default()));
 	}
 
 	const CODE_TOMBSTONE_DEPOSIT: &str = r#"
@@ -1422,7 +1422,7 @@ mod tests {
 
 	#[test]
 	fn tombstone_deposit() {
-		assert_ok!(execute(CODE_TOMBSTONE_DEPOSIT, vec![], MockExt::default(),));
+		assert_ok!(execute(CODE_TOMBSTONE_DEPOSIT, vec![], MockExt::default()));
 	}
 
 	const CODE_RANDOM: &str = r#"
@@ -1596,7 +1596,7 @@ mod tests {
 	#[test]
 	fn deposit_event() {
 		let mut mock_ext = MockExt::default();
-		assert_ok!(execute(CODE_DEPOSIT_EVENT, vec![], &mut mock_ext,));
+		assert_ok!(execute(CODE_DEPOSIT_EVENT, vec![], &mut mock_ext));
 
 		assert_eq!(
 			mock_ext.events,
@@ -2033,7 +2033,7 @@ mod tests {
 		let call = Call::System(frame_system::Call::remark(b"Hello World".to_vec()));
 		let mut ext = MockExt::default();
 		let result = execute(CODE_CALL_RUNTIME, call.encode(), &mut ext).unwrap();
-		assert_eq!(*ext.runtime_calls.borrow(), vec![call],);
+		assert_eq!(*ext.runtime_calls.borrow(), vec![call]);
 		// 0 = ReturnCode::Success
 		assert_eq!(u32::from_le_bytes(result.data.0.try_into().unwrap()), 0);
 	}
@@ -2050,6 +2050,6 @@ mod tests {
 				origin: ErrorOrigin::Caller,
 			})
 		);
-		assert_eq!(*ext.runtime_calls.borrow(), vec![],);
+		assert_eq!(*ext.runtime_calls.borrow(), vec![]);
 	}
 }

--- a/frame/democracy/src/benchmarking.rs
+++ b/frame/democracy/src/benchmarking.rs
@@ -778,4 +778,4 @@ benchmarks! {
 	}
 }
 
-impl_benchmark_test_suite!(Democracy, crate::tests::new_test_ext(), crate::tests::Test,);
+impl_benchmark_test_suite!(Democracy, crate::tests::new_test_ext(), crate::tests::Test);

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -374,7 +374,7 @@ pub mod pallet {
 			let who = ensure_signed(origin)?;
 
 			let actual_count = <Candidates<T>>::decode_len().unwrap_or(0);
-			ensure!(actual_count as u32 <= candidate_count, Error::<T>::InvalidWitnessData,);
+			ensure!(actual_count as u32 <= candidate_count, Error::<T>::InvalidWitnessData);
 
 			let index = Self::is_candidate(&who).err().ok_or(Error::<T>::DuplicatedCandidate)?;
 
@@ -1677,7 +1677,7 @@ mod tests {
 			assert_eq!(candidate_ids(), Vec::<u64>::new());
 			assert_ok!(submit_candidacy(Origin::signed(1)));
 			assert_eq!(candidate_ids(), vec![1]);
-			assert_noop!(submit_candidacy(Origin::signed(1)), Error::<Test>::DuplicatedCandidate,);
+			assert_noop!(submit_candidacy(Origin::signed(1)), Error::<Test>::DuplicatedCandidate);
 		});
 	}
 
@@ -1695,7 +1695,7 @@ mod tests {
 			assert!(Elections::runners_up().is_empty());
 			assert!(candidate_ids().is_empty());
 
-			assert_noop!(submit_candidacy(Origin::signed(5)), Error::<Test>::MemberSubmit,);
+			assert_noop!(submit_candidacy(Origin::signed(5)), Error::<Test>::MemberSubmit);
 		});
 	}
 
@@ -1715,7 +1715,7 @@ mod tests {
 			assert_eq!(members_ids(), vec![4, 5]);
 			assert_eq!(runners_up_ids(), vec![3]);
 
-			assert_noop!(submit_candidacy(Origin::signed(3)), Error::<Test>::RunnerUpSubmit,);
+			assert_noop!(submit_candidacy(Origin::signed(3)), Error::<Test>::RunnerUpSubmit);
 		});
 	}
 
@@ -1850,7 +1850,7 @@ mod tests {
 	#[test]
 	fn cannot_vote_for_no_candidate() {
 		ExtBuilder::default().build_and_execute(|| {
-			assert_noop!(vote(Origin::signed(2), vec![], 20), Error::<Test>::NoVotes,);
+			assert_noop!(vote(Origin::signed(2), vec![], 20), Error::<Test>::NoVotes);
 		});
 	}
 
@@ -2004,7 +2004,7 @@ mod tests {
 			assert_ok!(submit_candidacy(Origin::signed(5)));
 			assert_ok!(submit_candidacy(Origin::signed(4)));
 
-			assert_noop!(vote(Origin::signed(2), vec![4], 1), Error::<Test>::LowBalance,);
+			assert_noop!(vote(Origin::signed(2), vec![4], 1), Error::<Test>::LowBalance);
 		})
 	}
 

--- a/frame/elections/src/lib.rs
+++ b/frame/elections/src/lib.rs
@@ -694,7 +694,7 @@ pub mod pallet {
 			#[pallet::compact] index: VoteIndex,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
-			ensure!(!total.is_zero(), Error::<T>::ZeroDeposit,);
+			ensure!(!total.is_zero(), Error::<T>::ZeroDeposit);
 
 			let candidate = T::Lookup::lookup(candidate)?;
 			ensure!(index == Self::vote_index(), Error::<T>::InvalidVoteIndex);
@@ -711,7 +711,7 @@ pub mod pallet {
 			ensure!(total > leaderboard[0].0, Error::<T>::UnworthyCandidate);
 
 			if let Some(p) = Self::members().iter().position(|&(ref c, _)| c == &candidate) {
-				ensure!(p < expiring.len(), Error::<T>::DuplicatedCandidate,);
+				ensure!(p < expiring.len(), Error::<T>::DuplicatedCandidate);
 			}
 
 			let voters = Self::all_voters();
@@ -916,12 +916,12 @@ impl<T: Config> Pallet<T> {
 
 		ensure!(!Self::presentation_active(), Error::<T>::ApprovalPresentation);
 		ensure!(index == Self::vote_index(), Error::<T>::InvalidVoteIndex);
-		ensure!(!candidates_len.is_zero(), Error::<T>::ZeroCandidates,);
+		ensure!(!candidates_len.is_zero(), Error::<T>::ZeroCandidates);
 		// Prevent a vote from voters that provide a list of votes that exceeds the candidates
 		// length since otherwise an attacker may be able to submit a very long list of `votes` that
 		// far exceeds the amount of candidates and waste more computation than a reasonable voting
 		// bond would cover.
-		ensure!(candidates_len >= votes.len(), Error::<T>::TooManyVotes,);
+		ensure!(candidates_len >= votes.len(), Error::<T>::TooManyVotes);
 		ensure!(value >= T::MinimumVotingLock::get(), Error::<T>::InsufficientLockedValue);
 
 		// Amount to be locked up.

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -1226,9 +1226,9 @@ mod tests {
 
 		let header = new_test_ext(1).execute_with(|| {
 			// Make sure `on_runtime_upgrade` is called.
-			RUNTIME_VERSION.with(|v| *v.borrow_mut() = sp_version::RuntimeVersion {
-				spec_version: 1,
-				..Default::default()
+			RUNTIME_VERSION.with(|v| {
+				*v.borrow_mut() =
+					sp_version::RuntimeVersion { spec_version: 1, ..Default::default() }
 			});
 
 			// Let's build some fake block.
@@ -1246,16 +1246,15 @@ mod tests {
 		});
 
 		// Reset to get the correct new genesis below.
-		RUNTIME_VERSION.with(|v| *v.borrow_mut() = sp_version::RuntimeVersion {
-			spec_version: 0,
-			..Default::default()
+		RUNTIME_VERSION.with(|v| {
+			*v.borrow_mut() = sp_version::RuntimeVersion { spec_version: 0, ..Default::default() }
 		});
 
 		new_test_ext(1).execute_with(|| {
 			// Make sure `on_runtime_upgrade` is called.
-			RUNTIME_VERSION.with(|v| *v.borrow_mut() = sp_version::RuntimeVersion {
-				spec_version: 1,
-				..Default::default()
+			RUNTIME_VERSION.with(|v| {
+				*v.borrow_mut() =
+					sp_version::RuntimeVersion { spec_version: 1, ..Default::default() }
 			});
 
 			<Executive as ExecuteBlock<Block<TestXt>>>::execute_block(Block::new(header, vec![xt]));

--- a/frame/gilt/src/benchmarking.rs
+++ b/frame/gilt/src/benchmarking.rs
@@ -133,4 +133,4 @@ benchmarks! {
 	}: { Gilt::<T>::pursue_target(q) }
 }
 
-impl_benchmark_test_suite!(Gilt, crate::mock::new_test_ext(), crate::mock::Test,);
+impl_benchmark_test_suite!(Gilt, crate::mock::new_test_ext(), crate::mock::Test);

--- a/frame/grandpa/src/tests.rs
+++ b/frame/grandpa/src/tests.rs
@@ -234,7 +234,7 @@ fn schedule_pause_only_when_live() {
 		Grandpa::schedule_pause(1).unwrap();
 
 		// we've switched to the pending pause state
-		assert_eq!(Grandpa::state(), StoredState::PendingPause { scheduled_at: 1u64, delay: 1 },);
+		assert_eq!(Grandpa::state(), StoredState::PendingPause { scheduled_at: 1u64, delay: 1 });
 
 		Grandpa::on_finalize(1);
 		let _ = System::finalize();
@@ -248,7 +248,7 @@ fn schedule_pause_only_when_live() {
 		let _ = System::finalize();
 
 		// after finalizing block 2 the set should have switched to paused state
-		assert_eq!(Grandpa::state(), StoredState::Paused,);
+		assert_eq!(Grandpa::state(), StoredState::Paused);
 	});
 }
 
@@ -260,14 +260,14 @@ fn schedule_resume_only_when_paused() {
 		// the set is currently live, resuming it is an error
 		assert_noop!(Grandpa::schedule_resume(1), Error::<Test>::ResumeFailed);
 
-		assert_eq!(Grandpa::state(), StoredState::Live,);
+		assert_eq!(Grandpa::state(), StoredState::Live);
 
 		// we schedule a pause to be applied instantly
 		Grandpa::schedule_pause(0).unwrap();
 		Grandpa::on_finalize(1);
 		let _ = System::finalize();
 
-		assert_eq!(Grandpa::state(), StoredState::Paused,);
+		assert_eq!(Grandpa::state(), StoredState::Paused);
 
 		// we schedule the set to go back live in 2 blocks
 		initialize_block(2, Default::default());
@@ -284,7 +284,7 @@ fn schedule_resume_only_when_paused() {
 		let _ = System::finalize();
 
 		// it should be live at block 4
-		assert_eq!(Grandpa::state(), StoredState::Live,);
+		assert_eq!(Grandpa::state(), StoredState::Live);
 	});
 }
 

--- a/frame/identity/src/benchmarking.rs
+++ b/frame/identity/src/benchmarking.rs
@@ -413,4 +413,4 @@ benchmarks! {
 
 }
 
-impl_benchmark_test_suite!(Identity, crate::tests::new_test_ext(), crate::tests::Test,);
+impl_benchmark_test_suite!(Identity, crate::tests::new_test_ext(), crate::tests::Test);

--- a/frame/im-online/src/benchmarking.rs
+++ b/frame/im-online/src/benchmarking.rs
@@ -96,4 +96,4 @@ benchmarks! {
 	}
 }
 
-impl_benchmark_test_suite!(ImOnline, crate::mock::new_test_ext(), crate::mock::Runtime,);
+impl_benchmark_test_suite!(ImOnline, crate::mock::new_test_ext(), crate::mock::Runtime);

--- a/frame/im-online/src/tests.rs
+++ b/frame/im-online/src/tests.rs
@@ -37,7 +37,7 @@ use sp_runtime::{
 #[test]
 fn test_unresponsiveness_slash_fraction() {
 	// A single case of unresponsiveness is not slashed.
-	assert_eq!(UnresponsivenessOffence::<()>::slash_fraction(1, 50), Perbill::zero(),);
+	assert_eq!(UnresponsivenessOffence::<()>::slash_fraction(1, 50), Perbill::zero());
 
 	assert_eq!(
 		UnresponsivenessOffence::<()>::slash_fraction(5, 50),
@@ -435,7 +435,7 @@ fn should_handle_non_linear_session_progress() {
 		// if we don't have valid results for the current session progres then
 		// we'll fallback to `HeartbeatAfter` and only heartbeat on block 5.
 		MOCK_CURRENT_SESSION_PROGRESS.with(|p| *p.borrow_mut() = Some(None));
-		assert_eq!(ImOnline::send_heartbeats(2).err(), Some(OffchainErr::TooEarly),);
+		assert_eq!(ImOnline::send_heartbeats(2).err(), Some(OffchainErr::TooEarly));
 
 		MOCK_CURRENT_SESSION_PROGRESS.with(|p| *p.borrow_mut() = Some(None));
 		assert!(ImOnline::send_heartbeats(5).ok().is_some());
@@ -463,7 +463,7 @@ fn test_does_not_heartbeat_early_in_the_session() {
 		// heartbeating after 10% of the session has elapsed.
 		MOCK_CURRENT_SESSION_PROGRESS
 			.with(|p| *p.borrow_mut() = Some(Some(Permill::from_float(0.05))));
-		assert_eq!(ImOnline::send_heartbeats(2).err(), Some(OffchainErr::TooEarly),);
+		assert_eq!(ImOnline::send_heartbeats(2).err(), Some(OffchainErr::TooEarly));
 	});
 }
 
@@ -492,7 +492,7 @@ fn test_probability_of_heartbeating_increases_with_session_progress() {
 
 		let assert_too_early = |progress, random| {
 			set_test(progress, random);
-			assert_eq!(ImOnline::send_heartbeats(2).err(), Some(OffchainErr::TooEarly),);
+			assert_eq!(ImOnline::send_heartbeats(2).err(), Some(OffchainErr::TooEarly));
 		};
 
 		let assert_heartbeat_ok = |progress, random| {

--- a/frame/indices/src/benchmarking.rs
+++ b/frame/indices/src/benchmarking.rs
@@ -93,4 +93,4 @@ benchmarks! {
 	// TODO in another PR: lookup and unlookup trait weights (not critical)
 }
 
-impl_benchmark_test_suite!(Indices, crate::mock::new_test_ext(), crate::mock::Test,);
+impl_benchmark_test_suite!(Indices, crate::mock::new_test_ext(), crate::mock::Test);

--- a/frame/lottery/src/benchmarking.rs
+++ b/frame/lottery/src/benchmarking.rs
@@ -170,4 +170,4 @@ benchmarks! {
 	}
 }
 
-impl_benchmark_test_suite!(Lottery, crate::mock::new_test_ext(), crate::mock::Test,);
+impl_benchmark_test_suite!(Lottery, crate::mock::new_test_ext(), crate::mock::Test);

--- a/frame/lottery/src/tests.rs
+++ b/frame/lottery/src/tests.rs
@@ -177,7 +177,7 @@ fn buy_ticket_works_as_simple_passthrough() {
 		);
 
 		let bad_origin_call = Box::new(Call::Balances(BalancesCall::force_transfer(0, 0, 0)));
-		assert_noop!(Lottery::buy_ticket(Origin::signed(1), bad_origin_call), BadOrigin,);
+		assert_noop!(Lottery::buy_ticket(Origin::signed(1), bad_origin_call), BadOrigin);
 
 		// User can call other txs, but doesn't get a ticket
 		let remark_call = Box::new(Call::System(SystemCall::remark(b"hello, world!".to_vec())));

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -459,7 +459,7 @@ mod benchmark {
 		}
 	}
 
-	impl_benchmark_test_suite!(Membership, crate::tests::new_bench_ext(), crate::tests::Test,);
+	impl_benchmark_test_suite!(Membership, crate::tests::new_bench_ext(), crate::tests::Test);
 }
 
 #[cfg(test)]

--- a/frame/merkle-mountain-range/primitives/src/lib.rs
+++ b/frame/merkle-mountain-range/primitives/src/lib.rs
@@ -569,7 +569,7 @@ mod tests {
 		let opaque = cases.iter().map(OpaqueLeaf::from_leaf).collect::<Vec<_>>();
 
 		// then
-		assert_eq!(encoded_compact, opaque,);
+		assert_eq!(encoded_compact, opaque);
 	}
 
 	#[test]

--- a/frame/merkle-mountain-range/src/benchmarking.rs
+++ b/frame/merkle-mountain-range/src/benchmarking.rs
@@ -37,4 +37,4 @@ benchmarks_instance_pallet! {
 	}
 }
 
-impl_benchmark_test_suite!(Pallet, crate::tests::new_test_ext(), crate::mock::Test,);
+impl_benchmark_test_suite!(Pallet, crate::tests::new_test_ext(), crate::mock::Test);

--- a/frame/merkle-mountain-range/src/mmr/utils.rs
+++ b/frame/merkle-mountain-range/src/mmr/utils.rs
@@ -121,6 +121,6 @@ mod tests {
 				actual_sizes.push(mmr.size());
 			})
 		}
-		assert_eq!(sizes[1..], actual_sizes[..],);
+		assert_eq!(sizes[1..], actual_sizes[..]);
 	}
 }

--- a/frame/multisig/src/benchmarking.rs
+++ b/frame/multisig/src/benchmarking.rs
@@ -296,4 +296,4 @@ benchmarks! {
 	}
 }
 
-impl_benchmark_test_suite!(Multisig, crate::tests::new_test_ext(), crate::tests::Test,);
+impl_benchmark_test_suite!(Multisig, crate::tests::new_test_ext(), crate::tests::Test);

--- a/frame/offences/benchmarking/src/lib.rs
+++ b/frame/offences/benchmarking/src/lib.rs
@@ -401,4 +401,4 @@ benchmarks! {
 	}
 }
 
-impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test,);
+impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);

--- a/frame/proxy/src/benchmarking.rs
+++ b/frame/proxy/src/benchmarking.rs
@@ -247,4 +247,4 @@ benchmarks! {
 	}
 }
 
-impl_benchmark_test_suite!(Proxy, crate::tests::new_test_ext(), crate::tests::Test,);
+impl_benchmark_test_suite!(Proxy, crate::tests::new_test_ext(), crate::tests::Test);

--- a/frame/scheduler/src/benchmarking.rs
+++ b/frame/scheduler/src/benchmarking.rs
@@ -141,4 +141,4 @@ benchmarks! {
 	}
 }
 
-impl_benchmark_test_suite!(Scheduler, crate::tests::new_test_ext(), crate::tests::Test,);
+impl_benchmark_test_suite!(Scheduler, crate::tests::new_test_ext(), crate::tests::Test);

--- a/frame/session/benchmarking/src/lib.rs
+++ b/frame/session/benchmarking/src/lib.rs
@@ -162,4 +162,4 @@ fn check_membership_proof_setup<T: Config>(
 	(key, Historical::<T>::prove(key).unwrap())
 }
 
-impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test, extra = false,);
+impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test, extra = false);

--- a/frame/session/src/tests.rs
+++ b/frame/session/src/tests.rs
@@ -293,7 +293,7 @@ fn periodic_session_works() {
 	// 1/10 of progress.
 	assert!(P::should_end_session(3u64));
 	assert_eq!(P::estimate_next_session_rotation(3u64).0.unwrap(), 3);
-	assert_eq!(P::estimate_current_session_progress(3u64).0.unwrap(), Permill::from_percent(10),);
+	assert_eq!(P::estimate_current_session_progress(3u64).0.unwrap(), Permill::from_percent(10));
 
 	for i in (1u64..10).map(|i| 3 + i) {
 		assert!(!P::should_end_session(i));

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1569,7 +1569,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let controller = ensure_signed(origin)?;
 			let mut ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
-			ensure!(ledger.unlocking.len() < MAX_UNLOCKING_CHUNKS, Error::<T>::NoMoreChunks,);
+			ensure!(ledger.unlocking.len() < MAX_UNLOCKING_CHUNKS, Error::<T>::NoMoreChunks);
 
 			let mut value = value.min(ledger.active);
 

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -593,7 +593,7 @@ pub(crate) fn current_era() -> EraIndex {
 pub(crate) fn bond_validator(stash: AccountId, ctrl: AccountId, val: Balance) {
 	let _ = Balances::make_free_balance_be(&stash, val);
 	let _ = Balances::make_free_balance_be(&ctrl, val);
-	assert_ok!(Staking::bond(Origin::signed(stash), ctrl, val, RewardDestination::Controller,));
+	assert_ok!(Staking::bond(Origin::signed(stash), ctrl, val, RewardDestination::Controller));
 	assert_ok!(Staking::validate(Origin::signed(ctrl), ValidatorPrefs::default()));
 }
 
@@ -605,7 +605,7 @@ pub(crate) fn bond_nominator(
 ) {
 	let _ = Balances::make_free_balance_be(&stash, val);
 	let _ = Balances::make_free_balance_be(&ctrl, val);
-	assert_ok!(Staking::bond(Origin::signed(stash), ctrl, val, RewardDestination::Controller,));
+	assert_ok!(Staking::bond(Origin::signed(stash), ctrl, val, RewardDestination::Controller));
 	assert_ok!(Staking::nominate(Origin::signed(ctrl), target));
 }
 

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -259,13 +259,13 @@ fn rewards_should_work() {
 			init_balance_10 + part_for_10 * total_payout_0 * 2 / 3,
 			2,
 		);
-		assert_eq_error_rate!(Balances::total_balance(&11), init_balance_11, 2,);
+		assert_eq_error_rate!(Balances::total_balance(&11), init_balance_11, 2);
 		assert_eq_error_rate!(
 			Balances::total_balance(&20),
 			init_balance_20 + part_for_20 * total_payout_0 * 1 / 3,
 			2,
 		);
-		assert_eq_error_rate!(Balances::total_balance(&21), init_balance_21, 2,);
+		assert_eq_error_rate!(Balances::total_balance(&21), init_balance_21, 2);
 		assert_eq_error_rate!(
 			Balances::total_balance(&100),
 			init_balance_100 +
@@ -297,13 +297,13 @@ fn rewards_should_work() {
 			init_balance_10 + part_for_10 * (total_payout_0 * 2 / 3 + total_payout_1),
 			2,
 		);
-		assert_eq_error_rate!(Balances::total_balance(&11), init_balance_11, 2,);
+		assert_eq_error_rate!(Balances::total_balance(&11), init_balance_11, 2);
 		assert_eq_error_rate!(
 			Balances::total_balance(&20),
 			init_balance_20 + part_for_20 * total_payout_0 * 1 / 3,
 			2,
 		);
-		assert_eq_error_rate!(Balances::total_balance(&21), init_balance_21, 2,);
+		assert_eq_error_rate!(Balances::total_balance(&21), init_balance_21, 2);
 		assert_eq_error_rate!(
 			Balances::total_balance(&100),
 			init_balance_100 +
@@ -468,7 +468,7 @@ fn no_candidate_emergency_condition() {
 
 			// try trigger new era
 			mock::run_to_block(20);
-			assert_eq!(*staking_events().last().unwrap(), Event::StakingElectionFailed,);
+			assert_eq!(*staking_events().last().unwrap(), Event::StakingElectionFailed);
 			// No new era is created
 			assert_eq!(current_era, CurrentEra::<Test>::get());
 
@@ -607,7 +607,7 @@ fn nominators_also_get_slashed_pro_rata() {
 		let slash_percent = Perbill::from_percent(5);
 		let initial_exposure = Staking::eras_stakers(active_era(), 11);
 		// 101 is a nominator for 11
-		assert_eq!(initial_exposure.others.first().unwrap().who, 101,);
+		assert_eq!(initial_exposure.others.first().unwrap().who, 101);
 
 		// staked values;
 		let nominator_stake = Staking::ledger(100).unwrap().active;
@@ -639,8 +639,8 @@ fn nominators_also_get_slashed_pro_rata() {
 		assert!(nominator_share > 0);
 
 		// both stakes must have been decreased pro-rata.
-		assert_eq!(Staking::ledger(100).unwrap().active, nominator_stake - nominator_share,);
-		assert_eq!(Staking::ledger(10).unwrap().active, validator_stake - validator_share,);
+		assert_eq!(Staking::ledger(100).unwrap().active, nominator_stake - nominator_share);
+		assert_eq!(Staking::ledger(10).unwrap().active, validator_stake - validator_share);
 		assert_eq!(
 			balances(&101).0, // free balance
 			nominator_balance - nominator_share,
@@ -905,7 +905,7 @@ fn cannot_reserve_staked_balance() {
 		// Confirm account 11 (via controller 10) is totally staked
 		assert_eq!(Staking::eras_stakers(Staking::active_era().unwrap().index, 11).own, 1000);
 		// Confirm account 11 cannot reserve as a result
-		assert_noop!(Balances::reserve(&11, 1), BalancesError::<Test, _>::LiquidityRestrictions,);
+		assert_noop!(Balances::reserve(&11, 1), BalancesError::<Test, _>::LiquidityRestrictions);
 
 		// Give account 11 extra free balance
 		let _ = Balances::make_free_balance_be(&11, 10000);
@@ -1312,7 +1312,7 @@ fn rebond_works() {
 		assert_eq!(Staking::active_era().unwrap().index, 2);
 
 		// Try to rebond some funds. We get an error since no fund is unbonded.
-		assert_noop!(Staking::rebond(Origin::signed(10), 500), Error::<Test>::NoUnlockChunk,);
+		assert_noop!(Staking::rebond(Origin::signed(10), 500), Error::<Test>::NoUnlockChunk);
 
 		// Unbond almost all of the funds in stash.
 		Staking::unbond(Origin::signed(10), 900).unwrap();
@@ -2606,9 +2606,9 @@ fn slashing_nominators_by_span_max() {
 
 		let get_span = |account| <Staking as crate::Store>::SlashingSpans::get(&account).unwrap();
 
-		assert_eq!(get_span(11).iter().collect::<Vec<_>>(), expected_spans,);
+		assert_eq!(get_span(11).iter().collect::<Vec<_>>(), expected_spans);
 
-		assert_eq!(get_span(101).iter().collect::<Vec<_>>(), expected_spans,);
+		assert_eq!(get_span(101).iter().collect::<Vec<_>>(), expected_spans);
 
 		// second slash: higher era, higher value, same span.
 		on_offence_in_era(
@@ -3724,7 +3724,7 @@ fn cannot_rebond_to_lower_than_ed() {
 			);
 
 			// now bond a wee bit more
-			assert_noop!(Staking::rebond(Origin::signed(20), 5), Error::<Test>::InsufficientBond,);
+			assert_noop!(Staking::rebond(Origin::signed(20), 5), Error::<Test>::InsufficientBond);
 		})
 }
 

--- a/frame/support/procedural/src/storage/parse.rs
+++ b/frame/support/procedural/src/storage/parse.rs
@@ -380,7 +380,7 @@ fn get_module_instance(
 		(None, None, None) => Ok(None),
 		(Some(instance), None, _) => Err(syn::Error::new(
 			instance.span(),
-			format!("Expect instantiable trait bound for instance: {}. {}", instance, right_syntax,),
+			format!("Expect instantiable trait bound for instance: {}. {}", instance, right_syntax),
 		)),
 		(None, Some(instantiable), _) => Err(syn::Error::new(
 			instantiable.span(),

--- a/frame/support/src/storage/generator/double_map.rs
+++ b/frame/support/src/storage/generator/double_map.rs
@@ -532,7 +532,7 @@ mod test_iterators {
 				vec![(3, 3), (0, 0), (2, 2), (1, 1)],
 			);
 
-			assert_eq!(DoubleMap::iter_values().collect::<Vec<_>>(), vec![3, 0, 2, 1],);
+			assert_eq!(DoubleMap::iter_values().collect::<Vec<_>>(), vec![3, 0, 2, 1]);
 
 			assert_eq!(
 				DoubleMap::drain().collect::<Vec<_>>(),
@@ -559,9 +559,9 @@ mod test_iterators {
 				vec![(1, 1), (2, 2), (0, 0), (3, 3)],
 			);
 
-			assert_eq!(DoubleMap::iter_key_prefix(k1).collect::<Vec<_>>(), vec![1, 2, 0, 3],);
+			assert_eq!(DoubleMap::iter_key_prefix(k1).collect::<Vec<_>>(), vec![1, 2, 0, 3]);
 
-			assert_eq!(DoubleMap::iter_prefix_values(k1).collect::<Vec<_>>(), vec![1, 2, 0, 3],);
+			assert_eq!(DoubleMap::iter_prefix_values(k1).collect::<Vec<_>>(), vec![1, 2, 0, 3]);
 
 			assert_eq!(
 				DoubleMap::drain_prefix(k1).collect::<Vec<_>>(),

--- a/frame/support/src/storage/generator/nmap.rs
+++ b/frame/support/src/storage/generator/nmap.rs
@@ -495,9 +495,9 @@ mod test_iterators {
 				vec![((3, 3), 3), ((0, 0), 0), ((2, 2), 2), ((1, 1), 1)],
 			);
 
-			assert_eq!(NMap::iter_keys().collect::<Vec<_>>(), vec![(3, 3), (0, 0), (2, 2), (1, 1)],);
+			assert_eq!(NMap::iter_keys().collect::<Vec<_>>(), vec![(3, 3), (0, 0), (2, 2), (1, 1)]);
 
-			assert_eq!(NMap::iter_values().collect::<Vec<_>>(), vec![3, 0, 2, 1],);
+			assert_eq!(NMap::iter_values().collect::<Vec<_>>(), vec![3, 0, 2, 1]);
 
 			assert_eq!(
 				NMap::drain().collect::<Vec<_>>(),
@@ -524,9 +524,9 @@ mod test_iterators {
 				vec![(1, 1), (2, 2), (0, 0), (3, 3)],
 			);
 
-			assert_eq!(NMap::iter_key_prefix((k1,)).collect::<Vec<_>>(), vec![1, 2, 0, 3],);
+			assert_eq!(NMap::iter_key_prefix((k1,)).collect::<Vec<_>>(), vec![1, 2, 0, 3]);
 
-			assert_eq!(NMap::iter_prefix_values((k1,)).collect::<Vec<_>>(), vec![1, 2, 0, 3],);
+			assert_eq!(NMap::iter_prefix_values((k1,)).collect::<Vec<_>>(), vec![1, 2, 0, 3]);
 
 			assert_eq!(
 				NMap::drain_prefix((k1,)).collect::<Vec<_>>(),

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -1030,7 +1030,7 @@ pub trait StoragePrefixedMap<Value: FullCodec> {
 					None => unhashed::kill(&previous_key),
 				},
 				None => {
-					log::error!("old key failed to decode at {:?}", previous_key,);
+					log::error!("old key failed to decode at {:?}", previous_key);
 					continue
 				},
 			}

--- a/frame/support/test/src/pallet_version.rs
+++ b/frame/support/test/src/pallet_version.rs
@@ -25,5 +25,5 @@ fn ensure_that_current_pallet_version_is_correct() {
 		patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
 	};
 
-	assert_eq!(expected, crate_to_pallet_version!(),)
+	assert_eq!(expected, crate_to_pallet_version!())
 }

--- a/frame/support/test/tests/derive_no_bound.rs
+++ b/frame/support/test/tests/derive_no_bound.rs
@@ -153,8 +153,8 @@ fn test_enum() {
 		TestEnum::VariantUnnamed(0, 0, 0, Default::default())
 	);
 
-	assert_eq!(Enum2::<Runtime>::default(), Enum2::<Runtime>::VariantNamed { a: 0, b: 0, c: 0 },);
-	assert_eq!(Enum3::<Runtime>::default(), Enum3::<Runtime>::VariantUnit,);
+	assert_eq!(Enum2::<Runtime>::default(), Enum2::<Runtime>::VariantNamed { a: 0, b: 0, c: 0 });
+	assert_eq!(Enum3::<Runtime>::default(), Enum3::<Runtime>::VariantUnit);
 
 	assert!(variant_0 != variant_0_bis);
 	assert!(variant_1 != variant_1_bis);
@@ -184,6 +184,6 @@ fn test_enum() {
 		format!("{:?}", variant_1),
 		String::from("Enum::VariantNamed { a: 1, b: 2, c: 3, phantom: PhantomData }"),
 	);
-	assert_eq!(format!("{:?}", variant_2), String::from("Enum::VariantUnit"),);
-	assert_eq!(format!("{:?}", variant_3), String::from("Enum::VariantUnit2"),);
+	assert_eq!(format!("{:?}", variant_2), String::from("Enum::VariantUnit"));
+	assert_eq!(format!("{:?}", variant_3), String::from("Enum::VariantUnit2"));
 }

--- a/frame/support/test/tests/pallet_instance.rs
+++ b/frame/support/test/tests/pallet_instance.rs
@@ -314,7 +314,7 @@ fn call_expand() {
 		DispatchInfo { weight: 3, class: DispatchClass::Normal, pays_fee: Pays::Yes }
 	);
 	assert_eq!(call_foo.get_call_name(), "foo");
-	assert_eq!(pallet::Call::<Runtime>::get_call_names(), &["foo", "foo_transactional"],);
+	assert_eq!(pallet::Call::<Runtime>::get_call_names(), &["foo", "foo_transactional"]);
 
 	let call_foo = pallet::Call::<Runtime, pallet::Instance1>::foo(3);
 	assert_eq!(

--- a/frame/system/benchmarking/src/lib.rs
+++ b/frame/system/benchmarking/src/lib.rs
@@ -139,4 +139,4 @@ benchmarks! {
 	}
 }
 
-impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test,);
+impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);

--- a/frame/system/src/extensions/check_weight.rs
+++ b/frame/system/src/extensions/check_weight.rs
@@ -606,7 +606,7 @@ mod tests {
 			assert_eq!(BlockWeight::<Test>::get().total(), info.weight + 256);
 
 			assert_ok!(CheckWeight::<Test>::post_dispatch(pre, &info, &post_info, len, &Ok(())));
-			assert_eq!(BlockWeight::<Test>::get().total(), post_info.actual_weight.unwrap() + 256,);
+			assert_eq!(BlockWeight::<Test>::get().total(), post_info.actual_weight.unwrap() + 256);
 		})
 	}
 

--- a/frame/system/src/tests.rs
+++ b/frame/system/src/tests.rs
@@ -314,9 +314,9 @@ fn deposit_event_topics() {
 
 		// Check that the topic-events mapping reflects the deposited topics.
 		// Note that these are indexes of the events.
-		assert_eq!(System::event_topics(&topics[0]), vec![(BLOCK_NUMBER, 0), (BLOCK_NUMBER, 1)],);
-		assert_eq!(System::event_topics(&topics[1]), vec![(BLOCK_NUMBER, 0), (BLOCK_NUMBER, 2)],);
-		assert_eq!(System::event_topics(&topics[2]), vec![(BLOCK_NUMBER, 0)],);
+		assert_eq!(System::event_topics(&topics[0]), vec![(BLOCK_NUMBER, 0), (BLOCK_NUMBER, 1)]);
+		assert_eq!(System::event_topics(&topics[1]), vec![(BLOCK_NUMBER, 0), (BLOCK_NUMBER, 2)]);
+		assert_eq!(System::event_topics(&topics[2]), vec![(BLOCK_NUMBER, 0)]);
 	});
 }
 
@@ -343,12 +343,12 @@ fn prunes_block_hash_mappings() {
 
 		// first 5 block hashes are pruned
 		for n in 0..5 {
-			assert_eq!(System::block_hash(n), H256::zero(),);
+			assert_eq!(System::block_hash(n), H256::zero());
 		}
 
 		// the remaining 10 are kept
 		for n in 5..15 {
-			assert_eq!(System::block_hash(n), [n as u8; 32].into(),);
+			assert_eq!(System::block_hash(n), [n as u8; 32].into());
 		}
 	})
 }

--- a/frame/timestamp/src/benchmarking.rs
+++ b/frame/timestamp/src/benchmarking.rs
@@ -57,4 +57,4 @@ benchmarks! {
 	}
 }
 
-impl_benchmark_test_suite!(Timestamp, crate::tests::new_test_ext(), crate::tests::Test,);
+impl_benchmark_test_suite!(Timestamp, crate::tests::new_test_ext(), crate::tests::Test);

--- a/frame/tips/src/benchmarking.rs
+++ b/frame/tips/src/benchmarking.rs
@@ -192,4 +192,4 @@ benchmarks! {
 	}: _(RawOrigin::Root, hash)
 }
 
-impl_benchmark_test_suite!(TipsMod, crate::tests::new_test_ext(), crate::tests::Test,);
+impl_benchmark_test_suite!(TipsMod, crate::tests::new_test_ext(), crate::tests::Test);

--- a/frame/tips/src/tests.rs
+++ b/frame/tips/src/tests.rs
@@ -314,7 +314,7 @@ fn slash_tip_works() {
 		assert_eq!(last_event(), RawEvent::NewTip(h));
 
 		// can't remove from any origin
-		assert_noop!(TipsModTestInst::slash_tip(Origin::signed(0), h.clone()), BadOrigin,);
+		assert_noop!(TipsModTestInst::slash_tip(Origin::signed(0), h.clone()), BadOrigin);
 
 		// can remove from root.
 		assert_ok!(TipsModTestInst::slash_tip(Origin::root(), h.clone()));

--- a/frame/transaction-storage/src/benchmarking.rs
+++ b/frame/transaction-storage/src/benchmarking.rs
@@ -145,4 +145,4 @@ benchmarks! {
 	}
 }
 
-impl_benchmark_test_suite!(TransactionStorage, crate::mock::new_test_ext(), crate::mock::Test,);
+impl_benchmark_test_suite!(TransactionStorage, crate::mock::new_test_ext(), crate::mock::Test);

--- a/frame/treasury/src/benchmarking.rs
+++ b/frame/treasury/src/benchmarking.rs
@@ -96,4 +96,4 @@ benchmarks_instance_pallet! {
 	}
 }
 
-impl_benchmark_test_suite!(Treasury, crate::tests::new_test_ext(), crate::tests::Test,);
+impl_benchmark_test_suite!(Treasury, crate::tests::new_test_ext(), crate::tests::Test);

--- a/frame/utility/src/benchmarking.rs
+++ b/frame/utility/src/benchmarking.rs
@@ -65,4 +65,4 @@ benchmarks! {
 	}
 }
 
-impl_benchmark_test_suite!(Pallet, crate::tests::new_test_ext(), crate::tests::Test,);
+impl_benchmark_test_suite!(Pallet, crate::tests::new_test_ext(), crate::tests::Test);

--- a/primitives/api/test/tests/decl_and_impl.rs
+++ b/primitives/api/test/tests/decl_and_impl.rs
@@ -193,7 +193,7 @@ fn check_runtime_api_versions() {
 fn mock_runtime_api_has_api() {
 	let mock = MockApi { block: None };
 
-	assert!(mock.has_api::<dyn ApiWithCustomVersion<Block>>(&BlockId::Number(0)).unwrap(),);
+	assert!(mock.has_api::<dyn ApiWithCustomVersion<Block>>(&BlockId::Number(0)).unwrap());
 	assert!(mock.has_api::<dyn Api<Block>>(&BlockId::Number(0)).unwrap());
 }
 

--- a/primitives/arithmetic/fuzzer/src/normalize.rs
+++ b/primitives/arithmetic/fuzzer/src/normalize.rs
@@ -51,7 +51,7 @@ fn main() {
 					let sum: u128 = normalized.iter().map(|x| *x as u128).sum();
 
 					// if this function returns Ok(), then it will ALWAYS be accurate.
-					assert_eq!(sum, norm as u128, "sums don't match {:?}, {}", normalized, norm,);
+					assert_eq!(sum, norm as u128, "sums don't match {:?}, {}", normalized, norm);
 				} else {
 					panic!("Should have returned Ok for input = {:?}, target = {:?}", data, norm);
 				}

--- a/primitives/arithmetic/src/biguint.rs
+++ b/primitives/arithmetic/src/biguint.rs
@@ -639,9 +639,9 @@ pub mod tests {
 
 	#[test]
 	fn equality_works() {
-		assert_eq!(BigUint { digits: vec![1, 2, 3] } == BigUint { digits: vec![1, 2, 3] }, true,);
-		assert_eq!(BigUint { digits: vec![3, 2, 3] } == BigUint { digits: vec![1, 2, 3] }, false,);
-		assert_eq!(BigUint { digits: vec![0, 1, 2, 3] } == BigUint { digits: vec![1, 2, 3] }, true,);
+		assert_eq!(BigUint { digits: vec![1, 2, 3] } == BigUint { digits: vec![1, 2, 3] }, true);
+		assert_eq!(BigUint { digits: vec![3, 2, 3] } == BigUint { digits: vec![1, 2, 3] }, false);
+		assert_eq!(BigUint { digits: vec![0, 1, 2, 3] } == BigUint { digits: vec![1, 2, 3] }, true);
 	}
 
 	#[test]
@@ -667,7 +667,7 @@ pub mod tests {
 		use sp_std::convert::TryFrom;
 		assert_eq!(u64::try_from(with_limbs(1)).unwrap(), 1);
 		assert_eq!(u64::try_from(with_limbs(2)).unwrap(), u32::MAX as u64 + 2);
-		assert_eq!(u64::try_from(with_limbs(3)).unwrap_err(), "cannot fit a number into u64",);
+		assert_eq!(u64::try_from(with_limbs(3)).unwrap_err(), "cannot fit a number into u64");
 		assert_eq!(u128::try_from(with_limbs(3)).unwrap(), u32::MAX as u128 + u64::MAX as u128 + 3);
 	}
 

--- a/primitives/arithmetic/src/lib.rs
+++ b/primitives/arithmetic/src/lib.rs
@@ -300,13 +300,13 @@ mod normalize_tests {
 	#[test]
 	fn fails_on_if_input_sum_large() {
 		assert!(normalize(vec![1u8; 255].as_ref(), 10).is_ok());
-		assert_eq!(normalize(vec![1u8; 256].as_ref(), 10), Err("sum of input cannot fit in `T`"),);
+		assert_eq!(normalize(vec![1u8; 256].as_ref(), 10), Err("sum of input cannot fit in `T`"));
 	}
 
 	#[test]
 	fn does_not_fail_on_subtraction_overflow() {
-		assert_eq!(normalize(vec![1u8, 100, 100].as_ref(), 10).unwrap(), vec![1, 9, 0],);
-		assert_eq!(normalize(vec![1u8, 8, 9].as_ref(), 1).unwrap(), vec![0, 1, 0],);
+		assert_eq!(normalize(vec![1u8, 100, 100].as_ref(), 10).unwrap(), vec![1, 9, 0]);
+		assert_eq!(normalize(vec![1u8, 8, 9].as_ref(), 1).unwrap(), vec![0, 1, 0]);
 	}
 
 	#[test]
@@ -358,40 +358,40 @@ mod normalize_tests {
 
 	#[test]
 	fn normalize_works_all_le() {
-		assert_eq!(normalize(vec![8u32, 9, 7, 10].as_ref(), 40).unwrap(), vec![10, 10, 10, 10],);
+		assert_eq!(normalize(vec![8u32, 9, 7, 10].as_ref(), 40).unwrap(), vec![10, 10, 10, 10]);
 
-		assert_eq!(normalize(vec![7u32, 7, 7, 7].as_ref(), 40).unwrap(), vec![10, 10, 10, 10],);
+		assert_eq!(normalize(vec![7u32, 7, 7, 7].as_ref(), 40).unwrap(), vec![10, 10, 10, 10]);
 
-		assert_eq!(normalize(vec![7u32, 7, 7, 10].as_ref(), 40).unwrap(), vec![11, 11, 8, 10],);
+		assert_eq!(normalize(vec![7u32, 7, 7, 10].as_ref(), 40).unwrap(), vec![11, 11, 8, 10]);
 
-		assert_eq!(normalize(vec![7u32, 8, 7, 10].as_ref(), 40).unwrap(), vec![11, 8, 11, 10],);
+		assert_eq!(normalize(vec![7u32, 8, 7, 10].as_ref(), 40).unwrap(), vec![11, 8, 11, 10]);
 
-		assert_eq!(normalize(vec![7u32, 7, 8, 10].as_ref(), 40).unwrap(), vec![11, 11, 8, 10],);
+		assert_eq!(normalize(vec![7u32, 7, 8, 10].as_ref(), 40).unwrap(), vec![11, 11, 8, 10]);
 	}
 
 	#[test]
 	fn normalize_works_some_ge() {
-		assert_eq!(normalize(vec![8u32, 11, 9, 10].as_ref(), 40).unwrap(), vec![10, 11, 9, 10],);
+		assert_eq!(normalize(vec![8u32, 11, 9, 10].as_ref(), 40).unwrap(), vec![10, 11, 9, 10]);
 	}
 
 	#[test]
 	fn always_inc_min() {
-		assert_eq!(normalize(vec![10u32, 7, 10, 10].as_ref(), 40).unwrap(), vec![10, 10, 10, 10],);
-		assert_eq!(normalize(vec![10u32, 10, 7, 10].as_ref(), 40).unwrap(), vec![10, 10, 10, 10],);
-		assert_eq!(normalize(vec![10u32, 10, 10, 7].as_ref(), 40).unwrap(), vec![10, 10, 10, 10],);
+		assert_eq!(normalize(vec![10u32, 7, 10, 10].as_ref(), 40).unwrap(), vec![10, 10, 10, 10]);
+		assert_eq!(normalize(vec![10u32, 10, 7, 10].as_ref(), 40).unwrap(), vec![10, 10, 10, 10]);
+		assert_eq!(normalize(vec![10u32, 10, 10, 7].as_ref(), 40).unwrap(), vec![10, 10, 10, 10]);
 	}
 
 	#[test]
 	fn normalize_works_all_ge() {
-		assert_eq!(normalize(vec![12u32, 11, 13, 10].as_ref(), 40).unwrap(), vec![10, 10, 10, 10],);
+		assert_eq!(normalize(vec![12u32, 11, 13, 10].as_ref(), 40).unwrap(), vec![10, 10, 10, 10]);
 
-		assert_eq!(normalize(vec![13u32, 13, 13, 13].as_ref(), 40).unwrap(), vec![10, 10, 10, 10],);
+		assert_eq!(normalize(vec![13u32, 13, 13, 13].as_ref(), 40).unwrap(), vec![10, 10, 10, 10]);
 
-		assert_eq!(normalize(vec![13u32, 13, 13, 10].as_ref(), 40).unwrap(), vec![12, 9, 9, 10],);
+		assert_eq!(normalize(vec![13u32, 13, 13, 10].as_ref(), 40).unwrap(), vec![12, 9, 9, 10]);
 
-		assert_eq!(normalize(vec![13u32, 12, 13, 10].as_ref(), 40).unwrap(), vec![9, 12, 9, 10],);
+		assert_eq!(normalize(vec![13u32, 12, 13, 10].as_ref(), 40).unwrap(), vec![9, 12, 9, 10]);
 
-		assert_eq!(normalize(vec![13u32, 13, 12, 10].as_ref(), 40).unwrap(), vec![9, 9, 12, 10],);
+		assert_eq!(normalize(vec![13u32, 13, 12, 10].as_ref(), 40).unwrap(), vec![9, 9, 12, 10]);
 	}
 }
 

--- a/primitives/arithmetic/src/rational.rs
+++ b/primitives/arithmetic/src/rational.rs
@@ -389,7 +389,7 @@ mod tests {
 			r(7, MAX128).checked_sub(r(MAX128, MAX128)),
 			Err("overflow while subtracting numerators"),
 		);
-		assert_eq!(r(1, 10).checked_sub(r(2, 10)), Err("overflow while subtracting numerators"),);
+		assert_eq!(r(1, 10).checked_sub(r(2, 10)), Err("overflow while subtracting numerators"));
 	}
 
 	#[test]
@@ -433,8 +433,8 @@ mod tests {
 			(MAX128 / 1000 * 555) + (455 * 555 / 1000),
 		);
 
-		assert_eq!(multiply_by_rational(2 * MAX64 - 1, MAX64, MAX64).unwrap(), 2 * MAX64 - 1,);
-		assert_eq!(multiply_by_rational(2 * MAX64 - 1, MAX64 - 1, MAX64).unwrap(), 2 * MAX64 - 3,);
+		assert_eq!(multiply_by_rational(2 * MAX64 - 1, MAX64, MAX64).unwrap(), 2 * MAX64 - 1);
+		assert_eq!(multiply_by_rational(2 * MAX64 - 1, MAX64 - 1, MAX64).unwrap(), 2 * MAX64 - 3);
 
 		assert_eq!(
 			multiply_by_rational(MAX64 + 100, MAX64_2, MAX64_2 / 2).unwrap(),
@@ -449,7 +449,7 @@ mod tests {
 			multiply_by_rational(2u128.pow(66) - 1, 2u128.pow(65) - 1, 2u128.pow(65)).unwrap(),
 			73786976294838206461,
 		);
-		assert_eq!(multiply_by_rational(1_000_000_000, MAX128 / 8, MAX128 / 2).unwrap(), 250000000,);
+		assert_eq!(multiply_by_rational(1_000_000_000, MAX128 / 8, MAX128 / 2).unwrap(), 250000000);
 
 		assert_eq!(
 			multiply_by_rational(
@@ -464,8 +464,8 @@ mod tests {
 
 	#[test]
 	fn multiply_by_rational_a_b_are_interchangeable() {
-		assert_eq!(multiply_by_rational(10, MAX128, MAX128 / 2), Ok(20),);
-		assert_eq!(multiply_by_rational(MAX128, 10, MAX128 / 2), Ok(20),);
+		assert_eq!(multiply_by_rational(10, MAX128, MAX128 / 2), Ok(20));
+		assert_eq!(multiply_by_rational(MAX128, 10, MAX128 / 2), Ok(20));
 	}
 
 	#[test]

--- a/primitives/core/src/offchain/testing.rs
+++ b/primitives/core/src/offchain/testing.rs
@@ -150,7 +150,7 @@ impl OffchainState {
 				panic!("Missing pending request: {:?}.\n\nAll: {:?}", id, self.requests);
 			},
 			Some(req) => {
-				assert_eq!(*req, expected,);
+				assert_eq!(*req, expected);
 				req.response = Some(response.into());
 				req.response_headers = response_headers.into_iter().collect();
 			},

--- a/primitives/inherents/src/lib.rs
+++ b/primitives/inherents/src/lib.rs
@@ -462,7 +462,7 @@ mod tests {
 
 		let inherent_data = provider.create_inherent_data().unwrap();
 
-		assert_eq!(inherent_data.get_data::<u32>(&TEST_INHERENT_0).unwrap().unwrap(), 42u32,);
+		assert_eq!(inherent_data.get_data::<u32>(&TEST_INHERENT_0).unwrap().unwrap(), 42u32);
 	}
 
 	#[test]

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -1108,7 +1108,7 @@ pub trait Logging {
 	/// Instead of using directly, prefer setting up `RuntimeLogger` and using `log` macros.
 	fn log(level: LogLevel, target: &str, message: &[u8]) {
 		if let Ok(message) = std::str::from_utf8(message) {
-			log::log!(target: target, log::Level::from(level), "{}", message,)
+			log::log!(target: target, log::Level::from(level), "{}", message)
 		}
 	}
 

--- a/primitives/npos-elections/src/node.rs
+++ b/primitives/npos-elections/src/node.rs
@@ -191,20 +191,20 @@ mod tests {
 		Node::set_parent_of(&e, &a);
 		Node::set_parent_of(&a, &d);
 
-		assert_eq!(Node::root(&e), (d.clone(), vec![e.clone(), a.clone(), d.clone()]),);
+		assert_eq!(Node::root(&e), (d.clone(), vec![e.clone(), a.clone(), d.clone()]));
 
-		assert_eq!(Node::root(&a), (d.clone(), vec![a.clone(), d.clone()]),);
+		assert_eq!(Node::root(&a), (d.clone(), vec![a.clone(), d.clone()]));
 
-		assert_eq!(Node::root(&c), (d.clone(), vec![c.clone(), b.clone(), a.clone(), d.clone()]),);
+		assert_eq!(Node::root(&c), (d.clone(), vec![c.clone(), b.clone(), a.clone(), d.clone()]));
 
 		// 	D 	    A <-- B <-- C
 		// 	F <-- /	\
 		// 			 <-- E
 		Node::set_parent_of(&a, &f);
 
-		assert_eq!(Node::root(&a), (f.clone(), vec![a.clone(), f.clone()]),);
+		assert_eq!(Node::root(&a), (f.clone(), vec![a.clone(), f.clone()]));
 
-		assert_eq!(Node::root(&c), (f.clone(), vec![c.clone(), b.clone(), a.clone(), f.clone()]),);
+		assert_eq!(Node::root(&c), (f.clone(), vec![c.clone(), b.clone(), a.clone(), f.clone()]));
 	}
 
 	#[test]

--- a/primitives/npos-elections/src/tests.rs
+++ b/primitives/npos-elections/src/tests.rs
@@ -747,7 +747,7 @@ mod assignment_convert_normalize {
 			}
 		);
 
-		assert_eq!(assignment.into_staked(125), staked,);
+		assert_eq!(assignment.into_staked(125), staked);
 	}
 
 	#[test]
@@ -817,7 +817,7 @@ mod assignment_convert_normalize {
 	fn staked_assignment_can_normalize() {
 		let mut a = StakedAssignment { who: 1, distribution: vec![(2, 33), (3, 66)] };
 		a.try_normalize(100).unwrap();
-		assert_eq!(a, StakedAssignment { who: 1, distribution: vec![(2, 34), (3, 66),] },);
+		assert_eq!(a, StakedAssignment { who: 1, distribution: vec![(2, 34), (3, 66),] });
 	}
 }
 
@@ -827,16 +827,16 @@ mod score {
 	fn score_comparison_is_lexicographical_no_epsilon() {
 		let epsilon = Perbill::zero();
 		// only better in the fist parameter, worse in the other two ✅
-		assert_eq!(is_score_better([12, 10, 35], [10, 20, 30], epsilon), true,);
+		assert_eq!(is_score_better([12, 10, 35], [10, 20, 30], epsilon), true);
 
 		// worse in the first, better in the other two ❌
-		assert_eq!(is_score_better([9, 30, 10], [10, 20, 30], epsilon), false,);
+		assert_eq!(is_score_better([9, 30, 10], [10, 20, 30], epsilon), false);
 
 		// equal in the first, the second one dictates.
-		assert_eq!(is_score_better([10, 25, 40], [10, 20, 30], epsilon), true,);
+		assert_eq!(is_score_better([10, 25, 40], [10, 20, 30], epsilon), true);
 
 		// equal in the first two, the last one dictates.
-		assert_eq!(is_score_better([10, 20, 40], [10, 20, 30], epsilon), false,);
+		assert_eq!(is_score_better([10, 20, 40], [10, 20, 30], epsilon), false);
 	}
 
 	#[test]
@@ -845,37 +845,37 @@ mod score {
 
 		{
 			// no more than 1 percent (10) better in the first param.
-			assert_eq!(is_score_better([1009, 5000, 100000], [1000, 5000, 100000], epsilon), false,);
+			assert_eq!(is_score_better([1009, 5000, 100000], [1000, 5000, 100000], epsilon), false);
 
 			// now equal, still not better.
-			assert_eq!(is_score_better([1010, 5000, 100000], [1000, 5000, 100000], epsilon), false,);
+			assert_eq!(is_score_better([1010, 5000, 100000], [1000, 5000, 100000], epsilon), false);
 
 			// now it is.
-			assert_eq!(is_score_better([1011, 5000, 100000], [1000, 5000, 100000], epsilon), true,);
+			assert_eq!(is_score_better([1011, 5000, 100000], [1000, 5000, 100000], epsilon), true);
 		}
 
 		{
 			// First score score is epsilon better, but first score is no longer `ge`. Then this is
 			// still not a good solution.
-			assert_eq!(is_score_better([999, 6000, 100000], [1000, 5000, 100000], epsilon), false,);
+			assert_eq!(is_score_better([999, 6000, 100000], [1000, 5000, 100000], epsilon), false);
 		}
 
 		{
 			// first score is equal or better, but not epsilon. Then second one is the determinant.
-			assert_eq!(is_score_better([1005, 5000, 100000], [1000, 5000, 100000], epsilon), false,);
+			assert_eq!(is_score_better([1005, 5000, 100000], [1000, 5000, 100000], epsilon), false);
 
-			assert_eq!(is_score_better([1005, 5050, 100000], [1000, 5000, 100000], epsilon), false,);
+			assert_eq!(is_score_better([1005, 5050, 100000], [1000, 5000, 100000], epsilon), false);
 
-			assert_eq!(is_score_better([1005, 5051, 100000], [1000, 5000, 100000], epsilon), true,);
+			assert_eq!(is_score_better([1005, 5051, 100000], [1000, 5000, 100000], epsilon), true);
 		}
 
 		{
 			// first score and second are equal or less than epsilon more, third is determinant.
-			assert_eq!(is_score_better([1005, 5025, 100000], [1000, 5000, 100000], epsilon), false,);
+			assert_eq!(is_score_better([1005, 5025, 100000], [1000, 5000, 100000], epsilon), false);
 
-			assert_eq!(is_score_better([1005, 5025, 99_000], [1000, 5000, 100000], epsilon), false,);
+			assert_eq!(is_score_better([1005, 5025, 99_000], [1000, 5000, 100000], epsilon), false);
 
-			assert_eq!(is_score_better([1005, 5025, 98_999], [1000, 5000, 100000], epsilon), true,);
+			assert_eq!(is_score_better([1005, 5025, 98_999], [1000, 5000, 100000], epsilon), true);
 		}
 	}
 
@@ -999,7 +999,7 @@ mod solution_type {
 
 		let encoded = compact.encode();
 
-		assert_eq!(compact, Decode::decode(&mut &encoded[..]).unwrap(),);
+		assert_eq!(compact, Decode::decode(&mut &encoded[..]).unwrap());
 		assert_eq!(compact.voter_count(), 4);
 		assert_eq!(compact.edge_count(), 2 + 4);
 		assert_eq!(compact.unique_targets(), vec![10, 11, 20, 40, 50, 51]);
@@ -1137,7 +1137,7 @@ mod solution_type {
 			}
 		);
 
-		assert_eq!(compacted.unique_targets(), vec![0, 1, 2, 3, 4, 5, 6, 7, 8],);
+		assert_eq!(compacted.unique_targets(), vec![0, 1, 2, 3, 4, 5, 6, 7, 8]);
 
 		let voter_at = |a: u32| -> Option<AccountId> {
 			voters.get(<u32 as TryInto<usize>>::try_into(a).unwrap()).cloned()
@@ -1146,7 +1146,7 @@ mod solution_type {
 			targets.get(<u8 as TryInto<usize>>::try_into(a).unwrap()).cloned()
 		};
 
-		assert_eq!(compacted.into_assignment(voter_at, target_at).unwrap(), assignments,);
+		assert_eq!(compacted.into_assignment(voter_at, target_at).unwrap(), assignments);
 	}
 
 	#[test]

--- a/primitives/runtime-interface/proc-macro/src/runtime_interface/bare_function_interface.rs
+++ b/primitives/runtime-interface/proc-macro/src/runtime_interface/bare_function_interface.rs
@@ -190,7 +190,7 @@ fn generate_call_to_trait(
 	let crate_ = generate_crate_access();
 	let method_name = create_function_ident_with_version(&method.sig.ident, version);
 	let expect_msg =
-		format!("`{}` called outside of an Externalities-provided environment.", method_name,);
+		format!("`{}` called outside of an Externalities-provided environment.", method_name);
 	let arg_names = get_function_argument_names(&method.sig);
 
 	if takes_self_argument(&method.sig) {

--- a/primitives/runtime-interface/proc-macro/src/utils.rs
+++ b/primitives/runtime-interface/proc-macro/src/utils.rs
@@ -116,14 +116,14 @@ pub fn create_exchangeable_host_function_ident(name: &Ident) -> Ident {
 /// Create the host function identifier for the given function name.
 pub fn create_host_function_ident(name: &Ident, version: u32, trait_name: &Ident) -> Ident {
 	Ident::new(
-		&format!("ext_{}_{}_version_{}", trait_name.to_string().to_snake_case(), name, version,),
+		&format!("ext_{}_{}_version_{}", trait_name.to_string().to_snake_case(), name, version),
 		Span::call_site(),
 	)
 }
 
 /// Create the host function identifier for the given function name.
 pub fn create_function_ident_with_version(name: &Ident, version: u32) -> Ident {
-	Ident::new(&format!("{}_version_{}", name, version,), Span::call_site())
+	Ident::new(&format!("{}_version_{}", name, version), Span::call_site())
 }
 
 /// Returns the function arguments of the given `Signature`, minus any `self` arguments.

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -929,7 +929,7 @@ mod tests {
 		let encoded = error.encode();
 		let decoded = DispatchError::decode(&mut &encoded[..]).unwrap();
 		assert_eq!(encoded, vec![3, 1, 2]);
-		assert_eq!(decoded, DispatchError::Module { index: 1, error: 2, message: None },);
+		assert_eq!(decoded, DispatchError::Module { index: 1, error: 2, message: None });
 	}
 
 	#[test]

--- a/primitives/sandbox/without_std.rs
+++ b/primitives/sandbox/without_std.rs
@@ -39,7 +39,7 @@ mod ffi {
 		// We need to ensure that sizes of a callable function pointer and host function index is
 		// indeed equal.
 		// We can't use `static_assertions` create because it makes compiler panic, fallback to runtime assert.
-		// const_assert!(mem::size_of::<HostFuncIndex>() == mem::size_of::<HostFuncType<T>>(),);
+		// const_assert!(mem::size_of::<HostFuncIndex>() == mem::size_of::<HostFuncType<T>>());
 		assert!(mem::size_of::<HostFuncIndex>() == mem::size_of::<HostFuncType<T>>());
 		mem::transmute::<HostFuncIndex, HostFuncType<T>>(idx)
 	}

--- a/primitives/state-machine/src/ext.rs
+++ b/primitives/state-machine/src/ext.rs
@@ -1118,7 +1118,7 @@ mod tests {
 		);
 
 		assert_eq!(ext.child_storage(child_info, &[20]), None);
-		assert_eq!(ext.child_storage_hash(child_info, &[20]), None,);
+		assert_eq!(ext.child_storage_hash(child_info, &[20]), None);
 
 		assert_eq!(ext.child_storage(child_info, &[30]), Some(vec![31]));
 		assert_eq!(

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -1062,7 +1062,7 @@ mod tests {
 			TaskExecutor::new(),
 		);
 
-		assert_eq!(state_machine.execute(ExecutionStrategy::NativeWhenPossible).unwrap(), vec![66],);
+		assert_eq!(state_machine.execute(ExecutionStrategy::NativeWhenPossible).unwrap(), vec![66]);
 	}
 
 	#[test]
@@ -1365,7 +1365,7 @@ mod tests {
 			);
 
 			ext.storage_append(key.clone(), reference_data[0].encode());
-			assert_eq!(ext.storage(key.as_slice()), Some(vec![reference_data[0].clone()].encode()),);
+			assert_eq!(ext.storage(key.as_slice()), Some(vec![reference_data[0].clone()].encode()));
 		}
 		overlay.start_transaction();
 		{
@@ -1380,7 +1380,7 @@ mod tests {
 			for i in reference_data.iter().skip(1) {
 				ext.storage_append(key.clone(), i.encode());
 			}
-			assert_eq!(ext.storage(key.as_slice()), Some(reference_data.encode()),);
+			assert_eq!(ext.storage(key.as_slice()), Some(reference_data.encode()));
 		}
 		overlay.rollback_transaction().unwrap();
 		{
@@ -1391,7 +1391,7 @@ mod tests {
 				changes_trie::disabled_state::<_, u64>(),
 				None,
 			);
-			assert_eq!(ext.storage(key.as_slice()), Some(vec![reference_data[0].clone()].encode()),);
+			assert_eq!(ext.storage(key.as_slice()), Some(vec![reference_data[0].clone()].encode()));
 		}
 	}
 
@@ -1434,7 +1434,7 @@ mod tests {
 				None,
 			);
 
-			assert_eq!(ext.storage(key.as_slice()), Some(vec![Item::InitializationItem].encode()),);
+			assert_eq!(ext.storage(key.as_slice()), Some(vec![Item::InitializationItem].encode()));
 
 			ext.storage_append(key.clone(), Item::DiscardedItem.encode());
 
@@ -1455,7 +1455,7 @@ mod tests {
 				None,
 			);
 
-			assert_eq!(ext.storage(key.as_slice()), Some(vec![Item::InitializationItem].encode()),);
+			assert_eq!(ext.storage(key.as_slice()), Some(vec![Item::InitializationItem].encode()));
 
 			ext.storage_append(key.clone(), Item::CommitedItem.encode());
 
@@ -1536,7 +1536,7 @@ mod tests {
 			local_result1.into_iter().collect::<Vec<_>>(),
 			vec![(b"value3".to_vec(), Some(vec![142]))],
 		);
-		assert_eq!(local_result2.into_iter().collect::<Vec<_>>(), vec![(b"value2".to_vec(), None)],);
+		assert_eq!(local_result2.into_iter().collect::<Vec<_>>(), vec![(b"value2".to_vec(), None)]);
 	}
 
 	#[test]

--- a/test-utils/runtime/client/src/trait_tests.rs
+++ b/test-utils/runtime/client/src/trait_tests.rs
@@ -56,7 +56,7 @@ where
 	// G -> A1
 	let a1 = client.new_block(Default::default()).unwrap().build().unwrap().block;
 	block_on(client.import(BlockOrigin::Own, a1.clone())).unwrap();
-	assert_eq!(blockchain.leaves().unwrap(), vec![a1.hash()],);
+	assert_eq!(blockchain.leaves().unwrap(), vec![a1.hash()]);
 
 	// A1 -> A2
 	let a2 = client
@@ -68,7 +68,7 @@ where
 	block_on(client.import(BlockOrigin::Own, a2.clone())).unwrap();
 
 	#[allow(deprecated)]
-	assert_eq!(blockchain.leaves().unwrap(), vec![a2.hash()],);
+	assert_eq!(blockchain.leaves().unwrap(), vec![a2.hash()]);
 
 	// A2 -> A3
 	let a3 = client
@@ -79,7 +79,7 @@ where
 		.block;
 	block_on(client.import(BlockOrigin::Own, a3.clone())).unwrap();
 
-	assert_eq!(blockchain.leaves().unwrap(), vec![a3.hash()],);
+	assert_eq!(blockchain.leaves().unwrap(), vec![a3.hash()]);
 
 	// A3 -> A4
 	let a4 = client
@@ -89,7 +89,7 @@ where
 		.unwrap()
 		.block;
 	block_on(client.import(BlockOrigin::Own, a4.clone())).unwrap();
-	assert_eq!(blockchain.leaves().unwrap(), vec![a4.hash()],);
+	assert_eq!(blockchain.leaves().unwrap(), vec![a4.hash()]);
 
 	// A4 -> A5
 	let a5 = client
@@ -100,7 +100,7 @@ where
 		.block;
 
 	block_on(client.import(BlockOrigin::Own, a5.clone())).unwrap();
-	assert_eq!(blockchain.leaves().unwrap(), vec![a5.hash()],);
+	assert_eq!(blockchain.leaves().unwrap(), vec![a5.hash()]);
 
 	// A1 -> B2
 	let mut builder = client
@@ -118,7 +118,7 @@ where
 		.unwrap();
 	let b2 = builder.build().unwrap().block;
 	block_on(client.import(BlockOrigin::Own, b2.clone())).unwrap();
-	assert_eq!(blockchain.leaves().unwrap(), vec![a5.hash(), b2.hash()],);
+	assert_eq!(blockchain.leaves().unwrap(), vec![a5.hash(), b2.hash()]);
 
 	// B2 -> B3
 	let b3 = client
@@ -129,7 +129,7 @@ where
 		.block;
 
 	block_on(client.import(BlockOrigin::Own, b3.clone())).unwrap();
-	assert_eq!(blockchain.leaves().unwrap(), vec![a5.hash(), b3.hash()],);
+	assert_eq!(blockchain.leaves().unwrap(), vec![a5.hash(), b3.hash()]);
 
 	// B3 -> B4
 	let b4 = client
@@ -139,7 +139,7 @@ where
 		.unwrap()
 		.block;
 	block_on(client.import(BlockOrigin::Own, b4.clone())).unwrap();
-	assert_eq!(blockchain.leaves().unwrap(), vec![a5.hash(), b4.hash()],);
+	assert_eq!(blockchain.leaves().unwrap(), vec![a5.hash(), b4.hash()]);
 
 	// // B2 -> C3
 	let mut builder = client
@@ -156,7 +156,7 @@ where
 		.unwrap();
 	let c3 = builder.build().unwrap().block;
 	block_on(client.import(BlockOrigin::Own, c3.clone())).unwrap();
-	assert_eq!(blockchain.leaves().unwrap(), vec![a5.hash(), b4.hash(), c3.hash()],);
+	assert_eq!(blockchain.leaves().unwrap(), vec![a5.hash(), b4.hash(), c3.hash()]);
 
 	// A1 -> D2
 	let mut builder = client
@@ -173,7 +173,7 @@ where
 		.unwrap();
 	let d2 = builder.build().unwrap().block;
 	block_on(client.import(BlockOrigin::Own, d2.clone())).unwrap();
-	assert_eq!(blockchain.leaves().unwrap(), vec![a5.hash(), b4.hash(), c3.hash(), d2.hash()],);
+	assert_eq!(blockchain.leaves().unwrap(), vec![a5.hash(), b4.hash(), c3.hash(), d2.hash()]);
 }
 
 /// helper to test the `children` implementation for various backends

--- a/utils/fork-tree/src/lib.rs
+++ b/utils/fork-tree/src/lib.rs
@@ -980,22 +980,22 @@ mod test {
 
 		tree.finalize_root(&"A");
 
-		assert_eq!(tree.best_finalized_number, Some(1),);
+		assert_eq!(tree.best_finalized_number, Some(1));
 
-		assert_eq!(tree.import("A", 1, (), &is_descendent_of), Err(Error::Revert),);
+		assert_eq!(tree.import("A", 1, (), &is_descendent_of), Err(Error::Revert));
 	}
 
 	#[test]
 	fn import_doesnt_add_duplicates() {
 		let (mut tree, is_descendent_of) = test_fork_tree();
 
-		assert_eq!(tree.import("A", 1, (), &is_descendent_of), Err(Error::Duplicate),);
+		assert_eq!(tree.import("A", 1, (), &is_descendent_of), Err(Error::Duplicate));
 
-		assert_eq!(tree.import("I", 4, (), &is_descendent_of), Err(Error::Duplicate),);
+		assert_eq!(tree.import("I", 4, (), &is_descendent_of), Err(Error::Duplicate));
 
-		assert_eq!(tree.import("G", 3, (), &is_descendent_of), Err(Error::Duplicate),);
+		assert_eq!(tree.import("G", 3, (), &is_descendent_of), Err(Error::Duplicate));
 
-		assert_eq!(tree.import("K", 3, (), &is_descendent_of), Err(Error::Duplicate),);
+		assert_eq!(tree.import("K", 3, (), &is_descendent_of), Err(Error::Duplicate));
 	}
 
 	#[test]
@@ -1057,7 +1057,7 @@ mod test {
 		let original_roots = tree.roots.clone();
 
 		// finalizing a block prior to any in the node doesn't change the tree
-		assert_eq!(tree.finalize(&"0", 0, &is_descendent_of), Ok(FinalizationResult::Unchanged),);
+		assert_eq!(tree.finalize(&"0", 0, &is_descendent_of), Ok(FinalizationResult::Unchanged));
 
 		assert_eq!(tree.roots, original_roots);
 
@@ -1073,12 +1073,12 @@ mod test {
 		);
 
 		// finalizing anything lower than what we observed will fail
-		assert_eq!(tree.best_finalized_number, Some(1),);
+		assert_eq!(tree.best_finalized_number, Some(1));
 
-		assert_eq!(tree.finalize(&"Z", 1, &is_descendent_of), Err(Error::Revert),);
+		assert_eq!(tree.finalize(&"Z", 1, &is_descendent_of), Err(Error::Revert));
 
 		// trying to finalize a node without finalizing its ancestors first will fail
-		assert_eq!(tree.finalize(&"H", 3, &is_descendent_of), Err(Error::UnfinalizedAncestor),);
+		assert_eq!(tree.finalize(&"H", 3, &is_descendent_of), Err(Error::UnfinalizedAncestor));
 
 		// after finalizing "F" we can finalize "H"
 		assert_eq!(
@@ -1144,7 +1144,7 @@ mod test {
 			vec![("L", 4), ("I", 4)],
 		);
 
-		assert_eq!(tree.best_finalized_number, Some(3),);
+		assert_eq!(tree.best_finalized_number, Some(3));
 
 		// finalizing N (which is not a part of the tree):
 		// 1) removes roots that are not ancestors/descendants of N (I)
@@ -1161,7 +1161,7 @@ mod test {
 			vec![],
 		);
 
-		assert_eq!(tree.best_finalized_number, Some(6),);
+		assert_eq!(tree.best_finalized_number, Some(6));
 	}
 
 	#[test]
@@ -1327,7 +1327,7 @@ mod test {
 				Ok(Some(false)),
 			);
 
-			assert_eq!(n_is_descendent_of_calls.load(Ordering::SeqCst), 1,);
+			assert_eq!(n_is_descendent_of_calls.load(Ordering::SeqCst), 1);
 		}
 
 		n_is_descendent_of_calls.store(0, Ordering::SeqCst);
@@ -1350,7 +1350,7 @@ mod test {
 				Ok(FinalizationResult::Changed(Some(10))),
 			);
 
-			assert_eq!(n_is_descendent_of_calls.load(Ordering::SeqCst), 1,);
+			assert_eq!(n_is_descendent_of_calls.load(Ordering::SeqCst), 1);
 		}
 	}
 
@@ -1377,7 +1377,7 @@ mod test {
 
 		let removed = tree.prune(&"C", &3, &is_descendent_of, &|_| true).unwrap();
 
-		assert_eq!(tree.roots.iter().map(|node| node.hash).collect::<Vec<_>>(), vec!["B"],);
+		assert_eq!(tree.roots.iter().map(|node| node.hash).collect::<Vec<_>>(), vec!["B"]);
 
 		assert_eq!(
 			tree.iter().map(|(hash, _, _)| *hash).collect::<Vec<_>>(),
@@ -1391,9 +1391,9 @@ mod test {
 
 		let removed = tree.prune(&"E", &5, &is_descendent_of, &|_| true).unwrap();
 
-		assert_eq!(tree.roots.iter().map(|node| node.hash).collect::<Vec<_>>(), vec!["D"],);
+		assert_eq!(tree.roots.iter().map(|node| node.hash).collect::<Vec<_>>(), vec!["D"]);
 
-		assert_eq!(tree.iter().map(|(hash, _, _)| *hash).collect::<Vec<_>>(), vec!["D", "E"],);
+		assert_eq!(tree.iter().map(|(hash, _, _)| *hash).collect::<Vec<_>>(), vec!["D", "E"]);
 
 		assert_eq!(removed.map(|(hash, _, _)| hash).collect::<Vec<_>>(), vec!["B", "C"]);
 	}

--- a/utils/frame/remote-externalities/src/lib.rs
+++ b/utils/frame/remote-externalities/src/lib.rs
@@ -344,7 +344,7 @@ impl<B: BlockT> Builder<B> {
 
 	/// initialize `Self` from state snapshot. Panics if the file does not exist.
 	fn load_state_snapshot(&self, path: &Path) -> Result<Vec<KeyPair>, &'static str> {
-		info!(target: LOG_TARGET, "scraping key-pairs from state snapshot {:?}", path,);
+		info!(target: LOG_TARGET, "scraping key-pairs from state snapshot {:?}", path);
 		let bytes = fs::read(path).map_err(|_| "fs::read failed.")?;
 		Decode::decode(&mut &*bytes).map_err(|_| "decode failed")
 	}

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -489,7 +489,7 @@ fn compact_wasm_file(
 			wasm_binary_name.clone().unwrap_or_else(|| default_wasm_binary_name.clone());
 
 		let wasm_compact_compressed_file =
-			project.join(format!("{}.compact.compressed.wasm", file_name,));
+			project.join(format!("{}.compact.compressed.wasm", file_name));
 
 		if compress_wasm(&compact_binary.0, &wasm_compact_compressed_file) {
 			Some(WasmBinary(wasm_compact_compressed_file))


### PR DESCRIPTION
rustfmt can't remove commas inside macros as some of those have meaning.

reviewers please keep an eye out for commas related to single tuples (I can't see any in there).