### PR TITLE
WIP: Enable continuous package release to crates.io

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,6 @@ variables:                         &default-vars
   CI_IMAGE:                        "paritytech/ci-linux:production"
   # FIXME set to release
   CARGO_UNLEASH_INSTALL_PARAMS:    "--version 1.0.0-alpha.12"
-  CARGO_UNLEASH_PKG_DEF:           "--skip node node-* pallet-template pallet-example pallet-example-* subkey chain-spec-builder"
 
 default:
   cache:                           {}
@@ -345,7 +344,7 @@ unleash-check:
     # TODO: Implement this optimization in cargo-unleash rather than here
     - mkdir -p target/unleash
     - export CARGO_TARGET_DIR=target/unleash
-    - cargo unleash check ${CARGO_UNLEASH_PKG_DEF}
+    - cargo unleash check
 
 test-frame-examples-compile-to-wasm:
   # into one job
@@ -686,7 +685,7 @@ publish-to-crates-io:
     # cycle and cannot proceed with publishing/checking
     - cargo unleash de-dev-deps
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
-    - cargo unleash em-dragons --no-check --owner github:paritytech:core-devs ${CARGO_UNLEASH_PKG_DEF}
+    - cargo unleash em-dragons --no-check --owner github:paritytech:core-devs
   allow_failure:                   true
 
 #### stage:                        deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -676,16 +676,13 @@ publish-to-crates-io:
   needs:
     - job:                         unleash-check
   <<:                              *docker-env
-  rules:
-    - if: $CI_COMMIT_REF_NAME =~ /^ci-release-.*$/
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   script:
     # TODO: Don't specify crates version in dev-dependencies - cargo automatically
     # prunes such dependencies from the manifest. Otherwise we form a package
     # cycle and cannot proceed with publishing/checking
     - cargo unleash de-dev-deps
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
-    - cargo unleash em-dragons --no-check --owner github:paritytech:core-devs
+    - cargo unleash em-dragons --no-check --owner github:paritytech:core-devs --dry-run
   allow_failure:                   true
 
 #### stage:                        deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -337,6 +337,9 @@ unleash-check:
   <<:                              *test-refs-no-trigger
   script:
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
+    # TODO: Don't specify crates version in dev-dependencies - cargo automatically
+    # prunes such dependencies from the manifest. Otherwise we form a package
+    # cycle and cannot proceed with publishing/checking
     - cargo unleash de-dev-deps
     # Reuse build artifacts when running checks (cuts down check time by 3x)
     # TODO: Implement this optimization in cargo-unleash rather than here
@@ -671,11 +674,17 @@ publish-draft-release:
 
 publish-to-crates-io:
   stage:                           publish
+  needs:
+    - job:                         unleash-check
   <<:                              *docker-env
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^ci-release-.*$/
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   script:
+    # TODO: Don't specify crates version in dev-dependencies - cargo automatically
+    # prunes such dependencies from the manifest. Otherwise we form a package
+    # cycle and cannot proceed with publishing/checking
+    - cargo unleash de-dev-deps
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
     - cargo unleash em-dragons --no-check --owner github:paritytech:core-devs ${CARGO_UNLEASH_PKG_DEF}
   allow_failure:                   true

--- a/bin/node/bench/Cargo.toml
+++ b/bin/node/bench/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate node integration benchmarks."
 edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/bin/node/browser-testing/Cargo.toml
+++ b/bin/node/browser-testing/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 description = "Tests for the in-browser light client."
 edition = "2018"
 license = "Apache-2.0"
+publish = false
 
 [dependencies]
 futures-timer = "3.0.2"

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -9,6 +9,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 default-run = "substrate"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+publish = false
 
 [package.metadata.wasm-pack.profile.release]
 # `wasm-opt` has some problems on linux, see

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node/inspect/Cargo.toml
+++ b/bin/node/inspect/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node/primitives/Cargo.toml
+++ b/bin/node/primitives/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node/rpc-client/Cargo.toml
+++ b/bin/node/rpc-client/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node/rpc/Cargo.toml
+++ b/bin/node/rpc/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -7,6 +7,7 @@ build = "build.rs"
 license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
-publish = true
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/example-offchain-worker/Cargo.toml
+++ b/frame/example-offchain-worker/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME example pallet for offchain worker"
 readme = "README.md"
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/example-parallel/Cargo.toml
+++ b/frame/example-parallel/Cargo.toml
@@ -7,6 +7,7 @@ license = "Unlicense"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME example pallet using runtime worker threads"
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/example/Cargo.toml
+++ b/frame/example/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME example pallet"
 readme = "README.md"
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
...rather than doing it only on select tags. This should publish only versions that are not published yet.

Related #7634

cc @gnunicorn @TriplEight 