### PR TITLE
staking: only disable slashed validators and keep then disabled for whole era

### DIFF
--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -572,7 +572,7 @@ decl_module! {
 }
 
 impl<T: Config> Module<T> {
-	/// Returns the number of validators in the current session.
+	/// Get the number of validators in the current session.
 	pub fn validators_len() -> usize {
 		<Validators<T>>::decode_len().unwrap_or(0)
 	}

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -617,14 +617,13 @@ pub struct UnappliedSlash<AccountId, Balance: HasCompact> {
 ///
 /// This is needed because `Staking` sets the `ValidatorIdOf` of the `pallet_session::Config`
 pub trait SessionInterface<AccountId>: frame_system::Config {
-	/// Disable a given validator by stash ID.
-	///
-	/// Returns `true` if new era should be forced at the end of this session.
-	/// This allows preventing a situation where there is too many validators
-	/// disabled and block production stalls.
-	fn disable_validator(validator: &AccountId) -> Result<bool, ()>;
+	/// Disable the validator at the given index, returns `false` if the validator was already
+	/// disabled.
+	fn disable_validator(validator_index: usize) -> bool;
 	/// Get the validators from session.
 	fn validators() -> Vec<AccountId>;
+	/// Get the number of validators in the session.
+	fn validators_len() -> usize;
 	/// Prune historical session tries up to but not including the given index.
 	fn prune_historical_up_to(up_to: SessionIndex);
 }
@@ -643,12 +642,16 @@ where
 		Option<<T as frame_system::Config>::AccountId>,
 	>,
 {
-	fn disable_validator(validator: &<T as frame_system::Config>::AccountId) -> Result<bool, ()> {
-		<pallet_session::Pallet<T>>::disable(validator)
+	fn disable_validator(validator_index: usize) -> bool {
+		<pallet_session::Pallet<T>>::disable_index(validator_index)
 	}
 
 	fn validators() -> Vec<<T as frame_system::Config>::AccountId> {
 		<pallet_session::Pallet<T>>::validators()
+	}
+
+	fn validators_len() -> usize {
+		<pallet_session::Pallet<T>>::validators_len()
 	}
 
 	fn prune_historical_up_to(up_to: SessionIndex) {
@@ -916,6 +919,10 @@ pub mod pallet {
 		/// their reward. This used to limit the i/o cost for the nominator payout.
 		#[pallet::constant]
 		type MaxNominatorRewardedPerValidator: Get<u32>;
+
+		/// The fraction of the validator set that is safe to be offending.
+		/// After the threshold is reached a new era will be forced.
+		type OffendingValidatorsThreshold: Get<Perbill>;
 
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
@@ -1207,6 +1214,9 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn current_planned_session)]
 	pub type CurrentPlannedSession<T> = StorageValue<_, SessionIndex, ValueQuery>;
+
+	#[pallet::storage]
+	pub(crate) type OffendingValidators<T: Config> = StorageValue<_, Vec<u32>, ValueQuery>;
 
 	/// True if network has been upgraded to this version.
 	/// Storage version of the pallet.
@@ -2568,6 +2578,8 @@ impl<T: Config> Pallet<T> {
 					Self::end_era(active_era, session_index);
 				}
 			}
+
+			<OffendingValidators<T>>::take();
 		}
 	}
 

--- a/frame/staking/src/slashing.rs
+++ b/frame/staking/src/slashing.rs
@@ -56,7 +56,7 @@ use super::{
 use codec::{Decode, Encode};
 use frame_support::{
 	ensure,
-	traits::{Currency, Imbalance, OnUnbalanced},
+	traits::{Currency, Get, Imbalance, OnUnbalanced},
 };
 use sp_runtime::{
 	traits::{Saturating, Zero},
@@ -278,11 +278,9 @@ pub(crate) fn compute_slash<T: Config>(
 			spans.end_span(now);
 			<Pallet<T>>::chill_stash(stash);
 
-			// make sure to disable validator till the end of this session
-			if T::SessionInterface::disable_validator(stash).unwrap_or(false) {
-				// force a new era, to select a new validator set
-				<Pallet<T>>::ensure_new_era()
-			}
+			// add the validator to the offenders list and make sure it is disabled for
+			// the duration of the session
+			add_offending_validator::<T>(params.stash, true);
 		}
 	}
 
@@ -316,12 +314,40 @@ fn kick_out_if_recent<T: Config>(params: SlashParams<T>) {
 		spans.end_span(params.now);
 		<Pallet<T>>::chill_stash(params.stash);
 
-		// make sure to disable validator till the end of this session
-		if T::SessionInterface::disable_validator(params.stash).unwrap_or(false) {
-			// force a new era, to select a new validator set
-			<Pallet<T>>::ensure_new_era()
-		}
+		// add the validator to the offenders list but since there's no slash being
+		// applied there's no need to disable the validator
+		add_offending_validator::<T>(params.stash, false);
 	}
+}
+
+/// Add the given validator to the offenders list and optionally disable it.
+/// If after adding the validator `OffendingValidatorsThreshold` is reached
+/// a new era will be forced.
+fn add_offending_validator<T: Config>(stash: &T::AccountId, disable: bool) {
+	<Pallet<T> as Store>::OffendingValidators::mutate(|offending| {
+		let validator_index =
+			match T::SessionInterface::validators().iter().position(|i| i == stash) {
+				Some(index) => index,
+				None => return,
+			};
+
+		let validator_index_u32 = validator_index as u32;
+		if let Err(index) = offending.binary_search(&validator_index_u32) {
+			offending.insert(index, validator_index_u32);
+
+			let offending_threshold = T::OffendingValidatorsThreshold::get() *
+				T::SessionInterface::validators_len() as u32;
+
+			if offending.len() > offending_threshold as usize {
+				// force a new era, to select a new validator set
+				<Pallet<T>>::ensure_new_era()
+			}
+
+			if disable {
+				T::SessionInterface::disable_validator(validator_index);
+			}
+		}
+	});
 }
 
 /// Slash nominators. Accepts general parameters and the prior slash percentage of the validator.


### PR DESCRIPTION
This PR changes the logic for disabling validators and trigger a new era. Whenever a validator commits an offence it is now tracked in the staking pallet and whenever a threshold is reached a new era is started. Only offences that led to a slash lead to the validator being disabled (e.g. if the validator is offline just by itself it is not disabled). Additionally the staking pallet makes sure that disabled validators stay disabled for the whole era.

The reason to not disable validators when there's no slash is https://github.com/paritytech/substrate/pull/9414 which will make sure that disabled validators can't author new blocks. If a validator is not slashed we can assume that the offence was not critical enough to block the validator from participating in consensus (it will be kicked from the set whenever the next era starts).

Fixes https://github.com/paritytech/polkadot/issues/2088.