### PR TITLE
Add  ss58 prefix 88 for Aurgon Network (chongya.com)

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -592,6 +592,8 @@ ss58_address_format!(
 		(77, "manta", "Manta Network, standard account (*25519).")
 	CalamariAccount =>
 		(78, "calamari", "Manta Canary Network, standard account (*25519).")
+	AurogonAccount =>
+                (88, "aurogon", "Aurogon Network, standard account (*25519).")
 	PolkaSmith =>
 		(98, "polkasmith", "PolkaSmith Canary Network, standard account (*25519).")
 	PolkaFoundry =>

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -515,6 +515,15 @@
 			"website": "https://manta.network"
 		},
 		{
+                        "prefix": 88,
+                        "network": "aurogon",
+                        "displayName": "Aurogon Network",
+                        "symbols": ["ARGN", "CYGO"],
+                        "decimals": [12, 12],
+                        "standardAccount": "*25519",
+                        "website": "https://aurogon.chongya.com"
+                },
+		{
 			"prefix": 98,
 			"network": "polkasmith",
 			"displayName": "PolkaSmith Canary Network",


### PR DESCRIPTION
Added ss58 prefix for https://chongya.com Aurgon Netwrok

Prefix  88, likes doesn't collide with other prefixes.

I've added this prefix to files:
ss58-registry.json
primitives/core/src/crypto.rs

Hope everything is ok.
