### PR TITLE
Stabilize `seal_debug_message`

### DIFF
--- a/frame/contracts/CHANGELOG.md
+++ b/frame/contracts/CHANGELOG.md
@@ -38,9 +38,10 @@ In other words: Upgrading this pallet will not break pre-existing contracts.
 
 ### Changed
 
-- Replaced `seal_println` with the **unstable** `seal_debug_message` API which allows
-output to an RPC client.
+- Replaced `seal_println` with the `seal_debug_message` API which allows outputting debug
+messages to the console and RPC clients.
 [#8773](https://github.com/paritytech/substrate/pull/8773)
+[#9550](https://github.com/paritytech/substrate/pull/9550)
 
 - Make storage and fields of `Schedule` private to the crate.
 [#8359](https://github.com/paritytech/substrate/pull/8359)

--- a/frame/contracts/fixtures/debug_message_invalid_utf8.wat
+++ b/frame/contracts/fixtures/debug_message_invalid_utf8.wat
@@ -1,6 +1,6 @@
 ;; Emit a "Hello World!" debug message
 (module
-	(import "__unstable__" "seal_debug_message" (func $seal_debug_message (param i32 i32) (result i32)))
+	(import "seal0" "seal_debug_message" (func $seal_debug_message (param i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(data (i32.const 0) "\fc")

--- a/frame/contracts/fixtures/debug_message_logging_disabled.wat
+++ b/frame/contracts/fixtures/debug_message_logging_disabled.wat
@@ -1,6 +1,6 @@
 ;; Emit a "Hello World!" debug message but assume that logging is disabled.
 (module
-	(import "__unstable__" "seal_debug_message" (func $seal_debug_message (param i32 i32) (result i32)))
+	(import "seal0" "seal_debug_message" (func $seal_debug_message (param i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(data (i32.const 0) "Hello World!")

--- a/frame/contracts/fixtures/debug_message_works.wat
+++ b/frame/contracts/fixtures/debug_message_works.wat
@@ -1,6 +1,6 @@
 ;; Emit a "Hello World!" debug message
 (module
-	(import "__unstable__" "seal_debug_message" (func $seal_debug_message (param i32 i32) (result i32)))
+	(import "seal0" "seal_debug_message" (func $seal_debug_message (param i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(data (i32.const 0) "Hello World!")

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -1039,7 +1039,7 @@ benchmarks! {
 		let code = WasmModule::<T>::from(ModuleDefinition {
 			memory: Some(ImportedMemory { min_pages: 1, max_pages: 1 }),
 			imported_functions: vec![ImportedFunction {
-				module: "__unstable__",
+				module: "seal0",
 				name: "seal_debug_message",
 				params: vec![ValueType::I32, ValueType::I32],
 				return_type: Some(ValueType::I32),

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -2615,7 +2615,6 @@ fn reinstrument_does_charge() {
 }
 
 #[test]
-#[cfg(feature = "unstable-interface")]
 fn debug_message_works() {
 	let (wasm, code_hash) = compile_module::<Test>("debug_message_works").unwrap();
 
@@ -2638,7 +2637,6 @@ fn debug_message_works() {
 }
 
 #[test]
-#[cfg(feature = "unstable-interface")]
 fn debug_message_logging_disabled() {
 	let (wasm, code_hash) = compile_module::<Test>("debug_message_logging_disabled").unwrap();
 
@@ -2663,7 +2661,6 @@ fn debug_message_logging_disabled() {
 }
 
 #[test]
-#[cfg(feature = "unstable-interface")]
 fn debug_message_invalid_utf8() {
 	let (wasm, code_hash) = compile_module::<Test>("debug_message_invalid_utf8").unwrap();
 

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -1932,11 +1932,10 @@ mod tests {
 	}
 
 	#[test]
-	#[cfg(feature = "unstable-interface")]
 	fn debug_message_works() {
 		const CODE_DEBUG_MESSAGE: &str = r#"
 (module
-	(import "__unstable__" "seal_debug_message" (func $seal_debug_message (param i32 i32) (result i32)))
+	(import "seal0" "seal_debug_message" (func $seal_debug_message (param i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(data (i32.const 0) "Hello World!")
@@ -1959,11 +1958,10 @@ mod tests {
 	}
 
 	#[test]
-	#[cfg(feature = "unstable-interface")]
 	fn debug_message_invalid_utf8_fails() {
 		const CODE_DEBUG_MESSAGE_FAIL: &str = r#"
 (module
-	(import "__unstable__" "seal_debug_message" (func $seal_debug_message (param i32 i32) (result i32)))
+	(import "seal0" "seal_debug_message" (func $seal_debug_message (param i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(data (i32.const 0) "\fc")

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -69,7 +69,6 @@ pub enum ReturnCode {
 	NotCallable = 8,
 	/// The call to `seal_debug_message` had no effect because debug message
 	/// recording was disabled.
-	#[cfg(feature = "unstable-interface")]
 	LoggingDisabled = 9,
 	/// The call dispatched by `seal_call_runtime` was executed but returned an error.
 	#[cfg(feature = "unstable-interface")]
@@ -175,7 +174,6 @@ pub enum RuntimeCosts {
 	/// Weight of calling `seal_deposit_event` with the given number of topics and event size.
 	DepositEvent { num_topic: u32, len: u32 },
 	/// Weight of calling `seal_debug_message`.
-	#[cfg(feature = "unstable-interface")]
 	DebugMessage,
 	/// Weight of calling `seal_set_rent_allowance`.
 	SetRentAllowance,
@@ -250,7 +248,6 @@ impl RuntimeCosts {
 				.deposit_event
 				.saturating_add(s.deposit_event_per_topic.saturating_mul(num_topic.into()))
 				.saturating_add(s.deposit_event_per_byte.saturating_mul(len.into())),
-			#[cfg(feature = "unstable-interface")]
 			DebugMessage => s.debug_message,
 			SetRentAllowance => s.set_rent_allowance,
 			SetStorage(len) =>
@@ -1748,7 +1745,7 @@ define_env!(Env, <E: Ext>,
 	// not being executed as an RPC. For example, they could allow users to disable logging
 	// through compile time flags (cargo features) for on-chain deployment. Additionally, the
 	// return value of this function can be cached in order to prevent further calls at runtime.
-	[__unstable__] seal_debug_message(ctx, str_ptr: u32, str_len: u32) -> ReturnCode => {
+	[seal0] seal_debug_message(ctx, str_ptr: u32, str_len: u32) -> ReturnCode => {
 		ctx.charge_gas(RuntimeCosts::DebugMessage)?;
 		if ctx.ext.append_debug_buffer("") {
 			let data = ctx.read_sandbox_memory(str_ptr, str_len)?;

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -1413,7 +1413,8 @@ impl<T: Config> Pallet<T> {
 				// Check that assignment.who is actually a voter (defensive-only).
 				// NOTE: while using the index map from `voter_index` is better than a blind linear
 				// search, this *still* has room for optimization. Note that we had the index when
-				// we did `solution -> assignment` and we lost it. Ideal is to keep the index around.
+				// we did `solution -> assignment` and we lost it. Ideal is to keep the index
+				// around.
 
 				// Defensive-only: must exist in the snapshot.
 				let snapshot_index =

--- a/frame/support/src/storage/migration.rs
+++ b/frame/support/src/storage/migration.rs
@@ -249,7 +249,8 @@ pub fn put_storage_value<T: Encode>(module: &[u8], item: &[u8], hash: &[u8], val
 	frame_support::storage::unhashed::put(&key, &value);
 }
 
-/// Remove all items under a storage prefix by the `module`, the map's `item` name and the key `hash`.
+/// Remove all items under a storage prefix by the `module`, the map's `item` name and the key
+/// `hash`.
 pub fn remove_storage_prefix(module: &[u8], item: &[u8], hash: &[u8]) {
 	let mut key = vec![0u8; 32 + hash.len()];
 	key[0..16].copy_from_slice(&Twox128::hash(module));

--- a/primitives/npos-elections/solution-type/src/lib.rs
+++ b/primitives/npos-elections/solution-type/src/lib.rs
@@ -79,7 +79,7 @@ pub(crate) fn syn_err(message: &'static str) -> syn::Error {
 /// 			(u8 /* first target*/, Perbill /* proportion for first target */ ),
 /// 			(u8 /* second target */, Perbill /* proportion for second target*/)
 /// 		], u8 /* last target */)
-///		],
+/// 		],
 /// 	voters4: ...,
 /// }
 ///


### PR DESCRIPTION
Stabilize without changes as introduced in #8773. It is implemented in ink! and works as intended.