### PR TITLE
Add RPC state_diffBlockStorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8061,6 +8061,7 @@ dependencies = [
  "assert_matches",
  "futures 0.3.16",
  "hash-db",
+ "hex",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "lazy_static",
@@ -8072,6 +8073,7 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sc-rpc-api",
+ "sc-rpc-server",
  "sc-tracing",
  "sc-transaction-pool",
  "sc-transaction-pool-api",
@@ -8089,13 +8091,13 @@ dependencies = [
  "sp-utils",
  "sp-version",
  "substrate-test-runtime-client",
+ "thiserror",
 ]
 
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
 dependencies = [
- "derive_more",
  "futures 0.3.16",
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -8113,6 +8115,7 @@ dependencies = [
  "sp-runtime",
  "sp-tracing",
  "sp-version",
+ "thiserror",
 ]
 
 [[package]]

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -14,7 +14,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0" }
-derive_more = "0.99.2"
 futures = "0.3.16"
 jsonrpc-core = "18.0.0"
 jsonrpc-core-client = "18.0.0"
@@ -22,6 +21,8 @@ jsonrpc-derive = "18.0.0"
 jsonrpc-pubsub = "18.0.0"
 log = "0.4.8"
 parking_lot = "0.11.1"
+thiserror = "1.0"
+
 sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
 sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
 sp-runtime = { path = "../../primitives/runtime", version = "4.0.0-dev" }

--- a/client/rpc-api/src/chain/error.rs
+++ b/client/rpc-api/src/chain/error.rs
@@ -28,22 +28,14 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub type FutureResult<T> = jsonrpc_core::BoxFuture<Result<T>>;
 
 /// Chain RPC errors.
-#[derive(Debug, derive_more::Display, derive_more::From)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
 	/// Client error.
-	#[display(fmt = "Client error: {}", _0)]
-	Client(Box<dyn std::error::Error + Send>),
+	#[error("Client error: {}", .0)]
+	Client(#[from] Box<dyn std::error::Error + Send>),
 	/// Other error type.
+	#[error("{0}")]
 	Other(String),
-}
-
-impl std::error::Error for Error {
-	fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-		match self {
-			Error::Client(ref err) => Some(&**err),
-			_ => None,
-		}
-	}
 }
 
 /// Base error code for all chain errors.

--- a/client/rpc-api/src/offchain/error.rs
+++ b/client/rpc-api/src/offchain/error.rs
@@ -24,22 +24,14 @@ use jsonrpc_core as rpc;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Offchain RPC errors.
-#[derive(Debug, derive_more::Display, derive_more::From)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
 	/// Unavailable storage kind error.
-	#[display(fmt = "This storage kind is not available yet.")]
+	#[error("This storage kind is not available yet.")]
 	UnavailableStorageKind,
 	/// Call to an unsafe RPC was denied.
-	UnsafeRpcCalled(crate::policy::UnsafeRpcError),
-}
-
-impl std::error::Error for Error {
-	fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-		match self {
-			Self::UnsafeRpcCalled(err) => Some(err),
-			_ => None,
-		}
-	}
+	#[error(transparent)]
+	UnsafeRpcCalled(#[from] crate::policy::UnsafeRpcError),
 }
 
 /// Base error code for all offchain errors.

--- a/client/rpc-api/src/state/error.rs
+++ b/client/rpc-api/src/state/error.rs
@@ -28,13 +28,13 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub type FutureResult<T> = jsonrpc_core::BoxFuture<Result<T>>;
 
 /// State RPC errors.
-#[derive(Debug, derive_more::Display, derive_more::From)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
 	/// Client error.
