### PR TITLE
Make NextKeys public

### DIFF
--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -422,7 +422,7 @@ decl_storage! {
 		DisabledValidators get(fn disabled_validators): Vec<u32>;
 
 		/// The next session keys for a validator.
-		NextKeys: map hasher(twox_64_concat) T::ValidatorId => Option<T::Keys>;
+		NextKeys get(fn next_keys): map hasher(twox_64_concat) T::ValidatorId => Option<T::Keys>;
 
 		/// The owner of a key. The key is the `KeyTypeId` + the encoded key.
 		KeyOwner: map hasher(twox_64_concat) (KeyTypeId, Vec<u8>) => Option<T::ValidatorId>;


### PR DESCRIPTION
This makes the sessions pallet NextKeys storage accessible to other pallets, which is useful to ensure that an account has its session keys set before allowing a change in validators which includes them.

Please advise if there is a better way of doing this!