### PR TITLE
improve decode for UncheckedExtrinsic

### DIFF
--- a/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -26,7 +26,7 @@ use crate::{
 	transaction_validity::{InvalidTransaction, TransactionValidityError},
 	OpaqueExtrinsic,
 };
-use codec::{Decode, Encode, EncodeLike, Error, Input, Compact};
+use codec::{Compact, Decode, Encode, EncodeLike, Error, Input};
 use sp_io::hashing::blake2_256;
 use sp_std::{fmt, prelude::*};
 
@@ -450,6 +450,9 @@ mod tests {
 	#[test]
 	fn large_bad_prefix_should_work() {
 		let encoded = Compact::<u32>::from(u32::MAX).encode();
-		assert_eq!(Ex::decode(&mut &encoded[..]), Err(Error::from("Not enough data to fill buffer")));
+		assert_eq!(
+			Ex::decode(&mut &encoded[..]),
+			Err(Error::from("Not enough data to fill buffer"))
+		);
 	}
 }

--- a/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -26,7 +26,7 @@ use crate::{
 	transaction_validity::{InvalidTransaction, TransactionValidityError},
 	OpaqueExtrinsic,
 };
-use codec::{Decode, Encode, EncodeLike, Error, Input};
+use codec::{Decode, Encode, EncodeLike, Error, Input, Compact};
 use sp_io::hashing::blake2_256;
 use sp_std::{fmt, prelude::*};
 
@@ -203,7 +203,7 @@ where
 		// with substrate's generic `Vec<u8>` type. Basically this just means accepting that there
 		// will be a prefix of vector length (we don't need
 		// to use this).
-		let _length_do_not_remove_me_see_above: Vec<()> = Decode::decode(input)?;
+		let _length_do_not_remove_me_see_above: Compact<u32> = Decode::decode(input)?;
 
 		let version = input.read_byte()?;
 
@@ -445,5 +445,11 @@ mod tests {
 		let opaque: OpaqueExtrinsic = ux.into();
 		let opaque_encoded = opaque.encode();
 		assert_eq!(opaque_encoded, encoded);
+	}
+
+	#[test]
+	fn large_bad_prefix_should_work() {
+		let encoded = Compact::<u32>::from(u32::MAX).encode();
+		assert_eq!(Ex::decode(&mut &encoded[..]), Err(Error::from("Not enough data to fill buffer")));
 	}
 }


### PR DESCRIPTION
Without this patch, decode malicious input could take forever.

I don't think this is currently a DOS issue because OpaqueExtrinsic will ensure the length prefix must be valid.

However, I am experimenting some more custom transaction format and passing user supplied data to UncheckedExtrinsic, and some my of unit tests are taking forever to complete.