### PR TITLE
Emit Events on Block 0 for Tests

### DIFF
--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1278,7 +1278,9 @@ impl<T: Config> Pallet<T> {
 	/// It is expected that light-clients could subscribe to this topics.
 	pub fn deposit_event_indexed(topics: &[T::Hash], event: T::Event) {
 		let block_number = Self::block_number();
-		// Don't populate events on genesis.
+		// Don't populate events on genesis for live chains.
+		// For tests, we don't check this to improve developer experience.
+		#[cfg(not(test))]
 		if block_number.is_zero() {
 			return
 		}

--- a/frame/system/src/tests.rs
+++ b/frame/system/src/tests.rs
@@ -437,21 +437,6 @@ fn runtime_upgraded_with_set_storage() {
 }
 
 #[test]
-fn events_not_emitted_during_genesis() {
-	new_test_ext().execute_with(|| {
-		// Block Number is zero at genesis
-		assert!(System::block_number().is_zero());
-		let mut account_data = AccountInfo::default();
-		System::on_created_account(Default::default(), &mut account_data);
-		assert!(System::events().is_empty());
-		// Events will be emitted starting on block 1
-		System::set_block_number(1);
-		System::on_created_account(Default::default(), &mut account_data);
-		assert!(System::events().len() == 1);
-	});
-}
-
-#[test]
 fn ensure_one_of_works() {
 	fn ensure_root_or_signed(o: RawOrigin<u64>) -> Result<Either<(), u64>, Origin> {
 		EnsureOneOf::<u64, EnsureRoot<u64>, EnsureSigned<u64>>::try_origin(o.into())


### PR DESCRIPTION
This PR allows events to appear in tests on block 0.

Historically, we did not allow events on block 0 to prevent hundreds / thousands of events to appear in the genesis of a chain when populating the initial users and other such runtime state.

We still want this, but for tests, it can be confusing for users that sometimes events do not appear when they are on block 0.

This should be a good compromise between the two.