### PR TITLE
Reduce the number of types in build_transport for transport

### DIFF
--- a/client/network/src/transport.rs
+++ b/client/network/src/transport.rs
@@ -58,20 +58,16 @@ pub fn build_transport(
 		let desktop_trans =
 			websocket::WsConfig::new(desktop_trans.clone()).or_transport(desktop_trans);
 		let dns_init = futures::executor::block_on(dns::DnsConfig::system(desktop_trans.clone()));
-		OptionalTransport::some(if let Ok(dns) = dns_init {
+		EitherTransport::Left(if let Ok(dns) = dns_init {
 			EitherTransport::Left(dns)
 		} else {
 			EitherTransport::Right(desktop_trans.map_err(dns::DnsErr::Transport))
 		})
 	} else {
-		// For the in-memory case we set up the transport with an `.or_transport` below.
-		OptionalTransport::none()
+		EitherTransport::Right(OptionalTransport::some(
+			libp2p::core::transport::MemoryTransport::default(),
+		))
 	};
-	let transport = transport.or_transport(if memory_only {
-		OptionalTransport::some(libp2p::core::transport::MemoryTransport::default())
-	} else {
-		OptionalTransport::none()
-	});
 
 	let (transport, bandwidth) = bandwidth::BandwidthLogging::new(transport);
 


### PR DESCRIPTION
> What does it do?

Previously the resulting type of transport was `OrTransport<OptionalTransport<EitherTransport<A,B>>, OptionalTransport<C>>`. Now it is `EitherTransport<EitherTransport<A,B>, OptionalTransport<C>>`.

The semantics is unchanged but the code is simplified a little bit.