### PR TITLE
aura, babe: don't allow disabled validators to build blocks

### DIFF
--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -197,6 +197,7 @@ impl pallet_randomness_collective_flip::Config for Runtime {}
 
 impl pallet_aura::Config for Runtime {
 	type AuthorityId = AuraId;
+	type DisabledValidators = ();
 }
 
 impl pallet_grandpa::Config for Runtime {

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -346,6 +346,7 @@ impl pallet_babe::Config for Runtime {
 	type EpochDuration = EpochDuration;
 	type ExpectedBlockTime = ExpectedBlockTime;
 	type EpochChangeTrigger = pallet_babe::ExternalTrigger;
+	type DisabledValidators = Session;
 
 	type KeyOwnerProofSystem = Historical;
 

--- a/frame/aura/src/mock.rs
+++ b/frame/aura/src/mock.rs
@@ -20,13 +20,17 @@
 #![cfg(test)]
 
 use crate as pallet_aura;
-use frame_support::{parameter_types, traits::GenesisBuild};
-use sp_consensus_aura::ed25519::AuthorityId;
+use frame_support::{
+	parameter_types,
+	traits::{DisabledValidators, GenesisBuild},
+};
+use sp_consensus_aura::{ed25519::AuthorityId, AuthorityIndex};
 use sp_core::H256;
 use sp_runtime::{
 	testing::{Header, UintAuthorityId},
 	traits::IdentityLookup,
 };
+use sp_std::cell::RefCell;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -83,8 +87,32 @@ impl pallet_timestamp::Config for Test {
 	type WeightInfo = ();
 }
 
+thread_local! {
+	static DISABLED_VALIDATORS: RefCell<Vec<AuthorityIndex>> = RefCell::new(Default::default());
+}
+
+pub struct MockDisabledValidators;
+
+impl MockDisabledValidators {
+	pub fn disable_validator(index: AuthorityIndex) {
+		DISABLED_VALIDATORS.with(|v| {
+			let mut disabled = v.borrow_mut();
+			if let Err(i) = disabled.binary_search(&index) {
+				disabled.insert(i, index);
+			}
+		})
+	}
+}
+
+impl DisabledValidators for MockDisabledValidators {
+	fn is_disabled(index: AuthorityIndex) -> bool {
+		DISABLED_VALIDATORS.with(|v| v.borrow().binary_search(&index).is_ok())
+	}
+}
+
 impl pallet_aura::Config for Test {
 	type AuthorityId = AuthorityId;
+	type DisabledValidators = MockDisabledValidators;
 }
 
 pub fn new_test_ext(authorities: Vec<u64>) -> sp_io::TestExternalities {

--- a/frame/aura/src/tests.rs
+++ b/frame/aura/src/tests.rs
@@ -19,12 +19,38 @@
 
 #![cfg(test)]
 
-use crate::mock::{new_test_ext, Aura};
+use crate::mock::{new_test_ext, Aura, MockDisabledValidators, System};
+use codec::Encode;
+use frame_support::traits::OnInitialize;
+use frame_system::InitKind;
+use sp_consensus_aura::{Slot, AURA_ENGINE_ID};
+use sp_runtime::{Digest, DigestItem};
 
 #[test]
 fn initial_values() {
 	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
 		assert_eq!(Aura::current_slot(), 0u64);
 		assert_eq!(Aura::authorities().len(), 4);
+	});
+}
+
+#[test]
+#[should_panic(
+	expected = "Validator with index 1 is disabled and should not be attempting to author blocks."
+)]
+fn disabled_validators_cannot_author_blocks() {
+	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
+		// slot 1 should be authored by validator at index 1
+		let slot = Slot::from(1);
+		let pre_digest =
+			Digest { logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())] };
+
+		System::initialize(&42, &System::parent_hash(), &pre_digest, InitKind::Full);
+
+		// let's disable the validator
+		MockDisabledValidators::disable_validator(1);
+
+		// and we should not be able to initialize the block
+		Aura::on_initialize(42);
 	});
 }

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -238,6 +238,7 @@ impl Config for Test {
 	type EpochDuration = EpochDuration;
 	type ExpectedBlockTime = ExpectedBlockTime;
 	type EpochChangeTrigger = crate::ExternalTrigger;
+	type DisabledValidators = Session;
 
 	type KeyOwnerProofSystem = Historical;
 

--- a/frame/babe/src/tests.rs
+++ b/frame/babe/src/tests.rs
@@ -374,7 +374,9 @@ fn tracks_block_numbers_when_current_and_previous_epoch_started() {
 }
 
 #[test]
-#[should_panic(expected = "Validator with index 0 is disabled and should not be attempting to author blocks.")]
+#[should_panic(
+	expected = "Validator with index 0 is disabled and should not be attempting to author blocks."
+)]
 fn disabled_validators_cannot_author_blocks() {
 	new_test_ext(4).execute_with(|| {
 		start_era(1);

--- a/frame/babe/src/tests.rs
+++ b/frame/babe/src/tests.rs
@@ -374,6 +374,29 @@ fn tracks_block_numbers_when_current_and_previous_epoch_started() {
 }
 
 #[test]
+#[should_panic(expected = "Validator with index 0 is disabled and should not be attempting to author blocks.")]
+fn disabled_validators_cannot_author_blocks() {
+	new_test_ext(4).execute_with(|| {
+		start_era(1);
+
+		// let's disable the validator at index 1
+		Session::disable_index(1);
+
+		// the mocking infrastructure always authors all blocks using authority index 0,
+		// so we should still be able to author blocks
+		start_era(2);
+
+		assert_eq!(Staking::current_era().unwrap(), 2);
+
+		// let's disable the validator at index 0
+		Session::disable_index(0);
+
+		// this should now panic as the validator authoring blocks is disabled
+		start_era(3);
+	});
+}
+
+#[test]
 fn report_equivocation_current_session_works() {
 	let (pairs, mut ext) = new_test_ext_with_pairs(3);
 
@@ -394,8 +417,8 @@ fn report_equivocation_current_session_works() {
 			);
 		}
 
-		// we will use the validator at index 0 as the offending authority
-		let offending_validator_index = 0;
+		// we will use the validator at index 1 as the offending authority
+		let offending_validator_index = 1;
 		let offending_validator_id = Session::validators()[offending_validator_index];
 		let offending_authority_pair = pairs
 			.into_iter()
@@ -456,7 +479,7 @@ fn report_equivocation_old_session_works() {
 		let authorities = Babe::authorities();
 
 		// we will use the validator at index 0 as the offending authority
-		let offending_validator_index = 0;
+		let offending_validator_index = 1;
 		let offending_validator_id = Session::validators()[offending_validator_index];
 		let offending_authority_pair = pairs
 			.into_iter()

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -892,3 +892,9 @@ impl<T: Config> EstimateNextNewSession<T::BlockNumber> for Module<T> {
 		T::NextSessionRotation::estimate_next_session_rotation(now)
 	}
 }
+
+impl<T: Config> frame_support::traits::DisabledValidators for Module<T> {
+	fn is_disabled(index: u32) -> bool {
+		<Module<T>>::disabled_validators().binary_search(&index).is_ok()
+	}
+}

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -38,9 +38,9 @@ pub use members::{
 
 mod validation;
 pub use validation::{
-	EstimateNextNewSession, EstimateNextSessionRotation, FindAuthor, KeyOwnerProofSystem, Lateness,
-	OneSessionHandler, ValidatorRegistration, ValidatorSet, ValidatorSetWithIdentification,
-	VerifySeal,
+	DisabledValidators, EstimateNextNewSession, EstimateNextSessionRotation, FindAuthor,
+	KeyOwnerProofSystem, Lateness, OneSessionHandler, ValidatorRegistration, ValidatorSet,
+	ValidatorSetWithIdentification, VerifySeal,
 };
 
 mod filter;

--- a/frame/support/src/traits/validation.rs
+++ b/frame/support/src/traits/validation.rs
@@ -244,3 +244,17 @@ pub trait ValidatorRegistration<ValidatorId> {
 	/// module
 	fn is_registered(id: &ValidatorId) -> bool;
 }
+
+/// Trait used to check whether a given validator is currently disabled and should not be
+/// participating in consensus (e.g. because they equivocated).
+/// The [Session module](../../pallet_session/index.html) is an implementor.
+pub trait DisabledValidators {
+	/// Returns true if the given validator is disabled.
+	fn is_disabled(index: u32) -> bool;
+}
+
+impl DisabledValidators for () {
+	fn is_disabled(_index: u32) -> bool {
+		false
+	}
+}

--- a/frame/support/src/traits/validation.rs
+++ b/frame/support/src/traits/validation.rs
@@ -247,7 +247,6 @@ pub trait ValidatorRegistration<ValidatorId> {
 
 /// Trait used to check whether a given validator is currently disabled and should not be
 /// participating in consensus (e.g. because they equivocated).
-/// The [Session module](../../pallet_session/index.html) is an implementor.
 pub trait DisabledValidators {
 	/// Returns true if the given validator is disabled.
 	fn is_disabled(index: u32) -> bool;

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -582,6 +582,7 @@ impl pallet_babe::Config for Runtime {
 	// are manually adding the digests. normally in this situation you'd use
 	// pallet_babe::SameAuthoritiesForever.
 	type EpochChangeTrigger = pallet_babe::ExternalTrigger;
+	type DisabledValidators = ();
 
 	type KeyOwnerProofSystem = ();
 


### PR DESCRIPTION
Partial fix for #8004.

As part of module initialization we check whether the given validator has been disabled and if so we panic to make sure it is not able to author blocks. The reason that this is implemented in the runtime and not on the client-side is because implementing this on the client-side would require us to be fork-aware (one validator might have been disabled on a given fork but not another one).

polkadot companion: https://github.com/paritytech/polkadot/pull/3524