### PR TITLE
Remove unused pdqselect dependency from `sc-consensus-babe`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6048,12 +6048,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pdqselect"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
-
-[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7380,7 +7374,6 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.11.1",
- "pdqselect",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "retain_mut",

--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -50,7 +50,6 @@ log = "0.4.8"
 schnorrkel = { version = "0.9.1", features = ["preaudit_deprecated"] }
 rand = "0.7.2"
 merlin = "2.0"
-pdqselect = "0.1.0"
 derive_more = "0.99.2"
 retain_mut = "0.1.3"
 async-trait = "0.1.50"


### PR DESCRIPTION
This dependency is no longer used so should be safe to drop