### PR TITLE
Add setter configurable only for benchmarking or tests

### DIFF
--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -1591,7 +1591,7 @@ pub trait BlockNumberProvider {
 	///
 	/// It allows for setting the block number that will later be fetched
 	/// This is useful in case the block number provider is different than System
-	#[cfg(any(feature = "runtime-benchmarks", test))]
+	#[cfg(feature = "runtime-benchmarks")]
 	fn set_block_number(_block: Self::BlockNumber) {}
 }
 

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -1585,6 +1585,14 @@ pub trait BlockNumberProvider {
 	/// ```
 	/// .
 	fn current_block_number() -> Self::BlockNumber;
+
+	/// Utility function only to be used in benchmarking scenarios, to be implemented optionally,
+	/// else a noop.
+	///
+	/// It allows for setting the block number that will later be fetched
+	/// This is useful in case the block number provider is different than System
+	#[cfg(any(feature = "runtime-benchmarks", test))]
+	fn set_block_number(_block: Self::BlockNumber) {}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR adds a setter for BlockNumberProvider if compiling with runtime-benchmarks features. This allows to write benchmarking that is independent to the BlockProvider used, as it allows to set the desired mocked block number.

This is a problem we have encountered in https://github.com/PureStake/crowdloan-rewards/pull/44 (cc @JoshOrndorff), where we want to write benchmark code that is agnostic of the block provider. But to benchmark correctly one of the extrinsics, we need to specifically set the block number in the block provider.