### PR TITLE
Show storage info in the raw benchmark output.

### DIFF
--- a/utils/frame/benchmarking-cli/src/command.rs
+++ b/utils/frame/benchmarking-cli/src/command.rs
@@ -407,6 +407,20 @@ impl BenchmarkCmd {
 				println!();
 			}
 
+			if !self.no_storage_info {
+				let mut comments: Vec<String> = Default::default();
+				crate::writer::add_storage_comments(
+					&mut comments,
+					&batch.db_results,
+					&storage_info,
+				);
+				println!("Raw Storage Info\n========");
+				for comment in comments {
+					println!("{}", comment);
+				}
+				println!("");
+			}
+
 			// Conduct analysis.
 			if !self.no_median_slopes {
 				println!("Median Slopes Analysis\n========");
@@ -425,6 +439,7 @@ impl BenchmarkCmd {
 				{
 					println!("Writes = {:?}", analysis);
 				}
+				println!("");
 			}
 			if !self.no_min_squares {
 				println!("Min Squares Analysis\n========");
@@ -443,6 +458,7 @@ impl BenchmarkCmd {
 				{
 					println!("Writes = {:?}", analysis);
 				}
+				println!("");
 			}
 		}
 

--- a/utils/frame/benchmarking-cli/src/lib.rs
+++ b/utils/frame/benchmarking-cli/src/lib.rs
@@ -141,4 +141,11 @@ pub struct BenchmarkCmd {
 	/// When nothing is provided, we list all benchmarks.
 	#[structopt(long)]
 	pub list: bool,
+
+	/// If enabled, the storage info is not displayed in the output next to the analysis.
+	///
+	/// This is independent of the storage info appearing in the *output file*. Use a Handlebar
+	/// template for that purpose.
+	#[structopt(long)]
+	pub no_storage_info: bool,
 }

--- a/utils/frame/benchmarking-cli/src/writer.rs
+++ b/utils/frame/benchmarking-cli/src/writer.rs
@@ -357,7 +357,7 @@ pub fn write_results(
 // This function looks at the keys touched during the benchmark, and the storage info we collected
 // from the pallets, and creates comments with information about the storage keys touched during
 // each benchmark.
-fn add_storage_comments(
+pub(crate) fn add_storage_comments(
 	comments: &mut Vec<String>,
 	results: &[BenchmarkResult],
 	storage_info: &[StorageInfo],


### PR DESCRIPTION
This is useful to see the storage items touched by running a single benchmark, without needing to use a file output. 


example: 

```
Pallet: "pallet_election_provider_multi_phase", Extrinsic: "submit", Lowest values: [], Highest values: [], Steps: 5, Repeat: 3
Raw Storage Info
========
Storage: ElectionProviderMultiPhase SignedSubmissionIndices (r:1 w:1)
Storage: ElectionProviderMultiPhase CurrentPhase (r:1 w:0)
Storage: ElectionProviderMultiPhase SnapshotMetadata (r:1 w:0)
Storage: TransactionPayment NextFeeMultiplier (r:1 w:0)
Storage: ElectionProviderMultiPhase SignedSubmissionNextIndex (r:1 w:1)
Storage: ElectionProviderMultiPhase SignedSubmissionsMap (r:0 w:1)

Median Slopes Analysis
========
-- Extrinsic Time --

Model:
Time ~=     25.8
    + c    0.115
              µs

Reads = 5 + (0 * c)
Writes = 3 + (0 * c)

Min Squares Analysis
========
-- Extrinsic Time --

Data points distribution:
    c   mean µs  sigma µs       %
    1     26.72     1.276    4.7%
    2     26.54     1.154    4.3%
    3     26.62     0.991    3.7%
    4     26.82     1.119    4.1%
    5     27.11     0.963    3.5%
    6     27.09     0.995    3.6%
    7     27.27     1.172    4.2%
    8      27.3     1.008    3.6%
    9      27.3     0.932    3.4%

Quality and confidence:
param     error
c         0.083

Model:
Time ~=    26.46
    + c    0.103
              µs

Reads = 5 + (0 * c)
Writes = 3 + (0 * c)


```