### PR TITLE
Multithreaded POW mining worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2216,9 +2216,9 @@ checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
 
 [[package]]
 name = "futures-lite"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -7634,6 +7634,7 @@ dependencies = [
  "async-trait",
  "derive_more",
  "futures 0.3.16",
+ "futures-core",
  "futures-timer 3.0.2",
  "log 0.4.14",
  "parity-scale-codec",
@@ -7649,6 +7650,8 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "substrate-prometheus-endpoint",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -10186,9 +10189,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
+checksum = "92036be488bb6594459f2e03b60e42df6f937fe6ca5c5ffdcb539c6b84dc40f5"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.0.1",
@@ -10296,6 +10299,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite 0.2.6",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/client/consensus/pow/Cargo.toml
+++ b/client/consensus/pow/Cargo.toml
@@ -31,3 +31,6 @@ parking_lot = "0.11.1"
 derive_more = "0.99.2"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../../utils/prometheus", version = "0.9.0"}
 async-trait = "0.1.50"
+tokio = { version = "1.10.1", features = ["sync"] }
+tokio-stream = { version = "0.1.7", features = ['sync'] }
+futures-core = "0.3.16"

--- a/client/consensus/pow/src/worker.rs
+++ b/client/consensus/pow/src/worker.rs
@@ -16,23 +16,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use futures::{
-	prelude::*,
-	task::{Context, Poll},
-};
-use futures_timer::Delay;
-use log::*;
-use sc_client_api::ImportNotifications;
-use sc_consensus::{BlockImportParams, BoxBlockImport, StateAction, StorageChanges};
-use sp_consensus::{BlockOrigin, Proposal};
-use sp_runtime::{
-	generic::BlockId,
-	traits::{Block as BlockT, Header as HeaderT},
-	DigestItem,
-};
-use std::{borrow::Cow, collections::HashMap, pin::Pin, time::Duration};
+//!
+use futures::{ready, Stream, StreamExt};
+use sp_consensus::Proposal;
+use sp_runtime::traits::Block as BlockT;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio_stream::wrappers::WatchStream;
 
-use crate::{PowAlgorithm, PowIntermediate, Seal, INTERMEDIATE_KEY, POW_ENGINE_ID};
+use crate::{PowAlgorithm, Seal};
 
 /// Mining metadata. This is the information needed to start an actual mining loop.
 #[derive(Clone, Eq, PartialEq)]
@@ -47,187 +39,82 @@ pub struct MiningMetadata<H, D> {
 	pub difficulty: D,
 }
 
+#[derive(Clone)]
+pub struct MiningData<H, D> {
+	pub metadata: MiningMetadata<H, D>,
+	/// sink to send the seal back to the authorship task
+	pub sender: tokio::sync::mpsc::Sender<Seal>,
+}
+
 /// A build of mining, containing the metadata and the block proposal.
-pub struct MiningBuild<
-	Block: BlockT,
-	Algorithm: PowAlgorithm<Block>,
-	C: sp_api::ProvideRuntimeApi<Block>,
-	Proof,
-> {
+pub struct MiningBuild<B: BlockT, A: PowAlgorithm<B>, C: sp_api::ProvideRuntimeApi<B>, P> {
 	/// Mining metadata.
-	pub metadata: MiningMetadata<Block::Hash, Algorithm::Difficulty>,
+	pub metadata: MiningMetadata<B::Hash, A::Difficulty>,
 	/// Mining proposal.
-	pub proposal: Proposal<Block, sp_api::TransactionFor<C, Block>, Proof>,
+	pub proposal: Proposal<B, sp_api::TransactionFor<C, B>, P>,
 }
 
-/// Mining worker that exposes structs to query the current mining build and submit mined blocks.
-pub struct MiningWorker<
-	Block: BlockT,
-	Algorithm: PowAlgorithm<Block>,
-	C: sp_api::ProvideRuntimeApi<Block>,
-	L: sc_consensus::JustificationSyncLink<Block>,
-	Proof,
-> {
-	pub(crate) build: Option<MiningBuild<Block, Algorithm, C, Proof>>,
-	pub(crate) algorithm: Algorithm,
-	pub(crate) block_import: BoxBlockImport<Block, sp_api::TransactionFor<C, Block>>,
-	pub(crate) justification_sync_link: L,
+type MetadataReciever<H, D> = tokio::sync::watch::Receiver<Option<MiningData<H, D>>>;
+type MetadataProducer<H, D> = tokio::sync::watch::Sender<Option<MiningData<H, D>>>;
+
+// so this is Unpin
+type MetadataWatchStream<H, D> = WatchStream<Option<MiningData<H, D>>>;
+
+/// A clone-able stream that yields [`MiningData`].
+/// Every instance of the stream will recieve the same data
+/// as the stream is implemented on top of a spmc channel
+/// see [`tokio::sync::watch::Receiver`]
+pub struct MiningDataStream<H: Clone, D: Clone> {
+	consumer: MetadataReciever<H, D>,
+	inner: MetadataWatchStream<H, D>,
+	version: usize,
 }
 
-impl<Block, Algorithm, C, L, Proof> MiningWorker<Block, Algorithm, C, L, Proof>
+impl<H, D> Clone for MiningDataStream<H, D>
 where
-	Block: BlockT,
-	C: sp_api::ProvideRuntimeApi<Block>,
-	Algorithm: PowAlgorithm<Block>,
-	Algorithm::Difficulty: 'static + Send,
-	L: sc_consensus::JustificationSyncLink<Block>,
-	sp_api::TransactionFor<C, Block>: Send + 'static,
+	H: 'static + Clone + Send + Sync + Unpin,
+	D: 'static + Clone + Send + Sync + Unpin,
 {
-	/// Get the current best hash. `None` if the worker has just started or the client is doing
-	/// major syncing.
-	pub fn best_hash(&self) -> Option<Block::Hash> {
-		self.build.as_ref().map(|b| b.metadata.best_hash)
-	}
+	fn clone(&self) -> Self {
+		let consumer = self.consumer.clone();
+		let inner = WatchStream::new(consumer.clone());
 
-	pub(crate) fn on_major_syncing(&mut self) {
-		self.build = None;
-	}
-
-	pub(crate) fn on_build(&mut self, build: MiningBuild<Block, Algorithm, C, Proof>) {
-		self.build = Some(build);
-	}
-
-	/// Get a copy of the current mining metadata, if available.
-	pub fn metadata(&self) -> Option<MiningMetadata<Block::Hash, Algorithm::Difficulty>> {
-		self.build.as_ref().map(|b| b.metadata.clone())
-	}
-
-	/// Submit a mined seal. The seal will be validated again. Returns true if the submission is
-	/// successful.
-	pub async fn submit(&mut self, seal: Seal) -> bool {
-		if let Some(build) = self.build.take() {
-			match self.algorithm.verify(
-				&BlockId::Hash(build.metadata.best_hash),
-				&build.metadata.pre_hash,
-				build.metadata.pre_runtime.as_ref().map(|v| &v[..]),
-				&seal,
-				build.metadata.difficulty,
-			) {
-				Ok(true) => (),
-				Ok(false) => {
-					warn!(
-						target: "pow",
-						"Unable to import mined block: seal is invalid",
-					);
-					return false
-				},
-				Err(err) => {
-					warn!(
-						target: "pow",
-						"Unable to import mined block: {:?}",
-						err,
-					);
-					return false
-				},
-			}
-
-			let seal = DigestItem::Seal(POW_ENGINE_ID, seal);
-			let (header, body) = build.proposal.block.deconstruct();
-
-			let mut import_block = BlockImportParams::new(BlockOrigin::Own, header);
-			import_block.post_digests.push(seal);
-			import_block.body = Some(body);
-			import_block.state_action =
-				StateAction::ApplyChanges(StorageChanges::Changes(build.proposal.storage_changes));
-
-			let intermediate = PowIntermediate::<Algorithm::Difficulty> {
-				difficulty: Some(build.metadata.difficulty),
-			};
-
-			import_block
-				.intermediates
-				.insert(Cow::from(INTERMEDIATE_KEY), Box::new(intermediate) as Box<_>);
-
-			let header = import_block.post_header();
-			match self.block_import.import_block(import_block, HashMap::default()).await {
-				Ok(res) => {
-					res.handle_justification(
-						&header.hash(),
-						*header.number(),
-						&mut self.justification_sync_link,
-					);
-
-					info!(
-						target: "pow",
-						"✅ Successfully mined block on top of: {}",
-						build.metadata.best_hash
-					);
-					true
-				},
-				Err(err) => {
-					warn!(
-						target: "pow",
-						"Unable to import mined block: {:?}",
-						err,
-					);
-					false
-				},
-			}
-		} else {
-			warn!(
-				target: "pow",
-				"Unable to import mined block: build does not exist",
-			);
-			false
-		}
+		Self { consumer, inner, version: 1 }
 	}
 }
 
-/// A stream that waits for a block import or timeout.
-pub struct UntilImportedOrTimeout<Block: BlockT> {
-	import_notifications: ImportNotifications<Block>,
-	timeout: Duration,
-	inner_delay: Option<Delay>,
-}
+impl<H, D> MiningDataStream<H, D>
+where
+	H: 'static + Clone + Send + Sync + Unpin,
+	D: 'static + Clone + Send + Sync + Unpin,
+{
+	pub fn new() -> (MetadataProducer<H, D>, Self) {
+		let (producer, consumer):(MetadataProducer<H, D>, MetadataReciever<H, D>) = tokio::sync::watch::channel(None);
 
-impl<Block: BlockT> UntilImportedOrTimeout<Block> {
-	/// Create a new stream using the given import notification and timeout duration.
-	pub fn new(import_notifications: ImportNotifications<Block>, timeout: Duration) -> Self {
-		Self { import_notifications, timeout, inner_delay: None }
+		let inner = WatchStream::new(consumer.clone());
+
+		(producer, Self { consumer, inner, version: 1 })
 	}
 }
 
-impl<Block: BlockT> Stream for UntilImportedOrTimeout<Block> {
-	type Item = ();
+impl<H, D> Stream for MiningDataStream<H, D>
+where
+	H: 'static + Clone + Send + Sync + Unpin,
+	D: 'static + Clone + Send + Sync + Unpin,
+{
+	type Item = MiningData<H, D>;
 
-	fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<()>> {
-		let mut fire = false;
-
-		loop {
-			match Stream::poll_next(Pin::new(&mut self.import_notifications), cx) {
-				Poll::Pending => break,
-				Poll::Ready(Some(_)) => {
-					fire = true;
-				},
-				Poll::Ready(None) => return Poll::Ready(None),
+	fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		match ready!(self.inner.poll_next_unpin(cx)) {
+			Some(Some(item)) => Poll::Ready(Some(item)),
+			Some(None) => {
+				if self.version == 1 {
+					self.version += 1;
+					return Poll::Pending;
+				}
+				Poll::Ready(None)
 			}
-		}
-
-		let timeout = self.timeout.clone();
-		let inner_delay = self.inner_delay.get_or_insert_with(|| Delay::new(timeout));
-
-		match Future::poll(Pin::new(inner_delay), cx) {
-			Poll::Pending => (),
-			Poll::Ready(()) => {
-				fire = true;
-			},
-		}
-
-		if fire {
-			self.inner_delay = None;
-			Poll::Ready(Some(()))
-		} else {
-			Poll::Pending
+			None => Poll::Ready(None),
 		}
 	}
 }


### PR DESCRIPTION
What this PR does?

This PR modifies the `sc_consensus_pow::start_mining worker` to return a clonable channel that recieves a broadcast of  the latest  mining metadata, so nodes can try to compute the seal using a multithreaded approach.