### PR TITLE
CI: stop publishing to crates.io until unleash is fixed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,9 +55,15 @@ default:
       - artifacts/
 
 .kubernetes-env:                   &kubernetes-env
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - unknown_failure
+      - api_failure
+  interruptible:                   true
   tags:
     - kubernetes-parity-build
-  interruptible:                   true
 
 .rust-info-script:                 &rust-info-script
   - rustup show
@@ -675,7 +681,9 @@ publish-to-crates-io:
   <<:                              *docker-env
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^ci-release-.*$/
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+    # FIXME: wait until https://github.com/paritytech/cargo-unleash/issues/50 is fixed, also
+    # remove allow_failure: true on the check job
+    # - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   script:
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
     - cargo unleash em-dragons --no-check --owner github:paritytech:core-devs ${CARGO_UNLEASH_PKG_DEF}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,6 +103,7 @@ default:
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+    - if: $CI_COMMIT_REF_NAME =~ /^ci-release-.*$/
 
 .test-refs-no-trigger-prs-only:   &test-refs-no-trigger-prs-only
   rules:
@@ -349,6 +350,7 @@ unleash-check:
     - mkdir -p target/unleash
     - export CARGO_TARGET_DIR=target/unleash
     - cargo unleash check ${CARGO_UNLEASH_PKG_DEF}
+  # FIXME: this job must not fail, or unleash-to-crates-io will publish broken stuff
   allow_failure:                   true
 
 test-frame-examples-compile-to-wasm:
@@ -676,7 +678,7 @@ publish-draft-release:
     - ./.maintain/gitlab/publish_draft_release.sh
   allow_failure:                   true
 
-publish-to-crates-io:
+unleash-to-crates-io:
   stage:                           publish
   <<:                              *docker-env
   rules:


### PR DESCRIPTION
- stop publishing to crates.io until unleash is fixed
- allow k8s runners auto-restart on system failures.

CC: https://github.com/paritytech/cargo-unleash/issues/50 https://github.com/paritytech/substrate/pull/9373
@s3krit just FYI about releasing to crates.io