### PR TITLE
Simplify `NativeExecutionDispatch` and remove the `native_executor_instance!` macro

### DIFF
--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -3,7 +3,6 @@
 use node_template_runtime::{self, opaque::Block, RuntimeApi};
 use sc_client_api::{ExecutorProvider, RemoteBackend};
 use sc_consensus_aura::{ImportQueueParams, SlotProportion, StartAuraParams};
-use sc_executor::native_executor_instance;
 pub use sc_executor::NativeExecutor;
 use sc_finality_grandpa::SharedVoterState;
 use sc_keystore::LocalKeystore;
@@ -14,12 +13,19 @@ use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
 use std::{sync::Arc, time::Duration};
 
 // Our native executor instance.
-native_executor_instance!(
-	pub Executor,
-	node_template_runtime::api::dispatch,
-	node_template_runtime::native_version,
-	frame_benchmarking::benchmarking::HostFunctions,
-);
+pub struct Executor;
+
+impl sc_executor::NativeExecutionDispatch for Executor {
+	type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
+
+	fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
+		node_template_runtime::api::dispatch(method, data)
+	}
+
+	fn native_version() -> sc_executor::NativeVersion {
+		node_template_runtime::native_version()
+	}
+}
 
 type FullClient = sc_service::TFullClient<Block, RuntimeApi, Executor>;
 type FullBackend = sc_service::TFullBackend<Block>;

--- a/bin/node/executor/src/lib.rs
+++ b/bin/node/executor/src/lib.rs
@@ -18,14 +18,19 @@
 //! A `CodeExecutor` specialization which uses natively compiled runtime when the wasm to be
 //! executed is equivalent to the natively compiled code.
 
-use sc_executor::native_executor_instance;
 pub use sc_executor::NativeExecutor;
 
 // Declare an instance of the native executor named `Executor`. Include the wasm binary as the
-// equivalent wasm code.
-native_executor_instance!(
-	pub Executor,
-	node_runtime::api::dispatch,
-	node_runtime::native_version,
-	frame_benchmarking::benchmarking::HostFunctions,
-);
+pub struct Executor;
+
+impl sc_executor::NativeExecutionDispatch for Executor {
+	type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
+
+	fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
+		node_runtime::api::dispatch(method, data)
+	}
+
+	fn native_version() -> sc_executor::NativeVersion {
+		node_runtime::native_version()
+	}
+}

--- a/bin/node/executor/src/lib.rs
+++ b/bin/node/executor/src/lib.rs
@@ -21,6 +21,7 @@
 pub use sc_executor::NativeExecutor;
 
 // Declare an instance of the native executor named `Executor`. Include the wasm binary as the
