### PR TITLE
Generate storage info for pallet im_online

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -933,8 +933,8 @@ parameter_types! {
 	pub const StakingUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
 	pub const MaxAuthorities: u32 = 100;
 	pub const MaxKeys: u32 = 10_000;
-  	pub const MaxPeerInHeartbeats: u32 = 10_000;
-  	pub const MaxPeerDataEncodingSize: u32 = 1_000;
+	pub const MaxPeerInHeartbeats: u32 = 10_000;
+	pub const MaxPeerDataEncodingSize: u32 = 1_000;
 }
 
 impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Runtime
@@ -1000,8 +1000,8 @@ impl pallet_im_online::Config for Runtime {
 	type UnsignedPriority = ImOnlineUnsignedPriority;
 	type WeightInfo = pallet_im_online::weights::SubstrateWeight<Runtime>;
 	type MaxKeys = MaxKeys;
-  	type MaxPeerInHeartbeats = MaxPeerInHeartbeats;
-  	type MaxPeerDataEncodingSize = MaxPeerDataEncodingSize;
+	type MaxPeerInHeartbeats = MaxPeerInHeartbeats;
+	type MaxPeerDataEncodingSize = MaxPeerDataEncodingSize;
 }
 
 impl pallet_offences::Config for Runtime {

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -932,6 +932,9 @@ parameter_types! {
 	/// We prioritize im-online heartbeats over election solution submission.
 	pub const StakingUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
 	pub const MaxAuthorities: u32 = 100;
+	pub const MaxKeys: u32 = 10_000;
+  	pub const MaxPeerInHeartbeats: u32 = 10_000;
+  	pub const MaxPeerDataEncodingSize: u32 = 1_000;
 }
 
 impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Runtime
@@ -996,6 +999,9 @@ impl pallet_im_online::Config for Runtime {
 	type ReportUnresponsiveness = Offences;
 	type UnsignedPriority = ImOnlineUnsignedPriority;
 	type WeightInfo = pallet_im_online::weights::SubstrateWeight<Runtime>;
+	type MaxKeys = MaxKeys;
+  	type MaxPeerInHeartbeats = MaxPeerInHeartbeats;
+  	type MaxPeerDataEncodingSize = MaxPeerDataEncodingSize;
 }
 
 impl pallet_offences::Config for Runtime {

--- a/frame/im-online/src/benchmarking.rs
+++ b/frame/im-online/src/benchmarking.rs
@@ -22,7 +22,7 @@
 use super::*;
 
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
-use frame_support::traits::UnfilteredDispatchable;
+use frame_support::{traits::UnfilteredDispatchable, WeakBoundedVec};
 use frame_system::RawOrigin;
 use sp_core::{offchain::OpaqueMultiaddr, OpaquePeerId};
 use sp_runtime::{
@@ -46,7 +46,9 @@ pub fn create_heartbeat<T: Config>(
 	for _ in 0..k {
 		keys.push(T::AuthorityId::generate_pair(None));
 	}
-	Keys::<T>::put(keys.clone());
+	let bounded_keys = WeakBoundedVec::<_, T::MaxKeys>::try_from(keys)
+		.map_err(|| "More than the maximum number of keys provided")?;
+	Keys::<T>::put(bounded_keys);
 
 	let network_state = OpaqueNetworkState {
 		peer_id: OpaquePeerId::default(),

--- a/frame/im-online/src/benchmarking.rs
+++ b/frame/im-online/src/benchmarking.rs
@@ -46,7 +46,7 @@ pub fn create_heartbeat<T: Config>(
 	for _ in 0..k {
 		keys.push(T::AuthorityId::generate_pair(None));
 	}
-	let bounded_keys = WeakBoundedVec::<_, T::MaxKeys>::try_from(keys)
+	let bounded_keys = WeakBoundedVec::<_, T::MaxKeys>::try_from(keys.clone())
 		.map_err(|()| "More than the maximum number of keys provided")?;
 	Keys::<T>::put(bounded_keys);
 

--- a/frame/im-online/src/benchmarking.rs
+++ b/frame/im-online/src/benchmarking.rs
@@ -47,7 +47,7 @@ pub fn create_heartbeat<T: Config>(
 		keys.push(T::AuthorityId::generate_pair(None));
 	}
 	let bounded_keys = WeakBoundedVec::<_, T::MaxKeys>::try_from(keys)
-		.map_err(|| "More than the maximum number of keys provided")?;
+		.map_err(|()| "More than the maximum number of keys provided")?;
 	Keys::<T>::put(bounded_keys);
 
 	let network_state = OpaqueNetworkState {

--- a/frame/im-online/src/mock.rs
+++ b/frame/im-online/src/mock.rs
@@ -217,6 +217,9 @@ impl frame_support::traits::EstimateNextSessionRotation<u64> for TestNextSession
 
 parameter_types! {
 	pub const UnsignedPriority: u64 = 1 << 20;
+	pub const MaxKeys: u32 = 10_000;
+	pub const MaxPeerInHeartbeats: u32 = 10_000;
+	pub const MaxPeerDataEncodingSize: u32 = 1_000;
 }
 
 impl Config for Runtime {
@@ -227,6 +230,9 @@ impl Config for Runtime {
 	type ReportUnresponsiveness = OffenceHandler;
 	type UnsignedPriority = UnsignedPriority;
 	type WeightInfo = ();
+	type MaxKeys = MaxKeys;
+	type MaxPeerInHeartbeats = MaxPeerInHeartbeats;
+	type MaxPeerDataEncodingSize = MaxPeerDataEncodingSize;
 }
 
 impl<LocalCall> frame_system::offchain::SendTransactionTypes<LocalCall> for Runtime

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -146,6 +146,9 @@ pallet_staking_reward_curve::build! {
 parameter_types! {
 	pub const RewardCurve: &'static sp_runtime::curve::PiecewiseLinear<'static> = &I_NPOS;
 	pub const MaxNominatorRewardedPerValidator: u32 = 64;
+	pub const MaxKeys: u32 = 10_000;
+	  pub const MaxPeerInHeartbeats: u32 = 10_000;
+	  pub const MaxPeerDataEncodingSize: u32 = 1_000;
 }
 
 pub type Extrinsic = sp_runtime::testing::TestXt<Call, ()>;
@@ -186,6 +189,9 @@ impl pallet_im_online::Config for Test {
 	type ReportUnresponsiveness = Offences;
 	type UnsignedPriority = ();
 	type WeightInfo = ();
+	type MaxKeys = MaxKeys;
+	type MaxPeerInHeartbeats = MaxPeerInHeartbeats;
+	type MaxPeerDataEncodingSize = MaxPeerDataEncodingSize;
 }
 
 impl pallet_offences::Config for Test {

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -114,7 +114,7 @@ mod mock;
 mod tests;
 pub mod weights;
 
-use codec::Decode;
+use codec::{Decode, MaxEncodedLen};
 use frame_support::{
 	decl_error, decl_event, decl_module, decl_storage,
 	dispatch::{self, DispatchError, DispatchResult},
@@ -367,7 +367,7 @@ pub trait Config: frame_system::Config {
 	type Event: From<Event> + Into<<Self as frame_system::Config>::Event>;
 
 	/// A stable ID for a validator.
-	type ValidatorId: Member + Parameter;
+	type ValidatorId: Member + Parameter + MaxEncodedLen;
 
 	/// A conversion from account ID to validator ID.
 	///

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -52,7 +52,7 @@ mod misc;
 pub use misc::{
 	Backing, ConstU32, EnsureInherentsAreFirst, EstimateCallFee, ExecuteBlock, ExtrinsicCall, Get,
 	GetBacking, GetDefault, HandleLifetime, IsSubType, IsType, Len, OffchainWorker,
-	OnKilledAccount, OnNewAccount, SameOrOther, Time, TryDrop, UnixTime,
+	OnKilledAccount, OnNewAccount, SameOrOther, Time, TryDrop, UnixTime, WrapperOpaque,
 };
 
 mod stored_map;

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -17,8 +17,10 @@
 
 //! Smaller traits used in FRAME which don't need their own file.
 
-use crate::dispatch::Parameter;
+use crate::{dispatch::Parameter, TypeInfo};
+use codec::{Decode, Encode, EncodeLike, Input, MaxEncodedLen};
 use sp_runtime::{traits::Block as BlockT, DispatchError};
+use sp_std::vec::Vec;
 
 /// Anything that can have a `::len()` method.
 pub trait Len {
@@ -375,5 +377,50 @@ pub trait EstimateCallFee<Call, Balance> {
 impl<Call, Balance: From<u32>, const T: u32> EstimateCallFee<Call, Balance> for ConstU32<T> {
 	fn estimate_call_fee(_: &Call, _: crate::weights::PostDispatchInfo) -> Balance {
 		T.into()
+	}
+}
+
+/// A wrapper for any type `T` which implement encode/decode in a way compatible with `Vec<u8>`.
+///
+/// The encoding is the encoding of `T` prepended with the compact encoding of its size in bytes.
+/// Thus the encoded value can be decoded as a `Vec<u8>`.
+#[derive(Debug, Eq, PartialEq, Default, Clone, MaxEncodedLen, TypeInfo)]
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+pub struct WrapperOpaque<T>(pub T);
+
+impl<T: Encode> EncodeLike for WrapperOpaque<T> {}
+
+impl<T: Encode> Encode for WrapperOpaque<T> {
+	fn size_hint(&self) -> usize {
+		// Compact<u32> usually takes at most 4 bytes
+		self.0.size_hint().saturating_add(4)
+	}
+
+	fn encode_to<O: codec::Output + ?Sized>(&self, dest: &mut O) {
+		self.0.encode().encode_to(dest);
+	}
+
+	fn encode(&self) -> Vec<u8> {
+		self.0.encode().encode()
+	}
+
+	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+		self.0.encode().using_encoded(f)
+	}
+}
+
+impl<T: Decode> Decode for WrapperOpaque<T> {
+	fn decode<I: Input>(input: &mut I) -> Result<Self, codec::Error> {
+		Ok(Self(T::decode(&mut &<Vec<u8>>::decode(input)?[..])?))
+	}
+
+	fn skip<I: Input>(input: &mut I) -> Result<(), codec::Error> {
+		<Vec<u8>>::skip(input)
+	}
+}
+
+impl<T> From<T> for WrapperOpaque<T> {
+	fn from(t: T) -> Self {
+		Self(t)
 	}
 }

--- a/frame/support/src/traits/validation.rs
+++ b/frame/support/src/traits/validation.rs
@@ -18,7 +18,7 @@
 //! Traits for dealing with validation and validators.
 
 use crate::{dispatch::Parameter, weights::Weight};
-use codec::{Codec, Decode};
+use codec::{Codec, Decode, MaxEncodedLen};
 use sp_runtime::{
 	traits::{Convert, Zero},
 	BoundToRuntimeAppPublic, ConsensusEngineId, Permill, RuntimeAppPublic,
@@ -31,7 +31,7 @@ use sp_std::prelude::*;
 /// Something that can give information about the current validator set.
 pub trait ValidatorSet<AccountId> {
 	/// Type for representing validator id in a session.
-	type ValidatorId: Parameter;
+	type ValidatorId: Parameter + MaxEncodedLen;
 	/// A type for converting `AccountId` to `ValidatorId`.
 	type ValidatorIdOf: Convert<AccountId, Option<Self::ValidatorId>>;
 

--- a/primitives/runtime/src/testing.rs
+++ b/primitives/runtime/src/testing.rs
@@ -18,7 +18,7 @@
 //! Testing utilities.
 
 use crate::{
-	codec::{Codec, Decode, Encode},
+	codec::{Codec, Decode, Encode, MaxEncodedLen},
 	generic,
 	scale_info::TypeInfo,
 	traits::{
@@ -59,6 +59,7 @@ use std::{
 	Deserialize,
 	PartialOrd,
 	Ord,
+	MaxEncodedLen,
 	TypeInfo,
 )]
 pub struct UintAuthorityId(pub u64);


### PR DESCRIPTION
Fixes part of #8629

Refactor Im Online to use WeakBoundedVec instead of Vec, and generate storage info for that pallet.

polkadot companion: paritytech/polkadot#3744

@shawntabrizi @KiChjang @thiolliere 