### PR TITLE
Remove invalid and unneeded codec implementation.

### DIFF
--- a/frame/identity/src/types.rs
+++ b/frame/identity/src/types.rs
@@ -152,7 +152,7 @@ impl<Balance: Encode + Decode + MaxEncodedLen + Copy + Clone + Debug + Eq + Part
 /// The fields that we use to identify the owner of an account with. Each corresponds to a field
 /// in the `IdentityInfo` struct.
 #[repr(u64)]
-#[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, BitFlags, RuntimeDebug)]
+#[derive(Clone, Copy, PartialEq, Eq, BitFlags, RuntimeDebug)]
 pub enum IdentityField {
 	Display = 0b0000000000000000000000000000000000000000000000000000000000000001,
 	Legal = 0b0000000000000000000000000000000000000000000000000000000000000010,
@@ -164,19 +164,13 @@ pub enum IdentityField {
 	Twitter = 0b0000000000000000000000000000000000000000000000000000000010000000,
 }
 
-impl MaxEncodedLen for IdentityField {
-	fn max_encoded_len() -> usize {
-		u64::max_encoded_len()
-	}
-}
-
 /// Wrapper type for `BitFlags<IdentityField>` that implements `Codec`.
 #[derive(Clone, Copy, PartialEq, Default, RuntimeDebug)]
 pub struct IdentityFields(pub(crate) BitFlags<IdentityField>);
 
 impl MaxEncodedLen for IdentityFields {
 	fn max_encoded_len() -> usize {
-		IdentityField::max_encoded_len()
+		u64::max_encoded_len()
 	}
 }
 


### PR DESCRIPTION
Derivation of Encode/Decode for codec encodes the variant into a u8. But here the variant discriminant is u64.

Also the type doesn't needs to implement Encode/Decode.

The PR simply removes the implementation