### PR TITLE
Support test-runner to submit unsigned_extrinsic

### DIFF
--- a/bin/node/test-runner-example/src/lib.rs
+++ b/bin/node/test-runner-example/src/lib.rs
@@ -107,7 +107,7 @@ mod tests {
 			// submit extrinsics
 			let alice = MultiSigner::from(Alice.public()).into_account();
 			let _hash = node
-				.submit_extrinsic(frame_system::Call::remark((b"hello world").to_vec()), alice)
+				.submit_extrinsic(frame_system::Call::remark((b"hello world").to_vec()), Some(alice))
 				.await
 				.unwrap();
 

--- a/bin/node/test-runner-example/src/lib.rs
+++ b/bin/node/test-runner-example/src/lib.rs
@@ -107,7 +107,10 @@ mod tests {
 			// submit extrinsics
 			let alice = MultiSigner::from(Alice.public()).into_account();
 			let _hash = node
-				.submit_extrinsic(frame_system::Call::remark((b"hello world").to_vec()), Some(alice))
+				.submit_extrinsic(
+					frame_system::Call::remark((b"hello world").to_vec()),
+					Some(alice),
+				)
 				.await
 				.unwrap();
 

--- a/test-utils/test-runner/src/node.rs
+++ b/test-utils/test-runner/src/node.rs
@@ -181,7 +181,7 @@ where
 		sp_externalities::set_and_run_with_externalities(&mut ext, closure)
 	}
 
-	/// submit some extrinsic to the node, providing the sending account.
+	/// submit some extrinsic to the node. if signer is None, will submit unsigned_extrinsic.
 	pub async fn submit_extrinsic(
 		&self,
 		call: impl Into<<T::Runtime as frame_system::Config>::Call>,


### PR DESCRIPTION
polkadot companion: paritytech/polkadot#3589

- Support test-runner to submit unsigned_extrinsic.
- Add `pool` to return a reference to the pool.