### PR TITLE
Add ERC20 compatible trait to retrieve name, symbol, decimals and all…

### DIFF
--- a/frame/assets/src/functions.rs
+++ b/frame/assets/src/functions.rs
@@ -18,6 +18,7 @@
 //! Functions for the Assets pallet.
 
 use super::*;
+use frame_support::traits::Get;
 
 // The main implementation block for the module.
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
@@ -477,5 +478,86 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 		Self::deposit_event(Event::Transferred(id, source.clone(), dest.clone(), credit));
 		Ok(credit)
+	}
+
+	/// Creates an approval from `owner` to spend `amount` of asset `id` tokens by 'delegate'
+	/// while reserving `T::ApprovalDeposit` from owner
+	///
+	/// If an approval already exists, the new amount is added to such existing approval
+	pub(super) fn do_approve_transfer(
+		id: T::AssetId,
+		owner: &T::AccountId,
+		delegate: &T::AccountId,
+		amount: T::Balance,
+	) -> DispatchResult {
+		let mut d = Asset::<T, I>::get(id).ok_or(Error::<T, I>::Unknown)?;
+		ensure!(!d.is_frozen, Error::<T, I>::Frozen);
+		Approvals::<T, I>::try_mutate(
+			(id, &owner, &delegate),
+			|maybe_approved| -> DispatchResult {
+				let mut approved = match maybe_approved.take() {
+					// an approval already exists and is being updated
+					Some(a) => a,
+					// a new approval is created
+					None => {
+						d.approvals.saturating_inc();
+						Default::default()
+					},
+				};
+				let deposit_required = T::ApprovalDeposit::get();
+				if approved.deposit < deposit_required {
+					T::Currency::reserve(&owner, deposit_required - approved.deposit)?;
+					approved.deposit = deposit_required;
+				}
+				approved.amount = approved.amount.saturating_add(amount);
+				*maybe_approved = Some(approved);
+				Ok(())
+			},
+		)?;
+		Asset::<T, I>::insert(id, d);
+		Self::deposit_event(Event::ApprovedTransfer(id, owner.clone(), delegate.clone(), amount));
+
+		Ok(())
+	}
+
+	/// Reduces the asset `id` balance of `owner` by some `amount` and increases the balance of
+	/// `dest` by (similar) amount, checking that 'delegate' has an existing approval from `owner`
+	/// to spend`amount`.
+	///
+	/// Will fail if `amount` is greater than the approval from `owner` to 'delegate'
+	/// Will unreserve the deposit from `owner` if the entire approved `amount` is spent by
+	/// 'delegate'
+	pub(super) fn do_transfer_approved(
+		id: T::AssetId,
+		owner: &T::AccountId,
+		delegate: &T::AccountId,
+		destination: &T::AccountId,
+		amount: T::Balance,
+	) -> DispatchResult {
+		Approvals::<T, I>::try_mutate_exists(
+			(id, &owner, delegate),
+			|maybe_approved| -> DispatchResult {
+				let mut approved = maybe_approved.take().ok_or(Error::<T, I>::Unapproved)?;
+				let remaining =
+					approved.amount.checked_sub(&amount).ok_or(Error::<T, I>::Unapproved)?;
+
+				let f = TransferFlags { keep_alive: false, best_effort: false, burn_dust: false };
+				Self::do_transfer(id, &owner, &destination, amount, None, f)?;
+
+				if remaining.is_zero() {
+					T::Currency::unreserve(&owner, approved.deposit);
+					Asset::<T, I>::mutate(id, |maybe_details| {
+						if let Some(details) = maybe_details {
+							details.approvals.saturating_dec();
+						}
+					});
+				} else {
+					approved.amount = remaining;
+					*maybe_approved = Some(approved);
+				}
+				Ok(())
+			},
+		)?;
+		Ok(())
 	}
 }

--- a/frame/assets/src/impl_fungibles.rs
+++ b/frame/assets/src/impl_fungibles.rs
@@ -147,3 +147,50 @@ impl<T: Config<I>, I: 'static> fungibles::Unbalanced<T::AccountId> for Pallet<T,
 		}
 	}
 }
