### PR TITLE
Expose `storage_prefix` logic, and remove duplicate code

### DIFF
--- a/frame/support/src/migrations.rs
+++ b/frame/support/src/migrations.rs
@@ -30,14 +30,7 @@ impl<T: GetStorageVersion + PalletInfoAccess> PalletVersionToStorageVersionHelpe
 		const PALLET_VERSION_STORAGE_KEY_POSTFIX: &[u8] = b":__PALLET_VERSION__:";
 
 		fn pallet_version_key(name: &str) -> [u8; 32] {
-			let pallet_name = sp_io::hashing::twox_128(name.as_bytes());
-			let postfix = sp_io::hashing::twox_128(PALLET_VERSION_STORAGE_KEY_POSTFIX);
-
-			let mut final_key = [0u8; 32];
-			final_key[..16].copy_from_slice(&pallet_name);
-			final_key[16..].copy_from_slice(&postfix);
-
-			final_key
+			crate::storage::storage_prefix(name.as_bytes(), PALLET_VERSION_STORAGE_KEY_POSTFIX)
 		}
 
 		sp_io::storage::clear(&pallet_version_key(<T as PalletInfoAccess>::name()));

--- a/frame/support/src/storage/generator/double_map.rs
+++ b/frame/support/src/storage/generator/double_map.rs
@@ -17,7 +17,7 @@
 
 use crate::{
 	hash::{ReversibleStorageHasher, StorageHasher},
-	storage::{self, unhashed, KeyPrefixIterator, PrefixIterator, StorageAppend},
+	storage::{self, storage_prefix, unhashed, KeyPrefixIterator, PrefixIterator, StorageAppend},
 	Never,
 };
 use codec::{Decode, Encode, EncodeLike, FullCodec, FullEncode};
