### PR TITLE
reset cache when storage possibly change (fix init of tests).

### DIFF
--- a/primitives/state-machine/src/in_memory_backend.rs
+++ b/primitives/state-machine/src/in_memory_backend.rs
@@ -74,8 +74,9 @@ where
 
 	/// Apply the given transaction to this backend and set the root to the given value.
 	pub fn apply_transaction(&mut self, root: H::Out, transaction: MemoryDB<H>) {
-		self.backend_storage_mut().consolidate(transaction);
-		self.essence.set_root(root);
+		let mut storage = sp_std::mem::take(self).into_storage();
+		storage.consolidate(transaction);
+		*self = TrieBackend::new(storage, root);
 	}
 
 	/// Compare with another in-memory backend.

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -1641,8 +1641,9 @@ mod tests {
 			]
 			.into_iter(),
 		);
-		remote_backend.backend_storage_mut().consolidate(transaction);
-		remote_backend.essence.set_root(remote_root.clone());
+		let mut remote_storage = remote_backend.into_storage();
+		remote_storage.consolidate(transaction);
+		let remote_backend = TrieBackend::new(remote_storage, remote_root);
 		let remote_proof = prove_child_read(remote_backend, &child_info1, &[b"key1"]).unwrap();
 		let remote_proof = test_compact(remote_proof, &remote_root);
 		let local_result1 = read_child_proof_check::<BlakeTwo256, _>(

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -1619,7 +1619,7 @@ mod tests {
 		let child_info2 = ChildInfo::new_default(b"sub2");
 		// this root will be include in proof
 		let child_info3 = ChildInfo::new_default(b"sub");
-		let mut remote_backend = trie_backend::tests::test_trie();
+		let remote_backend = trie_backend::tests::test_trie();
 		let (remote_root, transaction) = remote_backend.full_storage_root(
 			std::iter::empty(),
 			vec![

--- a/primitives/state-machine/src/trie_backend.rs
+++ b/primitives/state-machine/src/trie_backend.rs
@@ -56,11 +56,6 @@ where
 		self.essence.backend_storage()
 	}
 
-	/// Get backend storage reference.
-	pub fn backend_storage_mut(&mut self) -> &mut S {
-		self.essence.backend_storage_mut()
-	}
-
 	/// Get trie root.
 	pub fn root(&self) -> &H::Out {
 		self.essence.root()

--- a/primitives/state-machine/src/trie_backend_essence.rs
+++ b/primitives/state-machine/src/trie_backend_essence.rs
@@ -92,14 +92,6 @@ where
 		&self.storage
 	}
 
-	/// Get backend storage reference.
-	pub fn backend_storage_mut(&mut self) -> &mut S {
-		#[cfg(feature = "std")]
-		self.reset_cache();
-
-		&mut self.storage
-	}
-
 	/// Get trie root.
 	pub fn root(&self) -> &H::Out {
 		&self.root

--- a/primitives/state-machine/src/trie_backend_essence.rs
+++ b/primitives/state-machine/src/trie_backend_essence.rs
@@ -94,6 +94,9 @@ where
 
 	/// Get backend storage reference.
 	pub fn backend_storage_mut(&mut self) -> &mut S {
+		#[cfg(feature = "std")]
+		self.reset_cache();
+
 		&mut self.storage
 	}
 


### PR DESCRIPTION
Very small pr to reset root cache when building state (in some other branch my tests did fail due to the root caching when using test externalities).