### PR TITLE
Remove unused in state machine

### DIFF
--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -35,7 +35,7 @@ tracing = { version = "0.1.22", optional = true }
 hex-literal = "0.3.1"
 sp-runtime = { version = "4.0.0-dev", path = "../runtime" }
 pretty_assertions = "0.6.1"
-rand = { version = "0.7.2", feature = ["small_rng"] }
+rand = { version = "0.7.2" }
 
 [features]
 default = ["std"]

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -1579,7 +1579,7 @@ mod tests {
 		let mut seed = [0; 16];
 		for i in 0..50u32 {
 			let mut child_infos = Vec::new();
-			&seed[0..4].copy_from_slice(&i.to_be_bytes()[..]);
+			seed[0..4].copy_from_slice(&i.to_be_bytes()[..]);
 			let mut rand = SmallRng::from_seed(seed);
 
 			let nb_child_trie = rand.next_u32() as usize % 25;


### PR DESCRIPTION
* the features `small_rng` for rand in dev dependency is misswritten and never used (or is the feature about configuring a faster rng for tests ?)
* some unneeded borrow of unit type was done (the type is `&()`).