### PR TITLE
Fix benchmarking macro for pallet with instance and where clause

### DIFF
--- a/frame/babe/src/benchmarking.rs
+++ b/frame/babe/src/benchmarking.rs
@@ -69,14 +69,12 @@ benchmarks! {
 mod tests {
 	use super::*;
 	use crate::mock::*;
-	use frame_support::assert_ok;
 
-	#[test]
-	fn test_benchmarks() {
-		new_test_ext(3).execute_with(|| {
-			assert_ok!(test_benchmark_check_equivocation_proof::<Test>());
-		})
-	}
+	frame_benchmarking::impl_benchmark_test_suite!(
+		Pallet,
+		crate::mock::new_test_ext(3),
+		crate::mock::Test,
+	);
 
 	#[test]
 	fn test_generate_equivocation_report_blob() {

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -21,7 +21,10 @@
 
 #[cfg(feature = "std")]
 mod analysis;
+#[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_instance;
 mod utils;
 
 #[cfg(feature = "std")]
@@ -1093,7 +1096,7 @@ macro_rules! impl_benchmark_test_suite {
 		$test:path
 		$(, $( $rest:tt )* )?
 	) => {
-		impl_benchmark_test_suite!(
+		$crate::impl_benchmark_test_suite!(
 			@selected:
 				$bench_module,
 				$new_test_ext,
@@ -1118,7 +1121,7 @@ macro_rules! impl_benchmark_test_suite {
 			benchmarks_path = $benchmarks_path:ident
 			$(, $( $rest:tt )* )?
 	) => {
-		impl_benchmark_test_suite!(
+		$crate::impl_benchmark_test_suite!(
 			@selected:
 				$bench_module,
 				$new_test_ext,
@@ -1143,7 +1146,7 @@ macro_rules! impl_benchmark_test_suite {
 			extra = $extra:expr
 			$(, $( $rest:tt )* )?
 	) => {
-		impl_benchmark_test_suite!(
+		$crate::impl_benchmark_test_suite!(
 			@selected:
 				$bench_module,
 				$new_test_ext,
@@ -1168,7 +1171,7 @@ macro_rules! impl_benchmark_test_suite {
 			exec_name = $exec_name:ident
 			$(, $( $rest:tt )* )?
 	) => {
-		impl_benchmark_test_suite!(
+		$crate::impl_benchmark_test_suite!(
 			@selected:
 				$bench_module,
 				$new_test_ext,

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -173,10 +173,10 @@ macro_rules! whitelist {
 /// #[test]
 /// fn test_benchmarks() {
 ///   new_test_ext().execute_with(|| {
-///     assert_ok!(test_benchmark_dummy::<Test>());
-///     assert_err!(test_benchmark_other_name::<Test>(), "Bad origin");
-///     assert_ok!(test_benchmark_sort_vector::<Test>());
-///     assert_err!(test_benchmark_broken_benchmark::<Test>(), "You forgot to sort!");
+///     assert_ok!(Pallet::<Test>::test_benchmark_dummy());
+///     assert_err!(Pallet::<Test>::test_benchmark_other_name(), "Bad origin");
+///     assert_ok!(Pallet::<Test>::test_benchmark_sort_vector());
+///     assert_err!(Pallet::<Test>::test_benchmark_broken_benchmark(), "You forgot to sort!");
 ///   });
 /// }
 /// ```

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -143,8 +143,8 @@ macro_rules! whitelist {
 /// ```
 ///
 /// Test functions are automatically generated for each benchmark and are accessible to you when you
-/// run `cargo test`. All tests are named `test_benchmark_<benchmark_name>`, expect you to pass them
-/// the Runtime Config, and run them in a test externalities environment. The test function runs your
+/// run `cargo test`. All tests are named `test_benchmark_<benchmark_name>`, implemented on the
+/// Pallet struct, and run them in a test externalities environment. The test function runs your
 /// benchmark just like a regular benchmark, but only testing at the lowest and highest values for
 /// each component. The function will return `Ok(())` if the benchmarks return no errors.
 ///

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -291,13 +291,13 @@ mod benchmarks {
 	#[test]
 	fn benchmarks_generate_unit_tests() {
 		new_test_ext().execute_with(|| {
-			assert_ok!(test_benchmark_set_value::<Test>());
-			assert_ok!(test_benchmark_other_name::<Test>());
-			assert_ok!(test_benchmark_sort_vector::<Test>());
-			assert_err!(test_benchmark_bad_origin::<Test>(), "Bad origin");
-			assert_err!(test_benchmark_bad_verify::<Test>(), "You forgot to sort!");
-			assert_ok!(test_benchmark_no_components::<Test>());
-			assert_ok!(test_benchmark_variable_components::<Test>());
+			assert_ok!(Pallet::<Test>::test_benchmark_set_value());
+			assert_ok!(Pallet::<Test>::test_benchmark_other_name());
+			assert_ok!(Pallet::<Test>::test_benchmark_sort_vector());
+			assert_err!(Pallet::<Test>::test_benchmark_bad_origin(), "Bad origin");
+			assert_err!(Pallet::<Test>::test_benchmark_bad_verify(), "You forgot to sort!");
+			assert_ok!(Pallet::<Test>::test_benchmark_no_components());
+			assert_ok!(Pallet::<Test>::test_benchmark_variable_components());
 		});
 	}
 }

--- a/frame/benchmarking/src/tests_instance.rs
+++ b/frame/benchmarking/src/tests_instance.rs
@@ -1,0 +1,183 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020-2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the benchmark macro for instantiable modules
+
+#![cfg(test)]
+
+use super::*;
+use frame_support::parameter_types;
+use sp_runtime::{
+	testing::{Header, H256},
+	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
+};
+use sp_std::prelude::*;
+
+mod pallet_test {
+	use frame_support::pallet_prelude::Get;
+
+	frame_support::decl_storage! {
+		trait Store for Module<T: Config<I>, I: Instance = DefaultInstance> as Test where
+			<T as OtherConfig>::OtherEvent: Into<<T as Config<I>>::Event>
+		{
+			pub Value get(fn value): Option<u32>;
+		}
+	}
+
+	frame_support::decl_module! {
+		pub struct Module<T: Config<I>, I: Instance = DefaultInstance> for enum Call where
+			origin: T::Origin, <T as OtherConfig>::OtherEvent: Into<<T as Config<I>>::Event>
+		{
+			#[weight = 0]
+			fn set_value(origin, n: u32) -> frame_support::dispatch::DispatchResult {
+				let _sender = frame_system::ensure_signed(origin)?;
+				Value::<I>::put(n);
+				Ok(())
+			}
+
+			#[weight = 0]
+			fn dummy(origin, _n: u32) -> frame_support::dispatch::DispatchResult {
+				let _sender = frame_system::ensure_none(origin)?;
+				Ok(())
+			}
+		}
+	}
+
+	pub trait OtherConfig {
+		type OtherEvent;
+	}
+
+	pub trait Config<I: Instance = DefaultInstance>: frame_system::Config + OtherConfig
+	where
+		Self::OtherEvent: Into<<Self as Config<I>>::Event>,
+	{
+		type Event;
+		type LowerBound: Get<u32>;
+		type UpperBound: Get<u32>;
+	}
+}
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		TestPallet: pallet_test::{Pallet, Call, Storage},
+	}
+);
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type Origin = Origin;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Call = Call;
+	type Hashing = BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+}
+
+parameter_types! {
+	pub const LowerBound: u32 = 1;
+	pub const UpperBound: u32 = 100;
+}
+
+impl pallet_test::Config for Test {
+	type Event = Event;
+	type LowerBound = LowerBound;
+	type UpperBound = UpperBound;
+}
+
+impl pallet_test::OtherConfig for Test {
+	type OtherEvent = Event;
+}
+
+fn new_test_ext() -> sp_io::TestExternalities {
+	GenesisConfig::default().build_storage().unwrap().into()
+}
+
+mod benchmarks {
+	use super::pallet_test::{self, Value};
+	use crate::account;
+	use frame_support::{ensure, traits::Get, StorageValue};
+	use frame_system::RawOrigin;
+	use sp_std::prelude::*;
+
+	// Additional used internally by the benchmark macro.
+	use super::pallet_test::{Call, Config, Pallet};
+	use frame_support::traits::Instance;
+
+	crate::benchmarks_instance! {
+		where_clause {
+			where
+				<T as pallet_test::OtherConfig>::OtherEvent: Clone
+					+ Into<<T as pallet_test::Config<I>>::Event>,
+				<T as pallet_test::Config<I>>::Event: Clone,
+		}
+
+		set_value {
+			let b in 1 .. 1000;
+			let caller = account::<T::AccountId>("caller", 0, 0);
+		}: _ (RawOrigin::Signed(caller), b.into())
+		verify {
+			assert_eq!(Value::<pallet_test::DefaultInstance>::get(), Some(b));
+		}
+
+		other_name {
+			let b in 1 .. 1000;
+		}: dummy (RawOrigin::None, b.into())
+
+		sort_vector {
+			let x in 1 .. 10000;
+			let mut m = Vec::<u32>::new();
+			for i in (0..x).rev() {
+				m.push(i);
+			}
+		}: {
+			m.sort();
+		} verify {
+			ensure!(m[0] == 0, "You forgot to sort!")
+		}
+	}
+
+	crate::impl_benchmark_test_suite!(
+		Pallet,
+		crate::tests_instance::new_test_ext(),
+		crate::tests_instance::Test
+	);
+}

--- a/frame/benchmarking/src/tests_instance.rs
+++ b/frame/benchmarking/src/tests_instance.rs
@@ -134,7 +134,7 @@ fn new_test_ext() -> sp_io::TestExternalities {
 mod benchmarks {
 	use super::pallet_test::{self, Value};
 	use crate::account;
-	use frame_support::{ensure, traits::Get, StorageValue};
+	use frame_support::{ensure, StorageValue};
 	use frame_system::RawOrigin;
 	use sp_std::prelude::*;
 

--- a/frame/grandpa/src/benchmarking.rs
+++ b/frame/grandpa/src/benchmarking.rs
@@ -76,15 +76,12 @@ benchmarks! {
 mod tests {
 	use super::*;
 	use crate::mock::*;
-	use frame_support::assert_ok;
 
-	#[test]
-	fn test_benchmarks() {
-		new_test_ext(vec![(1, 1), (2, 1), (3, 1)]).execute_with(|| {
-			assert_ok!(test_benchmark_check_equivocation_proof::<Test>());
-			assert_ok!(test_benchmark_note_stalled::<Test>());
-		})
-	}
+	frame_benchmarking::impl_benchmark_test_suite!(
+		Pallet,
+		crate::mock::new_test_ext(vec![(1, 1), (2, 1), (3, 1)]),
+		crate::mock::Test,
+	);
 
 	#[test]
 	fn test_generate_equivocation_report_blob() {


### PR DESCRIPTION
# Breaking change

The macros `frame_benchmarking::benchmark`, `frame_benchmarking::benchmark_instance`, `frame_benchmarking::benchmark_instance_pallet`, now generate the test function as method on the Pallet struct instead of a regular function.
So to write test instead of writing benchmark test like:
```rust
#[test]
fn test_benchmarks() {
  new_test_ext().execute_with(|| {
    assert_ok!(test_benchmark_dummy::<Test>());
  }
}
```
you must write:
```rust
#[test]
fn test_benchmarks() {
  new_test_ext().execute_with(|| {
    assert_ok!(Pallet::<Test>::test_benchmark_dummy());
  }
}
```
But best is to use the test macro `impl_benchmark_test_suite`.

# Description

Currently the benchmark macro doesn't fully support where clause for pallet with instances.

This should fix it.

You can read the first commit to see a minimal diff, the second commit is for formatting correctly.

I need to implement test as there seem to be no test for the benchmark macro ? cc @shawntabrizi 

cc @kianenigma 