-	#[display(fmt = "Client error: {}", _0)]
-	Client(Box<dyn std::error::Error + Send>),
+	#[error("Client error: {}", .0)]
+	Client(#[from] Box<dyn std::error::Error + Send>),
 	/// Provided block range couldn't be resolved to a list of blocks.
-	#[display(fmt = "Cannot resolve a block range ['{:?}' ... '{:?}]. {}", from, to, details)]
+	#[error("Cannot resolve a block range ['{:?}' ... '{:?}]. {}", .from, .to, .details)]
 	InvalidBlockRange {
 		/// Beginning of the block range.
 		from: String,
@@ -44,7 +44,7 @@ pub enum Error {
 		details: String,
 	},
 	/// Provided count exceeds maximum value.
-	#[display(fmt = "count exceeds maximum value. value: {}, max: {}", value, max)]
+	#[error("count exceeds maximum value. value: {}, max: {}", .value, .max)]
 	InvalidCount {
 		/// Provided value
 		value: u32,
@@ -52,16 +52,8 @@ pub enum Error {
 		max: u32,
 	},
 	/// Call to an unsafe RPC was denied.
-	UnsafeRpcCalled(crate::policy::UnsafeRpcError),
-}
-
-impl std::error::Error for Error {
-	fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-		match self {
-			Error::Client(ref err) => Some(&**err),
-			_ => None,
-		}
-	}
+	#[error(transparent)]
+	UnsafeRpcCalled(#[from] crate::policy::UnsafeRpcError),
 }
 
 /// Base code for all state errors.

--- a/client/rpc-api/src/system/error.rs
+++ b/client/rpc-api/src/system/error.rs
@@ -25,16 +25,15 @@ use jsonrpc_core as rpc;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// System RPC errors.
-#[derive(Debug, derive_more::Display, derive_more::From)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
 	/// Provided block range couldn't be resolved to a list of blocks.
-	#[display(fmt = "Node is not fully functional: {}", _0)]
+	#[error("Node is not fully functional: {}", .0)]
 	NotHealthy(Health),
 	/// Peer argument is malformatted.
+	#[error("{0}")]
 	MalformattedPeerArg(String),
 }
-
-impl std::error::Error for Error {}
 
 /// Base code for all system errors.
 const BASE_ERROR: i64 = 2000;

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -14,12 +14,15 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 sc-rpc-api = { version = "0.10.0-dev", path = "../rpc-api" }
+sc-rpc-server = { version = "4.0.0-dev", path = "../rpc-servers" }
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 futures = "0.3.16"
 jsonrpc-pubsub = "18.0.0"
+hex = "0.4"
 log = "0.4.8"
+thiserror = "1.0"
 sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
 rpc = { package = "jsonrpc-core", version = "18.0.0" }
 sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }

