### PR TITLE
Fix Spellcheck for Benchmarking Template

### DIFF
--- a/utils/frame/benchmarking-cli/src/template.hbs
+++ b/utils/frame/benchmarking-cli/src/template.hbs
@@ -17,7 +17,7 @@
 use frame_support::{traits::Get, weights::Weight};
 use sp_std::marker::PhantomData;
 
-/// Weight functions for {{pallet}}.
+/// Weight functions for `{{pallet}}`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> {{pallet}}::WeightInfo for WeightInfo<T> {
 	{{~#each benchmarks as |benchmark|}}


### PR DESCRIPTION
Spellchecker keeps complaining that pallet name isn't a real word. This puts that text in a code block.