### PR TITLE
Remove unused origin

### DIFF
--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -1063,9 +1063,6 @@ pub mod pallet {
 		CallNotAllowed,
 	}
 
-	#[pallet::origin]
-	pub struct Origin<T>(PhantomData<T>);
-
 	#[pallet::validate_unsigned]
 	impl<T: Config> ValidateUnsigned for Pallet<T> {
 		type Call = Call<T>;


### PR DESCRIPTION
pallet election provider multi phase provide an origin but doesn't associated any logic anywhere.

What is it used for ?