### PR TITLE
crate missing dependency when compiled on its own with std

### DIFF
--- a/frame/support/procedural/tools/Cargo.toml
+++ b/frame/support/procedural/tools/Cargo.toml
@@ -11,13 +11,9 @@ description = "Proc macro helpers for procedural macros"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
-[features]
-default = [ "std" ]
-std = [ "syn/extra-traits" ]
-
 [dependencies]
 frame-support-procedural-tools-derive = { version = "3.0.0", path = "./derive" }
 proc-macro2 = "1.0.28"
 quote = "1.0.3"
-syn = { version = "1.0.58", features = ["full", "visit"] }
+syn = { version = "1.0.58", features = ["full", "visit", "extra-traits"] }
 proc-macro-crate = "1.0.0"

--- a/frame/support/procedural/tools/Cargo.toml
+++ b/frame/support/procedural/tools/Cargo.toml
@@ -11,6 +11,10 @@ description = "Proc macro helpers for procedural macros"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[features]
+default = [ "std" ]
+std = [ "syn/extra-traits" ]
+
 [dependencies]
 frame-support-procedural-tools-derive = { version = "3.0.0", path = "./derive" }
 proc-macro2 = "1.0.28"


### PR DESCRIPTION
This doesn't compile on its own as it needs `Debug` and that's
in the extra-traits syn feature.