### PR TITLE
Distinguish all tips in history according to tip hash

### DIFF
--- a/frame/tips/src/benchmarking.rs
+++ b/frame/tips/src/benchmarking.rs
@@ -105,7 +105,7 @@ benchmarks! {
 			awesome_person.clone()
 		)?;
 		let reason_hash = T::Hashing::hash(&reason[..]);
-		let hash = T::Hashing::hash_of(&(&reason_hash, &awesome_person));
+		let hash = T::Hashing::hash_of(&(&reason_hash, &awesome_person, &frame_system::Pallet::<T>::block_number()));
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
 		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
@@ -132,7 +132,7 @@ benchmarks! {
 			value
 		)?;
 		let reason_hash = T::Hashing::hash(&reason[..]);
-		let hash = T::Hashing::hash_of(&(&reason_hash, &beneficiary));
+		let hash = T::Hashing::hash_of(&(&reason_hash, &beneficiary, &frame_system::Pallet::<T>::block_number()));
 		ensure!(Tips::<T>::contains_key(hash), "tip does not exist");
 		create_tips::<T>(t - 1, hash.clone(), value)?;
 		let caller = account("member", t - 1, SEED);
@@ -159,7 +159,7 @@ benchmarks! {
 
 		// Create a bunch of tips
 		let reason_hash = T::Hashing::hash(&reason[..]);
-		let hash = T::Hashing::hash_of(&(&reason_hash, &beneficiary));
+		let hash = T::Hashing::hash_of(&(&reason_hash, &beneficiary, &frame_system::Pallet::<T>::block_number()));
 		ensure!(Tips::<T>::contains_key(hash), "tip does not exist");
 
 		create_tips::<T>(t, hash.clone(), value)?;
@@ -187,7 +187,7 @@ benchmarks! {
 		)?;
 
 		let reason_hash = T::Hashing::hash(&reason[..]);
-		let hash = T::Hashing::hash_of(&(&reason_hash, &beneficiary));
+		let hash = T::Hashing::hash_of(&(&reason_hash, &beneficiary, &frame_system::Pallet::<T>::block_number()));
 		ensure!(Tips::<T>::contains_key(hash), "tip does not exist");
 	}: _(RawOrigin::Root, hash)
 }

--- a/frame/tips/src/lib.rs
+++ b/frame/tips/src/lib.rs
@@ -248,7 +248,8 @@ pub mod pallet {
 
 			let reason_hash = T::Hashing::hash(&reason[..]);
 			ensure!(!Reasons::<T>::contains_key(&reason_hash), Error::<T>::AlreadyKnown);
-			let hash = T::Hashing::hash_of(&(&reason_hash, &who));
+			let now = <frame_system::Pallet<T>>::block_number();
+			let hash = T::Hashing::hash_of(&(&reason_hash, &who, &now));
 			ensure!(!Tips::<T>::contains_key(&hash), Error::<T>::AlreadyKnown);
 
 			let deposit = T::TipReportDepositBase::get() +
@@ -338,7 +339,8 @@ pub mod pallet {
 			ensure!(T::Tippers::contains(&tipper), BadOrigin);
 			let reason_hash = T::Hashing::hash(&reason[..]);
 			ensure!(!Reasons::<T>::contains_key(&reason_hash), Error::<T>::AlreadyKnown);
-			let hash = T::Hashing::hash_of(&(&reason_hash, &who));
+			let now = <frame_system::Pallet<T>>::block_number();
+			let hash = T::Hashing::hash_of(&(&reason_hash, &who, &now));
 
 			Reasons::<T>::insert(&reason_hash, &reason);
 			Self::deposit_event(Event::NewTip(hash.clone()));


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

The current tip hash is determined by the sender and reason.

```rust
let reason_hash = T::Hashing::hash(&reason[..]);
ensure!(!Reasons::<T>::contains_key(&reason_hash), Error::<T>::AlreadyKnown);
let hash = T::Hashing::hash_of(&(&reason_hash, &who));
ensure!(!Tips::<T>::contains_key(&hash), Error::<T>::AlreadyKnown);
// ...
Reasons::<T>::insert(&reason_hash, &reason);
let tip = OpenTip {
  reason: reason_hash,
  who,
  finder,
  deposit,
  closes: None,
  tips: vec![],
  finders_fee: true,
};
Tips::<T>::insert(&hash, tip);
```

Theoretically, the same tip hash can be constructed (it‘s possible that the same tip hash may exist for all historical tips, although it's impossible to store the same tip hash on the chain at the same time)