+
+impl<T: Config<I>, I: 'static> fungibles::Erc20Compatible<<T as SystemConfig>::AccountId>
+	for Pallet<T, I>
+{
+	fn name(asset: Self::AssetId) -> Vec<u8> {
+		Metadata::<T, I>::get(asset).name.to_vec()
+	}
+
+	fn symbol(asset: Self::AssetId) -> Vec<u8> {
+		Metadata::<T, I>::get(asset).symbol.to_vec()
+	}
+
+	fn decimals(asset: Self::AssetId) -> u8 {
+		Metadata::<T, I>::get(asset).decimals
+	}
+
+	fn approve(
+		asset: Self::AssetId,
+		owner: &<T as SystemConfig>::AccountId,
+		delegate: &<T as SystemConfig>::AccountId,
+		amount: Self::Balance,
+	) -> DispatchResult {
+		Self::do_approve_transfer(asset, owner, delegate, amount)
+	}
+
+	// Aprove spending tokens from a given account
+	fn transfer_from(
+		asset: Self::AssetId,
+		owner: &<T as SystemConfig>::AccountId,
+		delegate: &<T as SystemConfig>::AccountId,
+		dest: &<T as SystemConfig>::AccountId,
+		amount: Self::Balance,
+	) -> DispatchResult {
+		Self::do_transfer_approved(asset, owner, delegate, dest, amount)
+	}
+
+	// Check the amount approved to be spent by an owner to a spender
+	fn allowance(
+		asset: Self::AssetId,
+		owner: &<T as SystemConfig>::AccountId,
+		delegate: &<T as SystemConfig>::AccountId,
+	) -> Self::Balance {
+		Approvals::<T, I>::get((asset, &owner, &delegate))
+			.map(|x| x.amount)
+			.unwrap_or_else(Zero::zero)
+	}
+}

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -1121,35 +1121,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let owner = ensure_signed(origin)?;
 			let delegate = T::Lookup::lookup(delegate)?;
-
-			let mut d = Asset::<T, I>::get(id).ok_or(Error::<T, I>::Unknown)?;
-			ensure!(!d.is_frozen, Error::<T, I>::Frozen);
-			Approvals::<T, I>::try_mutate(
-				(id, &owner, &delegate),
-				|maybe_approved| -> DispatchResult {
-					let mut approved = match maybe_approved.take() {
-						// an approval already exists and is being updated
-						Some(a) => a,
-						// a new approval is created
-						None => {
-							d.approvals.saturating_inc();
-							Default::default()
-						},
-					};
-					let deposit_required = T::ApprovalDeposit::get();
-					if approved.deposit < deposit_required {
-						T::Currency::reserve(&owner, deposit_required - approved.deposit)?;
-						approved.deposit = deposit_required;
-					}
-					approved.amount = approved.amount.saturating_add(amount);
-					*maybe_approved = Some(approved);
-					Ok(())
-				},
-			)?;
-			Asset::<T, I>::insert(id, d);
-			Self::deposit_event(Event::ApprovedTransfer(id, owner, delegate, amount));
-
-			Ok(())
+			Self::do_approve_transfer(id, &owner, &delegate, amount)
 		}
 
 		/// Cancel all of some asset approved for delegated transfer by a third-party account.
@@ -1256,33 +1228,7 @@ pub mod pallet {
 			let delegate = ensure_signed(origin)?;
 			let owner = T::Lookup::lookup(owner)?;
 			let destination = T::Lookup::lookup(destination)?;
-
-			Approvals::<T, I>::try_mutate_exists(
-				(id, &owner, delegate),
-				|maybe_approved| -> DispatchResult {
-					let mut approved = maybe_approved.take().ok_or(Error::<T, I>::Unapproved)?;
-					let remaining =
-						approved.amount.checked_sub(&amount).ok_or(Error::<T, I>::Unapproved)?;
-
-					let f =
-						TransferFlags { keep_alive: false, best_effort: false, burn_dust: false };
-					Self::do_transfer(id, &owner, &destination, amount, None, f)?;
-
-					if remaining.is_zero() {
-						T::Currency::unreserve(&owner, approved.deposit);
-						Asset::<T, I>::mutate(id, |maybe_details| {
-							if let Some(details) = maybe_details {
-								details.approvals.saturating_dec();
-							}
-						});
-					} else {
-						approved.amount = remaining;
-						*maybe_approved = Some(approved);
-					}
-					Ok(())
-				},
-			)?;
-			Ok(())
+			Self::do_transfer_approved(id, &owner, &delegate, &destination, amount)
 		}
 	}
 }

