### PR TITLE
Display warning on try-runtime spec_name mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7112,6 +7112,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-version",
  "tokio 0.2.25",
 ]
 

--- a/utils/frame/remote-externalities/Cargo.toml
+++ b/utils/frame/remote-externalities/Cargo.toml
@@ -27,6 +27,7 @@ serde = "1.0.126"
 sp-io = { version = "4.0.0-dev", path = "../../../primitives/io" }
 sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
+sp-version = { version = "4.0.0-dev", path = "../../../primitives/version" }
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["macros", "rt-threaded"] }

--- a/utils/frame/remote-externalities/src/rpc_api.rs
+++ b/utils/frame/remote-externalities/src/rpc_api.rs
@@ -88,3 +88,24 @@ async fn build_client<S: AsRef<str>>(from: S) -> Result<WsClient, String> {
 		.await
 		.map_err(|e| format!("`WsClientBuilder` failed to build: {:?}", e))
 }
+
+/// Get the runtime of a given chain.
+pub async fn get_runtime_version<Block, S>(
+	from: S,
+	at: Option<Block::Hash>,
+) -> Result<sp_version::RuntimeVersion, String>
+where
+	S: AsRef<str>,
+	Block: BlockT + serde::de::DeserializeOwned,
+	Block::Header: HeaderT,
+{
+	let params = if let Some(at) = at { vec![hash_to_json::<Block>(at)?] } else { vec![] };
+	let client = build_client(from).await?;
+	client
+		.request::<sp_version::RuntimeVersion>(
+			"state_getRuntimeVersion",
+			JsonRpcParams::Array(params),
+		)
+		.await
+		.map_err(|e| format!("state_getRuntimeVersion request failed: {:?}", e))
+}

--- a/utils/frame/remote-externalities/src/rpc_api.rs
+++ b/utils/frame/remote-externalities/src/rpc_api.rs
@@ -89,7 +89,7 @@ async fn build_client<S: AsRef<str>>(from: S) -> Result<WsClient, String> {
 		.map_err(|e| format!("`WsClientBuilder` failed to build: {:?}", e))
 }
 
