### PR TITLE
companion_build: enable runtime-benchmarks feature

### DIFF
--- a/.maintain/gitlab/check_polkadot_companion_build.sh
+++ b/.maintain/gitlab/check_polkadot_companion_build.sh
@@ -96,4 +96,4 @@ diener patch --crates-to-patch ../ --substrate --path Cargo.toml
 cargo update -p sp-core
 
 # Test Polkadot pr or master branch with this Substrate commit.
-time cargo test --all --release --verbose
+time cargo test --workspace --release --verbose --features=runtime-benchmarks


### PR DESCRIPTION
To catch problems like #9485 breaking build w/o requiring a companion.