### PR TITLE
Use correct `ExecutionContext` for `check_inherents`

### DIFF
--- a/client/consensus/aura/src/import_queue.rs
+++ b/client/consensus/aura/src/import_queue.rs
@@ -41,7 +41,7 @@ use sp_consensus_aura::{
 	AURA_ENGINE_ID,
 };
 use sp_consensus_slots::Slot;
-use sp_core::crypto::Pair;
+use sp_core::{crypto::Pair, ExecutionContext};
 use sp_inherents::{CreateInherentDataProviders, InherentDataProvider as _};
 use sp_runtime::{
 	generic::{BlockId, OpaqueDigestItemId},
@@ -149,6 +149,7 @@ where
 		block_id: BlockId<B>,
 		inherent_data: sp_inherents::InherentData,
 		create_inherent_data_providers: CIDP::InherentDataProviders,
+		execution_context: ExecutionContext,
 	) -> Result<(), Error<B>>
 	where
 		C: ProvideRuntimeApi<B>,
@@ -169,7 +170,7 @@ where
 		let inherent_res = self
 			.client
 			.runtime_api()
-			.check_inherents(&block_id, block, inherent_data)
+			.check_inherents_with_context(&block_id, execution_context, block, inherent_data)
 			.map_err(|e| Error::Client(e.into()))?;
 
 		if !inherent_res.ok() {
@@ -261,6 +262,7 @@ where
 							BlockId::Hash(parent_hash),
 							inherent_data,
 							create_inherent_data_providers,
+							block.origin.into(),
 						)
 						.await
 						.map_err(|e| e.to_string())?;

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -112,7 +112,7 @@ use sp_consensus::{
 };
 use sp_consensus_babe::inherents::BabeInherentData;
 use sp_consensus_slots::Slot;
-use sp_core::crypto::Public;
+use sp_core::{crypto::Public, ExecutionContext};
 use sp_inherents::{CreateInherentDataProviders, InherentData, InherentDataProvider};
 use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
 use sp_runtime::{
@@ -1006,6 +1006,7 @@ where
 		block_id: BlockId<Block>,
 		inherent_data: InherentData,
 		create_inherent_data_providers: CIDP::InherentDataProviders,
+		execution_context: ExecutionContext,
 	) -> Result<(), Error<Block>> {
 		if let Err(e) = self.can_author_with.can_author_with(&block_id) {
 			debug!(
@@ -1020,7 +1021,7 @@ where
 		let inherent_res = self
 			.client
 			.runtime_api()
-			.check_inherents(&block_id, block, inherent_data)
+			.check_inherents_with_context(&block_id, execution_context, block, inherent_data)
 			.map_err(Error::RuntimeApi)?;
 
 		if !inherent_res.ok() {
@@ -1244,6 +1245,7 @@ where
 						BlockId::Hash(parent_hash),
 						inherent_data,
 						create_inherent_data_providers,
+						block.origin.into(),
 					)
 					.await?;
 

--- a/client/consensus/pow/src/lib.rs
+++ b/client/consensus/pow/src/lib.rs
@@ -61,6 +61,7 @@ use sp_consensus::{
 	CanAuthorWith, Environment, Error as ConsensusError, Proposer, SelectChain, SyncOracle,
 };
 use sp_consensus_pow::{Seal, TotalDifficulty, POW_ENGINE_ID};
+use sp_core::ExecutionContext;
 use sp_inherents::{CreateInherentDataProviders, InherentDataProvider};
 use sp_runtime::{
 	generic::{BlockId, Digest, DigestItem},
@@ -272,6 +273,7 @@ where
 		block: B,
 		block_id: BlockId<B>,
 		inherent_data_providers: CIDP::InherentDataProviders,
+		execution_context: ExecutionContext,
 	) -> Result<(), Error<B>> {
 		if *block.header().number() < self.check_inherents_after {
 			return Ok(())
@@ -294,7 +296,7 @@ where
 		let inherent_res = self
 			.client
 			.runtime_api()
-			.check_inherents(&block_id, block, inherent_data)
+			.check_inherents_with_context(&block_id, execution_context, block, inherent_data)
 			.map_err(|e| Error::Client(e.into()))?;
 
 		if !inherent_res.ok() {
@@ -360,6 +362,7 @@ where
 				self.create_inherent_data_providers
 					.create_inherent_data_providers(parent_hash, ())
 					.await?,
+				block.origin.into(),
 			)
 			.await?;
 

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -64,7 +64,7 @@ use sp_consensus::{BlockOrigin, BlockStatus, Error as ConsensusError};
 use sp_core::{
 	convert_hash,
 	storage::{well_known_keys, ChildInfo, PrefixedStorageKey, StorageData, StorageKey},
-	ChangesTrieConfiguration, ExecutionContext, NativeOrEncoded,
+	ChangesTrieConfiguration, NativeOrEncoded,
 };
 #[cfg(feature = "test-helpers")]
 use sp_keystore::SyncCryptoStorePtr;
@@ -958,11 +958,7 @@ where
 			// block.
 			(true, None, Some(ref body)) => {
 				let runtime_api = self.runtime_api();
-				let execution_context = if import_block.origin == BlockOrigin::NetworkInitialSync {
-					ExecutionContext::Syncing
-				} else {
-					ExecutionContext::Importing
-				};
+				let execution_context = import_block.origin.into();
 
 				runtime_api.execute_block_with_context(
 					&at,

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1.42"
 codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
 futures = { version = "0.3.1", features = ["thread-pool"] }
 log = "0.4.8"
-sp-core = { path= "../../core", version = "4.0.0-dev"}
+sp-core = { path = "../../core", version = "4.0.0-dev"}
 sp-inherents = { version = "4.0.0-dev", path = "../../inherents" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../state-machine" }
 futures-timer = "3.0.1"

--- a/primitives/consensus/common/src/lib.rs
+++ b/primitives/consensus/common/src/lib.rs
@@ -75,6 +75,16 @@ pub enum BlockOrigin {
 	File,
 }
 
+impl From<BlockOrigin> for sp_core::ExecutionContext {
+	fn from(origin: BlockOrigin) -> Self {
+		if origin == BlockOrigin::NetworkInitialSync {
+			sp_core::ExecutionContext::Syncing
+		} else {
+			sp_core::ExecutionContext::Importing
+		}
+	}
+}
+
 /// Environment for a Consensus instance.
 ///
 /// Creates proposer instance.


### PR DESCRIPTION
Before we used the `other` context, while we are actually either in the
import or sync context.

