### PR TITLE
Update trybuild to get better normalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10672,9 +10672,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1768998d9a3b179411618e377dbb134c58a88cda284b0aa71c42c40660127d46"
+checksum = "c02c413315329fc96167f922b46fd0caa3a43f4697b7a7896b183c7142635832"
 dependencies = [
  "dissimilar",
  "glob",

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -20,7 +20,7 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../" 
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 sp-core = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/core" }
 sp-std = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/std" }
-trybuild = "1.0.42"
+trybuild = "1.0.43"
 pretty_assertions = "0.6.1"
 rustversion = "1.0.0"
 frame-metadata = { version = "14.0.0-dev", default-features = false, path = "../../metadata" }

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
@@ -33,9 +33,9 @@ error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeEncode` is
 20  |         pub fn foo(origin: OriginFor<T>, bar: T::Bar) -> DispatchResultWithPostInfo {
     |                                               ^ the trait `WrapperTypeEncode` is not implemented for `<T as pallet::Config>::Bar`
     |
-   ::: /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/parity-scale-codec-2.2.0/src/codec.rs:223:21
+   ::: $CARGO/parity-scale-codec-2.2.0/src/codec.rs
     |
-223 |     fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+    |     fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
     |                     ------ required by this bound in `encode_to`
     |
     = note: required because of the requirements on the impl of `pallet::_::_parity_scale_codec::Encode` for `<T as pallet::Config>::Bar`
@@ -46,9 +46,9 @@ error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeDecode` is
 20  |         pub fn foo(origin: OriginFor<T>, bar: T::Bar) -> DispatchResultWithPostInfo {
     |                                               ^ the trait `WrapperTypeDecode` is not implemented for `<T as pallet::Config>::Bar`
     |
-   ::: /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/parity-scale-codec-2.2.0/src/codec.rs:284:18
+   ::: $CARGO/parity-scale-codec-2.2.0/src/codec.rs
     |
-284 |     fn decode<I: Input>(input: &mut I) -> Result<Self, Error>;
+    |     fn decode<I: Input>(input: &mut I) -> Result<Self, Error>;
     |                  ----- required by this bound in `pallet::_::_parity_scale_codec::Decode::decode`
     |
     = note: required because of the requirements on the impl of `Decode` for `<T as pallet::Config>::Bar`

--- a/primitives/api/test/Cargo.toml
+++ b/primitives/api/test/Cargo.toml
@@ -22,7 +22,7 @@ sp-consensus = { version = "0.10.0-dev", path = "../../consensus/common" }
 sc-block-builder = { version = "0.10.0-dev", path = "../../../client/block-builder" }
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../state-machine" }
-trybuild = "1.0.42"
+trybuild = "1.0.43"
 rustversion = "1.0.0"
 
 [dev-dependencies]

--- a/primitives/npos-elections/compact/Cargo.toml
+++ b/primitives/npos-elections/compact/Cargo.toml
@@ -24,4 +24,4 @@ proc-macro-crate = "1.0.0"
 parity-scale-codec = "2.0.1"
 sp-arithmetic = { path = "../../arithmetic" , version = "4.0.0-dev"}
 sp-npos-elections = { path = ".." , version = "4.0.0-dev"}
-trybuild = "1.0.42"
+trybuild = "1.0.43"

--- a/primitives/runtime-interface/Cargo.toml
+++ b/primitives/runtime-interface/Cargo.toml
@@ -31,7 +31,7 @@ sp-state-machine = { version = "0.10.0-dev", path = "../state-machine" }
 sp-core = { version = "4.0.0-dev", path = "../core" }
 sp-io = { version = "4.0.0-dev", path = "../io" }
 rustversion = "1.0.0"
-trybuild = "1.0.42"
+trybuild = "1.0.43"
 
 [features]
 default = [ "std" ]

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -18,4 +18,4 @@ tokio = { version = "0.2.13", features = ["macros"] }
 
 [dev-dependencies]
 sc-service = { version = "0.10.0-dev", path = "../client/service" }
-trybuild = { version = "1.0.42", features = [ "diff" ] }
+trybuild = { version = "1.0.43", features = [ "diff" ] }


### PR DESCRIPTION
The old `trybuild` version didn't normalized cargo registry paths, but
this is now done :)

