### PR TITLE
Fix compact proof decoding unaccessed last child trie. 

### DIFF
--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -35,6 +35,7 @@ tracing = { version = "0.1.22", optional = true }
 hex-literal = "0.3.1"
 sp-runtime = { version = "4.0.0-dev", path = "../runtime" }
 pretty_assertions = "0.6.1"
+rand = { version = "0.7.2", feature = ["small_rng"] }
 
 [features]
 default = ["std"]

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -1515,7 +1515,9 @@ mod tests {
 	#[test]
 	fn prove_read_and_proof_check_works() {
 		let child_info = ChildInfo::new_default(b"sub1");
+		let missing_child_info = ChildInfo::new_default(b"sub1sub2"); // key will include other child root to proof.
 		let child_info = &child_info;
+		let missing_child_info = &missing_child_info;
 		// fetch read proof from 'remote' full node
 		let remote_backend = trie_backend::tests::test_trie();
 		let remote_root = remote_backend.storage_root(std::iter::empty()).0;
@@ -1553,11 +1555,20 @@ mod tests {
 			&[b"value2"],
 		)
 		.unwrap();
+		let local_result3 = read_child_proof_check::<BlakeTwo256, _>(
+			remote_root,
+			remote_proof.clone(),
+			missing_child_info,
+			&[b"dummy"],
+		)
+		.unwrap();
+
 		assert_eq!(
 			local_result1.into_iter().collect::<Vec<_>>(),
 			vec![(b"value3".to_vec(), Some(vec![142]))],
 		);
 		assert_eq!(local_result2.into_iter().collect::<Vec<_>>(), vec![(b"value2".to_vec(), None)]);
+		assert_eq!(local_result3.into_iter().collect::<Vec<_>>(), vec![(b"dummy".to_vec(), None)]);
 	}
 
 	#[test]

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -1573,9 +1573,9 @@ mod tests {
 
 	#[test]
 	fn child_read_compact_stress_test() {
-		use rand::{RngCore, SeedableRng};
-		use rand::rngs::SmallRng;
-		let mut storage: HashMap<Option<ChildInfo>, BTreeMap<StorageKey, StorageValue>> = Default::default();
+		use rand::{rngs::SmallRng, RngCore, SeedableRng};
+		let mut storage: HashMap<Option<ChildInfo>, BTreeMap<StorageKey, StorageValue>> =
+			Default::default();
 		let mut seed = [0; 16];
 		for i in 0..50u32 {
 			let mut child_infos = Vec::new();
@@ -1601,7 +1601,7 @@ mod tests {
 				storage.insert(Some(child_info), items);
 			}
 
-			let trie: InMemoryBackend::<BlakeTwo256> = storage.clone().into();
+			let trie: InMemoryBackend<BlakeTwo256> = storage.clone().into();
 			let trie_root = trie.root().clone();
 			let backend = crate::ProvingBackend::new(&trie);
 			let mut queries = Vec::new();
@@ -1614,7 +1614,7 @@ mod tests {
 					rand.fill_bytes(&mut key[..]);
 					ChildInfo::new_default(key.as_slice())
 				} else {
-				 child_infos[rand.next_u32() as usize % nb_child_trie].clone()
+					child_infos[rand.next_u32() as usize % nb_child_trie].clone()
 				};
 
 				if let Some(values) = storage.get(&Some(child_info.clone())) {
@@ -1623,11 +1623,18 @@ mod tests {
 						for (i, (key, value)) in values.iter().enumerate() {
 							if i == ix {
 								assert_eq!(
-									&backend.child_storage(&child_info, key.as_slice()).unwrap().unwrap(),
+									&backend
+										.child_storage(&child_info, key.as_slice())
+										.unwrap()
+										.unwrap(),
 									value
 								);
-								queries.push((child_info.clone(), key.clone(), Some(value.clone())));
-								break;
+								queries.push((
+									child_info.clone(),
+									key.clone(),
+									Some(value.clone()),
+								));
+								break
 							}
 						}
 					}

--- a/primitives/trie/src/trie_codec.rs
+++ b/primitives/trie/src/trie_codec.rs
@@ -161,8 +161,9 @@ where
 	}
 
 	let mut previous_extracted_child_trie = None;
+	let mut nodes_iter = nodes_iter.peekable();
 	for child_root in child_tries.into_iter() {
-		if previous_extracted_child_trie.is_none() {
+		if previous_extracted_child_trie.is_none() && nodes_iter.peek().is_some() {
 			let (top_root, _) =
 				trie_db::decode_compact_from_iter::<L, _, _, _>(db, &mut nodes_iter)?;
 			previous_extracted_child_trie = Some(top_root);


### PR DESCRIPTION
Found this while searching for possible issues for https://github.com/paritytech/cumulus/issues/598.

Not sure if it is the actual issue, but it is one.

The case where other child root is included in proof was incorrectly handled when the last child root included was not accessed.