### PR TITLE
Added ss58 prefix for melodity beats mainnet (dolabs.studio)

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -576,7 +576,7 @@ ss58_address_format!(
 		(47, "reserved47", "Reserved for future use (47).")
 	NeatcoinAccount =>
 		(48, "neatcoin", "Neatcoin mainnet, standard account (*25519).")
-	NeatcoinAccount =>
+	MelodityBeatsAccount =>
 		(57, "beats", "Melodity Beats Mainnet, standard account (*25519).")
 	HydraDXAccount =>
 		(63, "hydradx", "HydraDX standard account (*25519).")

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -576,6 +576,8 @@ ss58_address_format!(
 		(47, "reserved47", "Reserved for future use (47).")
 	NeatcoinAccount =>
 		(48, "neatcoin", "Neatcoin mainnet, standard account (*25519).")
+	NeatcoinAccount =>
+		(57, "beats", "Melodity Beats Mainnet, standard account (*25519).")
 	HydraDXAccount =>
 		(63, "hydradx", "HydraDX standard account (*25519).")
 	AventusAccount =>

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -443,6 +443,15 @@
 			"website": "https://neatcoin.org"
 		},
 		{
+			"prefix": 57,
+			"network": "beats",
+			"displayName": "Melodity Beats Mainnet",
+			"symbols": ["MELB"],
+			"decimals": [12],
+			"standardAccount": "*25519",
+			"website": "https://dolabs.studio"
+		},
+		{
 			"prefix": 63,
 			"network": "hydradx",
 			"displayName": "HydraDX",


### PR DESCRIPTION
Added ss58 prefix for https://dolabs.studio melodity beats chain 

The prefix, 57, doesn't collide with other prefixes.
I've added a prefix to

ss58-registry.json
primitives/core/src/crypto.rs

Hope everything is ok.