-/// Get the runtime of a given chain.
+/// Get the runtime version of a given chain.
 pub async fn get_runtime_version<Block, S>(
 	from: S,
 	at: Option<Block::Hash>,

--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -502,7 +502,6 @@ async fn check_spec_name<Block: BlockT + serde::de::DeserializeOwned>(
 	expected_spec_name: String,
 ) {
 	let expected_spec_name = expected_spec_name.to_lowercase();
-	// let expected_runtime_str: sp_runtime::RuntimeString = expected_spec_name.into();
 	match remote_externalities::rpc_api::get_runtime_version::<Block, _>(uri.clone(), None)
 		.await
 		.map(|version| String::from(version.spec_name.clone()))

--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -32,10 +32,7 @@ use sp_core::{
 	storage::{well_known_keys, StorageData, StorageKey},
 };
 use sp_keystore::{testing::KeyStore, KeystoreExt};
-use sp_runtime::{
-	traits::{Block as BlockT, Header as HeaderT, NumberFor},
-	RuntimeString,
-};
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
 use sp_state_machine::StateMachine;
 use std::{fmt::Debug, path::PathBuf, str::FromStr, sync::Arc};
 

--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -32,7 +32,10 @@ use sp_core::{
 	storage::{well_known_keys, StorageData, StorageKey},
 };
 use sp_keystore::{testing::KeyStore, KeystoreExt};
-use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
+use sp_runtime::{
+	traits::{Block as BlockT, Header as HeaderT, NumberFor},
+	RuntimeString,
+};
 use sp_state_machine::StateMachine;
 use std::{fmt::Debug, path::PathBuf, str::FromStr, sync::Arc};
 
@@ -179,7 +182,7 @@ async fn on_runtime_upgrade<Block, ExecDispatch>(
 	config: Configuration,
 ) -> sc_cli::Result<()>
 where
-	Block: BlockT,
+	Block: BlockT + serde::de::DeserializeOwned,
 	Block::Hash: FromStr,
 	<Block::Hash as FromStr>::Err: Debug,
 	NumberFor<Block>: FromStr,
@@ -197,6 +200,8 @@ where
 		heap_pages,
 		max_runtime_instances,
 	);
+
+	check_spec_name::<Block>(shared.url.clone(), config.chain_spec.name().to_string()).await;
 
 	let ext = {
 		let builder = match command.state {
@@ -254,7 +259,7 @@ async fn offchain_worker<Block, ExecDispatch>(
 	config: Configuration,
 ) -> sc_cli::Result<()>
 where
-	Block: BlockT,
+	Block: BlockT + serde::de::DeserializeOwned,
 	Block::Hash: FromStr,
 	Block::Header: serde::de::DeserializeOwned,
 	<Block::Hash as FromStr>::Err: Debug,
@@ -273,6 +278,8 @@ where
 		heap_pages,
 		max_runtime_instances,
 	);
+
+	check_spec_name::<Block>(shared.url.clone(), config.chain_spec.name().to_string()).await;
 
 	let mode = match command.state {
 		State::Live { snapshot_path, modules } => {
@@ -360,6 +367,8 @@ where
 
 	let block_hash = shared.block_at::<Block>()?;
 	let block: Block = rpc_api::get_block::<Block, _>(shared.url.clone(), block_hash).await?;
+
+	check_spec_name::<Block>(shared.url.clone(), config.chain_spec.name().to_string()).await;
 
 	let mode = match command.state {
 		State::Snap { snapshot_path } => {
@@ -483,4 +492,32 @@ fn extract_code(spec: Box<dyn ChainSpec>) -> sc_cli::Result<(StorageKey, Storage
 	let code_key = StorageKey(well_known_keys::CODE.to_vec());
 
 	Ok((code_key, code))
+}
+
+/// Check the spec_name of an `ext`
+///
+/// If the version does not exist, or if it does not match with the given, it emits a warning.
+async fn check_spec_name<Block: BlockT + serde::de::DeserializeOwned>(
+	uri: String,
+	expected_spec_name: String,
+) {
+	// let expected_runtime_str: sp_runtime::RuntimeString = expected_spec_name.into();
+	match remote_externalities::rpc_api::get_runtime_version::<Block, _>(uri.clone(), None).await {
+		Ok(version)
+			if <RuntimeString as Into<String>>::into(version.spec_name.clone()).to_lowercase() ==
+				expected_spec_name.to_lowercase() =>
+		{
+			log::debug!("found matching spec: {:?}", version);
+		}
+		Ok(version) => {
+			log::warn!(
+				"version mismatch: remote spec name: {}, expected (local chain spec, aka. `--chain`): {}",
+				version.spec_name.to_lowercase(),
+				expected_spec_name.to_lowercase(),
+			);
+		},
+		Err(why) => {
+			log::error!("failed to fetch runtime version from {}: {:?}", uri, why);
+		},
+	}
 }

--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -505,7 +505,7 @@ async fn check_spec_name<Block: BlockT + serde::de::DeserializeOwned>(
 	// let expected_runtime_str: sp_runtime::RuntimeString = expected_spec_name.into();
 	match remote_externalities::rpc_api::get_runtime_version::<Block, _>(uri.clone(), None)
 		.await
-		.map(|version| <RuntimeString as Into<String>>::into(version.spec_name.clone()))
+		.map(|version| String::from(version.spec_name.clone()))
 		.map(|spec_name| spec_name.to_lowercase())
 	{
 		Ok(spec) if spec == expected_spec_name => {


### PR DESCRIPTION
Fixes https://github.com/paritytech/substrate/issues/9576

Note that we don't want to abort execution if there is a mismatch. For example, in substrate we want to only execute the migrations of one pallet over the state of polkadot. In this case, it is totally expected that the spec_names don't match. 

Example: 

```
2021-08-20 09:31:12.390  WARN main try_runtime_cli: version mismatch: remote spec name: kusama, expected (local chain spec, aka. `--chain`): development
``` 