### PR TITLE
Fixed block response limit check

### DIFF
--- a/client/network/src/block_request_handler.rs
+++ b/client/network/src/block_request_handler.rs
@@ -62,7 +62,7 @@ pub fn generate_protocol_config(protocol_id: &ProtocolId) -> ProtocolConfig {
 		name: generate_protocol_name(protocol_id).into(),
 		max_request_size: 1024 * 1024,
 		max_response_size: 16 * 1024 * 1024,
-		request_timeout: Duration::from_secs(40),
+		request_timeout: Duration::from_secs(20),
 		inbound_queue: None,
 	}
 }
@@ -355,7 +355,8 @@ impl<B: BlockT> BlockRequestHandler<B> {
 				indexed_body,
 			};
 
-			total_size += block_data.body.len();
+			total_size += block_data.body.iter().map(|ex| ex.len()).sum::<usize>();
+			total_size += block_data.indexed_body.iter().map(|ex| ex.len()).sum::<usize>();
 			blocks.push(block_data);
 
 			if blocks.len() >= max_blocks as usize || total_size > MAX_BODY_BYTES {

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -629,7 +629,7 @@ impl<B: BlockT> Protocol<B> {
 					} else {
 						None
 					},
-					receipt: if !block_data.message_queue.is_empty() {
+					receipt: if !block_data.receipt.is_empty() {
 						Some(block_data.receipt)
 					} else {
 						None

--- a/client/network/src/protocol/sync.rs
+++ b/client/network/src/protocol/sync.rs
@@ -70,7 +70,7 @@ mod state;
 mod warp;
 
 /// Maximum blocks to request in a single packet.
-const MAX_BLOCKS_TO_REQUEST: usize = 128;
+const MAX_BLOCKS_TO_REQUEST: usize = 64;
 
 /// Maximum blocks to store in the import queue.
 const MAX_IMPORTING_BLOCKS: usize = 2048;

--- a/client/network/src/protocol/sync/blocks.rs
+++ b/client/network/src/protocol/sync/blocks.rs
@@ -194,7 +194,7 @@ impl<B: BlockT> BlockCollection<B> {
 		for r in ranges {
 			self.blocks.remove(&r);
 		}
-		trace!(target: "sync", "Drained {} blocks", drained.len());
+		trace!(target: "sync", "Drained {} blocks from {:?}", drained.len(), from);
 		drained
 	}
 


### PR DESCRIPTION
When computing block response size, the code was incorrectly counting extrinsics rather than bytes.

Also decreased `MAX_BLOCKS_TO_REQUEST` so that the nodes can sync without waiting for others to upgrade and tweaked timeout value.

Fixes https://github.com/paritytech/polkadot/issues/3778