### PR TITLE
Remove spurious debug_assert!

### DIFF
--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -1026,7 +1026,6 @@ where
 	// future using `spawn_blocking`.
 	spawn_handle.spawn_blocking("network-worker", async move {
 		if network_start_rx.await.is_err() {
-			debug_assert!(false);
 			log::warn!(
 				"The NetworkStart returned as part of `build_network` has been silently dropped"
 			);


### PR DESCRIPTION
Fix https://github.com/paritytech/polkadot/issues/3688

See my comment in the issue.
This debug assertion can legitimately trigger if an error happens at initialization.
