### PR TITLE
New flags for vanity command 

### DIFF
--- a/client/cli/src/commands/vanity.rs
+++ b/client/cli/src/commands/vanity.rs
@@ -131,7 +131,7 @@ where
 					best = score;
 					if best >= top {
 						println!("best: {} == top: {}", best, top);
-						sender.send(utils::format_seed::<Pair>(seed.clone())).unwrap();
+						sender.send(utils::format_seed::<Pair>(seed.clone())).expect("Failed to send generated address");
 					}
 				}
 				done += 1;
@@ -153,7 +153,7 @@ where
 		});
 	}
 
-	Ok(rx.recv().unwrap())
+	Ok(rx.recv().expect("Failed to receive generated address"))
 }
 
 fn good_waypoint(done: u64) -> u64 {


### PR DESCRIPTION
This PR adds 2 options to the vanity generator command
1 - `--left`, this flag will only return addresses where the pattern is at the left most possible position (pattern: `Gabe`, address: `5Gabe...`)
2 - `--cores`, this flag makes it so multiple generators run at the same time for multithreading, the default is 1

Example using both flags:
```
subkey vanity --pattern Gabe --left --cores 4
```