### PR TITLE
Ignore `jsonrpc-*` in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
     labels: ["A2-insubstantial", "B0-silent", "C1-low 📌"]
     schedule:
       interval: "daily"
+    ignore:
+        - dependency-name: "jsonrpc-*"
+          versions: [">= 16"]


### PR DESCRIPTION
It seems that we are not going to upgrade this dependency but rather wait for `jsonrpsee`. In the meantime the PRs raised by dependabot are somewhat annoying. This disables them.