### PR TITLE
Fix clippy warnings

### DIFF
--- a/primitives/api/proc-macro/src/decl_runtime_apis.rs
+++ b/primitives/api/proc-macro/src/decl_runtime_apis.rs
@@ -183,7 +183,7 @@ fn generate_native_call_generators(decl: &ItemTrait) -> Result<TokenStream> {
 		{
 			<R as #crate_::DecodeLimit>::decode_with_depth_limit(
 				#crate_::MAX_EXTRINSIC_DEPTH,
-				&mut &#crate_::Encode::encode(input)[..],
+				&#crate_::Encode::encode(input)[..],
 			).map_err(map_error)
 		}
 	));
@@ -380,6 +380,7 @@ fn generate_call_api_at_calls(decl: &ItemTrait) -> Result<TokenStream> {
 		// Generate the generator function
 		result.push(quote!(
 			#[cfg(any(feature = "std", test))]
+			#[allow(clippy::too_many_arguments)]
 			pub fn #fn_name<
 				R: #crate_::Encode + #crate_::Decode + PartialEq,
 				NC: FnOnce() -> std::result::Result<R, #crate_::ApiError> + std::panic::UnwindSafe,


### PR DESCRIPTION
This fixes following clippy warnings appearing in other projects due to code generation:
```
error: the function `<R as
self::sp_api_hidden_includes_DECL_RUNTIME_APIS::sp_api::DecodeLimit>::decode_with_depth_limit` doesn't need a mutable reference
   --> crates/sp-consensus-poc/src/lib.rs:248:1
    |
248 | / sp_api::decl_runtime_apis! {
249 | |     /// API necessary for block authorship with PoC.
250 | |     pub trait PoCApi {
251 | |         /// Return the genesis configuration for PoC. The configuration is only read on genesis.
...   |
285 | |     }
286 | | }
    | |_^
```
```
error: this function has too many arguments (8/7)
   --> crates/sp-consensus-poc/src/lib.rs:248:1
    |
248 | / sp_api::decl_runtime_apis! {
249 | |     /// API necessary for block authorship with PoC.
250 | |     pub trait PoCApi {
251 | |         /// Return the genesis configuration for PoC. The configuration is only read on genesis.
...   |
284 | |     }
285 | | }
    | | ^ in this macro invocation
    | |_|
```

Which for my project allows to forbid clippy warnings.