### PR TITLE
Add some important events to batch & staking to ensure ease of analysis

### DIFF
--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -2508,6 +2508,11 @@ mod tests {
 					},
 					EventRecord {
 						phase: Phase::Initialization,
+						event: MetaEvent::Utility(pallet_utility::Event::ItemCompleted),
+						topics: vec![],
+					},
+					EventRecord {
+						phase: Phase::Initialization,
 						event: MetaEvent::Utility(pallet_utility::Event::BatchInterrupted(
 							1,
 							BadOrigin.into()

--- a/frame/offences/benchmarking/src/lib.rs
+++ b/frame/offences/benchmarking/src/lib.rs
@@ -289,7 +289,7 @@ benchmarks! {
 		let slash_amount = slash_fraction * bond_amount;
 		let reward_amount = slash_amount * (1 + n) / 2;
 		let slash = |id| core::iter::once(
-			<T as StakingConfig>::Event::from(StakingEvent::<T>::Slash(id, BalanceOf::<T>::from(slash_amount)))
+			<T as StakingConfig>::Event::from(StakingEvent::<T>::Slashed(id, BalanceOf::<T>::from(slash_amount)))
 		);
 		let chill = |id| core::iter::once(
 			<T as StakingConfig>::Event::from(StakingEvent::<T>::Chilled(id))

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -526,7 +526,7 @@ pub mod pallet {
 		/// the remainder from the maximum amount of reward.
 		/// \[era_index, validator_payout, remainder\]
 		EraPaid(EraIndex, BalanceOf<T>, BalanceOf<T>),
-		/// The nominator has been rewarded by this amount. \[era_index, stash, amount\]
+		/// The nominator has been rewarded by this amount. \[stash, amount\]
 		Rewarded(T::AccountId, BalanceOf<T>),
 		/// One validator (and its nominators) has been slashed by the given amount.
 		/// \[validator, amount\]

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -525,17 +525,17 @@ pub mod pallet {
 		/// The era payout has been set; the first balance is the validator-payout; the second is
 		/// the remainder from the maximum amount of reward.
 		/// \[era_index, validator_payout, remainder\]
-		EraPayout(EraIndex, BalanceOf<T>, BalanceOf<T>),
-		/// The staker has been rewarded by this amount. \[stash, amount\]
-		Reward(T::AccountId, BalanceOf<T>),
+		EraPaid(EraIndex, BalanceOf<T>, BalanceOf<T>),
+		/// The nominator has been rewarded by this amount. \[era_index, stash, amount\]
+		Rewarded(T::AccountId, BalanceOf<T>),
 		/// One validator (and its nominators) has been slashed by the given amount.
 		/// \[validator, amount\]
-		Slash(T::AccountId, BalanceOf<T>),
+		Slashed(T::AccountId, BalanceOf<T>),
 		/// An old slashing report from a prior era was discarded because it could
 		/// not be processed. \[session_index\]
 		OldSlashingReportDiscarded(SessionIndex),
 		/// A new set of stakers was elected.
-		StakingElection,
+		StakersElected,
 		/// An account has bonded this amount. \[stash, amount\]
 		///
 		/// NOTE: This event is only emitted when funds are bonded via a dispatchable. Notably,
@@ -553,6 +553,8 @@ pub mod pallet {
 		/// An account has stopped participating as either a validator or nominator.
 		/// \[stash\]
 		Chilled(T::AccountId),
+		/// The stakers' rewards are getting paid. \[era_index, validator_stash\]
+		PayoutStarted(EraIndex, T::AccountId),
 	}
 
 	#[pallet::error]

--- a/frame/staking/src/slashing.rs
+++ b/frame/staking/src/slashing.rs
@@ -584,7 +584,7 @@ pub fn do_slash<T: Config>(
 		<Pallet<T>>::update_ledger(&controller, &ledger);
 
 		// trigger the event
-		<Pallet<T>>::deposit_event(super::Event::<T>::Slash(stash.clone(), value));
+		<Pallet<T>>::deposit_event(super::Event::<T>::Slashed(stash.clone(), value));
 	}
 }
 

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -257,7 +257,7 @@ fn rewards_should_work() {
 		);
 		assert_eq!(
 			*mock::staking_events().last().unwrap(),
-			Event::EraPayout(0, total_payout_0, maximum_payout - total_payout_0)
+			Event::EraPaid(0, total_payout_0, maximum_payout - total_payout_0)
 		);
 		mock::make_all_reward_payment(0);
 
@@ -295,7 +295,7 @@ fn rewards_should_work() {
 		);
 		assert_eq!(
 			*mock::staking_events().last().unwrap(),
-			Event::EraPayout(1, total_payout_1, maximum_payout - total_payout_1)
+			Event::EraPaid(1, total_payout_1, maximum_payout - total_payout_1)
 		);
 		mock::make_all_reward_payment(1);
 
@@ -3942,7 +3942,7 @@ mod election_data_provider {
 			run_to_block(20);
 			assert_eq!(Staking::next_election_prediction(System::block_number()), 45);
 			assert_eq!(staking_events().len(), 1);
-			assert_eq!(*staking_events().last().unwrap(), Event::StakingElection);
+			assert_eq!(*staking_events().last().unwrap(), Event::StakersElected);
 
 			for b in 21..45 {
 				run_to_block(b);
@@ -3953,7 +3953,7 @@ mod election_data_provider {
 			run_to_block(45);
 			assert_eq!(Staking::next_election_prediction(System::block_number()), 70);
 			assert_eq!(staking_events().len(), 3);
-			assert_eq!(*staking_events().last().unwrap(), Event::StakingElection);
+			assert_eq!(*staking_events().last().unwrap(), Event::StakersElected);
 
 			Staking::force_no_eras(Origin::root()).unwrap();
 			assert_eq!(Staking::next_election_prediction(System::block_number()), u64::MAX);
@@ -3976,7 +3976,7 @@ mod election_data_provider {
 			run_to_block(55);
 			assert_eq!(Staking::next_election_prediction(System::block_number()), 55 + 25);
 			assert_eq!(staking_events().len(), 6);
-			assert_eq!(*staking_events().last().unwrap(), Event::StakingElection);
+			assert_eq!(*staking_events().last().unwrap(), Event::StakersElected);
 			// The new era has been planned, forcing is changed from `ForceNew` to `NotForcing`.
 			assert_eq!(ForceEra::<Test>::get(), Forcing::NotForcing);
 		})

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -108,6 +108,8 @@ pub mod pallet {
 		BatchInterrupted(u32, DispatchError),
 		/// Batch of dispatches completed fully with no error.
 		BatchCompleted,
+		/// A single item within a Batch of dispatches has completed with no error.
+		ItemCompleted,
 	}
 
 	#[pallet::call]
@@ -173,6 +175,7 @@ pub mod pallet {
 					// Return the actual used weight + base_weight of this call.
 					return Ok(Some(base_weight + weight).into())
 				}
+				Self::deposit_event(Event::ItemCompleted);
 			}
 			Self::deposit_event(Event::BatchCompleted);
 			let base_weight = T::WeightInfo::batch(calls_len as u32);
@@ -289,6 +292,7 @@ pub mod pallet {
 					err.post_info = Some(base_weight + weight).into();
 					err
 				})?;
+				Self::deposit_event(Event::ItemCompleted);
 			}
 			Self::deposit_event(Event::BatchCompleted);
 			let base_weight = T::WeightInfo::batch_all(calls_len as u32);


### PR DESCRIPTION
Allow events from batched items to be separated. Also ensure the validator stash and era index from which the rewards are derived is always recorded. Also rename the events which do not respect the past-participle naming convention.