### PR TITLE
`graph::ChainApi` and `graph::Pool` reexport

### DIFF
--- a/client/transaction-pool/src/lib.rs
+++ b/client/transaction-pool/src/lib.rs
@@ -44,7 +44,7 @@ use futures::{
 	future::{self, ready},
 	prelude::*,
 };
-pub use graph::{Options, Transaction};
+pub use graph::{Options, Transaction, ChainApi, Pool};
 use parking_lot::Mutex;
 use std::{
 	collections::{HashMap, HashSet},

--- a/client/transaction-pool/src/lib.rs
+++ b/client/transaction-pool/src/lib.rs
@@ -44,7 +44,7 @@ use futures::{
 	future::{self, ready},
 	prelude::*,
 };
-pub use graph::{Options, Transaction, ChainApi, Pool};
+pub use graph::{ChainApi, Options, Pool, Transaction};
 use parking_lot::Mutex;
 use std::{
 	collections::{HashMap, HashSet},
@@ -451,7 +451,7 @@ where
 		at: &BlockId<Self::Block>,
 		xt: sc_transaction_pool_api::LocalTransactionFor<Self>,
 	) -> Result<Self::Hash, Self::Error> {
-		use graph::{ChainApi, ValidatedTransaction};
+		use graph::ValidatedTransaction;
 		use sp_runtime::{
 			traits::SaturatedConversion, transaction_validity::TransactionValidityError,
 		};


### PR DESCRIPTION
With https://github.com/paritytech/substrate/pull/9228 `ChainApi` trait is only available in the `test_helpers` module - which's name is misleading when importing it as a dependency in a project.

This PR just reexports `ChainApi` and `Pool` - previously publicly available in `sc_transaction_graph` crate. 