### PR TITLE
Fix compilation issue of `pallet_contracts`

### DIFF
--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -64,6 +64,7 @@ std = [
 	"sp-io/std",
 	"sp-std/std",
 	"sp-sandbox/std",
+	"frame-benchmarking/std",
 	"frame-support/std",
 	"frame-system/std",
 	"pwasm-utils/std",
@@ -71,6 +72,7 @@ std = [
 	"pallet-contracts-primitives/std",
 	"pallet-contracts-proc-macro/full",
 	"log/std",
+	"rand/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking",


### PR DESCRIPTION
Running `cargo check --features runtime-benchmarks` led to a compilation error when executed inside the pallet contracts directory. This was due to missing propagation of the `std` feature in some cases. This PR fixes that.

credits to @thiolliere for figuring that out