### PR TITLE
Update stored_map_works test, triggers potential bug.

### DIFF
--- a/frame/system/src/tests.rs
+++ b/frame/system/src/tests.rs
@@ -50,12 +50,52 @@ fn stored_map_works() {
 		assert_ok!(System::insert(&0, 69));
 		assert!(System::is_provider_required(&0));
 
+		assert_eq!(
+			Account::<Test>::get(0),
+			AccountInfo { nonce: 0, providers: 1, consumers: 1, sufficients: 0, data: 69 }
+		);
+
 		System::dec_consumers(&0);
 		assert!(!System::is_provider_required(&0));
+
+		assert_eq!(
+			Account::<Test>::get(0),
+			AccountInfo { nonce: 0, providers: 1, consumers: 0, sufficients: 0, data: 69 }
+		);
 
 		assert!(KILLED.with(|r| r.borrow().is_empty()));
 		assert_ok!(System::remove(&0));
 		assert_eq!(KILLED.with(|r| r.borrow().clone()), vec![0u64]);
+
+		assert_ok!(System::try_mutate_exists(&0, |data| -> Result<(), &str>{
+			*data = Some(55);
+			Ok(())
+		}));
+
+		assert_eq!(
+			Account::<Test>::get(0),
+			AccountInfo { nonce: 0, providers: 1, consumers: 0, sufficients: 0, data: 55 }
+		);
+
+		assert_ok!(System::try_mutate_exists(&0, |data| -> Result<(), &str>{
+			*data = Some(Default::default());
+			Ok(())
+		}));
+
+		assert_eq!(
+			Account::<Test>::get(0),
+			AccountInfo { nonce: 0, providers: 1, consumers: 0, sufficients: 0, data: 0 }
+		);
+
+		assert_ok!(System::try_mutate_exists(&0, |data| -> Result<(), &str>{
+			*data = Some(55);
+			Ok(())
+		}));
+
+		assert_eq!(
+			Account::<Test>::get(0),
+			AccountInfo { nonce: 0, providers: 1, consumers: 0, sufficients: 0, data: 55 }
+		);
 	});
 }
 


### PR DESCRIPTION
I have updated 'stored_map_works' test case with the usage of the 'try_mutate_exist' function to trigger behavior described in this discussion https://github.com/paritytech/substrate/pull/9463.
Here is the description of the test case:
1. Set up the AccountData into the '55'.
2. check that 'providers' and 'consumers' has been unchanged, 'data' is equal to '55'.
3. change data to the 'default' value '0'.
4. check that 'providers' and 'consumers' has been unchanged, 'data' is equal to '0'.
5. change data to the '55' again.
6. check that 'providers' and 'consumers' has been unchanged, 'data' is equal to '55'.

But the existing behavior is different that I am expecting to this test case, so after changing the value from the 'default' the 'providers' counter has been incremented.