### PR TITLE
Clean up `node-template`

### DIFF
--- a/bin/node-template/node/src/command.rs
+++ b/bin/node-template/node/src/command.rs
@@ -1,20 +1,3 @@
-// This file is part of Substrate.
-
-// Copyright (C) 2017-2021 Parity Technologies (UK) Ltd.
-// SPDX-License-Identifier: Apache-2.0
-
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 use crate::{
 	chain_spec,
 	cli::{Cli, Subcommand},

--- a/bin/node-template/node/src/lib.rs
+++ b/bin/node-template/node/src/lib.rs
@@ -1,3 +1,0 @@
-pub mod chain_spec;
-pub mod rpc;
-pub mod service;


### PR DESCRIPTION
I recently used the `node-template` and those two things stood out to me:
* The file [`node-template/node/src/lib.rs`](https://github.com/paritytech/substrate/blob/master/bin/node-template/node/src/lib.rs) seems to be an old artifact. I don't see it referenced anywhere and can run the node without it.
* [`node-template/node/src/command.rs`](https://github.com/paritytech/substrate/blob/master/bin/node-template/node/src/command.rs#L1-L16) contains an Apache license header, but the `node-template` is unlicensed [here](https://github.com/paritytech/substrate/blob/master/bin/node-template/LICENSE).