### PR TITLE
make `fn inject_referendum` public

### DIFF
--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -1586,7 +1586,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Start a referendum
-	fn inject_referendum(
+	pub fn inject_referendum(
 		end: T::BlockNumber,
 		proposal_hash: T::Hash,
 		threshold: VoteThreshold,


### PR DESCRIPTION
This PR makes the `inject_referendum` function from `pallet_democracy` public. This function is used within Substrate to quickly schedule a referendum when testing.

The Moonbeam team is writing EVM precompiles to expose this pallet's functionality to the EVM, and I would like to use it the same way when testing the precompiles.