### PR TITLE
Make `SimpleSlotWorker::claim_slot()` async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7446,6 +7446,7 @@ dependencies = [
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/client/consensus/aura/Cargo.toml
+++ b/client/consensus/aura/Cargo.toml
@@ -48,4 +48,5 @@ sc-network = { version = "0.10.0-dev", path = "../../network" }
 sc-network-test = { version = "0.8.0", path = "../../network/test" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }
 tempfile = "3.1.0"
+tokio = { version = "1.10.0", features = ["rt-multi-thread", "macros"] }
 parking_lot = "0.11.1"


### PR DESCRIPTION
`SimpleSlotWorker::claim_slot()` is already called from async context and it is painful to work with if `claim_slot()` isn't async too.

There is some cloning required to satisfy the compiler, but hopefully that is acceptable.