### PR TITLE
example typo

### DIFF
--- a/frame/support/procedural/src/lib.rs
+++ b/frame/support/procedural/src/lib.rs
@@ -288,8 +288,8 @@ pub fn decl_storage(input: TokenStream) -> TokenStream {
 /// ```nocompile
 /// construct_runtime!(
 ///     pub enum Runtime where
-///         Block = runtime::Block,
-///         NodeBlock = Block,
+///         Block = Block,
+///         NodeBlock = node::Block,
 ///         UncheckedExtrinsic = UncheckedExtrinsic
 ///     {
 ///         System: system::{Pallet, Call, Event<T>, Config<T>} = 0,

--- a/frame/support/procedural/src/lib.rs
+++ b/frame/support/procedural/src/lib.rs
@@ -288,8 +288,8 @@ pub fn decl_storage(input: TokenStream) -> TokenStream {
 /// ```nocompile
 /// construct_runtime!(
 ///     pub enum Runtime where
-///         Block = Block,
-///         NodeBlock = runtime::Block,
+///         Block = runtime::Block,
+///         NodeBlock = Block,
 ///         UncheckedExtrinsic = UncheckedExtrinsic
 ///     {
 ///         System: system::{Pallet, Call, Event<T>, Config<T>} = 0,


### PR DESCRIPTION
Reading the docs just above think these types might want to be the other way around?