### PR TITLE
Make System Events Private from the Runtime

### DIFF
--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -612,9 +612,12 @@ pub mod pallet {
 	pub(super) type Digest<T: Config> = StorageValue<_, DigestOf<T>, ValueQuery>;
 
 	/// Events deposited for the current block.
+	///
+	/// NOTE: This storage item is explicitly unbounded since it is never intended to be read
+	/// from within the runtime.
 	#[pallet::storage]
-	#[pallet::getter(fn events)]
-	pub type Events<T: Config> = StorageValue<_, Vec<EventRecord<T::Event, T::Hash>>, ValueQuery>;
+	pub(super) type Events<T: Config> =
+		StorageValue<_, Vec<EventRecord<T::Event, T::Hash>>, ValueQuery>;
 
 	/// The number of events in the `Events<T>` list.
 	#[pallet::storage]
@@ -1446,6 +1449,16 @@ impl<T: Config> Pallet<T> {
 			],
 			children_default: map![],
 		})
+	}
+
+	/// Get the current events deposited by the runtime.
+	///
+	/// NOTE: This should only be used in tests. Reading events from the runtime can have a large
+	/// impact on the PoV size of a block. Users should use alternative and well bounded storage
+	/// items for any behavior like this.
+	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
+	pub fn events() -> Vec<EventRecord<T::Event, T::Hash>> {
+		Events::<T>::get()
 	}
 
 	/// Set the block number to something in particular. Can be used as an alternative to


### PR DESCRIPTION
We do not want to allow any Pallet to accidentally read from the events deposited into the runtime.

Doing so can have a huge impact on the PoV size of a block, and currently this is a very easy way to shoot yourself in the foot as a Parachain.

This PR removes the "easy" access to the storage item outside of tests and benchmarking.