### PR TITLE
Add feature "disable-ui-test" and use it for wasmer-sandbox ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -516,7 +516,7 @@ test-wasmer-sandbox:
   variables:
     <<:                            *default-vars
   script:
-    - time cargo test --release --features runtime-benchmarks,wasmer-sandbox
+    - time cargo test --release --features runtime-benchmarks,wasmer-sandbox,disable-ui-tests
     - sccache -s
 
 cargo-check-macos:

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -48,3 +48,5 @@ try-runtime = ["frame-support/try-runtime"]
 # WARNING: CI only execute pallet test with this feature,
 # if the feature intended to be used outside, CI and this message need to be updated.
 conditional-storage = []
+# Disable ui tests
+disable-ui-tests = []

--- a/frame/support/test/tests/construct_runtime_ui.rs
+++ b/frame/support/test/tests/construct_runtime_ui.rs
@@ -18,6 +18,7 @@
 use std::env;
 
 #[rustversion::attr(not(stable), ignore)]
+#[cfg(not(feature = "disable-ui-tests"))]
 #[test]
 fn ui() {
 	// As trybuild is using `cargo check`, we don't need the real WASM binaries.

--- a/frame/support/test/tests/decl_module_ui.rs
+++ b/frame/support/test/tests/decl_module_ui.rs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 #[rustversion::attr(not(stable), ignore)]
+#[cfg(not(feature = "disable-ui-tests"))]
 #[test]
 fn decl_module_ui() {
 	// As trybuild is using `cargo check`, we don't need the real WASM binaries.

--- a/frame/support/test/tests/decl_storage_ui.rs
+++ b/frame/support/test/tests/decl_storage_ui.rs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 #[rustversion::attr(not(stable), ignore)]
+#[cfg(not(feature = "disable-ui-tests"))]
 #[test]
 fn decl_storage_ui() {
 	// As trybuild is using `cargo check`, we don't need the real WASM binaries.

--- a/frame/support/test/tests/derive_no_bound_ui.rs
+++ b/frame/support/test/tests/derive_no_bound_ui.rs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 #[rustversion::attr(not(stable), ignore)]
+#[cfg(not(feature = "disable-ui-tests"))]
 #[test]
 fn derive_no_bound_ui() {
 	// As trybuild is using `cargo check`, we don't need the real WASM binaries.

--- a/frame/support/test/tests/pallet_ui.rs
+++ b/frame/support/test/tests/pallet_ui.rs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 #[rustversion::attr(not(stable), ignore)]
+#[cfg(not(feature = "disable-ui-tests"))]
 #[test]
 fn pallet_ui() {
 	// As trybuild is using `cargo check`, we don't need the real WASM binaries.


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/9799

Add feature "disable-ui-test" and use it for wasmer-sandbox ci