### PR TITLE
Consistently use `I::from(Self::get())` in `parameter_types!`

### DIFF
--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -359,7 +359,6 @@ macro_rules! parameter_types {
 	(IMPL_CONST $name:ident, $type:ty, $value:expr) => {
 		impl $name {
 			/// Returns the value of this parameter type.
-			#[allow(unused)]
 			pub const fn get() -> $type {
 				$value
 			}
@@ -367,14 +366,13 @@ macro_rules! parameter_types {
 
 		impl<I: From<$type>> $crate::traits::Get<I> for $name {
 			fn get() -> I {
-				I::from($value)
+				I::from(Self::get())
 			}
 		}
 	};
 	(IMPL $name:ident, $type:ty, $value:expr) => {
 		impl $name {
 			/// Returns the value of this parameter type.
-			#[allow(unused)]
 			pub fn get() -> $type {
 				$value
 			}
@@ -382,7 +380,7 @@ macro_rules! parameter_types {
 
 		impl<I: From<$type>> $crate::traits::Get<I> for $name {
 			fn get() -> I {
-				I::from($value)
+				I::from(Self::get())
 			}
 		}
 	};


### PR DESCRIPTION
This small change produces much nicer generated code. Here's a diff between the `cargo expand` of the node runtime before and after:

```diff
...
impl<I: From<BlockLength>> ::frame_support::traits::Get<I> for RuntimeBlockLength {
     fn get() -> I {
-        I::from(BlockLength::max_with_normal_ratio(
-            5 * 1024 * 1024,
-            NORMAL_DISPATCH_RATIO,
-        ))
+        I::from(Self::get())
     }
 }
 pub struct RuntimeBlockWeights;
 impl RuntimeBlockWeights {
     /// Returns the value of this parameter type.
-    #[allow(unused)]
     pub fn get() -> BlockWeights {
         BlockWeights::builder()
             .base_block(BlockExecutionWeight::get())
@@ -247,36 +242,19 @@
 }
 impl<I: From<BlockWeights>> ::frame_support::traits::Get<I> for RuntimeBlockWeights {
     fn get() -> I {
-        I::from(
-            BlockWeights::builder()
-                .base_block(BlockExecutionWeight::get())
-                .for_class(DispatchClass::all(), |weights| {
-                    weights.base_extrinsic = ExtrinsicBaseWeight::get();
-                })
-                .for_class(DispatchClass::Normal, |weights| {
-                    weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT);
-                })
-                .for_class(DispatchClass::Operational, |weights| {
-                    weights.max_total = Some(MAXIMUM_BLOCK_WEIGHT);
-                    weights.reserved =
-                        Some(MAXIMUM_BLOCK_WEIGHT - NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT);
-                })
-                .avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
-                .build_or_panic(),
-        )
+        I::from(Self::get())
     }
 }
...
```