### PR TITLE
Silence Kademlia InboundRequestServed event

### DIFF
--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -733,7 +733,8 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 							let ev = DiscoveryOut::Discovered(peer);
 							return Poll::Ready(NetworkBehaviourAction::GenerateEvent(ev))
 						},
-						KademliaEvent::PendingRoutablePeer { .. } => {
+						KademliaEvent::PendingRoutablePeer { .. } |
+						KademliaEvent::InboundRequestServed { .. } => {
 							// We are not interested in this event at the moment.
 						},
 						KademliaEvent::OutboundQueryCompleted {
@@ -844,8 +845,8 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 							),
 						},
 						// We never start any other type of query.
-						e => {
-							debug!(target: "sub-libp2p", "Libp2p => Unhandled Kademlia event: {:?}", e)
+						KademliaEvent::OutboundQueryCompleted { result: e, .. } => {
+							warn!(target: "sub-libp2p", "Libp2p => Unhandled Kademlia event: {:?}", e)
 						},
 					},
 					NetworkBehaviourAction::DialAddress { address } =>


### PR DESCRIPTION
This PR no longer generates logs for the `InboundRequestServed` event, which is the new event that got added in a recent version of libp2p-kad, and reverts https://github.com/paritytech/substrate/pull/9599.
We now generate a `warn` only when a `OutboundQueryCompleted` that isn't handled above is received, because that's the event that we're not supposed to receive.