--- a/frame/assets/src/tests.rs
+++ b/frame/assets/src/tests.rs
@@ -784,3 +784,37 @@ fn balance_conversion_should_work() {
 		);
 	});
 }
+
+#[test]
+fn querying_name_symbol_and_decimals_should_work() {
+	new_test_ext().execute_with(|| {
+		use frame_support::traits::tokens::fungibles::Erc20Compatible;
+		assert_ok!(Assets::force_create(Origin::root(), 0, 1, true, 1));
+		assert_ok!(Assets::force_set_metadata(
+			Origin::root(),
+			0,
+			vec![0u8; 10],
+			vec![1u8; 10],
+			12,
+			false
+		));
+		assert_eq!(Assets::name(0), vec![0u8; 10]);
+		assert_eq!(Assets::symbol(0), vec![1u8; 10]);
+		assert_eq!(Assets::decimals(0), 12);
+	});
+}
+
+#[test]
+fn querying_allowance_should_work() {
+	new_test_ext().execute_with(|| {
+		use frame_support::traits::tokens::fungibles::Erc20Compatible;
+		assert_ok!(Assets::force_create(Origin::root(), 0, 1, true, 1));
+		assert_ok!(Assets::mint(Origin::signed(1), 0, 1, 100));
+		Balances::make_free_balance_be(&1, 1);
+		assert_ok!(Assets::approve(0, &1, &2, 50));
+		assert_eq!(Assets::allowance(0, &1, &2), 50);
+		// Transfer asset 0, from owner 1 and delegate 2 to destination 3
+		assert_ok!(Assets::transfer_from(0, &1, &2, &3, 50));
+		assert_eq!(Assets::allowance(0, &1, &2), 0);
+	});
+}

--- a/frame/support/src/traits/tokens/fungibles.rs
+++ b/frame/support/src/traits/tokens/fungibles.rs
@@ -227,3 +227,36 @@ impl<AccountId, T: Balanced<AccountId> + MutateHold<AccountId>> BalancedHold<Acc
 		<Self as fungibles::Balanced<AccountId>>::slash(asset, who, actual)
 	}
 }
+
+/// Trait for making a set of fungible tokens ERC20 compatible.
+/// https://eips.ethereum.org/EIPS/eip-20
+pub trait Erc20Compatible<AccountId>: Transfer<AccountId> {
+	/// Name of the Asset
+	fn name(asset: Self::AssetId) -> Vec<u8>;
+
+	/// Symbol of the Asset
+	fn symbol(asset: Self::AssetId) -> Vec<u8>;
+
+	/// Number of decimals in which the token is represented
+	fn decimals(asset: Self::AssetId) -> u8;
+
+	// Aprove a delegate account to spend an amount of tokens owned by an owner
+	fn approve(
+		asset: Self::AssetId,
+		owner: &AccountId,
+		delegate: &AccountId,
+		amount: Self::Balance,
+	) -> DispatchResult;
+
+	// Transfer from a delegate account an amount approved by the owner of the asset
+	fn transfer_from(
+		asset: Self::AssetId,
+		owner: &AccountId,
+		delegate: &AccountId,
+		dest: &AccountId,
+		amount: Self::Balance,
+	) -> DispatchResult;
+
+	// Check the amount approved by an owner to be spent by a delegate
+	fn allowance(asset: Self::AssetId, owner: &AccountId, delegate: &AccountId) -> Self::Balance;
+}


### PR DESCRIPTION
This PR adds an ERC20 compatible trait for fungibles by extending the Inspect trait with _name_, _symbol_, _decimals_, _allowance_, _transfer_from_ and _approve_ functions.

It also implements such a trait for _pallet-assets_. This PR does not make any changes to the functionality of pallet-assets but rather moves the _approve_transfer_ and _transfer_approved_ functionality to the functions module. It also uses the existing storage to get the information necessary to satisfy the ERC20 trait
