### PR TITLE
Timestamp inherent doesn't pay fees

### DIFF
--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -191,7 +191,7 @@ pub mod pallet {
 			T::WeightInfo::set(),
 			DispatchClass::Mandatory
 		))]
-		pub fn set(origin: OriginFor<T>, #[pallet::compact] now: T::Moment) -> DispatchResultWithPostInfo {
+		pub fn set(origin: OriginFor<T>, #[pallet::compact] now: T::Moment) -> DispatchResult {
 			ensure_none(origin)?;
 			assert!(!DidUpdate::<T>::exists(), "Timestamp must be updated only once in the block");
 			let prev = Self::now();
@@ -204,7 +204,7 @@ pub mod pallet {
 
 			<T::OnTimestampSet as OnTimestampSet<_>>::on_timestamp_set(now);
 
-			Ok(Pays::No.into())
+			Ok(())
 		}
 	}
 

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -191,7 +191,7 @@ pub mod pallet {
 			T::WeightInfo::set(),
 			DispatchClass::Mandatory
 		))]
-		pub fn set(origin: OriginFor<T>, #[pallet::compact] now: T::Moment) -> DispatchResult {
+		pub fn set(origin: OriginFor<T>, #[pallet::compact] now: T::Moment) -> DispatchResultWithPostInfo {
 			ensure_none(origin)?;
 			assert!(!DidUpdate::<T>::exists(), "Timestamp must be updated only once in the block");
 			let prev = Self::now();
@@ -204,7 +204,7 @@ pub mod pallet {
 
 			<T::OnTimestampSet as OnTimestampSet<_>>::on_timestamp_set(now);
 
-			Ok(())
+			Ok(Pays::No.into())
 		}
 	}
 

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -189,7 +189,8 @@ pub mod pallet {
 		/// # </weight>
 		#[pallet::weight((
 			T::WeightInfo::set(),
-			DispatchClass::Mandatory
+			DispatchClass::Mandatory,
+			Pays::No,
 		))]
 		pub fn set(origin: OriginFor<T>, #[pallet::compact] now: T::Moment) -> DispatchResult {
 			ensure_none(origin)?;


### PR DESCRIPTION
This PR marks pallet timestamp's `set` extrinsic as `Pays::No`. Inherents never pay fees because there is no origin and in general the block author is not associated with a runtime account. Therefore this makes no changes in terms of actual fee collection. Rather this just makes it easier to do offchain accounting work to track fees by block.

Should this be handled somewhere deeper in FRAME so it applies to all inherents?

cc @crystalin 