### PR TITLE
pin `names` crate reference to prevent using ancient `rand` versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,12 +2015,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4144,10 +4138,9 @@ dependencies = [
 [[package]]
 name = "names"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
+source = "git+https://github.com/fnichol/names?rev=8ff6d9a0b5e52fd2454fdeac21c57f372d2da4e3#8ff6d9a0b5e52fd2454fdeac21c57f372d2da4e3"
 dependencies = [
- "rand 0.3.23",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -6566,29 +6559,6 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -6632,21 +6602,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.2",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -6741,15 +6696,6 @@ dependencies = [
  "crossbeam-utils 0.8.3",
  "lazy_static",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -37,7 +37,7 @@ sp-keystore = { version = "0.10.0-dev", path = "../../primitives/keystore" }
 sc-service = { version = "0.10.0-dev", default-features = false, path = "../service" }
 sc-telemetry = { version = "4.0.0-dev", path = "../telemetry" }
 sp-keyring = { version = "4.0.0-dev", path = "../../primitives/keyring" }
-names = { version = "0.11.0", default-features = false }
+names = { default-features = false, git = "https://github.com/fnichol/names", rev= "8ff6d9a0b5e52fd2454fdeac21c57f372d2da4e3" }
 structopt = "0.3.8"
 sc-tracing = { version = "4.0.0-dev", path = "../tracing" }
 chrono = "0.4.10"

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -37,7 +37,7 @@ sp-keystore = { version = "0.10.0-dev", path = "../../primitives/keystore" }
 sc-service = { version = "0.10.0-dev", default-features = false, path = "../service" }
 sc-telemetry = { version = "4.0.0-dev", path = "../telemetry" }
 sp-keyring = { version = "4.0.0-dev", path = "../../primitives/keyring" }
-names = "0.11.0"
+names = { version = "0.11.0", default-features = false }
 structopt = "0.3.8"
 sc-tracing = { version = "4.0.0-dev", path = "../tracing" }
 chrono = "0.4.10"


### PR DESCRIPTION
`sc-cli` depends on a crate called `names`. It generates random node names such as `complete-books-0731` when users the user starts a node without providing `--name`.

The latest [`names`](https://github.com/fnichol/names) crate version is 0.11.0 and still depends on an ancient versions of rand and the dependencies resolution bring 2 old versions of rand in our tree: 0.3.23 + 0.4.6.
 
This PR pins `names` to a more recent commit and allows the dependency resolution to drop 0.3.23 and 0.4.6 and another set of related deps.