### PR TITLE
Fix Inconsistent behaviour of repatriate_reserved after introducing account reference provider when ED is 0

### DIFF
--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -900,7 +900,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		f: impl FnOnce(&mut AccountData<T::Balance>, bool) -> Result<R, E>,
 	) -> Result<(R, DustCleaner<T, I>), E> {
 		let result = T::AccountStore::try_mutate_exists(who, |maybe_account| {
-			let is_new = maybe_account.is_none();
+			let is_new = maybe_account.is_none() && !system::Pallet::<T>::account_exists(who);
 			let mut account = maybe_account.take().unwrap_or_default();
 			f(&mut account, is_new).map(move |result| {
 				let maybe_endowed = if is_new { Some(account.free) } else { None };

--- a/frame/balances/src/tests_composite.rs
+++ b/frame/balances/src/tests_composite.rs
@@ -147,3 +147,28 @@ impl ExtBuilder {
 }
 
 decl_tests! { Test, ExtBuilder, EXISTENTIAL_DEPOSIT }
+
+#[test]
+fn repatriate_reserved_works_for_zero_account() {
+	// These functions all use `mutate_account` which may introduce a storage change when
+	// the account never existed to begin with, and shouldn't exist in the end.
+	<ExtBuilder>::default().existential_deposit(0).build().execute_with(|| {
+		let alice = 666;
+		let bob = 777;
+		assert_ok!(Balances::set_balance(Origin::root(), alice, 2000, 0));
+
+		assert_ok!(Balances::force_transfer(Origin::root(), alice, bob, 2000));
+
+		dbg!(alice, frame_system::Account::<Test>::get(alice));
+		dbg!(bob, frame_system::Account::<Test>::get(bob));
+
+		assert_ok!(frame_system::Pallet::<Test>::inc_consumers(&alice));
+		assert_ok!(Balances::reserve(&bob, 500));
+
+		dbg!(alice, frame_system::Account::<Test>::get(alice));
+		dbg!(bob, frame_system::Account::<Test>::get(bob));
+
+		// Repatriate Reserve
+		assert_ok!(Balances::repatriate_reserved(&bob, &alice, 500, Status::Free));
+	});
+}

--- a/frame/balances/src/tests_reentrancy.rs
+++ b/frame/balances/src/tests_reentrancy.rs
@@ -243,28 +243,3 @@ fn repatriating_reserved_balance_dust_removal_should_work() {
 		System::assert_last_event(Event::Balances(crate::Event::DustLost(2, 50)));
 	});
 }
-
-#[test]
-fn repatriate_reserved_works_for_zero_account() {
-	// These functions all use `mutate_account` which may introduce a storage change when
-	// the account never existed to begin with, and shouldn't exist in the end.
-	<ExtBuilder>::default().existential_deposit(0).build().execute_with(|| {
-		let alice = 666;
-		let bob = 777;
-		assert_ok!(Balances::set_balance(Origin::root(), alice, 2000, 0));
-
-		assert_ok!(Balances::force_transfer(Origin::root(), alice, bob, 2000));
-
-		dbg!(alice, frame_system::Account::<Test>::get(alice));
-		dbg!(bob, frame_system::Account::<Test>::get(bob));
-
-		assert_ok!(frame_system::Pallet::<Test>::inc_consumers(&alice));
-		assert_ok!(Balances::reserve(&bob, 500));
-
-		dbg!(alice, frame_system::Account::<Test>::get(alice));
-		dbg!(bob, frame_system::Account::<Test>::get(bob));
-
-		// Repatriate Reserve
-		assert_ok!(Balances::repatriate_reserved(&bob, &alice, 500, Status::Free));
-	});
-}

--- a/frame/balances/src/tests_reentrancy.rs
+++ b/frame/balances/src/tests_reentrancy.rs
@@ -246,33 +246,25 @@ fn repatriating_reserved_balance_dust_removal_should_work() {
 
 #[test]
 fn repatriate_reserved_works_for_zero_account() {
-    // These functions all use `mutate_account` which may introduce a storage change when
-    // the account never existed to begin with, and shouldn't exist in the end.
-    <ExtBuilder>::default()
-        .existential_deposit(0)
-        .build()
-        .execute_with(|| {
-            let alice = 666;
-            let bob = 777;
-            assert_ok!(Balances::set_balance(Origin::root(), alice, 2000, 0));
+	// These functions all use `mutate_account` which may introduce a storage change when
+	// the account never existed to begin with, and shouldn't exist in the end.
+	<ExtBuilder>::default().existential_deposit(0).build().execute_with(|| {
+		let alice = 666;
+		let bob = 777;
+		assert_ok!(Balances::set_balance(Origin::root(), alice, 2000, 0));
 
-            assert_ok!(Balances::force_transfer(Origin::root(), alice, bob, 2000));
+		assert_ok!(Balances::force_transfer(Origin::root(), alice, bob, 2000));
 
-            dbg!(alice, frame_system::Account::<Test>::get(alice));
-            dbg!(bob, frame_system::Account::<Test>::get(bob));
+		dbg!(alice, frame_system::Account::<Test>::get(alice));
+		dbg!(bob, frame_system::Account::<Test>::get(bob));
 
-            assert_ok!(frame_system::Pallet::<Test>::inc_consumers(&alice));
-            assert_ok!(Balances::reserve(&bob, 500));
+		assert_ok!(frame_system::Pallet::<Test>::inc_consumers(&alice));
+		assert_ok!(Balances::reserve(&bob, 500));
 
-            dbg!(alice, frame_system::Account::<Test>::get(alice));
-            dbg!(bob, frame_system::Account::<Test>::get(bob));
+		dbg!(alice, frame_system::Account::<Test>::get(alice));
+		dbg!(bob, frame_system::Account::<Test>::get(bob));
 
-            // Repatriate Reserve
-            assert_ok!(Balances::repatriate_reserved(
-                &bob,
-                &alice,
-                500,
-                Status::Free
-            ));
-        });
+		// Repatriate Reserve
+		assert_ok!(Balances::repatriate_reserved(&bob, &alice, 500, Status::Free));
+	});
 }

--- a/frame/balances/src/tests_reentrancy.rs
+++ b/frame/balances/src/tests_reentrancy.rs
@@ -243,3 +243,36 @@ fn repatriating_reserved_balance_dust_removal_should_work() {
 		System::assert_last_event(Event::Balances(crate::Event::DustLost(2, 50)));
 	});
 }
+
+#[test]
+fn repatriate_reserved_works_for_zero_account() {
+    // These functions all use `mutate_account` which may introduce a storage change when
+    // the account never existed to begin with, and shouldn't exist in the end.
+    <ExtBuilder>::default()
+        .existential_deposit(0)
+        .build()
+        .execute_with(|| {
+            let alice = 666;
+            let bob = 777;
+            assert_ok!(Balances::set_balance(Origin::root(), alice, 2000, 0));
+
+            assert_ok!(Balances::force_transfer(Origin::root(), alice, bob, 2000));
+
+            dbg!(alice, frame_system::Account::<Test>::get(alice));
+            dbg!(bob, frame_system::Account::<Test>::get(bob));
+
+            assert_ok!(frame_system::Pallet::<Test>::inc_consumers(&alice));
+            assert_ok!(Balances::reserve(&bob, 500));
+
+            dbg!(alice, frame_system::Account::<Test>::get(alice));
+            dbg!(bob, frame_system::Account::<Test>::get(bob));
+
+            // Repatriate Reserve
+            assert_ok!(Balances::repatriate_reserved(
+                &bob,
+                &alice,
+                500,
+                Status::Free
+            ));
+        });
+}


### PR DESCRIPTION
This test was moved from this issue https://github.com/paritytech/substrate/issues/7992 