### PR TITLE
Don't allow failure for cargo fmt

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -266,7 +266,6 @@ cargo-fmt:
   <<:                              *test-refs
   script:
     - cargo +nightly fmt --all -- --check
-  allow_failure:                   true
 
 cargo-check-benches:
   stage:                           test

--- a/client/utils/src/metrics.rs
+++ b/client/utils/src/metrics.rs
@@ -16,7 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-
 //! Metering primitives and globals
 
 use lazy_static::lazy_static;


### PR DESCRIPTION
In my opinion allowing failure for this CI check fails to accomplish what it is useful for: Allowing everyone to run `cargo fmt` without reformatting unrelated code. Code that is not properly formatted by `rustfmt` should be annotated to be skipped rather than failing the CI.