+// equivalent wasm code.
 pub struct Executor;
 
 impl sc_executor::NativeExecutionDispatch for Executor {

--- a/bin/node/executor/tests/common.rs
+++ b/bin/node/executor/tests/common.rs
@@ -67,8 +67,7 @@ impl AppCrypto<MultiSigner, MultiSignature> for TestAuthorityId {
 ///
 /// `compact` since it is after post-processing with wasm-gc which performs tree-shaking thus
 /// making the binary slimmer. There is a convention to use compact version of the runtime
-/// as canonical. This is why `native_executor_instance` also uses the compact version of the
-/// runtime.
+/// as canonical.
 pub fn compact_code_unwrap() -> &'static [u8] {
 	node_runtime::WASM_BINARY.expect(
 		"Development wasm binary is not available. Testing is only supported with the flag \

--- a/bin/node/test-runner-example/src/lib.rs
+++ b/bin/node/test-runner-example/src/lib.rs
@@ -28,15 +28,20 @@ use test_runner::{ChainInfo, SignatureVerificationOverride};
 
 type BlockImport<B, BE, C, SC> = BabeBlockImport<B, C, GrandpaBlockImport<BE, B, C, SC>>;
 
-sc_executor::native_executor_instance!(
-	pub Executor,
-	node_runtime::api::dispatch,
-	node_runtime::native_version,
-	(
-		frame_benchmarking::benchmarking::HostFunctions,
-		SignatureVerificationOverride,
-	)
-);
+pub struct Executor;
+
+impl sc_executor::NativeExecutionDispatch for Executor {
+	type ExtendHostFunctions =
+		(frame_benchmarking::benchmarking::HostFunctions, SignatureVerificationOverride);
+
+	fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
+		node_runtime::api::dispatch(method, data)
+	}
+
+	fn native_version() -> sc_executor::NativeVersion {
+		node_runtime::native_version()
+	}
+}
 
 /// ChainInfo implementation.
 struct NodeTemplateChainInfo;

--- a/bin/node/test-runner-example/src/lib.rs
+++ b/bin/node/test-runner-example/src/lib.rs
@@ -28,6 +28,7 @@ use test_runner::{ChainInfo, SignatureVerificationOverride};
 
 type BlockImport<B, BE, C, SC> = BabeBlockImport<B, C, GrandpaBlockImport<BE, B, C, SC>>;
 
+/// Executor instance.
 pub struct Executor;
 
 impl sc_executor::NativeExecutionDispatch for Executor {

--- a/bin/node/test-runner-example/src/lib.rs
+++ b/bin/node/test-runner-example/src/lib.rs
@@ -28,7 +28,8 @@ use test_runner::{ChainInfo, SignatureVerificationOverride};
 
 type BlockImport<B, BE, C, SC> = BabeBlockImport<B, C, GrandpaBlockImport<BE, B, C, SC>>;
 
-/// Executor instance.
+/// A unit struct which implements `NativeExecutionDispatch` feeding in the
+/// hard-coded runtime.
 pub struct Executor;
 
 impl sc_executor::NativeExecutionDispatch for Executor {

--- a/client/service/test/src/client/mod.rs
+++ b/client/service/test/src/client/mod.rs
@@ -27,7 +27,6 @@ use sc_client_db::{
 use sc_consensus::{
 	BlockCheckParams, BlockImport, BlockImportParams, ForkChoiceStrategy, ImportResult,
 };
-use sc_executor::native_executor_instance;
 use sc_service::client::{self, new_in_mem, Client, LocalCallExecutor};
 use sp_api::ProvideRuntimeApi;
 use sp_consensus::{BlockOrigin, BlockStatus, Error as ConsensusError, SelectChain};
@@ -63,11 +62,19 @@ mod light;
 
 const TEST_ENGINE_ID: ConsensusEngineId = *b"TEST";
 
-native_executor_instance!(
-	Executor,
-	substrate_test_runtime_client::runtime::api::dispatch,
-	substrate_test_runtime_client::runtime::native_version,
-);
+pub struct Executor;
+
+impl sc_executor::NativeExecutionDispatch for Executor {
+	type ExtendHostFunctions = ();
+
+	fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
+		substrate_test_runtime_client::runtime::api::dispatch(method, data)
+	}
+
+	fn native_version() -> sc_executor::NativeVersion {
+		substrate_test_runtime_client::runtime::native_version()
+	}
+}
 
 fn executor() -> sc_executor::NativeExecutor<Executor> {
 	sc_executor::NativeExecutor::new(sc_executor::WasmExecutionMethod::Interpreted, None, 8)

--- a/test-utils/runtime/client/src/lib.rs
+++ b/test-utils/runtime/client/src/lib.rs
@@ -58,6 +58,8 @@ pub mod prelude {
 	pub use super::{AccountKeyring, Sr25519Keyring};
 }
 
+/// A unit struct which implements `NativeExecutionDispatch` feeding in the
+/// hard-coded runtime.
 pub struct LocalExecutor;
 
 impl sc_executor::NativeExecutionDispatch for LocalExecutor {

--- a/test-utils/runtime/client/src/lib.rs
+++ b/test-utils/runtime/client/src/lib.rs
@@ -58,10 +58,18 @@ pub mod prelude {
 	pub use super::{AccountKeyring, Sr25519Keyring};
 }
 
-sc_executor::native_executor_instance! {
-	pub LocalExecutor,
-	substrate_test_runtime::api::dispatch,
-	substrate_test_runtime::native_version,
+pub struct LocalExecutor;
+
+impl sc_executor::NativeExecutionDispatch for LocalExecutor {
+	type ExtendHostFunctions = ();
+
+	fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
+		substrate_test_runtime::api::dispatch(method, data)
+	}
+
+	fn native_version() -> sc_executor::NativeVersion {
+		substrate_test_runtime::native_version()
+	}
 }
 
 /// Test client database backend.

--- a/test-utils/runtime/src/system.rs
+++ b/test-utils/runtime/src/system.rs
@@ -349,7 +349,7 @@ mod tests {
 	use super::*;
 
 	use crate::{wasm_binary_unwrap, Header, Transfer};
-	use sc_executor::{native_executor_instance, NativeExecutor, WasmExecutionMethod};
+	use sc_executor::{NativeExecutor, WasmExecutionMethod};
 	use sp_core::{
 		map,
 		traits::{CodeExecutor, RuntimeCode},
@@ -359,7 +359,19 @@ mod tests {
 	use substrate_test_runtime_client::{AccountKeyring, Sr25519Keyring};
 
 	// Declare an instance of the native executor dispatch for the test runtime.
-	native_executor_instance!(NativeDispatch, crate::api::dispatch, crate::native_version);
+	pub struct NativeDispatch;
+
+	impl sc_executor::NativeExecutionDispatch for NativeDispatch {
+		type ExtendHostFunctions = ();
+
+		fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
+			crate::api::dispatch(method, data)
+		}
+
+		fn native_version() -> sc_executor::NativeVersion {
+			crate::native_version()
+		}
+	}
 
 	fn executor() -> NativeExecutor<NativeDispatch> {
 		NativeExecutor::new(WasmExecutionMethod::Interpreted, None, 8)

--- a/test-utils/test-runner/src/lib.rs
+++ b/test-utils/test-runner/src/lib.rs
@@ -62,12 +62,19 @@
 //!
 //! type BlockImport<B, BE, C, SC> = BabeBlockImport<B, C, GrandpaBlockImport<BE, B, C, SC>>;
 //!
-//! sc_executor::native_executor_instance!(
-//! 	pub Executor,
-//! 	node_runtime::api::dispatch,
-//! 	node_runtime::native_version,
-//! 	SignatureVerificationOverride,
-//! );
+//! pub struct Executor;
+//!
+//! impl sc_executor::NativeExecutionDispatch for Executor {
+//! 	type ExtendHostFunctions = SignatureVerificationOverride;
+//!
+//! 	fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
+//! 		node_runtime::api::dispatch(method, data)
+//! 	}
+//!
+//! 	fn native_version() -> sc_executor::NativeVersion {
+//! 		node_runtime::native_version()
+//! 	}
+//! }
 //!
 //! struct Requirements;
 //!


### PR DESCRIPTION
Polkadot companion: https://github.com/paritytech/polkadot/pull/3643

Part of the `sc-executor` refactor. As the previous `NativeExecutionDispatch::dispatch(ext, method, data)` function was only used once, it was be inlined.
