### PR TITLE
Don't return misleading result with PostInfo in proxy-pallet

### DIFF
--- a/client/network/src/request_responses.rs
+++ b/client/network/src/request_responses.rs
@@ -788,7 +788,7 @@ pub enum ResponseFailure {
 /// Implements the libp2p [`RequestResponseCodec`] trait. Defines how streams of bytes are turned
 /// into requests and responses and vice-versa.
 #[derive(Debug, Clone)]
-#[doc(hidden)]// Needs to be public in order to satisfy the Rust compiler.
+#[doc(hidden)] // Needs to be public in order to satisfy the Rust compiler.
 pub struct GenericCodec {
 	max_request_size: u64,
 	max_response_size: u64,

--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -35,7 +35,7 @@ pub mod weights;
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
-	dispatch::{DispatchError, DispatchResultWithPostInfo, PostDispatchInfo},
+	dispatch::DispatchError,
 	ensure,
 	traits::{Currency, Get, InstanceFilter, IsSubType, IsType, OriginTrait, ReservableCurrency},
 	weights::GetDispatchInfo,
@@ -102,7 +102,7 @@ pub mod pallet {
 
 		/// The overarching call type.
 		type Call: Parameter
-			+ Dispatchable<Origin = Self::Origin, PostInfo = PostDispatchInfo>
+			+ Dispatchable<Origin = Self::Origin>
 			+ GetDispatchInfo
 			+ From<frame_system::Call<Self>>
 			+ IsSubType<Call<Self>>
@@ -196,7 +196,7 @@ pub mod pallet {
 			real: T::AccountId,
 			force_proxy_type: Option<T::ProxyType>,
 			call: Box<<T as Config>::Call>,
-		) -> DispatchResultWithPostInfo {
+		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let def = Self::find_proxy(&real, &who, force_proxy_type)?;
 			ensure!(def.delay.is_zero(), Error::<T>::Unannounced);
@@ -225,7 +225,7 @@ pub mod pallet {
 			delegate: T::AccountId,
 			proxy_type: T::ProxyType,
 			delay: T::BlockNumber,
-		) -> DispatchResultWithPostInfo {
+		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Self::add_proxy_delegate(&who, delegate, proxy_type, delay)
 		}
@@ -247,7 +247,7 @@ pub mod pallet {
 			delegate: T::AccountId,
 			proxy_type: T::ProxyType,
 			delay: T::BlockNumber,
-		) -> DispatchResultWithPostInfo {
+		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Self::remove_proxy_delegate(&who, delegate, proxy_type, delay)
 		}
@@ -263,7 +263,7 @@ pub mod pallet {
 		/// Weight is a function of the number of proxies the user has (P).
 		/// # </weight>
 		#[pallet::weight(T::WeightInfo::remove_proxies(T::MaxProxies::get().into()))]
-		pub fn remove_proxies(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+		pub fn remove_proxies(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let (_, old_deposit) = Proxies::<T>::take(&who);
 			T::Currency::unreserve(&who, old_deposit);
@@ -300,7 +300,7 @@ pub mod pallet {
 			proxy_type: T::ProxyType,
 			delay: T::BlockNumber,
 			index: u16,
-		) -> DispatchResultWithPostInfo {
+		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
 			let anonymous = Self::anonymous_account(&who, &proxy_type, index, None);
@@ -348,7 +348,7 @@ pub mod pallet {
 			index: u16,
 			#[pallet::compact] height: T::BlockNumber,
 			#[pallet::compact] ext_index: u32,
-		) -> DispatchResultWithPostInfo {
+		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
 			let when = (height, ext_index);
@@ -387,7 +387,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			real: T::AccountId,
 			call_hash: CallHashOf<T>,
-		) -> DispatchResultWithPostInfo {
+		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Proxies::<T>::get(&real)
 				.0
@@ -443,7 +443,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			real: T::AccountId,
 			call_hash: CallHashOf<T>,
-		) -> DispatchResultWithPostInfo {
+		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Self::edit_announcements(&who, |ann| ann.real != real || ann.call_hash != call_hash)?;
 
@@ -473,7 +473,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			delegate: T::AccountId,
 			call_hash: CallHashOf<T>,
-		) -> DispatchResultWithPostInfo {
+		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Self::edit_announcements(&delegate, |ann| {
 				ann.real != who || ann.call_hash != call_hash
@@ -513,7 +513,7 @@ pub mod pallet {
 			real: T::AccountId,
 			force_proxy_type: Option<T::ProxyType>,
 			call: Box<<T as Config>::Call>,
-		) -> DispatchResultWithPostInfo {
+		) -> DispatchResult {
 			ensure_signed(origin)?;
 			let def = Self::find_proxy(&real, &delegate, force_proxy_type)?;
 
@@ -641,7 +641,7 @@ impl<T: Config> Pallet<T> {
 		delegatee: T::AccountId,
 		proxy_type: T::ProxyType,
 		delay: T::BlockNumber,
-	) -> DispatchResultWithPostInfo {
+	) -> DispatchResult {
 		ensure!(delegator != &delegatee, Error::<T>::NoSelfProxy);
 		Proxies::<T>::try_mutate(delegator, |(ref mut proxies, ref mut deposit)| {
 			let proxy_def = ProxyDefinition { delegate: delegatee, proxy_type, delay };
@@ -671,7 +671,7 @@ impl<T: Config> Pallet<T> {
 		delegatee: T::AccountId,
 		proxy_type: T::ProxyType,
 		delay: T::BlockNumber,
-	) -> DispatchResultWithPostInfo {
+	) -> DispatchResult {
 		Proxies::<T>::try_mutate_exists(delegator, |x| {
 			let (mut proxies, old_deposit) = x.take().ok_or(Error::<T>::NotFound)?;
 			let proxy_def = ProxyDefinition { delegate: delegatee, proxy_type, delay };

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -2365,8 +2365,7 @@ impl<T: Config> Pallet<T> {
 		})?;
 
 		let controller = Self::bonded(&validator_stash).ok_or_else(|| {
-			Error::<T>::NotStash
-				.with_weight(T::WeightInfo::payout_stakers_alive_staked(0))
+			Error::<T>::NotStash.with_weight(T::WeightInfo::payout_stakers_alive_staked(0))
 		})?;
 		let mut ledger = <Ledger<T>>::get(&controller).ok_or(Error::<T>::NotController)?;
 


### PR DESCRIPTION
I didn't find any functions which really needs a PostInfo.

also autoformatting two unrelated files

fixes #9421


