### PR TITLE
Remove useless borrow

### DIFF
--- a/client/executor/common/src/util.rs
+++ b/client/executor/common/src/util.rs
@@ -105,7 +105,7 @@ pub mod wasmi {
 				let range = checked_range(dest_addr.into(), source.len(), destination.len())
 					.ok_or_else(|| Error::Other("memory write is out of bounds".into()))?;
 
-				&mut destination[range].copy_from_slice(source);
+				destination[range].copy_from_slice(source);
 				Ok(())
 			})
 		}


### PR DESCRIPTION
This is a refactoring artifact introduced in #5920. It was taking a borrow of a `()` expression which does not have any effect.