--- a/client/rpc/src/chain/mod.rs
+++ b/client/rpc/src/chain/mod.rs
@@ -87,7 +87,7 @@ where
 
 				// FIXME <2329>: Database seems to limit the block number to u32 for no reason
 				let block_num: u32 = num_or_hex.try_into().map_err(|_| {
-					Error::from(format!(
+					Error::Other(format!(
 						"`{:?}` > u32::MAX, the max block number is u32.",
 						num_or_hex
 					))
@@ -332,7 +332,9 @@ fn subscribe_headers<Block, Client, F, G, S>(
 		let header = client
 			.header(BlockId::Hash(best_block_hash()))
 			.map_err(client_err)
-			.and_then(|header| header.ok_or_else(|| "Best header missing.".to_string().into()))
+			.and_then(|header| {
+				header.ok_or_else(|| Error::Other("Best header missing.".to_string()))
+			})
 			.map_err(Into::into);
 
 		// send further subscriptions

--- a/client/rpc/src/state/state_full.rs
+++ b/client/rpc/src/state/state_full.rs
@@ -680,7 +680,7 @@ where
 					.into_iter()
 					.filter(|(k, _v)| storage_key_filter(k, &prefixes))
 					.map(|(k, v)| (StorageKey(k), v.map(StorageData)))
-					.collect::<Vec<_>>();
+					.collect::<HashMap<_, _, _>>();
 				let approx_payload_size =
 					BASE_PAYLOAD + main_storage_changes.len() * AVG_STORAGE_KV;
 				if approx_payload_size > rpc_max_payload {

--- a/client/rpc/src/state/state_light.rs
+++ b/client/rpc/src/state/state_light.rs
@@ -452,6 +452,14 @@ where
 	) -> FutureResult<sp_rpc::tracing::TraceBlockResponse> {
 		async move { Err(client_err(ClientError::NotAvailableOnLightClient)) }.boxed()
 	}
+
+	fn diff_block_storage(
+		&self,
+		_block: Block::Hash,
+		_storage_prefixes: Option<Vec<String>>,
+	) -> FutureResult<sp_rpc::storage::BlockStorageChangesResponse<Block::Hash>> {
+		async move { Err(client_err(ClientError::NotAvailableOnLightClient)) }.boxed()
+	}
 }
 
 impl<Block, F, Client> ChildStateBackend<Block, Client> for LightState<Block, F, Client>

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -21,6 +21,7 @@
 
 pub mod list;
 pub mod number;
+pub mod storage;
 pub mod tracing;
 
 /// A util function to assert the result of serialization and deserialization is the same.

--- a/primitives/rpc/src/storage.rs
+++ b/primitives/rpc/src/storage.rs
@@ -37,7 +37,7 @@ pub struct BlockStorageChanges<Hash> {
 	pub storage_changes: FxHashMap<StorageKey, Option<StorageData>>,
 }
 
-/// Error response for the `state_traceBlockStorageAt` RPC.
+/// Error response for the `state_diffBlockStorage` RPC.
 #[derive(Serialize, Deserialize, Default, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct StorageChangesError {
@@ -45,12 +45,12 @@ pub struct StorageChangesError {
 	pub error: String,
 }
 
-/// Response for the `state_traceBlockStorageAt` RPC.
+/// Response for the `state_diffBlockStorage` RPC.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub enum BlockStorageChangesResponse<Hash> {
-	/// Error block tracing response
+	/// Error block storage changes response
 	StorageChangesError(StorageChangesError),
-	/// Successful block storage tracing response
+	/// Successful block storage changes response
 	BlockStorageChanges(BlockStorageChanges<Hash>),
 }

--- a/primitives/rpc/src/storage.rs
+++ b/primitives/rpc/src/storage.rs
@@ -18,6 +18,7 @@
 //! Types for working with block storage change data
 
 use serde::{Deserialize, Serialize};
+use rustc_hash::FxHashMap;
 
 use sp_core::storage::{StorageData, StorageKey};
 
@@ -33,7 +34,7 @@ pub struct BlockStorageChanges<Hash> {
 	/// prefixes. Empty vector means do not filter out any storage prefixes.
 	pub storage_prefixes: Vec<String>,
 	/// Vec of storage key-value pair.
-	pub storage_changes: Vec<(StorageKey, Option<StorageData>)>,
+	pub storage_changes: FxHashMap<StorageKey, Option<StorageData>>,
 }
 
 /// Error response for the `state_traceBlockStorageAt` RPC.

--- a/primitives/rpc/src/storage.rs
+++ b/primitives/rpc/src/storage.rs
@@ -1,0 +1,55 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types for working with block storage change data
+
+use serde::{Deserialize, Serialize};
+
+use sp_core::storage::{StorageData, StorageKey};
+
+/// Container for all related storage changes for the block being re-executed.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockStorageChanges<Hash> {
+	/// Hash of the block being re-executed
+	pub block_hash: Hash,
+	/// Parent hash
+	pub parent_hash: Hash,
+	/// Storage prefixes targets used to filter out changes that do not have one of the storage
+	/// prefixes. Empty vector means do not filter out any storage prefixes.
+	pub storage_prefixes: Vec<String>,
+	/// Vec of storage key-value pair.
+	pub storage_changes: Vec<(StorageKey, Option<StorageData>)>,
+}
+
+/// Error response for the `state_traceBlockStorageAt` RPC.
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageChangesError {
+	/// Error message
+	pub error: String,
+}
+
+/// Response for the `state_traceBlockStorageAt` RPC.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum BlockStorageChangesResponse<Hash> {
+	/// Error block tracing response
+	StorageChangesError(StorageChangesError),
+	/// Successful block storage tracing response
+	BlockStorageChanges(BlockStorageChanges<Hash>),
+}

--- a/primitives/rpc/src/storage.rs
+++ b/primitives/rpc/src/storage.rs
@@ -17,8 +17,8 @@
 
 //! Types for working with block storage change data
 
-use serde::{Deserialize, Serialize};
 use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
 
 use sp_core::storage::{StorageData, StorageKey};
 


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

waiting #9631 to be merged firstly

## Summary

Add RPC `state_diffBlockStorage` (or other better names) to fetch all changed storages for a given block.

## example

```
curl \
  -H "Content-Type: application/json" \
  -d '{"id":1, "jsonrpc":"2.0", "method": "state_diffBlockStorage", "params": ["0x0268dff7aa545d493e4640871bcdbb43a09240e5fb3efb91d9900782cabaed35", ["f0c365c3cf59d671eb72da0e7a4113c4"]]}' \
  http://localhost:9933
```

```json
{
  "jsonrpc": "2.0",
  "result": {
    "blockStorageChanges": {
      "blockHash": "0x0268dff7aa545d493e4640871bcdbb43a09240e5fb3efb91d9900782cabaed35",
      "parentHash": "0x586b7314b7412d1a25bf26070908c5c41f57adc13efba511e0ecce583e8f85fe",
      "storageChanges": {
        "0xf0c365c3cf59d671eb72da0e7a4113c49f1f0515f462cdcf84e0f1d6045dfcbb": "0x40d1e1807b010000",
        "0xf0c365c3cf59d671eb72da0e7a4113c4bbd108c4899964f707fdaffb82636065": null
      },
      "storagePrefixes": [
        "f0c365c3cf59d671eb72da0e7a4113c4"
      ]
    }
  },
  "id": 1
}
```
