### PR TITLE
make justification-period configurable

### DIFF
--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -189,6 +189,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 	let name = config.network.node_name.clone();
 	let enable_grandpa = !config.disable_grandpa;
 	let prometheus_registry = config.prometheus_registry().cloned();
+	let justification_period = config.justification_period;
 
 	let rpc_extensions_builder = {
 		let client = client.clone();
@@ -275,7 +276,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 	let grandpa_config = sc_finality_grandpa::Config {
 		// FIXME #1578 make this available through chainspec
 		gossip_duration: Duration::from_millis(333),
-		justification_period: 512,
+		justification_period,
 		name: Some(name),
 		observer_enabled: false,
 		keystore,

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -266,6 +266,7 @@ pub fn new_full_base(
 	let name = config.network.node_name.clone();
 	let enable_grandpa = !config.disable_grandpa;
 	let prometheus_registry = config.prometheus_registry().cloned();
+	let justification_period = config.justification_period;
 
 	let _rpc_handlers = sc_service::spawn_tasks(sc_service::SpawnTasksParams {
 		config,
@@ -377,7 +378,7 @@ pub fn new_full_base(
 	let config = grandpa::Config {
 		// FIXME #1578 make this available through chainspec
 		gossip_duration: std::time::Duration::from_millis(333),
-		justification_period: 512,
+		justification_period,
 		name: Some(name),
 		observer_enabled: false,
 		keystore,

--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -50,6 +50,10 @@ pub struct RunCmd {
 	#[structopt(long)]
 	pub no_grandpa: bool,
 
+	/// Set justification generation period (in blocks). Default is 512.
+	#[structopt(long = "justification-period")]
+	pub justification_period: Option<u32>,
+
 	/// Experimental: Run in light client mode.
 	#[structopt(long = "light")]
 	pub light: bool,
@@ -375,6 +379,10 @@ impl CliConfiguration for RunCmd {
 
 	fn disable_grandpa(&self) -> Result<bool> {
 		Ok(self.no_grandpa)
+	}
+
+	fn justification_period(&self) -> Result<u32> {
+		Ok(self.justification_period.unwrap_or(512).max(1))
 	}
 
 	fn rpc_ws_max_connections(&self) -> Result<Option<usize>> {

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -461,6 +461,13 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		Ok(true)
 	}
 
+	/// Get justification generation period (in blocks).
+	///
+	/// By default this is `512`.
+	fn justification_period(&self) -> Result<u32> {
+		Ok(512)
+	}
+
 	/// Create a Configuration object from the current object
 	fn create_configuration<C: SubstrateCli>(
 		&self,
@@ -535,6 +542,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 			chain_spec,
 			max_runtime_instances,
 			announce_block: self.announce_block()?,
+			justification_period: self.justification_period()?,
 			role,
 			base_path: Some(base_path),
 			informant_output_format: Default::default(),

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -139,6 +139,8 @@ pub struct Configuration {
 	pub max_runtime_instances: usize,
 	/// Announce block automatically after they have been imported
 	pub announce_block: bool,
+	/// Justification generation period (in blocks).
+	pub justification_period: u32,
 	/// Base path of the configuration
 	pub base_path: Option<BasePath>,
 	/// Configuration of the output format that the informant uses.

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -266,6 +266,7 @@ fn node_config<
 		tracing_receiver: Default::default(),
 		max_runtime_instances: 8,
 		announce_block: true,
+		justification_period: 512,
 		base_path: Some(BasePath::new(root)),
 		informant_output_format: Default::default(),
 		disable_log_reloading: false,

--- a/test-utils/test-runner/src/utils.rs
+++ b/test-utils/test-runner/src/utils.rs
@@ -111,6 +111,7 @@ pub fn default_config(
 		tracing_receiver: Default::default(),
 		max_runtime_instances: 8,
 		announce_block: true,
+		justification_period: 512,
 		base_path: Some(base_path),
 		wasm_runtime_overrides: None,
 		informant_output_format,

--- a/utils/browser/src/lib.rs
+++ b/utils/browser/src/lib.rs
@@ -116,6 +116,7 @@ where
 		wasm_runtime_overrides: Default::default(),
 		max_runtime_instances: 8,
 		announce_block: true,
+		justification_period: 512,
 		base_path: None,
 		informant_output_format: sc_informant::OutputFormat { enable_color: false },
 		disable_log_reloading: false,


### PR DESCRIPTION
- add `justification_period` to `sc_service::Configuration`
- add `justification_period` to `sc_cli::Configuration` and set default to `512` which is the previous hard-coded value so it should not break or change any behavior
- add `justification-period` to CLI arg