### PR TITLE
WIP - Switch to using ss58-registry crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9017,6 +9017,7 @@ dependencies = [
  "sp-serializer",
  "sp-std",
  "sp-storage",
+ "ss58-registry",
  "substrate-bip39",
  "thiserror",
  "tiny-bip39",
@@ -9527,6 +9528,17 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "ss58-registry"
+version = "0.1.0"
+source = "git+https://github.com/gilescope/ss58-registry.git?branch=initial#1a454cc533a4bdda26308ec4c662e85355c850a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "stable_deref_trait"

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -64,6 +64,8 @@ hex = { version = "0.4", default-features = false, optional = true }
 twox-hash = { version = "1.5.0", default-features = false, optional = true }
 libsecp256k1 = { version = "0.6", default-features = false, features = ["hmac", "static-context"], optional = true }
 merlin = { version = "2.0", default-features = false, optional = true }
+ss58-registry = { git = "https://github.com/gilescope/ss58-registry.git", branch = "initial" }
+# ss58-registry = { path = "/home/gilescope/git/ss58-registry-fork" }
 
 sp-runtime-interface = { version = "4.0.0-dev", default-features = false, path = "../runtime-interface" }
 

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -26,8 +26,6 @@ use crate::{ed25519, sr25519};
 use base58::{FromBase58, ToBase58};
 use codec::{Decode, Encode, MaxEncodedLen};
 #[cfg(feature = "std")]
-use parking_lot::Mutex;
-#[cfg(feature = "std")]
 use rand::{rngs::OsRng, RngCore};
 #[cfg(feature = "std")]
 use regex::Regex;
@@ -37,8 +35,6 @@ pub use secrecy::ExposeSecret;
 #[cfg(feature = "std")]
 pub use secrecy::SecretString;
 use sp_runtime_interface::pass_by::PassByInner;
-#[cfg(feature = "std")]
-use sp_std::convert::TryInto;
 #[doc(hidden)]
 pub use sp_std::ops::Deref;
 use sp_std::{convert::TryFrom, hash::Hash, str, vec::Vec};
@@ -234,7 +230,7 @@ pub trait Ss58Codec: Sized + AsMut<[u8]> + AsRef<[u8]> + Default {
 	fn from_ss58check(s: &str) -> Result<Self, PublicError> {
 		Self::from_ss58check_with_version(s).and_then(|(r, v)| match v {
 			v if !v.is_custom() => Ok(r),
-			v if v == *DEFAULT_VERSION.lock() => Ok(r),
+			v if v.is_default() => Ok(r),
 			_ => Err(PublicError::UnknownVersion),
 		})
 	}
@@ -269,7 +265,7 @@ pub trait Ss58Codec: Sized + AsMut<[u8]> + AsRef<[u8]> + Default {
 		if data.len() != prefix_len + body_len + CHECKSUM_LEN {
 			return Err(PublicError::BadLength)
 		}
-		let format = ident.try_into().map_err(|_: ()| PublicError::UnknownVersion)?;
+		let format = ident.into();
 		if !Self::format_is_allowed(format) {
 			return Err(PublicError::FormatNotAllowed)
 		}
@@ -290,7 +286,7 @@ pub trait Ss58Codec: Sized + AsMut<[u8]> + AsRef<[u8]> + Default {
 	fn from_string(s: &str) -> Result<Self, PublicError> {
 		Self::from_string_with_version(s).and_then(|(r, v)| match v {
 			v if !v.is_custom() => Ok(r),
-			v if v == *DEFAULT_VERSION.lock() => Ok(r),
+			v if v.is_default() => Ok(r),
 			_ => Err(PublicError::UnknownVersion),
 		})
 	}
@@ -321,7 +317,7 @@ pub trait Ss58Codec: Sized + AsMut<[u8]> + AsRef<[u8]> + Default {
 	/// Return the ss58-check string for this key.
 	#[cfg(feature = "std")]
 	fn to_ss58check(&self) -> String {
-		self.to_ss58check_with_version(*DEFAULT_VERSION.lock())
+		self.to_ss58check_with_version(Ss58AddressFormat::default())
 	}
 
 	/// Some if the string is a properly encoded SS58Check address, optionally with
@@ -354,275 +350,10 @@ fn ss58hash(data: &[u8]) -> blake2_rfc::blake2b::Blake2bResult {
 	context.finalize()
 }
 
-#[cfg(feature = "std")]
-lazy_static::lazy_static! {
-	static ref DEFAULT_VERSION: Mutex<Ss58AddressFormat>
-		= Mutex::new(Ss58AddressFormat::SubstrateAccount);
-}
-
 #[cfg(feature = "full_crypto")]
-macro_rules! ss58_address_format {
-	( $( $identifier:tt => ($number:expr, $name:expr, $desc:tt) )* ) => (
-		/// A known address (sub)format/network ID for SS58.
-		#[derive(Copy, Clone, PartialEq, Eq, crate::RuntimeDebug)]
-		pub enum Ss58AddressFormat {
-			$(#[doc = $desc] $identifier),*,
-			/// Use a manually provided numeric value as a standard identifier
-			Custom(u16),
-		}
+ss58_registry::ss58_registry!();
 
-		#[cfg(feature = "std")]
-		impl std::fmt::Display for Ss58AddressFormat {
-			fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-				match self {
-					$(
-						Ss58AddressFormat::$identifier => write!(f, "{}", $name),
-					)*
-					Ss58AddressFormat::Custom(x) => write!(f, "{}", x),
-				}
 
-			}
-		}
-
-		static ALL_SS58_ADDRESS_FORMATS: [Ss58AddressFormat; 0 $(+ { let _ = $number; 1})*] = [
-			$(Ss58AddressFormat::$identifier),*,
-		];
-
-		impl Ss58AddressFormat {
-			/// names of all address formats
-			pub fn all_names() -> &'static [&'static str] {
-				&[
-					$($name),*,
-				]
-			}
-			/// All known address formats.
-			pub fn all() -> &'static [Ss58AddressFormat] {
-				&ALL_SS58_ADDRESS_FORMATS
-			}
-
-			/// Whether the address is custom.
-			pub fn is_custom(&self) -> bool {
-				matches!(self, Self::Custom(_))
-			}
-		}
-
-		impl TryFrom<u8> for Ss58AddressFormat {
-			type Error = ();
-
-			fn try_from(x: u8) -> Result<Ss58AddressFormat, ()> {
-				Ss58AddressFormat::try_from(x as u16)
-			}
-		}
-
-		impl From<Ss58AddressFormat> for u16 {
-			fn from(x: Ss58AddressFormat) -> u16 {
-				match x {
-					$(Ss58AddressFormat::$identifier => $number),*,
-					Ss58AddressFormat::Custom(n) => n,
-				}
-			}
-		}
-
-		impl TryFrom<u16> for Ss58AddressFormat {
-			type Error = ();
-
-			fn try_from(x: u16) -> Result<Ss58AddressFormat, ()> {
-				match x {
-					$($number => Ok(Ss58AddressFormat::$identifier)),*,
-					_ => Ok(Ss58AddressFormat::Custom(x)),
-				}
-			}
-		}
-
-		/// Error encountered while parsing `Ss58AddressFormat` from &'_ str
-		/// unit struct for now.
-		#[derive(Copy, Clone, PartialEq, Eq, crate::RuntimeDebug)]
-		pub struct ParseError;
-
-		impl<'a> TryFrom<&'a str> for Ss58AddressFormat {
-			type Error = ParseError;
-
-			fn try_from(x: &'a str) -> Result<Ss58AddressFormat, Self::Error> {
-				match x {
-					$($name => Ok(Ss58AddressFormat::$identifier)),*,
-					a => a.parse::<u16>().map(Ss58AddressFormat::Custom).map_err(|_| ParseError),
-				}
-			}
-		}
-
-		#[cfg(feature = "std")]
-		impl std::str::FromStr for Ss58AddressFormat {
-			type Err = ParseError;
-
-			fn from_str(data: &str) -> Result<Self, Self::Err> {
-				Self::try_from(data)
-			}
-		}
-
-		#[cfg(feature = "std")]
-		impl std::fmt::Display for ParseError {
-			fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-				write!(f, "failed to parse network value as u8")
-			}
-		}
-
-		#[cfg(feature = "std")]
-		impl Default for Ss58AddressFormat {
-			fn default() -> Self {
-				*DEFAULT_VERSION.lock()
-			}
-		}
-
-		#[cfg(feature = "std")]
-		impl From<Ss58AddressFormat> for String {
-			fn from(x: Ss58AddressFormat) -> String {
-				x.to_string()
-			}
-		}
-	)
-}
-
-#[cfg(feature = "full_crypto")]
-ss58_address_format!(
-	PolkadotAccount =>
-		(0, "polkadot", "Polkadot Relay-chain, standard account (*25519).")
-	BareSr25519 =>
-		(1, "sr25519", "Bare 32-bit Schnorr/Ristretto 25519 (S/R 25519) key.")
-	KusamaAccount =>
-		(2, "kusama", "Kusama Relay-chain, standard account (*25519).")
-	BareEd25519 =>
-		(3, "ed25519", "Bare 32-bit Edwards Ed25519 key.")
-	KatalChainAccount =>
-		(4, "katalchain", "Katal Chain, standard account (*25519).")
-	PlasmAccount =>
-		(5, "plasm", "Plasm Network, standard account (*25519).")
-	BifrostAccount =>
-		(6, "bifrost", "Bifrost mainnet, direct checksum, standard account (*25519).")
-	EdgewareAccount =>
-		(7, "edgeware", "Edgeware mainnet, standard account (*25519).")
-	KaruraAccount =>
-		(8, "karura", "Acala Karura canary network, standard account (*25519).")
-	ReynoldsAccount =>
-		(9, "reynolds", "Laminar Reynolds canary network, standard account (*25519).")
-	AcalaAccount =>
-		(10, "acala", "Acala mainnet, standard account (*25519).")
-	LaminarAccount =>
-		(11, "laminar", "Laminar mainnet, standard account (*25519).")
-	PolymathAccount =>
-		(12, "polymath", "Polymath network, standard account (*25519).")
-	SubstraTeeAccount =>
-		(13, "substratee", "Any SubstraTEE off-chain network private account (*25519).")
-	TotemAccount =>
-		(14, "totem", "Any Totem Live Accounting network standard account (*25519).")
-	SynesthesiaAccount =>
-		(15, "synesthesia", "Synesthesia mainnet, standard account (*25519).")
-	KulupuAccount =>
-		(16, "kulupu", "Kulupu mainnet, standard account (*25519).")
-	DarkAccount =>
-		(17, "dark", "Dark mainnet, standard account (*25519).")
-	DarwiniaAccount =>
-		(18, "darwinia", "Darwinia Chain mainnet, standard account (*25519).")
-	GeekAccount =>
-		(19, "geek", "GeekCash mainnet, standard account (*25519).")
-	StafiAccount =>
-		(20, "stafi", "Stafi mainnet, standard account (*25519).")
-	DockTestAccount =>
-		(21, "dock-testnet", "Dock testnet, standard account (*25519).")
-	DockMainAccount =>
-		(22, "dock-mainnet", "Dock mainnet, standard account (*25519).")
-	ShiftNrg =>
-		(23, "shift", "ShiftNrg mainnet, standard account (*25519).")
-	ZeroAccount =>
-		(24, "zero", "ZERO mainnet, standard account (*25519).")
-	AlphavilleAccount =>
-		(25, "alphaville", "ZERO testnet, standard account (*25519).")
-	JupiterAccount =>
-		(26, "jupiter", "Jupiter testnet, standard account (*25519).")
-	SubsocialAccount =>
-		(28, "subsocial", "Subsocial network, standard account (*25519).")
-	DhiwayAccount =>
-		(29, "cord", "Dhiway CORD network, standard account (*25519).")
-	PhalaAccount =>
-		(30, "phala", "Phala Network, standard account (*25519).")
-	LitentryAccount =>
-		(31, "litentry", "Litentry Network, standard account (*25519).")
-	RobonomicsAccount =>
-		(32, "robonomics", "Any Robonomics network standard account (*25519).")
-	DataHighwayAccount =>
-		(33, "datahighway", "DataHighway mainnet, standard account (*25519).")
-	AresAccount =>
-		(34, "ares", "Ares Protocol, standard account (*25519).")
-	ValiuAccount =>
-		(35, "vln", "Valiu Liquidity Network mainnet, standard account (*25519).")
-	CentrifugeAccount =>
-		(36, "centrifuge", "Centrifuge Chain mainnet, standard account (*25519).")
-	NodleAccount =>
-		(37, "nodle", "Nodle Chain mainnet, standard account (*25519).")
-	KiltAccount =>
-		(38, "kilt", "KILT Chain mainnet, standard account (*25519).")
-	PolimecAccount =>
-		(41, "poli", "Polimec Chain mainnet, standard account (*25519).")
-	SubstrateAccount =>
-		(42, "substrate", "Any Substrate network, standard account (*25519).")
-	BareSecp256k1 =>
-		(43, "secp256k1", "Bare ECDSA SECP256k1 key.")
-	ChainXAccount =>
-		(44, "chainx", "ChainX mainnet, standard account (*25519).")
-	UniartsAccount =>
-		(45, "uniarts", "UniArts Chain mainnet, standard account (*25519).")
-	Reserved46 =>
-		(46, "reserved46", "Reserved for future use (46).")
-	Reserved47 =>
-		(47, "reserved47", "Reserved for future use (47).")
-	NeatcoinAccount =>
-		(48, "neatcoin", "Neatcoin mainnet, standard account (*25519).")
-	HydraDXAccount =>
-		(63, "hydradx", "HydraDX standard account (*25519).")
-	AventusAccount =>
-		(65, "aventus", "Aventus Chain mainnet, standard account (*25519).")
-	CrustAccount =>
-		(66, "crust", "Crust Network, standard account (*25519).")
-	EquilibriumAccount =>
-		(67, "equilibrium", "Equilibrium Network, standard account (*25519).")
-	SoraAccount =>
-		(69, "sora", "SORA Network, standard account (*25519).")
-  ZeitgeistAccount =>
-		(73, "zeitgeist", "Zeitgeist network, standard account (*25519).")
-	MantaAccount =>
-		(77, "manta", "Manta Network, standard account (*25519).")
-	CalamariAccount =>
-		(78, "calamari", "Manta Canary Network, standard account (*25519).")
-	PolkaSmith =>
-		(98, "polkasmith", "PolkaSmith Canary Network, standard account (*25519).")
-	PolkaFoundry =>
-		(99, "polkafoundry", "PolkaFoundry Network, standard account (*25519).")
-  OriginTrailAccount =>
-		(101, "origintrail-parachain", "OriginTrail Parachain, ethereumm account (ECDSA).")
-	HeikoAccount =>
-		(110, "heiko", "Heiko, session key (*25519).")
-	ParallelAccount =>
-		(172, "parallel", "Parallel, session key (*25519).")
-	SocialAccount =>
-		(252, "social-network", "Social Network, standard account (*25519).")
-	Moonbeam =>
-		(1284, "moonbeam", "Moonbeam, session key (*25519).")
-	Moonriver =>
-		(1285, "moonriver", "Moonriver, session key (*25519).")
-	BasiliskAccount =>
-		(10041, "basilisk", "Basilisk standard account (*25519).")
-
-	// Note: 16384 and above are reserved.
-);
-
-/// Set the default "version" (actually, this is a bit of a misnomer and the version byte is
-/// typically used not just to encode format/version but also network identity) that is used for
-/// encoding and decoding SS58 addresses. If an unknown version is provided then it fails.
-///
-/// See `ss58_address_format!` for all current known "versions".
-#[cfg(feature = "std")]
-pub fn set_default_ss58_version(version: Ss58AddressFormat) {
-	*DEFAULT_VERSION.lock() = version
-}
 
 #[cfg(feature = "std")]
 lazy_static::lazy_static! {


### PR DESCRIPTION
Kicking the tires of the ss58-registry crate. 
(This is pointing to the initial crate PR for now.)

Slight changes:
Default using atomic rather than a mutex.
u8/u16 conversions are From rather than TryFrom as they are infallible due to the Custom(u16) arm of the enum.