@@ -62,7 +62,7 @@ pub trait StorageDoubleMap<K1: FullEncode, K2: FullEncode, V: FullCodec> {
 	/// The full prefix; just the hash of `module_prefix` concatenated to the hash of
 	/// `storage_prefix`.
 	fn prefix_hash() -> Vec<u8> {
-		let result = crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
+		let result = storage_prefix(Self::module_prefix(), Self::storage_prefix());
 		result.to_vec()
 	}
 
@@ -77,8 +77,7 @@ pub trait StorageDoubleMap<K1: FullEncode, K2: FullEncode, V: FullCodec> {
 	where
 		KArg1: EncodeLike<K1>,
 	{
-		let storage_prefix =
-			crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
+		let storage_prefix = storage_prefix(Self::module_prefix(), Self::storage_prefix());
 		let key_hashed = k1.borrow().using_encoded(Self::Hasher1::hash);
 
 		let mut final_key = Vec::with_capacity(storage_prefix.len() + key_hashed.as_ref().len());
@@ -95,8 +94,7 @@ pub trait StorageDoubleMap<K1: FullEncode, K2: FullEncode, V: FullCodec> {
 		KArg1: EncodeLike<K1>,
 		KArg2: EncodeLike<K2>,
 	{
-		let storage_prefix =
-			crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
+		let storage_prefix = storage_prefix(Self::module_prefix(), Self::storage_prefix());
 		let key1_hashed = k1.borrow().using_encoded(Self::Hasher1::hash);
 		let key2_hashed = k2.borrow().using_encoded(Self::Hasher2::hash);
 
@@ -304,8 +302,7 @@ where
 		key2: KeyArg2,
 	) -> Option<V> {
 		let old_key = {
-			let storage_prefix =
-				crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
+			let storage_prefix = storage_prefix(Self::module_prefix(), Self::storage_prefix());
 
 			let key1_hashed = key1.borrow().using_encoded(OldHasher1::hash);
 			let key2_hashed = key2.borrow().using_encoded(OldHasher2::hash);

--- a/frame/support/src/storage/generator/double_map.rs
+++ b/frame/support/src/storage/generator/double_map.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 use crate::{
-	hash::{ReversibleStorageHasher, StorageHasher, Twox128},
+	hash::{ReversibleStorageHasher, StorageHasher},
 	storage::{self, unhashed, KeyPrefixIterator, PrefixIterator, StorageAppend},
 	Never,
 };
@@ -62,16 +62,8 @@ pub trait StorageDoubleMap<K1: FullEncode, K2: FullEncode, V: FullCodec> {
 	/// The full prefix; just the hash of `module_prefix` concatenated to the hash of
 	/// `storage_prefix`.
 	fn prefix_hash() -> Vec<u8> {
-		let module_prefix_hashed = Twox128::hash(Self::module_prefix());
-		let storage_prefix_hashed = Twox128::hash(Self::storage_prefix());
-
-		let mut result =
-			Vec::with_capacity(module_prefix_hashed.len() + storage_prefix_hashed.len());
-
-		result.extend_from_slice(&module_prefix_hashed[..]);
-		result.extend_from_slice(&storage_prefix_hashed[..]);
-
-		result
+		let result = crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
+		result.to_vec()
 	}
 
 	/// Convert an optional value retrieved from storage to the type queried.
@@ -85,16 +77,13 @@ pub trait StorageDoubleMap<K1: FullEncode, K2: FullEncode, V: FullCodec> {
 	where
 		KArg1: EncodeLike<K1>,
 	{
-		let module_prefix_hashed = Twox128::hash(Self::module_prefix());
-		let storage_prefix_hashed = Twox128::hash(Self::storage_prefix());
+		let storage_prefix =
+			crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
 		let key_hashed = k1.borrow().using_encoded(Self::Hasher1::hash);
 
-		let mut final_key = Vec::with_capacity(
-			module_prefix_hashed.len() + storage_prefix_hashed.len() + key_hashed.as_ref().len(),
-		);
+		let mut final_key = Vec::with_capacity(storage_prefix.len() + key_hashed.as_ref().len());
 
-		final_key.extend_from_slice(&module_prefix_hashed[..]);
-		final_key.extend_from_slice(&storage_prefix_hashed[..]);
+		final_key.extend_from_slice(&storage_prefix[..]);
 		final_key.extend_from_slice(key_hashed.as_ref());
 
 		final_key
@@ -106,20 +95,16 @@ pub trait StorageDoubleMap<K1: FullEncode, K2: FullEncode, V: FullCodec> {
 		KArg1: EncodeLike<K1>,
 		KArg2: EncodeLike<K2>,
 	{
-		let module_prefix_hashed = Twox128::hash(Self::module_prefix());
-		let storage_prefix_hashed = Twox128::hash(Self::storage_prefix());
+		let storage_prefix =
+			crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
 		let key1_hashed = k1.borrow().using_encoded(Self::Hasher1::hash);
 		let key2_hashed = k2.borrow().using_encoded(Self::Hasher2::hash);
 
 		let mut final_key = Vec::with_capacity(
-			module_prefix_hashed.len() +
-				storage_prefix_hashed.len() +
-				key1_hashed.as_ref().len() +
-				key2_hashed.as_ref().len(),
+			storage_prefix.len() + key1_hashed.as_ref().len() + key2_hashed.as_ref().len(),
 		);
 
-		final_key.extend_from_slice(&module_prefix_hashed[..]);
-		final_key.extend_from_slice(&storage_prefix_hashed[..]);
+		final_key.extend_from_slice(&storage_prefix[..]);
 		final_key.extend_from_slice(key1_hashed.as_ref());
 		final_key.extend_from_slice(key2_hashed.as_ref());
 
@@ -319,20 +304,17 @@ where
 		key2: KeyArg2,
 	) -> Option<V> {
 		let old_key = {
-			let module_prefix_hashed = Twox128::hash(Self::module_prefix());
-			let storage_prefix_hashed = Twox128::hash(Self::storage_prefix());
+			let storage_prefix =
+				crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
+
 			let key1_hashed = key1.borrow().using_encoded(OldHasher1::hash);
 			let key2_hashed = key2.borrow().using_encoded(OldHasher2::hash);
 
 			let mut final_key = Vec::with_capacity(
-				module_prefix_hashed.len() +
-					storage_prefix_hashed.len() +
-					key1_hashed.as_ref().len() +
-					key2_hashed.as_ref().len(),
+				storage_prefix.len() + key1_hashed.as_ref().len() + key2_hashed.as_ref().len(),
 			);
 
-			final_key.extend_from_slice(&module_prefix_hashed[..]);
-			final_key.extend_from_slice(&storage_prefix_hashed[..]);
+			final_key.extend_from_slice(&storage_prefix[..]);
 			final_key.extend_from_slice(key1_hashed.as_ref());
 			final_key.extend_from_slice(key2_hashed.as_ref());
 

--- a/frame/support/src/storage/generator/map.rs
+++ b/frame/support/src/storage/generator/map.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 use crate::{
-	hash::{ReversibleStorageHasher, StorageHasher, Twox128},
+	hash::{ReversibleStorageHasher, StorageHasher},
 	storage::{self, unhashed, KeyPrefixIterator, PrefixIterator, StorageAppend},
 	Never,
 };
@@ -52,16 +52,8 @@ pub trait StorageMap<K: FullEncode, V: FullCodec> {
 	/// The full prefix; just the hash of `module_prefix` concatenated to the hash of
 	/// `storage_prefix`.
 	fn prefix_hash() -> Vec<u8> {
-		let module_prefix_hashed = Twox128::hash(Self::module_prefix());
-		let storage_prefix_hashed = Twox128::hash(Self::storage_prefix());
-
-		let mut result =
-			Vec::with_capacity(module_prefix_hashed.len() + storage_prefix_hashed.len());
-
-		result.extend_from_slice(&module_prefix_hashed[..]);
-		result.extend_from_slice(&storage_prefix_hashed[..]);
-
-		result
+		let result = crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
+		result.to_vec()
 	}
 
 	/// Convert an optional value retrieved from storage to the type queried.
@@ -75,16 +67,13 @@ pub trait StorageMap<K: FullEncode, V: FullCodec> {
 	where
 		KeyArg: EncodeLike<K>,
 	{
-		let module_prefix_hashed = Twox128::hash(Self::module_prefix());
-		let storage_prefix_hashed = Twox128::hash(Self::storage_prefix());
+		let storage_prefix =
+			crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
 		let key_hashed = key.borrow().using_encoded(Self::Hasher::hash);
 
-		let mut final_key = Vec::with_capacity(
-			module_prefix_hashed.len() + storage_prefix_hashed.len() + key_hashed.as_ref().len(),
-		);
+		let mut final_key = Vec::with_capacity(storage_prefix.len() + key_hashed.as_ref().len());
 
-		final_key.extend_from_slice(&module_prefix_hashed[..]);
-		final_key.extend_from_slice(&storage_prefix_hashed[..]);
+		final_key.extend_from_slice(&storage_prefix[..]);
 		final_key.extend_from_slice(key_hashed.as_ref());
 
 		final_key
@@ -330,18 +319,14 @@ impl<K: FullEncode, V: FullCodec, G: StorageMap<K, V>> storage::StorageMap<K, V>
 
 	fn migrate_key<OldHasher: StorageHasher, KeyArg: EncodeLike<K>>(key: KeyArg) -> Option<V> {
 		let old_key = {
-			let module_prefix_hashed = Twox128::hash(Self::module_prefix());
-			let storage_prefix_hashed = Twox128::hash(Self::storage_prefix());
+			let storage_prefix =
+				crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
 			let key_hashed = key.borrow().using_encoded(OldHasher::hash);
 
-			let mut final_key = Vec::with_capacity(
-				module_prefix_hashed.len() +
-					storage_prefix_hashed.len() +
-					key_hashed.as_ref().len(),
-			);
+			let mut final_key =
+				Vec::with_capacity(storage_prefix.len() + key_hashed.as_ref().len());
 
-			final_key.extend_from_slice(&module_prefix_hashed[..]);
-			final_key.extend_from_slice(&storage_prefix_hashed[..]);
+			final_key.extend_from_slice(&storage_prefix[..]);
 			final_key.extend_from_slice(key_hashed.as_ref());
 
 			final_key

--- a/frame/support/src/storage/generator/map.rs
+++ b/frame/support/src/storage/generator/map.rs
@@ -17,7 +17,7 @@
 
 use crate::{
 	hash::{ReversibleStorageHasher, StorageHasher},
-	storage::{self, unhashed, KeyPrefixIterator, PrefixIterator, StorageAppend},
+	storage::{self, storage_prefix, unhashed, KeyPrefixIterator, PrefixIterator, StorageAppend},
 	Never,
 };
 use codec::{Decode, Encode, EncodeLike, FullCodec, FullEncode};
@@ -52,7 +52,7 @@ pub trait StorageMap<K: FullEncode, V: FullCodec> {
 	/// The full prefix; just the hash of `module_prefix` concatenated to the hash of
 	/// `storage_prefix`.
 	fn prefix_hash() -> Vec<u8> {
-		let result = crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
+		let result = storage_prefix(Self::module_prefix(), Self::storage_prefix());
 		result.to_vec()
 	}
 
@@ -67,8 +67,7 @@ pub trait StorageMap<K: FullEncode, V: FullCodec> {
 	where
 		KeyArg: EncodeLike<K>,
 	{
-		let storage_prefix =
-			crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
+		let storage_prefix = storage_prefix(Self::module_prefix(), Self::storage_prefix());
 		let key_hashed = key.borrow().using_encoded(Self::Hasher::hash);
 
 		let mut final_key = Vec::with_capacity(storage_prefix.len() + key_hashed.as_ref().len());
@@ -319,8 +318,7 @@ impl<K: FullEncode, V: FullCodec, G: StorageMap<K, V>> storage::StorageMap<K, V>
 
 	fn migrate_key<OldHasher: StorageHasher, KeyArg: EncodeLike<K>>(key: KeyArg) -> Option<V> {
 		let old_key = {
-			let storage_prefix =
-				crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
+			let storage_prefix = storage_prefix(Self::module_prefix(), Self::storage_prefix());
 			let key_hashed = key.borrow().using_encoded(OldHasher::hash);
 
 			let mut final_key =

--- a/frame/support/src/storage/generator/nmap.rs
+++ b/frame/support/src/storage/generator/nmap.rs
@@ -31,7 +31,7 @@
 
 use crate::{
 	storage::{
-		self,
+		self, storage_prefix,
 		types::{
 			EncodeLikeTuple, HasKeyPrefix, HasReversibleKeyPrefix, KeyGenerator,
 			ReversibleKeyGenerator, TupleToEncodedIter,
@@ -70,7 +70,7 @@ pub trait StorageNMap<K: KeyGenerator, V: FullCodec> {
 	/// The full prefix; just the hash of `module_prefix` concatenated to the hash of
 	/// `storage_prefix`.
 	fn prefix_hash() -> Vec<u8> {
-		let result = crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
+		let result = storage_prefix(Self::module_prefix(), Self::storage_prefix());
 		result.to_vec()
 	}
 
@@ -85,8 +85,7 @@ pub trait StorageNMap<K: KeyGenerator, V: FullCodec> {
 	where
 		K: HasKeyPrefix<KP>,
 	{
-		let storage_prefix =
-			crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
+		let storage_prefix = storage_prefix(Self::module_prefix(), Self::storage_prefix());
 		let key_hashed = <K as HasKeyPrefix<KP>>::partial_key(key);
 
 		let mut final_key = Vec::with_capacity(storage_prefix.len() + key_hashed.len());
@@ -103,8 +102,7 @@ pub trait StorageNMap<K: KeyGenerator, V: FullCodec> {
 		KG: KeyGenerator,
 		KArg: EncodeLikeTuple<KG::KArg> + TupleToEncodedIter,
 	{
-		let storage_prefix =
-			crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
+		let storage_prefix = storage_prefix(Self::module_prefix(), Self::storage_prefix());
 		let key_hashed = KG::final_key(key);
 
 		let mut final_key = Vec::with_capacity(storage_prefix.len() + key_hashed.len());
@@ -271,8 +269,7 @@ where
 		KArg: EncodeLikeTuple<K::KArg> + TupleToEncodedIter,
 	{
 		let old_key = {
-			let storage_prefix =
-				crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix());
+			let storage_prefix = storage_prefix(Self::module_prefix(), Self::storage_prefix());
 			let key_hashed = K::migrate_key(&key, hash_fns);
 
 			let mut final_key = Vec::with_capacity(storage_prefix.len() + key_hashed.len());

--- a/frame/support/src/storage/generator/value.rs
+++ b/frame/support/src/storage/generator/value.rs
@@ -16,7 +16,6 @@
 // limitations under the License.
 
 use crate::{
-	hash::{StorageHasher, Twox128},
 	storage::{self, unhashed, StorageAppend},
 	Never,
 };
@@ -46,10 +45,7 @@ pub trait StorageValue<T: FullCodec> {
 
 	/// Generate the full key used in top storage.
 	fn storage_value_final_key() -> [u8; 32] {
-		let mut final_key = [0u8; 32];
-		final_key[0..16].copy_from_slice(&Twox128::hash(Self::module_prefix()));
-		final_key[16..32].copy_from_slice(&Twox128::hash(Self::storage_prefix()));
-		final_key
+		crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix())
 	}
 }
 

--- a/frame/support/src/storage/migration.rs
+++ b/frame/support/src/storage/migration.rs
@@ -17,7 +17,11 @@
 
 //! Some utilities for helping access storage with arbitrary key types.
 
-use crate::{hash::ReversibleStorageHasher, storage::unhashed, StorageHasher, Twox128};
+use crate::{
+	hash::ReversibleStorageHasher,
+	storage::{storage_prefix, unhashed},
+	StorageHasher, Twox128,
+};
 use codec::{Decode, Encode};
 use sp_std::prelude::*;
 
@@ -47,7 +51,7 @@ impl<T> StorageIterator<T> {
 	)]
 	pub fn with_suffix(module: &[u8], item: &[u8], suffix: &[u8]) -> Self {
 		let mut prefix = Vec::new();
-		let storage_prefix = crate::storage::storage_prefix(module, item);
+		let storage_prefix = storage_prefix(module, item);
 		prefix.extend_from_slice(&storage_prefix);
 		prefix.extend_from_slice(suffix);
 		let previous_key = prefix.clone();
@@ -112,7 +116,7 @@ impl<K, T, H: ReversibleStorageHasher> StorageKeyIterator<K, T, H> {
 	)]
 	pub fn with_suffix(module: &[u8], item: &[u8], suffix: &[u8]) -> Self {
 		let mut prefix = Vec::new();
-		let storage_prefix = crate::storage::storage_prefix(module, item);
+		let storage_prefix = storage_prefix(module, item);
 		prefix.extend_from_slice(&storage_prefix);
 		prefix.extend_from_slice(suffix);
 		let previous_key = prefix.clone();
@@ -173,7 +177,7 @@ pub fn storage_iter_with_suffix<T: Decode + Sized>(
 	suffix: &[u8],
 ) -> PrefixIterator<(Vec<u8>, T)> {
 	let mut prefix = Vec::new();
-	let storage_prefix = crate::storage::storage_prefix(module, item);
+	let storage_prefix = storage_prefix(module, item);
 	prefix.extend_from_slice(&storage_prefix);
 	prefix.extend_from_slice(suffix);
 	let previous_key = prefix.clone();
@@ -204,7 +208,7 @@ pub fn storage_key_iter_with_suffix<
 	suffix: &[u8],
 ) -> PrefixIterator<(K, T)> {
 	let mut prefix = Vec::new();
-	let storage_prefix = crate::storage::storage_prefix(module, item);
+	let storage_prefix = storage_prefix(module, item);
 
 	prefix.extend_from_slice(&storage_prefix);
 	prefix.extend_from_slice(suffix);
@@ -226,7 +230,7 @@ pub fn have_storage_value(module: &[u8], item: &[u8], hash: &[u8]) -> bool {
 /// Get a particular value in storage by the `module`, the map's `item` name and the key `hash`.
 pub fn get_storage_value<T: Decode + Sized>(module: &[u8], item: &[u8], hash: &[u8]) -> Option<T> {
 	let mut key = vec![0u8; 32 + hash.len()];
-	let storage_prefix = crate::storage::storage_prefix(module, item);
+	let storage_prefix = storage_prefix(module, item);
 	key[0..32].copy_from_slice(&storage_prefix);
 	key[32..].copy_from_slice(hash);
 	frame_support::storage::unhashed::get::<T>(&key)
@@ -235,7 +239,7 @@ pub fn get_storage_value<T: Decode + Sized>(module: &[u8], item: &[u8], hash: &[
 /// Take a particular value in storage by the `module`, the map's `item` name and the key `hash`.
 pub fn take_storage_value<T: Decode + Sized>(module: &[u8], item: &[u8], hash: &[u8]) -> Option<T> {
 	let mut key = vec![0u8; 32 + hash.len()];
-	let storage_prefix = crate::storage::storage_prefix(module, item);
+	let storage_prefix = storage_prefix(module, item);
 	key[0..32].copy_from_slice(&storage_prefix);
 	key[32..].copy_from_slice(hash);
 	frame_support::storage::unhashed::take::<T>(&key)
@@ -244,7 +248,7 @@ pub fn take_storage_value<T: Decode + Sized>(module: &[u8], item: &[u8], hash: &
 /// Put a particular value into storage by the `module`, the map's `item` name and the key `hash`.
 pub fn put_storage_value<T: Encode>(module: &[u8], item: &[u8], hash: &[u8], value: T) {
 	let mut key = vec![0u8; 32 + hash.len()];
-	let storage_prefix = crate::storage::storage_prefix(module, item);
+	let storage_prefix = storage_prefix(module, item);
 	key[0..32].copy_from_slice(&storage_prefix);
 	key[32..].copy_from_slice(hash);
 	frame_support::storage::unhashed::put(&key, &value);
@@ -254,7 +258,7 @@ pub fn put_storage_value<T: Encode>(module: &[u8], item: &[u8], hash: &[u8], val
 /// `hash`.
 pub fn remove_storage_prefix(module: &[u8], item: &[u8], hash: &[u8]) {
 	let mut key = vec![0u8; 32 + hash.len()];
-	let storage_prefix = crate::storage::storage_prefix(module, item);
+	let storage_prefix = storage_prefix(module, item);
 	key[0..32].copy_from_slice(&storage_prefix);
 	key[32..].copy_from_slice(hash);
 	frame_support::storage::unhashed::kill_prefix(&key, None);
@@ -294,8 +298,8 @@ pub fn move_storage_from_pallet(
 	old_pallet_name: &[u8],
 	new_pallet_name: &[u8],
 ) {
-	let new_prefix = crate::storage::storage_prefix(new_pallet_name, storage_name);
-	let old_prefix = crate::storage::storage_prefix(old_pallet_name, storage_name);
+	let new_prefix = storage_prefix(new_pallet_name, storage_name);
+	let old_prefix = storage_prefix(old_pallet_name, storage_name);
 
 	move_prefix(&old_prefix, &new_prefix);
 

--- a/frame/support/src/storage/migration.rs
+++ b/frame/support/src/storage/migration.rs
@@ -47,8 +47,8 @@ impl<T> StorageIterator<T> {
 	)]
 	pub fn with_suffix(module: &[u8], item: &[u8], suffix: &[u8]) -> Self {
 		let mut prefix = Vec::new();
-		prefix.extend_from_slice(&Twox128::hash(module));
-		prefix.extend_from_slice(&Twox128::hash(item));
+		let storage_prefix = crate::storage::storage_prefix(module, item);
+		prefix.extend_from_slice(&storage_prefix);
 		prefix.extend_from_slice(suffix);
 		let previous_key = prefix.clone();
 		Self { prefix, previous_key, drain: false, _phantom: Default::default() }
@@ -112,8 +112,8 @@ impl<K, T, H: ReversibleStorageHasher> StorageKeyIterator<K, T, H> {
 	)]
 	pub fn with_suffix(module: &[u8], item: &[u8], suffix: &[u8]) -> Self {
 		let mut prefix = Vec::new();
-		prefix.extend_from_slice(&Twox128::hash(module));
-		prefix.extend_from_slice(&Twox128::hash(item));
+		let storage_prefix = crate::storage::storage_prefix(module, item);
+		prefix.extend_from_slice(&storage_prefix);
 		prefix.extend_from_slice(suffix);
 		let previous_key = prefix.clone();
 		Self { prefix, previous_key, drain: false, _phantom: Default::default() }
@@ -173,8 +173,8 @@ pub fn storage_iter_with_suffix<T: Decode + Sized>(
 	suffix: &[u8],
 ) -> PrefixIterator<(Vec<u8>, T)> {
 	let mut prefix = Vec::new();
-	prefix.extend_from_slice(&Twox128::hash(module));
-	prefix.extend_from_slice(&Twox128::hash(item));
+	let storage_prefix = crate::storage::storage_prefix(module, item);
+	prefix.extend_from_slice(&storage_prefix);
 	prefix.extend_from_slice(suffix);
 	let previous_key = prefix.clone();
 	let closure = |raw_key_without_prefix: &[u8], raw_value: &[u8]| {
@@ -204,8 +204,9 @@ pub fn storage_key_iter_with_suffix<
 	suffix: &[u8],
 ) -> PrefixIterator<(K, T)> {
 	let mut prefix = Vec::new();
-	prefix.extend_from_slice(&Twox128::hash(module));
-	prefix.extend_from_slice(&Twox128::hash(item));
+	let storage_prefix = crate::storage::storage_prefix(module, item);
+
+	prefix.extend_from_slice(&storage_prefix);
 	prefix.extend_from_slice(suffix);
 	let previous_key = prefix.clone();
 	let closure = |raw_key_without_prefix: &[u8], raw_value: &[u8]| {
@@ -225,8 +226,8 @@ pub fn have_storage_value(module: &[u8], item: &[u8], hash: &[u8]) -> bool {
 /// Get a particular value in storage by the `module`, the map's `item` name and the key `hash`.
 pub fn get_storage_value<T: Decode + Sized>(module: &[u8], item: &[u8], hash: &[u8]) -> Option<T> {
 	let mut key = vec![0u8; 32 + hash.len()];
-	key[0..16].copy_from_slice(&Twox128::hash(module));
-	key[16..32].copy_from_slice(&Twox128::hash(item));
+	let storage_prefix = crate::storage::storage_prefix(module, item);
+	key[0..32].copy_from_slice(&storage_prefix);
 	key[32..].copy_from_slice(hash);
 	frame_support::storage::unhashed::get::<T>(&key)
 }
@@ -234,8 +235,8 @@ pub fn get_storage_value<T: Decode + Sized>(module: &[u8], item: &[u8], hash: &[
 /// Take a particular value in storage by the `module`, the map's `item` name and the key `hash`.
 pub fn take_storage_value<T: Decode + Sized>(module: &[u8], item: &[u8], hash: &[u8]) -> Option<T> {
 	let mut key = vec![0u8; 32 + hash.len()];
-	key[0..16].copy_from_slice(&Twox128::hash(module));
-	key[16..32].copy_from_slice(&Twox128::hash(item));
+	let storage_prefix = crate::storage::storage_prefix(module, item);
+	key[0..32].copy_from_slice(&storage_prefix);
 	key[32..].copy_from_slice(hash);
 	frame_support::storage::unhashed::take::<T>(&key)
 }
@@ -243,8 +244,8 @@ pub fn take_storage_value<T: Decode + Sized>(module: &[u8], item: &[u8], hash: &
 /// Put a particular value into storage by the `module`, the map's `item` name and the key `hash`.
 pub fn put_storage_value<T: Encode>(module: &[u8], item: &[u8], hash: &[u8], value: T) {
 	let mut key = vec![0u8; 32 + hash.len()];
-	key[0..16].copy_from_slice(&Twox128::hash(module));
-	key[16..32].copy_from_slice(&Twox128::hash(item));
+	let storage_prefix = crate::storage::storage_prefix(module, item);
+	key[0..32].copy_from_slice(&storage_prefix);
 	key[32..].copy_from_slice(hash);
 	frame_support::storage::unhashed::put(&key, &value);
 }
@@ -253,8 +254,8 @@ pub fn put_storage_value<T: Encode>(module: &[u8], item: &[u8], hash: &[u8], val
 /// `hash`.
 pub fn remove_storage_prefix(module: &[u8], item: &[u8], hash: &[u8]) {
 	let mut key = vec![0u8; 32 + hash.len()];
-	key[0..16].copy_from_slice(&Twox128::hash(module));
-	key[16..32].copy_from_slice(&Twox128::hash(item));
+	let storage_prefix = crate::storage::storage_prefix(module, item);
+	key[0..32].copy_from_slice(&storage_prefix);
 	key[32..].copy_from_slice(hash);
 	frame_support::storage::unhashed::kill_prefix(&key, None);
 }
@@ -293,13 +294,8 @@ pub fn move_storage_from_pallet(
 	old_pallet_name: &[u8],
 	new_pallet_name: &[u8],
 ) {
-	let mut new_prefix = Vec::new();
-	new_prefix.extend_from_slice(&Twox128::hash(new_pallet_name));
-	new_prefix.extend_from_slice(&Twox128::hash(storage_name));
-
-	let mut old_prefix = Vec::new();
-	old_prefix.extend_from_slice(&Twox128::hash(old_pallet_name));
-	old_prefix.extend_from_slice(&Twox128::hash(storage_name));
+	let new_prefix = crate::storage::storage_prefix(new_pallet_name, storage_name);
+	let old_prefix = crate::storage::storage_prefix(old_pallet_name, storage_name);
 
 	move_prefix(&old_prefix, &new_prefix);
 

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -18,7 +18,7 @@
 //! Stuff to do with the runtime's storage.
 
 use crate::{
-	hash::{ReversibleStorageHasher, StorageHasher, Twox128},
+	hash::{ReversibleStorageHasher, StorageHasher},
 	storage::types::{
 		EncodeLikeTuple, HasKeyPrefix, HasReversibleKeyPrefix, KeyGenerator,
 		ReversibleKeyGenerator, TupleToEncodedIter,
@@ -1108,10 +1108,7 @@ pub trait StoragePrefixedMap<Value: FullCodec> {
 
 	/// Final full prefix that prefixes all keys.
 	fn final_prefix() -> [u8; 32] {
-		let mut final_key = [0u8; 32];
-		final_key[0..16].copy_from_slice(&Twox128::hash(Self::module_prefix()));
-		final_key[16..32].copy_from_slice(&Twox128::hash(Self::storage_prefix()));
-		final_key
+		crate::storage::storage_prefix(Self::module_prefix(), Self::storage_prefix())
 	}
 
 	/// Remove all value of the storage.
@@ -1361,10 +1358,22 @@ where
 	}
 }
 
+/// Returns the storage prefix for a specific pallet and storage string.
+pub fn storage_prefix(pallet_name: &[u8], storage_name: &[u8]) -> [u8; 32] {
+	let pallet_hash = sp_io::hashing::twox_128(pallet_name);
+	let storage_hash = sp_io::hashing::twox_128(storage_name);
+
+	let mut final_key = [0u8; 32];
+	final_key[..16].copy_from_slice(&pallet_hash);
+	final_key[16..].copy_from_slice(&storage_hash);
+
+	final_key
+}
+
 #[cfg(test)]
 mod test {
 	use super::*;
-	use crate::{assert_ok, hash::Identity};
+	use crate::{assert_ok, hash::Identity, Twox128};
 	use bounded_vec::BoundedVec;
 	use core::convert::{TryFrom, TryInto};
 	use generator::StorageValue as _;

--- a/frame/support/src/traits/hooks.rs
+++ b/frame/support/src/traits/hooks.rs
@@ -124,14 +124,7 @@ pub trait OnRuntimeUpgradeHelpersExt {
 	/// them. See [`Self::set_temp_storage`] and [`Self::get_temp_storage`].
 	#[cfg(feature = "try-runtime")]
 	fn storage_key(ident: &str) -> [u8; 32] {
-		let prefix = sp_io::hashing::twox_128(ON_RUNTIME_UPGRADE_PREFIX);
-		let ident = sp_io::hashing::twox_128(ident.as_bytes());
-
-		let mut final_key = [0u8; 32];
-		final_key[..16].copy_from_slice(&prefix);
-		final_key[16..].copy_from_slice(&ident);
-
-		final_key
+		crate::storage::storage_prefix(ON_RUNTIME_UPGRADE_PREFIX, ident.as_bytes())
 	}
 
 	/// Get temporary storage data written by [`Self::set_temp_storage`].

--- a/frame/support/src/traits/metadata.rs
+++ b/frame/support/src/traits/metadata.rs
@@ -92,15 +92,7 @@ impl StorageVersion {
 	/// See [`STORAGE_VERSION_STORAGE_KEY_POSTFIX`] on how this key is built.
 	pub fn storage_key<P: PalletInfoAccess>() -> [u8; 32] {
 		let pallet_name = P::name();
-
-		let pallet_name = sp_io::hashing::twox_128(pallet_name.as_bytes());
-		let postfix = sp_io::hashing::twox_128(STORAGE_VERSION_STORAGE_KEY_POSTFIX);
-
-		let mut final_key = [0u8; 32];
-		final_key[..16].copy_from_slice(&pallet_name);
-		final_key[16..].copy_from_slice(&postfix);
-
-		final_key
+		crate::storage::storage_prefix(pallet_name.as_bytes(), STORAGE_VERSION_STORAGE_KEY_POSTFIX)
 	}
 
 	/// Put this storage version for the given pallet into the storage.

--- a/frame/support/test/tests/decl_storage.rs
+++ b/frame/support/test/tests/decl_storage.rs
@@ -428,16 +428,10 @@ mod tests {
 	#[test]
 	fn storage_info() {
 		use frame_support::{
-			pallet_prelude::*,
+			storage::storage_prefix as prefix,
 			traits::{StorageInfo, StorageInfoTrait},
-			StorageHasher,
 		};
-		let prefix = |pallet_name, storage_name| {
-			let mut res = [0u8; 32];
-			res[0..16].copy_from_slice(&Twox128::hash(pallet_name));
-			res[16..32].copy_from_slice(&Twox128::hash(storage_name));
-			res
-		};
+
 		pretty_assertions::assert_eq!(
 			<Module<TraitImpl>>::storage_info(),
 			vec![
@@ -717,15 +711,8 @@ mod test2 {
 	#[test]
 	fn storage_info() {
 		use frame_support::{
-			pallet_prelude::*,
+			storage::storage_prefix as prefix,
 			traits::{StorageInfo, StorageInfoTrait},
-			StorageHasher,
-		};
-		let prefix = |pallet_name, storage_name| {
-			let mut res = [0u8; 32];
-			res[0..16].copy_from_slice(&Twox128::hash(pallet_name));
-			res[16..32].copy_from_slice(&Twox128::hash(storage_name));
-			res
 		};
 		pretty_assertions::assert_eq!(
 			<Module<TraitImpl>>::storage_info(),

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -934,14 +934,7 @@ fn migrate_from_pallet_version_to_storage_version() {
 	const PALLET_VERSION_STORAGE_KEY_POSTFIX: &[u8] = b":__PALLET_VERSION__:";
 
 	fn pallet_version_key(name: &str) -> [u8; 32] {
-		let pallet_name = sp_io::hashing::twox_128(name.as_bytes());
-		let postfix = sp_io::hashing::twox_128(PALLET_VERSION_STORAGE_KEY_POSTFIX);
-
-		let mut final_key = [0u8; 32];
-		final_key[..16].copy_from_slice(&pallet_name);
-		final_key[16..].copy_from_slice(&postfix);
-
-		final_key
+		frame_support::storage::storage_prefix(name.as_bytes(), PALLET_VERSION_STORAGE_KEY_POSTFIX)
 	}
 
 	TestExternalities::default().execute_with(|| {
@@ -1274,16 +1267,8 @@ fn test_pallet_info_access() {
 #[test]
 fn test_storage_info() {
 	use frame_support::{
-		pallet_prelude::*,
+		storage::storage_prefix as prefix,
 		traits::{StorageInfo, StorageInfoTrait},
-		StorageHasher,
-	};
-
-	let prefix = |pallet_name, storage_name| {
-		let mut res = [0u8; 32];
-		res[0..16].copy_from_slice(&Twox128::hash(pallet_name));
-		res[16..32].copy_from_slice(&Twox128::hash(storage_name));
-		res
 	};
 
 	assert_eq!(


### PR DESCRIPTION
This exposes the logic behind generating a `storage_prefix`, and also removes lots of duplicated code where this function can be used instead.