### PR TITLE
Add SS58 prefix for Automata

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -608,8 +608,12 @@ ss58_address_format!(
 		(1284, "moonbeam", "Moonbeam, session key (*25519).")
 	Moonriver =>
 		(1285, "moonriver", "Moonriver, session key (*25519).")
+	Automata =>
+		(2349, "automata", "Automata mainnet standard account (*25519).")
 	BasiliskAccount =>
 		(10041, "basilisk", "Basilisk standard account (*25519).")
+	ContextFree =>
+		(11820, "contextfree", "Automata ContextFree standard account (*25519).")
 
 	// Note: 16384 and above are reserved.
 );

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -605,6 +605,15 @@
 			"website": "https://moonbeam.network"
 		},
 		{
+			"prefix": 2349,
+			"network": "automata",
+			"displayName": "Automata Mainnet",
+			"symbols": ["ATA"],
+			"decimals": [18],
+			"standardAccount": "*25519",
+			"website": "https://ata.network"
+		},
+		{
 			"prefix": 10041,
 			"network": "basilisk",
 			"displayName": "Basilisk",
@@ -612,6 +621,15 @@
 			"decimals": [12],
 			"standardAccount": "*25519",
 			"website": "https://bsx.fi"
+		},
+		{
+			"prefix": 11820,
+			"network": "contextfree",
+			"displayName": "Automata ContextFree",
+			"symbols": ["CTX"],
+			"decimals": [18],
+			"standardAccount": "*25519",
+			"website": "https://ata.network"
 		}
 	]
 }


### PR DESCRIPTION
Add SS58 prefix for Automata Mainnet and ContextFree Testnet
```
Mainnet => 2349
ContextFree => 11820
```
