### PR TITLE
Dont Convert Benchmark Error Too Early

### DIFF
--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -644,7 +644,7 @@ macro_rules! benchmark_backend {
 				&self,
 				components: &[($crate::BenchmarkParameter, u32)],
 				verify: bool
-			) -> Result<$crate::Box<dyn FnOnce() -> Result<(), $crate::BenchmarkError>>, &'static str> {
+			) -> Result<$crate::Box<dyn FnOnce() -> Result<(), $crate::BenchmarkError>>, $crate::BenchmarkError> {
 				$(
 					// Prepare instance
 					let $param = components.iter()
@@ -717,7 +717,7 @@ macro_rules! selected_benchmark {
 				&self,
 				components: &[($crate::BenchmarkParameter, u32)],
 				verify: bool
-			) -> Result<$crate::Box<dyn FnOnce() -> Result<(), $crate::BenchmarkError>>, &'static str> {
+			) -> Result<$crate::Box<dyn FnOnce() -> Result<(), $crate::BenchmarkError>>, $crate::BenchmarkError> {
 				match self {
 					$(
 						Self::$bench => <
@@ -1246,7 +1246,7 @@ macro_rules! impl_benchmark_test_suite {
 									}
 								}
 							},
-							Ok(Ok(_)) => (),
+							Ok(Ok(())) => (),
 						}
 					}
 					assert!(!anything_failed);

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -318,7 +318,7 @@ pub trait BenchmarkingSetup<T, I = ()> {
 		&self,
 		components: &[(BenchmarkParameter, u32)],
 		verify: bool,
-	) -> Result<Box<dyn FnOnce() -> Result<(), BenchmarkError>>, &'static str>;
+	) -> Result<Box<dyn FnOnce() -> Result<(), BenchmarkError>>, BenchmarkError>;
 }
 
 /// Grab an account, seeded by a name and index.

