### PR TITLE
Remove Filter and use Contains instead

### DIFF
--- a/bin/node-template/pallets/template/src/mock.rs
+++ b/bin/node-template/pallets/template/src/mock.rs
@@ -28,7 +28,7 @@ parameter_types! {
 }
 
 impl system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -144,7 +144,7 @@ parameter_types! {
 
 impl frame_system::Config for Runtime {
 	/// The basic call filter to use in dispatchable.
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	/// Block & extrinsics weights: base values and limits.
 	type BlockWeights = BlockWeights;
 	/// The maximum length of a block (in bytes).

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -26,7 +26,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{
-		AllowAll, Currency, DenyAll, Imbalance, InstanceFilter, KeyOwnerProofSystem,
+		Everything, Currency, Nothing, Imbalance, InstanceFilter, KeyOwnerProofSystem,
 		LockIdentifier, OnUnbalanced, U128CurrencyToVote,
 	},
 	weights::{
@@ -35,10 +35,7 @@ use frame_support::{
 	},
 	PalletId, RuntimeDebug,
 };
-use frame_system::{
-	limits::{BlockLength, BlockWeights},
-	EnsureOneOf, EnsureRoot,
-};
+use frame_system::{limits::{BlockLength, BlockWeights}, EnsureOneOf, EnsureRoot};
 pub use node_primitives::{AccountId, Signature};
 use node_primitives::{AccountIndex, Balance, BlockNumber, Hash, Index, Moment};
 use pallet_contracts::weights::WeightInfo;
@@ -192,7 +189,7 @@ parameter_types! {
 const_assert!(NORMAL_DISPATCH_RATIO.deconstruct() >= AVERAGE_ON_INITIALIZE_RATIO.deconstruct());
 
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = AllowAll;
+	type BaseCallFilter = Everything;
 	type BlockWeights = RuntimeBlockWeights;
 	type BlockLength = RuntimeBlockLength;
 	type DbWeight = RocksDbWeight;
@@ -857,7 +854,7 @@ impl pallet_contracts::Config for Runtime {
 	/// and make sure they are stable. Dispatchables exposed to contracts are not allowed to
 	/// change because that would break already deployed contracts. The `Call` structure itself
 	/// is not allowed to change the indices of existing pallets, too.
-	type CallFilter = DenyAll;
+	type CallFilter = Nothing;
 	type RentPayment = ();
 	type SignedClaimHandicap = SignedClaimHandicap;
 	type TombstoneDeposit = TombstoneDeposit;

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -26,8 +26,8 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{
-		Everything, Currency, Nothing, Imbalance, InstanceFilter, KeyOwnerProofSystem,
-		LockIdentifier, OnUnbalanced, U128CurrencyToVote,
+		Currency, Everything, Imbalance, InstanceFilter, KeyOwnerProofSystem, LockIdentifier,
+		Nothing, OnUnbalanced, U128CurrencyToVote,
 	},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
@@ -35,7 +35,10 @@ use frame_support::{
 	},
 	PalletId, RuntimeDebug,
 };
-use frame_system::{limits::{BlockLength, BlockWeights}, EnsureOneOf, EnsureRoot};
+use frame_system::{
+	limits::{BlockLength, BlockWeights},
+	EnsureOneOf, EnsureRoot,
+};
 pub use node_primitives::{AccountId, Signature};
 use node_primitives::{AccountIndex, Balance, BlockNumber, Hash, Index, Moment};
 use pallet_contracts::weights::WeightInfo;

--- a/docs/Upgrading-2.0-to-3.0.md
+++ b/docs/Upgrading-2.0-to-3.0.md
@@ -143,7 +143,7 @@ And update the overall definition for weights on frame and a few related types a
 +const_assert!(NORMAL_DISPATCH_RATIO.deconstruct() >= AVERAGE_ON_INITIALIZE_RATIO.deconstruct());
 +
 +impl frame_system::Config for Runtime {
- 	type BaseCallFilter = frame_support::traits::Everything;
+ 	type BaseCallFilter = frame_support::traits::AllowAll;
 +	type BlockWeights = RuntimeBlockWeights;
 +	type BlockLength = RuntimeBlockLength;
 +	type DbWeight = RocksDbWeight;

--- a/docs/Upgrading-2.0-to-3.0.md
+++ b/docs/Upgrading-2.0-to-3.0.md
@@ -143,7 +143,7 @@ And update the overall definition for weights on frame and a few related types a
 +const_assert!(NORMAL_DISPATCH_RATIO.deconstruct() >= AVERAGE_ON_INITIALIZE_RATIO.deconstruct());
 +
 +impl frame_system::Config for Runtime {
- 	type BaseCallFilter = frame_support::traits::AllowAll;
+ 	type BaseCallFilter = frame_support::traits::Everything;
 +	type BlockWeights = RuntimeBlockWeights;
 +	type BlockLength = RuntimeBlockLength;
 +	type DbWeight = RocksDbWeight;

--- a/frame/assets/src/mock.rs
+++ b/frame/assets/src/mock.rs
@@ -46,7 +46,7 @@ parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type Origin = Origin;

--- a/frame/atomic-swap/src/tests.rs
+++ b/frame/atomic-swap/src/tests.rs
@@ -31,7 +31,7 @@ parameter_types! {
 		frame_system::limits::BlockWeights::simple_max(1024);
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/aura/src/mock.rs
+++ b/frame/aura/src/mock.rs
@@ -55,7 +55,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/authority-discovery/src/lib.rs
+++ b/frame/authority-discovery/src/lib.rs
@@ -202,7 +202,7 @@ mod tests {
 	}
 
 	impl frame_system::Config for Test {
-		type BaseCallFilter = frame_support::traits::AllowAll;
+		type BaseCallFilter = frame_support::traits::Everything;
 		type BlockWeights = ();
 		type BlockLength = ();
 		type DbWeight = ();

--- a/frame/authorship/src/lib.rs
+++ b/frame/authorship/src/lib.rs
@@ -435,7 +435,7 @@ mod tests {
 	}
 
 	impl frame_system::Config for Test {
-		type BaseCallFilter = frame_support::traits::AllowAll;
+		type BaseCallFilter = frame_support::traits::Everything;
 		type BlockWeights = ();
 		type BlockLength = ();
 		type DbWeight = ();

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -74,7 +74,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/balances/src/tests_composite.rs
+++ b/frame/balances/src/tests_composite.rs
@@ -50,7 +50,7 @@ parameter_types! {
 	pub static ExistentialDeposit: u64 = 0;
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = BlockWeights;
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/balances/src/tests_local.rs
+++ b/frame/balances/src/tests_local.rs
@@ -52,7 +52,7 @@ parameter_types! {
 	pub static ExistentialDeposit: u64 = 0;
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = BlockWeights;
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/balances/src/tests_reentrancy.rs
+++ b/frame/balances/src/tests_reentrancy.rs
@@ -54,7 +54,7 @@ parameter_types! {
 	pub static ExistentialDeposit: u64 = 0;
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = BlockWeights;
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -87,7 +87,7 @@ frame_support::construct_runtime!(
 );
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/benchmarking/src/tests_instance.rs
+++ b/frame/benchmarking/src/tests_instance.rs
@@ -87,7 +87,7 @@ frame_support::construct_runtime!(
 );
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/bounties/src/tests.rs
+++ b/frame/bounties/src/tests.rs
@@ -59,7 +59,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -1011,7 +1011,7 @@ mod tests {
 			frame_system::limits::BlockWeights::simple_max(1024);
 	}
 	impl frame_system::Config for Test {
-		type BaseCallFilter = frame_support::traits::AllowAll;
+		type BaseCallFilter = frame_support::traits::Everything;
 		type BlockWeights = ();
 		type BlockLength = ();
 		type DbWeight = ();

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -26,7 +26,7 @@ use frame_support::{
 	dispatch::{DispatchError, DispatchResult, DispatchResultWithPostInfo, Dispatchable},
 	ensure,
 	storage::{with_transaction, TransactionOutcome},
-	traits::{Currency, ExistenceRequirement, Get, Contains, OriginTrait, Randomness, Time},
+	traits::{Contains, Currency, ExistenceRequirement, Get, OriginTrait, Randomness, Time},
 	weights::Weight,
 	DefaultNoBound,
 };
@@ -34,7 +34,10 @@ use frame_system::RawOrigin;
 use pallet_contracts_primitives::ExecReturnValue;
 use smallvec::{Array, SmallVec};
 use sp_core::crypto::UncheckedFrom;
-use sp_runtime::{traits::{Convert, Saturating}, Perbill};
+use sp_runtime::{
+	traits::{Convert, Saturating},
+	Perbill,
+};
 use sp_std::{marker::PhantomData, mem, prelude::*};
 
 pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -26,7 +26,7 @@ use frame_support::{
 	dispatch::{DispatchError, DispatchResult, DispatchResultWithPostInfo, Dispatchable},
 	ensure,
 	storage::{with_transaction, TransactionOutcome},
-	traits::{Currency, ExistenceRequirement, Filter, Get, OriginTrait, Randomness, Time},
+	traits::{Currency, ExistenceRequirement, Get, Contains, OriginTrait, Randomness, Time},
 	weights::Weight,
 	DefaultNoBound,
 };
@@ -34,10 +34,7 @@ use frame_system::RawOrigin;
 use pallet_contracts_primitives::ExecReturnValue;
 use smallvec::{Array, SmallVec};
 use sp_core::crypto::UncheckedFrom;
-use sp_runtime::{
-	traits::{Convert, Saturating},
-	Perbill,
-};
+use sp_runtime::{traits::{Convert, Saturating}, Perbill};
 use sp_std::{marker::PhantomData, mem, prelude::*};
 
 pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
@@ -1255,7 +1252,7 @@ where
 
 	fn call_runtime(&self, call: <Self::T as Config>::Call) -> DispatchResultWithPostInfo {
 		let mut origin: T::Origin = RawOrigin::Signed(self.address().clone()).into();
-		origin.add_filter(T::CallFilter::filter);
+		origin.add_filter(T::CallFilter::contains);
 		call.dispatch(origin)
 	}
 }

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -111,7 +111,7 @@ use crate::{
 };
 use frame_support::{
 	dispatch::Dispatchable,
-	traits::{Currency, Contains, Get, OnUnbalanced, Randomness, StorageVersion, Time},
+	traits::{Contains, Currency, Get, OnUnbalanced, Randomness, StorageVersion, Time},
 	weights::{GetDispatchInfo, PostDispatchInfo, Weight, WithPostDispatchInfo},
 };
 use frame_system::Pallet as System;

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -111,7 +111,7 @@ use crate::{
 };
 use frame_support::{
 	dispatch::Dispatchable,
-	traits::{Currency, Filter, Get, OnUnbalanced, Randomness, StorageVersion, Time},
+	traits::{Currency, Contains, Get, OnUnbalanced, Randomness, StorageVersion, Time},
 	weights::{GetDispatchInfo, PostDispatchInfo, Weight, WithPostDispatchInfo},
 };
 use frame_system::Pallet as System;
@@ -189,7 +189,7 @@ pub mod pallet {
 		/// Therefore please make sure to be restrictive about which dispatchables are allowed
 		/// in order to not introduce a new DoS vector like memory allocation patterns that can
 		/// be exploited to drive the runtime into a panic.
-		type CallFilter: Filter<<Self as frame_system::Config>::Call>;
+		type CallFilter: Contains<<Self as frame_system::Config>::Call>;
 
 		/// Handler for rent payments.
 		type RentPayment: OnUnbalanced<NegativeImbalanceOf<Self>>;

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -33,7 +33,7 @@ use frame_support::{
 	dispatch::DispatchErrorWithPostInfo,
 	parameter_types,
 	storage::child,
-	traits::{Currency, Filter, OnInitialize, ReservableCurrency},
+	traits::{Currency, Contains, OnInitialize, ReservableCurrency},
 	weights::{constants::WEIGHT_PER_SECOND, DispatchClass, PostDispatchInfo, Weight},
 };
 use frame_system::{self as system, EventRecord, Phase};
@@ -197,7 +197,7 @@ parameter_types! {
 	pub static ExistentialDeposit: u64 = 0;
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = BlockWeights;
 	type BlockLength = ();
 	type DbWeight = ();
@@ -282,7 +282,7 @@ impl TestFilter {
 	}
 }
 
-impl Filter<Call> for TestFilter {
+impl Contains<Call> for TestFilter {
 	fn filter(call: &Call) -> bool {
 		CALL_FILTER.with(|fltr| fltr.borrow()(call))
 	}

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -283,7 +283,7 @@ impl TestFilter {
 }
 
 impl Contains<Call> for TestFilter {
-	fn filter(call: &Call) -> bool {
+	fn contains(call: &Call) -> bool {
 		CALL_FILTER.with(|fltr| fltr.borrow()(call))
 	}
 }

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -33,7 +33,7 @@ use frame_support::{
 	dispatch::DispatchErrorWithPostInfo,
 	parameter_types,
 	storage::child,
-	traits::{Currency, Contains, OnInitialize, ReservableCurrency},
+	traits::{Contains, Currency, OnInitialize, ReservableCurrency},
 	weights::{constants::WEIGHT_PER_SECOND, DispatchClass, PostDispatchInfo, Weight},
 };
 use frame_system::{self as system, EventRecord, Phase};

--- a/frame/democracy/src/tests.rs
+++ b/frame/democracy/src/tests.rs
@@ -71,7 +71,7 @@ frame_support::construct_runtime!(
 // Test that a fitlered call can be dispatched.
 pub struct BaseFilter;
 impl Contains<Call> for BaseFilter {
-	fn filter(call: &Call) -> bool {
+	fn contains(call: &Call) -> bool {
 		!matches!(call, &Call::Balances(pallet_balances::Call::set_balance(..)))
 	}
 }

--- a/frame/democracy/src/tests.rs
+++ b/frame/democracy/src/tests.rs
@@ -22,7 +22,7 @@ use crate as pallet_democracy;
 use codec::Encode;
 use frame_support::{
 	assert_noop, assert_ok, ord_parameter_types, parameter_types,
-	traits::{Filter, GenesisBuild, OnInitialize, SortedMembers},
+	traits::{Contains, GenesisBuild, OnInitialize, SortedMembers},
 	weights::Weight,
 };
 use frame_system::{EnsureRoot, EnsureSignedBy};
@@ -70,7 +70,7 @@ frame_support::construct_runtime!(
 
 // Test that a fitlered call can be dispatched.
 pub struct BaseFilter;
-impl Filter<Call> for BaseFilter {
+impl Contains<Call> for BaseFilter {
 	fn filter(call: &Call) -> bool {
 		!matches!(call, &Call::Balances(pallet_balances::Call::set_balance(..)))
 	}
@@ -231,7 +231,7 @@ fn set_balance_proposal(value: u64) -> Vec<u8> {
 fn set_balance_proposal_is_correctly_filtered_out() {
 	for i in 0..10 {
 		let call = Call::decode(&mut &set_balance_proposal(i)[..]).unwrap();
-		assert!(!<Test as frame_system::Config>::BaseCallFilter::filter(&call));
+		assert!(!<Test as frame_system::Config>::BaseCallFilter::contains(&call));
 	}
 }
 

--- a/frame/election-provider-multi-phase/src/mock.rs
+++ b/frame/election-provider-multi-phase/src/mock.rs
@@ -195,7 +195,7 @@ pub fn witness() -> SolutionOrSnapshotSize {
 
 impl frame_system::Config for Runtime {
 	type SS58Prefix = ();
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -1120,7 +1120,7 @@ mod tests {
 	}
 
 	impl frame_system::Config for Test {
-		type BaseCallFilter = frame_support::traits::AllowAll;
+		type BaseCallFilter = frame_support::traits::Everything;
 		type BlockWeights = BlockWeights;
 		type BlockLength = ();
 		type DbWeight = ();

--- a/frame/elections/src/mock.rs
+++ b/frame/elections/src/mock.rs
@@ -37,7 +37,7 @@ parameter_types! {
 		frame_system::limits::BlockWeights::simple_max(1024);
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/example-offchain-worker/src/tests.rs
+++ b/frame/example-offchain-worker/src/tests.rs
@@ -54,7 +54,7 @@ parameter_types! {
 		frame_system::limits::BlockWeights::simple_max(1024);
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/example-parallel/src/tests.rs
+++ b/frame/example-parallel/src/tests.rs
@@ -45,7 +45,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type Origin = Origin;
 	type Call = Call;
 	type PalletInfo = PalletInfo;

--- a/frame/example/src/tests.rs
+++ b/frame/example/src/tests.rs
@@ -56,7 +56,7 @@ parameter_types! {
 		frame_system::limits::BlockWeights::simple_max(1024);
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -701,7 +701,7 @@ mod tests {
 		};
 	}
 	impl frame_system::Config for Runtime {
-		type BaseCallFilter = frame_support::traits::AllowAll;
+		type BaseCallFilter = frame_support::traits::Everything;
 		type BlockWeights = BlockWeights;
 		type BlockLength = ();
 		type DbWeight = ();

--- a/frame/gilt/src/mock.rs
+++ b/frame/gilt/src/mock.rs
@@ -51,7 +51,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type Origin = Origin;

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -75,7 +75,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/identity/src/tests.rs
+++ b/frame/identity/src/tests.rs
@@ -50,7 +50,7 @@ parameter_types! {
 		frame_system::limits::BlockWeights::simple_max(1024);
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type Origin = Origin;

--- a/frame/im-online/src/mock.rs
+++ b/frame/im-online/src/mock.rs
@@ -116,7 +116,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/indices/src/mock.rs
+++ b/frame/indices/src/mock.rs
@@ -46,7 +46,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/lottery/src/mock.rs
+++ b/frame/lottery/src/mock.rs
@@ -56,7 +56,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -499,7 +499,7 @@ mod tests {
 	}
 
 	impl frame_system::Config for Test {
-		type BaseCallFilter = frame_support::traits::AllowAll;
+		type BaseCallFilter = frame_support::traits::Everything;
 		type BlockWeights = ();
 		type BlockLength = ();
 		type DbWeight = ();

--- a/frame/merkle-mountain-range/src/mock.rs
+++ b/frame/merkle-mountain-range/src/mock.rs
@@ -46,7 +46,7 @@ parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;

--- a/frame/multisig/src/tests.rs
+++ b/frame/multisig/src/tests.rs
@@ -22,7 +22,7 @@
 use super::*;
 
 use crate as pallet_multisig;
-use frame_support::{assert_noop, assert_ok, parameter_types, traits::Filter};
+use frame_support::{assert_noop, assert_ok, parameter_types, traits::Contains};
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
@@ -94,8 +94,8 @@ parameter_types! {
 	pub const MaxSignatories: u16 = 3;
 }
 pub struct TestBaseCallFilter;
-impl Filter<Call> for TestBaseCallFilter {
-	fn filter(c: &Call) -> bool {
+impl Contains<Call> for TestBaseCallFilter {
+	fn contains(c: &Call) -> bool {
 		match *c {
 			Call::Balances(_) => true,
 			// Needed for benchmarking

--- a/frame/nicks/src/lib.rs
+++ b/frame/nicks/src/lib.rs
@@ -282,7 +282,7 @@ mod tests {
 			frame_system::limits::BlockWeights::simple_max(1024);
 	}
 	impl frame_system::Config for Test {
-		type BaseCallFilter = frame_support::traits::AllowAll;
+		type BaseCallFilter = frame_support::traits::Everything;
 		type BlockWeights = ();
 		type BlockLength = ();
 		type DbWeight = ();

--- a/frame/node-authorization/src/mock.rs
+++ b/frame/node-authorization/src/mock.rs
@@ -48,7 +48,7 @@ parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type DbWeight = ();
 	type BlockWeights = ();
 	type BlockLength = ();

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -40,7 +40,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/offences/src/mock.rs
+++ b/frame/offences/src/mock.rs
@@ -88,7 +88,7 @@ parameter_types! {
 		frame_system::limits::BlockWeights::simple_max(2 * WEIGHT_PER_SECOND);
 }
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = RocksDbWeight;

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -24,7 +24,8 @@ use super::*;
 use crate as proxy;
 use codec::{Decode, Encode};
 use frame_support::{
-	assert_noop, assert_ok, dispatch::DispatchError, parameter_types, traits::Contains, RuntimeDebug,
+	assert_noop, assert_ok, dispatch::DispatchError, parameter_types, traits::Contains,
+	RuntimeDebug,
 };
 use sp_core::H256;
 use sp_runtime::{

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -24,7 +24,7 @@ use super::*;
 use crate as proxy;
 use codec::{Decode, Encode};
 use frame_support::{
-	assert_noop, assert_ok, dispatch::DispatchError, parameter_types, traits::Filter, RuntimeDebug,
+	assert_noop, assert_ok, dispatch::DispatchError, parameter_types, traits::Contains, RuntimeDebug,
 };
 use sp_core::H256;
 use sp_runtime::{
@@ -132,8 +132,8 @@ impl InstanceFilter<Call> for ProxyType {
 	}
 }
 pub struct BaseFilter;
-impl Filter<Call> for BaseFilter {
-	fn filter(c: &Call) -> bool {
+impl Contains<Call> for BaseFilter {
+	fn contains(c: &Call) -> bool {
 		match *c {
 			// Remark is used as a no-op call in the benchmarking
 			Call::System(SystemCall::remark(_)) => true,

--- a/frame/randomness-collective-flip/src/lib.rs
+++ b/frame/randomness-collective-flip/src/lib.rs
@@ -196,7 +196,7 @@ mod tests {
 	}
 
 	impl frame_system::Config for Test {
-		type BaseCallFilter = frame_support::traits::AllowAll;
+		type BaseCallFilter = frame_support::traits::Everything;
 		type BlockWeights = ();
 		type BlockLength = BlockLength;
 		type DbWeight = ();

--- a/frame/recovery/src/mock.rs
+++ b/frame/recovery/src/mock.rs
@@ -52,7 +52,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -833,7 +833,7 @@ mod tests {
 	use crate as scheduler;
 	use frame_support::{
 		assert_err, assert_noop, assert_ok, ord_parameter_types, parameter_types,
-		traits::{Filter, OnFinalize, OnInitialize},
+		traits::{Contains, OnFinalize, OnInitialize},
 		weights::constants::RocksDbWeight,
 		Hashable,
 	};
@@ -925,8 +925,8 @@ mod tests {
 
 	// Scheduler must dispatch with root and no filter, this tests base filter is indeed not used.
 	pub struct BaseFilter;
-	impl Filter<Call> for BaseFilter {
-		fn filter(call: &Call) -> bool {
+	impl Contains<Call> for BaseFilter {
+		fn contains(call: &Call) -> bool {
 			!matches!(call, Call::Logger(LoggerCall::log(_, _)))
 		}
 	}
@@ -1006,7 +1006,7 @@ mod tests {
 	fn basic_scheduling_works() {
 		new_test_ext().execute_with(|| {
 			let call = Call::Logger(LoggerCall::log(42, 1000));
-			assert!(!<Test as frame_system::Config>::BaseCallFilter::filter(&call));
+			assert!(!<Test as frame_system::Config>::BaseCallFilter::contains(&call));
 			assert_ok!(Scheduler::do_schedule(DispatchTime::At(4), None, 127, root(), call));
 			run_to_block(3);
 			assert!(logger::log().is_empty());
@@ -1022,7 +1022,7 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			run_to_block(2);
 			let call = Call::Logger(LoggerCall::log(42, 1000));
-			assert!(!<Test as frame_system::Config>::BaseCallFilter::filter(&call));
+			assert!(!<Test as frame_system::Config>::BaseCallFilter::contains(&call));
 			// This will schedule the call 3 blocks after the next block... so block 3 + 3 = 6
 			assert_ok!(Scheduler::do_schedule(DispatchTime::After(3), None, 127, root(), call));
 			run_to_block(5);
@@ -1039,7 +1039,7 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			run_to_block(2);
 			let call = Call::Logger(LoggerCall::log(42, 1000));
-			assert!(!<Test as frame_system::Config>::BaseCallFilter::filter(&call));
+			assert!(!<Test as frame_system::Config>::BaseCallFilter::contains(&call));
 			assert_ok!(Scheduler::do_schedule(DispatchTime::After(0), None, 127, root(), call));
 			// Will trigger on the next block.
 			run_to_block(3);
@@ -1081,7 +1081,7 @@ mod tests {
 	fn reschedule_works() {
 		new_test_ext().execute_with(|| {
 			let call = Call::Logger(LoggerCall::log(42, 1000));
-			assert!(!<Test as frame_system::Config>::BaseCallFilter::filter(&call));
+			assert!(!<Test as frame_system::Config>::BaseCallFilter::contains(&call));
 			assert_eq!(
 				Scheduler::do_schedule(DispatchTime::At(4), None, 127, root(), call).unwrap(),
 				(4, 0)
@@ -1112,7 +1112,7 @@ mod tests {
 	fn reschedule_named_works() {
 		new_test_ext().execute_with(|| {
 			let call = Call::Logger(LoggerCall::log(42, 1000));
-			assert!(!<Test as frame_system::Config>::BaseCallFilter::filter(&call));
+			assert!(!<Test as frame_system::Config>::BaseCallFilter::contains(&call));
 			assert_eq!(
 				Scheduler::do_schedule_named(
 					1u32.encode(),
@@ -1154,7 +1154,7 @@ mod tests {
 	fn reschedule_named_perodic_works() {
 		new_test_ext().execute_with(|| {
 			let call = Call::Logger(LoggerCall::log(42, 1000));
-			assert!(!<Test as frame_system::Config>::BaseCallFilter::filter(&call));
+			assert!(!<Test as frame_system::Config>::BaseCallFilter::contains(&call));
 			assert_eq!(
 				Scheduler::do_schedule_named(
 					1u32.encode(),

--- a/frame/scored-pool/src/mock.rs
+++ b/frame/scored-pool/src/mock.rs
@@ -58,7 +58,7 @@ ord_parameter_types! {
 }
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -45,7 +45,7 @@ frame_support::construct_runtime!(
 );
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/session/src/mock.rs
+++ b/frame/session/src/mock.rs
@@ -234,7 +234,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/society/src/mock.rs
+++ b/frame/society/src/mock.rs
@@ -69,7 +69,7 @@ ord_parameter_types! {
 }
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/staking/README.md
+++ b/frame/staking/README.md
@@ -43,7 +43,7 @@ The staking system in Substrate NPoS is designed to make the following possible:
 #### Staking
 
 Almost any interaction with the Staking module requires a process of _**bonding**_ (also known
-as being a _staker_). To become *bonded*, a fund-holding account known as the _stash account_,
+as being a _staker_). To become *bonded*, a fund-holding register known as the _stash account_,
 which holds some or all of the funds that become frozen in place as part of the staking process,
 is paired with an active **controller** account, which issues instructions on how they shall be
 used.

--- a/frame/staking/README.md
+++ b/frame/staking/README.md
@@ -43,7 +43,7 @@ The staking system in Substrate NPoS is designed to make the following possible:
 #### Staking
 
 Almost any interaction with the Staking module requires a process of _**bonding**_ (also known
-as being a _staker_). To become *bonded*, a fund-holding register known as the _stash account_,
+as being a _staker_). To become *bonded*, a fund-holding account known as the _stash account_,
 which holds some or all of the funds that become frozen in place as part of the staking process,
 is paired with an active **controller** account, which issues instructions on how they shall be
 used.

--- a/frame/staking/fuzzer/src/mock.rs
+++ b/frame/staking/fuzzer/src/mock.rs
@@ -42,7 +42,7 @@ frame_support::construct_runtime!(
 );
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -60,7 +60,7 @@
 //! #### Staking
 //!
 //! Almost any interaction with the Staking pallet requires a process of _**bonding**_ (also known
-//! as being a _staker_). To become *bonded*, a fund-holding account known as the _stash account_,
+//! as being a _staker_). To become *bonded*, a fund-holding register known as the _stash account_,
 //! which holds some or all of the funds that become frozen in place as part of the staking process,
 //! is paired with an active **controller** account, which issues instructions on how they shall be
 //! used.

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -135,7 +135,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = RocksDbWeight;

--- a/frame/sudo/src/mock.rs
+++ b/frame/sudo/src/mock.rs
@@ -116,7 +116,7 @@ parameter_types! {
 
 pub struct BlockEverything;
 impl Contains<Call> for BlockEverything {
-	fn filter(_: &Call) -> bool {
+	fn contains(_: &Call) -> bool {
 		false
 	}
 }

--- a/frame/sudo/src/mock.rs
+++ b/frame/sudo/src/mock.rs
@@ -21,7 +21,7 @@ use super::*;
 use crate as sudo;
 use frame_support::{
 	parameter_types,
-	traits::{Filter, GenesisBuild},
+	traits::{Contains, GenesisBuild},
 };
 use frame_system::limits;
 use sp_core::H256;
@@ -115,7 +115,7 @@ parameter_types! {
 }
 
 pub struct BlockEverything;
-impl Filter<Call> for BlockEverything {
+impl Contains<Call> for BlockEverything {
 	fn filter(_: &Call) -> bool {
 		false
 	}

--- a/frame/support/procedural/src/construct_runtime/expand/origin.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/origin.rs
@@ -129,8 +129,8 @@ pub fn expand_outer_origin(
 			fn reset_filter(&mut self) {
 				let filter = <
 					<#runtime as #system_path::Config>::BaseCallFilter
-					as #scrate::traits::Filter<<#runtime as #system_path::Config>::Call>
-				>::filter;
+					as #scrate::traits::Contains<<#runtime as #system_path::Config>::Call>
+				>::contains;
 
 				self.filter = #scrate::sp_std::rc::Rc::new(Box::new(filter));
 			}

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -2814,7 +2814,7 @@ mod tests {
 		type Origin = OuterOrigin;
 		type AccountId = u32;
 		type Call = ();
-		type BaseCallFilter = frame_support::traits::AllowAll;
+		type BaseCallFilter = frame_support::traits::Everything;
 		type BlockNumber = u32;
 		type PalletInfo = Self;
 		type DbWeight = ();

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -32,9 +32,11 @@ pub use tokens::{
 
 mod members;
 pub use members::{
-	All, AsContains, ChangeMembers, Contains, ContainsLengthBound, InitializeMembers, IsInVec,
-	SortedMembers,
+	AsContains, ChangeMembers, Contains, ContainsLengthBound, InitializeMembers, IsInVec,
+	SortedMembers, Everything, Nothing,
 };
+#[allow(deprecated)]
+pub use members::{AllowAll, DenyAll, Filter};
 
 mod validation;
 pub use validation::{
@@ -45,8 +47,7 @@ pub use validation::{
 
 mod filter;
 pub use filter::{
-	AllowAll, ClearFilterGuard, DenyAll, Filter, FilterStack, FilterStackGuard, InstanceFilter,
-	IntegrityTest,
+	ClearFilterGuard, FilterStack, FilterStackGuard, InstanceFilter, IntegrityTest,
 };
 
 mod misc;

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -31,12 +31,12 @@ pub use tokens::{
 };
 
 mod members;
-pub use members::{
-	AsContains, ChangeMembers, Contains, ContainsLengthBound, InitializeMembers, IsInVec,
-	SortedMembers, Everything, Nothing,
-};
 #[allow(deprecated)]
 pub use members::{AllowAll, DenyAll, Filter};
+pub use members::{
+	AsContains, ChangeMembers, Contains, ContainsLengthBound, Everything, InitializeMembers,
+	IsInVec, Nothing, SortedMembers,
+};
 
 mod validation;
 pub use validation::{
@@ -46,9 +46,7 @@ pub use validation::{
 };
 
 mod filter;
-pub use filter::{
-	ClearFilterGuard, FilterStack, FilterStackGuard, InstanceFilter, IntegrityTest,
-};
+pub use filter::{ClearFilterGuard, FilterStack, FilterStackGuard, InstanceFilter, IntegrityTest};
 
 mod misc;
 pub use misc::{

--- a/frame/support/src/traits/filter.rs
+++ b/frame/support/src/traits/filter.rs
@@ -17,8 +17,8 @@
 
 //! Traits and associated utilities for dealing with abstract constraint filters.
 
-use sp_std::marker::PhantomData;
 pub use super::members::Contains;
+use sp_std::marker::PhantomData;
 
 /// Trait to add a constraint onto the filter.
 pub trait FilterStack<T>: Contains<T> {

--- a/frame/support/src/traits/filter.rs
+++ b/frame/support/src/traits/filter.rs
@@ -18,33 +18,10 @@
 //! Traits and associated utilities for dealing with abstract constraint filters.
 
 use sp_std::marker::PhantomData;
-
-/// Simple trait for providing a filter over a reference to some type.
-pub trait Filter<T> {
-	/// Determine if a given value should be allowed through the filter (returns `true`) or not.
-	fn filter(_: &T) -> bool;
-}
-
-/// A [`Filter`] that allows any value.
-pub enum AllowAll {}
-
-/// A [`Filter`] that denies any value.
-pub enum DenyAll {}
-
-impl<T> Filter<T> for AllowAll {
-	fn filter(_: &T) -> bool {
-		true
-	}
-}
-
-impl<T> Filter<T> for DenyAll {
-	fn filter(_: &T) -> bool {
-		false
-	}
-}
+pub use super::members::Contains;
 
 /// Trait to add a constraint onto the filter.
-pub trait FilterStack<T>: Filter<T> {
+pub trait FilterStack<T>: Contains<T> {
 	/// The type used to archive the stack.
 	type Stack;
 
@@ -135,15 +112,15 @@ macro_rules! impl_filter_stack {
 		mod $module {
 			#[allow(unused_imports)]
 			use super::*;
-			use $crate::traits::filter::{swap, take, RefCell, Vec, Box, Filter, FilterStack};
+			use $crate::traits::filter::{swap, take, RefCell, Vec, Box, Contains, FilterStack};
 
 			thread_local! {
 				static FILTER: RefCell<Vec<Box<dyn Fn(&$call) -> bool + 'static>>> = RefCell::new(Vec::new());
 			}
 
-			impl Filter<$call> for $target {
-				fn filter(call: &$call) -> bool {
-					<$base>::filter(call) &&
+			impl Contains<$call> for $target {
+				fn contains(call: &$call) -> bool {
+					<$base>::contains(call) &&
 						FILTER.with(|filter| filter.borrow().iter().all(|f| f(call)))
 				}
 			}
@@ -169,7 +146,7 @@ macro_rules! impl_filter_stack {
 		mod $module {
 			#[allow(unused_imports)]
 			use super::*;
-			use $crate::traits::{swap, take, RefCell, Vec, Box, Filter, FilterStack};
+			use $crate::traits::{swap, take, RefCell, Vec, Box, Contains, FilterStack};
 
 			struct ThisFilter(RefCell<Vec<Box<dyn Fn(&$call) -> bool + 'static>>>);
 			// NOTE: Safe only in wasm (guarded above) because there's only one thread.
@@ -178,9 +155,9 @@ macro_rules! impl_filter_stack {
 
 			static FILTER: ThisFilter = ThisFilter(RefCell::new(Vec::new()));
 
-			impl Filter<$call> for $target {
-				fn filter(call: &$call) -> bool {
-					<$base>::filter(call) && FILTER.0.borrow().iter().all(|f| f(call))
+			impl Contains<$call> for $target {
+				fn contains(call: &$call) -> bool {
+					<$base>::contains(call) && FILTER.0.borrow().iter().all(|f| f(call))
 				}
 			}
 
@@ -220,8 +197,8 @@ pub mod test_impl_filter_stack {
 
 	pub struct IsCallable;
 	pub struct BaseFilter;
-	impl Filter<u32> for BaseFilter {
-		fn filter(x: &u32) -> bool {
+	impl Contains<u32> for BaseFilter {
+		fn contains(x: &u32) -> bool {
 			x % 2 == 0
 		}
 	}
@@ -234,76 +211,76 @@ pub mod test_impl_filter_stack {
 
 	#[test]
 	fn impl_filter_stack_should_work() {
-		assert!(IsCallable::filter(&36));
-		assert!(IsCallable::filter(&40));
-		assert!(IsCallable::filter(&42));
-		assert!(!IsCallable::filter(&43));
+		assert!(IsCallable::contains(&36));
+		assert!(IsCallable::contains(&40));
+		assert!(IsCallable::contains(&42));
+		assert!(!IsCallable::contains(&43));
 
 		IsCallable::push(|x| *x < 42);
-		assert!(IsCallable::filter(&36));
-		assert!(IsCallable::filter(&40));
-		assert!(!IsCallable::filter(&42));
+		assert!(IsCallable::contains(&36));
+		assert!(IsCallable::contains(&40));
+		assert!(!IsCallable::contains(&42));
 
 		IsCallable::push(|x| *x % 3 == 0);
-		assert!(IsCallable::filter(&36));
-		assert!(!IsCallable::filter(&40));
+		assert!(IsCallable::contains(&36));
+		assert!(!IsCallable::contains(&40));
 
 		IsCallable::pop();
-		assert!(IsCallable::filter(&36));
-		assert!(IsCallable::filter(&40));
-		assert!(!IsCallable::filter(&42));
+		assert!(IsCallable::contains(&36));
+		assert!(IsCallable::contains(&40));
+		assert!(!IsCallable::contains(&42));
 
 		let saved = IsCallable::take();
-		assert!(IsCallable::filter(&36));
-		assert!(IsCallable::filter(&40));
-		assert!(IsCallable::filter(&42));
-		assert!(!IsCallable::filter(&43));
+		assert!(IsCallable::contains(&36));
+		assert!(IsCallable::contains(&40));
+		assert!(IsCallable::contains(&42));
+		assert!(!IsCallable::contains(&43));
 
 		IsCallable::restore(saved);
-		assert!(IsCallable::filter(&36));
-		assert!(IsCallable::filter(&40));
-		assert!(!IsCallable::filter(&42));
+		assert!(IsCallable::contains(&36));
+		assert!(IsCallable::contains(&40));
+		assert!(!IsCallable::contains(&42));
 
 		IsCallable::pop();
-		assert!(IsCallable::filter(&36));
-		assert!(IsCallable::filter(&40));
-		assert!(IsCallable::filter(&42));
-		assert!(!IsCallable::filter(&43));
+		assert!(IsCallable::contains(&36));
+		assert!(IsCallable::contains(&40));
+		assert!(IsCallable::contains(&42));
+		assert!(!IsCallable::contains(&43));
 	}
 
 	#[test]
 	fn guards_should_work() {
-		assert!(IsCallable::filter(&36));
-		assert!(IsCallable::filter(&40));
-		assert!(IsCallable::filter(&42));
-		assert!(!IsCallable::filter(&43));
+		assert!(IsCallable::contains(&36));
+		assert!(IsCallable::contains(&40));
+		assert!(IsCallable::contains(&42));
+		assert!(!IsCallable::contains(&43));
 		{
 			let _guard_1 = FilterStackGuard::<IsCallable, u32>::new(|x| *x < 42);
-			assert!(IsCallable::filter(&36));
-			assert!(IsCallable::filter(&40));
-			assert!(!IsCallable::filter(&42));
+			assert!(IsCallable::contains(&36));
+			assert!(IsCallable::contains(&40));
+			assert!(!IsCallable::contains(&42));
 			{
 				let _guard_2 = FilterStackGuard::<IsCallable, u32>::new(|x| *x % 3 == 0);
-				assert!(IsCallable::filter(&36));
-				assert!(!IsCallable::filter(&40));
+				assert!(IsCallable::contains(&36));
+				assert!(!IsCallable::contains(&40));
 			}
-			assert!(IsCallable::filter(&36));
-			assert!(IsCallable::filter(&40));
-			assert!(!IsCallable::filter(&42));
+			assert!(IsCallable::contains(&36));
+			assert!(IsCallable::contains(&40));
+			assert!(!IsCallable::contains(&42));
 			{
 				let _guard_2 = ClearFilterGuard::<IsCallable, u32>::new();
-				assert!(IsCallable::filter(&36));
-				assert!(IsCallable::filter(&40));
-				assert!(IsCallable::filter(&42));
-				assert!(!IsCallable::filter(&43));
+				assert!(IsCallable::contains(&36));
+				assert!(IsCallable::contains(&40));
+				assert!(IsCallable::contains(&42));
+				assert!(!IsCallable::contains(&43));
 			}
-			assert!(IsCallable::filter(&36));
-			assert!(IsCallable::filter(&40));
-			assert!(!IsCallable::filter(&42));
+			assert!(IsCallable::contains(&36));
+			assert!(IsCallable::contains(&40));
+			assert!(!IsCallable::contains(&42));
 		}
-		assert!(IsCallable::filter(&36));
-		assert!(IsCallable::filter(&40));
-		assert!(IsCallable::filter(&42));
-		assert!(!IsCallable::filter(&43));
+		assert!(IsCallable::contains(&36));
+		assert!(IsCallable::contains(&40));
+		assert!(IsCallable::contains(&42));
+		assert!(!IsCallable::contains(&43));
 	}
 }

--- a/frame/support/src/traits/members.rs
+++ b/frame/support/src/traits/members.rs
@@ -46,7 +46,9 @@ pub type AllowAll = Everything;
 #[deprecated = "Use `Nothing` instead"]
 pub type DenyAll = Nothing;
 #[deprecated = "Use `Contains` instead"]
-pub trait Filter<T> { fn filter(t: &T) -> bool; }
+pub trait Filter<T> {
+	fn filter(t: &T) -> bool;
+}
 #[allow(deprecated)]
 impl<T, C: Contains<T>> Filter<T> for C {
 	fn filter(t: &T) -> bool {

--- a/frame/support/src/traits/members.rs
+++ b/frame/support/src/traits/members.rs
@@ -25,11 +25,32 @@ pub trait Contains<T> {
 	fn contains(t: &T) -> bool;
 }
 
-/// A `Contains` implementation which always returns `true`.
-pub struct All<T>(PhantomData<T>);
-impl<T> Contains<T> for All<T> {
+/// A [`Contains`] implementation that contains every value.
+pub enum Everything {}
+impl<T> Contains<T> for Everything {
 	fn contains(_: &T) -> bool {
 		true
+	}
+}
+
+/// A [`Contains`] implementation that contains no value.
+pub enum Nothing {}
+impl<T> Contains<T> for Nothing {
+	fn contains(_: &T) -> bool {
+		false
+	}
+}
+
+#[deprecated = "Use `Everything` instead"]
+pub type AllowAll = Everything;
+#[deprecated = "Use `Nothing` instead"]
+pub type DenyAll = Nothing;
+#[deprecated = "Use `Contains` instead"]
+pub trait Filter<T> { fn filter(t: &T) -> bool; }
+#[allow(deprecated)]
+impl<T, C: Contains<T>> Filter<T> for C {
+	fn filter(t: &T) -> bool {
+		Self::contains(t)
 	}
 }
 

--- a/frame/support/test/tests/construct_runtime.rs
+++ b/frame/support/test/tests/construct_runtime.rs
@@ -229,7 +229,7 @@ pub type BlockNumber = u64;
 pub type Index = u64;
 
 impl system::Config for Runtime {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type Hash = H256;
 	type Origin = Origin;
 	type BlockNumber = BlockNumber;
@@ -268,14 +268,14 @@ pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, 
 
 mod origin_test {
 	use super::{module3, nested, system, Block, UncheckedExtrinsic};
-	use frame_support::traits::{Filter, OriginTrait};
+	use frame_support::traits::{Contains, OriginTrait};
 
 	impl nested::module3::Config for RuntimeOriginTest {}
 	impl module3::Config for RuntimeOriginTest {}
 
 	pub struct BaseCallFilter;
-	impl Filter<Call> for BaseCallFilter {
-		fn filter(c: &Call) -> bool {
+	impl Contains<Call> for BaseCallFilter {
+		fn contains(c: &Call) -> bool {
 			match c {
 				Call::NestedModule3(_) => true,
 				_ => false,

--- a/frame/support/test/tests/instance.rs
+++ b/frame/support/test/tests/instance.rs
@@ -275,7 +275,7 @@ pub type BlockNumber = u64;
 pub type Index = u64;
 
 impl system::Config for Runtime {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type Hash = H256;
 	type Origin = Origin;
 	type BlockNumber = BlockNumber;

--- a/frame/support/test/tests/issue2219.rs
+++ b/frame/support/test/tests/issue2219.rs
@@ -157,7 +157,7 @@ pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, ()>;
 
 impl system::Config for Runtime {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type Hash = H256;
 	type Origin = Origin;
 	type BlockNumber = BlockNumber;

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -493,7 +493,7 @@ frame_support::parameter_types!(
 );
 
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u32;

--- a/frame/support/test/tests/pallet_compatibility.rs
+++ b/frame/support/test/tests/pallet_compatibility.rs
@@ -223,7 +223,7 @@ frame_support::parameter_types!(
 );
 
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u32;

--- a/frame/support/test/tests/pallet_compatibility_instance.rs
+++ b/frame/support/test/tests/pallet_compatibility_instance.rs
@@ -206,7 +206,7 @@ impl frame_system::Config for Runtime {
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u32;

--- a/frame/support/test/tests/pallet_instance.rs
+++ b/frame/support/test/tests/pallet_instance.rs
@@ -243,7 +243,7 @@ frame_support::parameter_types!(
 );
 
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u32;

--- a/frame/support/test/tests/pallet_with_name_trait_is_valid.rs
+++ b/frame/support/test/tests/pallet_with_name_trait_is_valid.rs
@@ -129,7 +129,7 @@ mod tests {
 	}
 
 	impl frame_system::Config for Runtime {
-		type BaseCallFilter = frame_support::traits::AllowAll;
+		type BaseCallFilter = frame_support::traits::Everything;
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/support/test/tests/system.rs
+++ b/frame/support/test/tests/system.rs
@@ -25,7 +25,7 @@ pub trait Config: 'static + Eq + Clone {
 	type Origin: Into<Result<RawOrigin<Self::AccountId>, Self::Origin>>
 		+ From<RawOrigin<Self::AccountId>>;
 
-	type BaseCallFilter: frame_support::traits::Filter<Self::Call>;
+	type BaseCallFilter: frame_support::traits::Contains<Self::Call>;
 	type BlockNumber: Decode + Encode + EncodeLike + Clone + Default;
 	type Hash;
 	type AccountId: Encode + EncodeLike + Decode;

--- a/frame/system/benches/bench.rs
+++ b/frame/system/benches/bench.rs
@@ -71,7 +71,7 @@ frame_support::parameter_types! {
 		);
 }
 impl system::Config for Runtime {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = BlockLength;
 	type DbWeight = ();

--- a/frame/system/benchmarking/src/mock.rs
+++ b/frame/system/benchmarking/src/mock.rs
@@ -39,7 +39,7 @@ frame_support::construct_runtime!(
 );
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -85,7 +85,7 @@ use frame_support::{
 	dispatch::{DispatchResult, DispatchResultWithPostInfo},
 	storage,
 	traits::{
-		EnsureOrigin, Filter, Get, HandleLifetime, OnKilledAccount, OnNewAccount, OriginTrait,
+		EnsureOrigin, Contains, Get, HandleLifetime, OnKilledAccount, OnNewAccount, OriginTrait,
 		PalletInfo, SortedMembers, StoredMap,
 	},
 	weights::{
@@ -161,7 +161,7 @@ pub mod pallet {
 	pub trait Config: 'static + Eq + Clone {
 		/// The basic call filter to use in Origin. All origins are built with this filter as base,
 		/// except Root.
-		type BaseCallFilter: Filter<Self::Call>;
+		type BaseCallFilter: Contains<Self::Call>;
 
 		/// Block & extrinsics weights: base values and limits.
 		#[pallet::constant]

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -85,7 +85,7 @@ use frame_support::{
 	dispatch::{DispatchResult, DispatchResultWithPostInfo},
 	storage,
 	traits::{
-		EnsureOrigin, Contains, Get, HandleLifetime, OnKilledAccount, OnNewAccount, OriginTrait,
+		Contains, EnsureOrigin, Get, HandleLifetime, OnKilledAccount, OnNewAccount, OriginTrait,
 		PalletInfo, SortedMembers, StoredMap,
 	},
 	weights::{

--- a/frame/system/src/mock.rs
+++ b/frame/system/src/mock.rs
@@ -88,7 +88,7 @@ impl OnKilledAccount<u64> for RecordKilled {
 }
 
 impl Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = RuntimeBlockWeights;
 	type BlockLength = RuntimeBlockLength;
 	type Origin = Origin;

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -336,7 +336,7 @@ mod tests {
 			frame_system::limits::BlockWeights::simple_max(1024);
 	}
 	impl frame_system::Config for Test {
-		type BaseCallFilter = frame_support::traits::AllowAll;
+		type BaseCallFilter = frame_support::traits::Everything;
 		type BlockWeights = ();
 		type BlockLength = ();
 		type DbWeight = ();

--- a/frame/tips/src/tests.rs
+++ b/frame/tips/src/tests.rs
@@ -56,7 +56,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -742,7 +742,7 @@ mod tests {
 	}
 
 	impl frame_system::Config for Runtime {
-		type BaseCallFilter = frame_support::traits::AllowAll;
+		type BaseCallFilter = frame_support::traits::Everything;
 		type BlockWeights = BlockWeights;
 		type BlockLength = ();
 		type DbWeight = ();

--- a/frame/transaction-storage/src/mock.rs
+++ b/frame/transaction-storage/src/mock.rs
@@ -54,7 +54,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type Origin = Origin;

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -56,7 +56,7 @@ parameter_types! {
 		frame_system::limits::BlockWeights::simple_max(1024);
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/uniques/src/mock.rs
+++ b/frame/uniques/src/mock.rs
@@ -46,7 +46,7 @@ parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type Origin = Origin;

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -26,7 +26,7 @@ use frame_support::{
 	assert_err_ignore_postinfo, assert_noop, assert_ok, decl_module,
 	dispatch::{DispatchError, DispatchErrorWithPostInfo, Dispatchable},
 	parameter_types, storage,
-	traits::Filter,
+	traits::Contains,
 	weights::{Pays, Weight},
 };
 use sp_core::H256;
@@ -142,8 +142,8 @@ parameter_types! {
 impl example::Config for Test {}
 
 pub struct TestBaseCallFilter;
-impl Filter<Call> for TestBaseCallFilter {
-	fn filter(c: &Call) -> bool {
+impl Contains<Call> for TestBaseCallFilter {
+	fn contains(c: &Call) -> bool {
 		match *c {
 			// Transfer works. Use `transfer_keep_alive` for a call that doesn't pass the filter.
 			Call::Balances(pallet_balances::Call::transfer(..)) => true,
@@ -282,7 +282,7 @@ fn batch_with_root_works() {
 	new_test_ext().execute_with(|| {
 		let k = b"a".to_vec();
 		let call = Call::System(frame_system::Call::set_storage(vec![(k.clone(), k.clone())]));
-		assert!(!TestBaseCallFilter::filter(&call));
+		assert!(!TestBaseCallFilter::contains(&call));
 		assert_eq!(Balances::free_balance(1), 10);
 		assert_eq!(Balances::free_balance(2), 10);
 		assert_ok!(Utility::batch(

--- a/frame/vesting/src/mock.rs
+++ b/frame/vesting/src/mock.rs
@@ -48,7 +48,7 @@ parameter_types! {
 impl frame_system::Config for Test {
 	type AccountData = pallet_balances::AccountData<u64>;
 	type AccountId = u64;
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockHashCount = BlockHashCount;
 	type BlockLength = ();
 	type BlockNumber = u64;

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -537,7 +537,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = RuntimeBlockWeights;
 	type BlockLength = RuntimeBlockLength;
 	type Origin = Origin;


### PR DESCRIPTION
Part of https://github.com/paritytech/polkadot/issues/2841
Companion: paritytech/polkadot#3591

`Filter` and `Contains` do exactly the same thing, but are used in slightly different contexts. This just merges them, allowing some utilities written for `Contains` to be used where `Filter` was in use.

## Migration

Items within `frame_support::traits`:
- Usage of `Filter` should be replaced with `Contains`.
- Usage of `Filter::filter()` should be replaced with `Contains::contains()`. This includes derivative usage within the inheriting trait `FilterStack`. 
- Usage of `All<...>` should be replaced with `Everything` (**NOTE: The type agument should be dropped**).
- Usage of `AllowAll` should be replaced with `Everything`
- Usage of `DenyAll` should be replaced with `Nothing`

