### PR TITLE
nix: IDEs like rust-src

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -7,6 +7,7 @@ let
     });
   nixpkgs = import <nixpkgs> { overlays = [ mozillaOverlay ]; };
   rust-nightly = with nixpkgs; ((rustChannelOf { date = "2021-07-06"; channel = "nightly"; }).rust.override {
+    extensions = [ "rust-src" ];
     targets = [ "wasm32-unknown-unknown" ];
   });
 in
@@ -19,6 +20,7 @@ with nixpkgs; pkgs.mkShell {
     darwin.apple_sdk.frameworks.Security
   ];
 
+  RUST_SRC_PATH="${rust-nightly}/lib/rustlib/src/rust/src";
   LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
   PROTOC = "${protobuf}/bin/protoc";
   ROCKSDB_LIB_DIR = "${rocksdb}/lib";


### PR DESCRIPTION
We want things to be as easy as possible for people to get started hacking at substrate. 

If we include `rust-src` then once people `clone` and run `nix-shell`, rust analyzer and intellirust will just work from that shell. 