--- a/frame/bounties/src/benchmarking.rs
+++ b/frame/bounties/src/benchmarking.rs
@@ -134,7 +134,7 @@ benchmarks! {
 		Bounties::<T>::on_initialize(T::BlockNumber::zero());
 
 		let bounty_id = BountyCount::get() - 1;
-		let curator = T::Lookup::lookup(curator_lookup).map_err(|e| -> &'static str { e.into() } )?;
+		let curator = T::Lookup::lookup(curator_lookup).map_err(<&str>::from)?;
 
 		let beneficiary = T::Lookup::unlookup(account("beneficiary", 0, SEED));
 	}: _(RawOrigin::Signed(curator), bounty_id, beneficiary)
@@ -145,7 +145,7 @@ benchmarks! {
 		Bounties::<T>::on_initialize(T::BlockNumber::zero());
 
 		let bounty_id = BountyCount::get() - 1;
-		let curator = T::Lookup::lookup(curator_lookup).map_err(|e| -> &'static str { e.into() } )?;
+		let curator = T::Lookup::lookup(curator_lookup).map_err(<&str>::from)?;
 
 
 		let beneficiary_account: T::AccountId = account("beneficiary", 0, SEED);
@@ -183,7 +183,7 @@ benchmarks! {
 		Bounties::<T>::on_initialize(T::BlockNumber::zero());
 
 		let bounty_id = BountyCount::get() - 1;
-		let curator = T::Lookup::lookup(curator_lookup).map_err(|e| -> &'static str { e.into() } )?;
+		let curator = T::Lookup::lookup(curator_lookup).map_err(<&str>::from)?;
 	}: _(RawOrigin::Signed(curator), bounty_id, Vec::new())
 	verify {
 		assert_last_event::<T>(RawEvent::BountyExtended(bounty_id).into())

--- a/frame/bounties/src/benchmarking.rs
+++ b/frame/bounties/src/benchmarking.rs
@@ -134,7 +134,8 @@ benchmarks! {
 		Bounties::<T>::on_initialize(T::BlockNumber::zero());
 
 		let bounty_id = BountyCount::get() - 1;
-		let curator = T::Lookup::lookup(curator_lookup)?;
+		let curator = T::Lookup::lookup(curator_lookup).map_err(|e| -> &'static str { e.into() } )?;
+
 		let beneficiary = T::Lookup::unlookup(account("beneficiary", 0, SEED));
 	}: _(RawOrigin::Signed(curator), bounty_id, beneficiary)
 
@@ -144,7 +145,8 @@ benchmarks! {
 		Bounties::<T>::on_initialize(T::BlockNumber::zero());
 
 		let bounty_id = BountyCount::get() - 1;
-		let curator = T::Lookup::lookup(curator_lookup)?;
+		let curator = T::Lookup::lookup(curator_lookup).map_err(|e| -> &'static str { e.into() } )?;
+
 
 		let beneficiary_account: T::AccountId = account("beneficiary", 0, SEED);
 		let beneficiary = T::Lookup::unlookup(beneficiary_account.clone());
@@ -181,7 +183,7 @@ benchmarks! {
 		Bounties::<T>::on_initialize(T::BlockNumber::zero());
 
 		let bounty_id = BountyCount::get() - 1;
-		let curator = T::Lookup::lookup(curator_lookup)?;
+		let curator = T::Lookup::lookup(curator_lookup).map_err(|e| -> &'static str { e.into() } )?;
 	}: _(RawOrigin::Signed(curator), bounty_id, Vec::new())
 	verify {
 		assert_last_event::<T>(RawEvent::BountyExtended(bounty_id).into())

--- a/frame/collective/Cargo.toml
+++ b/frame/collective/Cargo.toml
@@ -39,6 +39,7 @@ std = [
 	"sp-runtime/std",
 	"frame-system/std",
 	"log/std",
+	"frame-benchmarking/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking",

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -2187,7 +2187,7 @@ benchmarks! {
 			);
 		}
 		#[cfg(not(feature = "std"))]
-		return Err("Run this bench with a native runtime in order to see the schedule.");
+		return Err("Run this bench with a native runtime in order to see the schedule.".into());
 	}: {}
 
 	// Execute one erc20 transfer using the ink! erc20 example contract.

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -1213,7 +1213,7 @@ benchmarks! {
 
 		for addr in &addresses {
 			if let Some(_) = ContractInfoOf::<T>::get(&addr) {
-				return Err("Expected that contract does not exist at this point.");
+				return Err("Expected that contract does not exist at this point.".into());
 			}
 		}
 	}: call(origin, callee, 0u32.into(), Weight::max_value(), vec![])

--- a/frame/election-provider-multi-phase/src/benchmarking.rs
+++ b/frame/election-provider-multi-phase/src/benchmarking.rs
@@ -279,7 +279,7 @@ frame_benchmarking::benchmarks! {
 		let raw_solution = solution_with_size::<T>(witness, a, d)?;
 		let ready_solution =
 			<MultiPhase<T>>::feasibility_check(raw_solution, ElectionCompute::Signed)
-				.map_err(|e| -> &'static str { e.into() } )?;
+				.map_err(<&str>::from)?;
 		<CurrentPhase<T>>::put(Phase::Signed);
 		// assume a queued solution is stored, regardless of where it comes from.
 		<QueuedSolution<T>>::put(ready_solution);

--- a/frame/election-provider-multi-phase/src/benchmarking.rs
+++ b/frame/election-provider-multi-phase/src/benchmarking.rs
@@ -308,7 +308,7 @@ frame_benchmarking::benchmarks! {
 			..Default::default()
 		};
 
-		<MultiPhase<T>>::create_snapshot().map_err(|e| -> &'static str { e.into() } )?;
+		<MultiPhase<T>>::create_snapshot().map_err(<&str>::from)?;
 		MultiPhase::<T>::on_initialize_open_signed();
 		<Round<T>>::put(1);
 

--- a/frame/election-provider-multi-phase/src/benchmarking.rs
+++ b/frame/election-provider-multi-phase/src/benchmarking.rs
@@ -278,7 +278,8 @@ frame_benchmarking::benchmarks! {
 		let witness = SolutionOrSnapshotSize { voters: v, targets: t };
 		let raw_solution = solution_with_size::<T>(witness, a, d)?;
 		let ready_solution =
-			<MultiPhase<T>>::feasibility_check(raw_solution, ElectionCompute::Signed)?;
+			<MultiPhase<T>>::feasibility_check(raw_solution, ElectionCompute::Signed)
+				.map_err(|e| -> &'static str { e.into() } )?;
 		<CurrentPhase<T>>::put(Phase::Signed);
 		// assume a queued solution is stored, regardless of where it comes from.
 		<QueuedSolution<T>>::put(ready_solution);
@@ -307,7 +308,7 @@ frame_benchmarking::benchmarks! {
 			..Default::default()
 		};
 
-		<MultiPhase<T>>::create_snapshot()?;
+		<MultiPhase<T>>::create_snapshot().map_err(|e| -> &'static str { e.into() } )?;
 		MultiPhase::<T>::on_initialize_open_signed();
 		<Round<T>>::put(1);
 

--- a/frame/im-online/src/benchmarking.rs
+++ b/frame/im-online/src/benchmarking.rs
@@ -83,7 +83,7 @@ benchmarks! {
 		let call = Call::heartbeat(input_heartbeat, signature);
 	}: {
 		ImOnline::<T>::validate_unsigned(TransactionSource::InBlock, &call)
-			.map_err(|e| -> &'static str { e.into() })?;
+			.map_err(<&str>::from)?;
 	}
 
 	validate_unsigned_and_then_heartbeat {
@@ -93,7 +93,7 @@ benchmarks! {
 		let call = Call::heartbeat(input_heartbeat, signature);
 	}: {
 		ImOnline::<T>::validate_unsigned(TransactionSource::InBlock, &call)
-			.map_err(|e| -> &'static str { e.into() })?;
+			.map_err(<&str>::from)?;
 		call.dispatch_bypass_filter(RawOrigin::None.into())?;
 	}
 }

--- a/frame/indices/Cargo.toml
+++ b/frame/indices/Cargo.toml
@@ -42,5 +42,6 @@ std = [
 runtime-benchmarks = [
 	"frame-benchmarking",
 	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/frame/multisig/Cargo.toml
+++ b/frame/multisig/Cargo.toml
@@ -39,5 +39,6 @@ std = [
 runtime-benchmarks = [
 	"frame-benchmarking",
 	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
 ]
 try-runtime = ["frame-support/try-runtime"]


### PR DESCRIPTION
This PR fixes an issue where the benchmarking pipeline was converting a `BenchmarkError` into a string too early, and thus losing some of the information that could be propagated upward.

This simple change fixes that.