### PR TITLE
rpc-api: use `thiserror` instead of `derive_more` for error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8095,7 +8095,6 @@ dependencies = [
 name = "sc-rpc-api"
 version = "0.10.0-dev"
 dependencies = [
- "derive_more",
  "futures 0.3.16",
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -8113,6 +8112,7 @@ dependencies = [
  "sp-runtime",
  "sp-tracing",
  "sp-version",
+ "thiserror",
 ]
 
 [[package]]

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -14,7 +14,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0" }
-derive_more = "0.99.2"
 futures = "0.3.16"
 jsonrpc-core = "18.0.0"
 jsonrpc-core-client = "18.0.0"
@@ -22,6 +21,8 @@ jsonrpc-derive = "18.0.0"
 jsonrpc-pubsub = "18.0.0"
 log = "0.4.8"
 parking_lot = "0.11.1"
+thiserror = "1.0"
+
 sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
 sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
 sp-runtime = { path = "../../primitives/runtime", version = "4.0.0-dev" }

--- a/client/rpc-api/src/chain/error.rs
+++ b/client/rpc-api/src/chain/error.rs
@@ -28,22 +28,14 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub type FutureResult<T> = jsonrpc_core::BoxFuture<Result<T>>;
 
 /// Chain RPC errors.
-#[derive(Debug, derive_more::Display, derive_more::From)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
 	/// Client error.
-	#[display(fmt = "Client error: {}", _0)]
-	Client(Box<dyn std::error::Error + Send>),
+	#[error("Client error: {}", .0)]
+	Client(#[from] Box<dyn std::error::Error + Send>),
 	/// Other error type.
+	#[error("{0}")]
 	Other(String),
-}
-
-impl std::error::Error for Error {
-	fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-		match self {
-			Error::Client(ref err) => Some(&**err),
-			_ => None,
-		}
-	}
 }
 
 /// Base error code for all chain errors.

--- a/client/rpc-api/src/offchain/error.rs
+++ b/client/rpc-api/src/offchain/error.rs
@@ -24,22 +24,14 @@ use jsonrpc_core as rpc;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Offchain RPC errors.
-#[derive(Debug, derive_more::Display, derive_more::From)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
 	/// Unavailable storage kind error.
-	#[display(fmt = "This storage kind is not available yet.")]
+	#[error("This storage kind is not available yet.")]
 	UnavailableStorageKind,
 	/// Call to an unsafe RPC was denied.
-	UnsafeRpcCalled(crate::policy::UnsafeRpcError),
-}
-
-impl std::error::Error for Error {
-	fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-		match self {
-			Self::UnsafeRpcCalled(err) => Some(err),
-			_ => None,
-		}
-	}
+	#[error(transparent)]
+	UnsafeRpcCalled(#[from] crate::policy::UnsafeRpcError),
 }
 
 /// Base error code for all offchain errors.

--- a/client/rpc-api/src/state/error.rs
+++ b/client/rpc-api/src/state/error.rs
@@ -28,13 +28,13 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub type FutureResult<T> = jsonrpc_core::BoxFuture<Result<T>>;
 
 /// State RPC errors.
-#[derive(Debug, derive_more::Display, derive_more::From)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
 	/// Client error.
-	#[display(fmt = "Client error: {}", _0)]
-	Client(Box<dyn std::error::Error + Send>),
+	#[error("Client error: {}", .0)]
+	Client(#[from] Box<dyn std::error::Error + Send>),
 	/// Provided block range couldn't be resolved to a list of blocks.
-	#[display(fmt = "Cannot resolve a block range ['{:?}' ... '{:?}]. {}", from, to, details)]
+	#[error("Cannot resolve a block range ['{:?}' ... '{:?}]. {}", .from, .to, .details)]
 	InvalidBlockRange {
 		/// Beginning of the block range.
 		from: String,
@@ -44,7 +44,7 @@ pub enum Error {
 		details: String,
 	},
 	/// Provided count exceeds maximum value.
-	#[display(fmt = "count exceeds maximum value. value: {}, max: {}", value, max)]
+	#[error("count exceeds maximum value. value: {}, max: {}", .value, .max)]
 	InvalidCount {
 		/// Provided value
 		value: u32,
@@ -52,16 +52,8 @@ pub enum Error {
 		max: u32,
 	},
 	/// Call to an unsafe RPC was denied.
-	UnsafeRpcCalled(crate::policy::UnsafeRpcError),
-}
-
-impl std::error::Error for Error {
-	fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-		match self {
-			Error::Client(ref err) => Some(&**err),
-			_ => None,
-		}
-	}
+	#[error(transparent)]
+	UnsafeRpcCalled(#[from] crate::policy::UnsafeRpcError),
 }
 
 /// Base code for all state errors.

--- a/client/rpc-api/src/system/error.rs
+++ b/client/rpc-api/src/system/error.rs
@@ -25,16 +25,15 @@ use jsonrpc_core as rpc;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// System RPC errors.
-#[derive(Debug, derive_more::Display, derive_more::From)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
 	/// Provided block range couldn't be resolved to a list of blocks.
-	#[display(fmt = "Node is not fully functional: {}", _0)]
+	#[error("Node is not fully functional: {}", .0)]
 	NotHealthy(Health),
 	/// Peer argument is malformatted.
+	#[error("{0}")]
 	MalformattedPeerArg(String),
 }
-
-impl std::error::Error for Error {}
 
 /// Base code for all system errors.
 const BASE_ERROR: i64 = 2000;

--- a/client/rpc/src/chain/mod.rs
+++ b/client/rpc/src/chain/mod.rs
@@ -87,7 +87,7 @@ where
 
 				// FIXME <2329>: Database seems to limit the block number to u32 for no reason
 				let block_num: u32 = num_or_hex.try_into().map_err(|_| {
-					Error::from(format!(
+					Error::Other(format!(
 						"`{:?}` > u32::MAX, the max block number is u32.",
 						num_or_hex
 					))
@@ -332,7 +332,9 @@ fn subscribe_headers<Block, Client, F, G, S>(
 		let header = client
 			.header(BlockId::Hash(best_block_hash()))
 			.map_err(client_err)
-			.and_then(|header| header.ok_or_else(|| "Best header missing.".to_string().into()))
+			.and_then(|header| {
+				header.ok_or_else(|| Error::Other("Best header missing.".to_string()))
+			})
 			.map_err(Into::into);
 
 		// send further subscriptions


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>