### PR TITLE
Expose destroy witness in Uniques

### DIFF
--- a/frame/support/src/traits/tokens/nonfungibles.rs
+++ b/frame/support/src/traits/tokens/nonfungibles.rs
@@ -96,6 +96,23 @@ pub trait Inspect<AccountId> {
 	fn can_transfer(_class: &Self::ClassId, _instance: &Self::InstanceId) -> bool {
 		true
 	}
+
+	/// Returns the `instances`, `instance_metadatas`,  and `attributes` corresponding to `class`.
+	///
+	/// By default returns `None`; class does not exist
+	fn destroy_witness(class: &Self::ClassId) -> Option<(u32, u32, u32)> {
+		let maybe_class_details = Class::<T, I>::get(class);
+
+		if let Some(class_details) = maybe_class_details {
+			Some((
+				class_details.instances,
+				class_details.instance_metadatas,
+				class_details.attributes,
+			))
+		} else {
+			None
+		}
+	}
 }
 
 /// Interface for enumerating assets in existence or owned by a given account over many collections

--- a/frame/support/src/traits/tokens/nonfungibles.rs
+++ b/frame/support/src/traits/tokens/nonfungibles.rs
@@ -99,19 +99,9 @@ pub trait Inspect<AccountId> {
 
 	/// Returns the `instances`, `instance_metadatas`,  and `attributes` corresponding to `class`.
 	///
-	/// By default returns `None`; class does not exist
-	fn destroy_witness(class: &Self::ClassId) -> Option<(u32, u32, u32)> {
-		let maybe_class_details = Class::<T, I>::get(class);
-
-		if let Some(class_details) = maybe_class_details {
-			Some((
-				class_details.instances,
-				class_details.instance_metadatas,
-				class_details.attributes,
-			))
-		} else {
-			None
-		}
+	/// By default this is `None`; class does not exist
+	fn destroy_witness(_class: &Self::ClassId) -> Option<(u32, u32, u32)> {
+		None
 	}
 }
 

--- a/frame/uniques/src/impl_nonfungibles.rs
+++ b/frame/uniques/src/impl_nonfungibles.rs
@@ -86,6 +86,13 @@ impl<T: Config<I>, I: 'static> Inspect<<T as SystemConfig>::AccountId> for Palle
 			_ => false,
 		}
 	}
+
+	/// Returns the `instances`, `instance_metadatas`,  and `attributes` corresponding to `class`.
+	///
+	/// By default this is `None`; class does not exist
+	fn destroy_witness(_class: &Self::ClassId) -> Option<(u32, u32, u32)> {
+		None
+	}
 }
 
 impl<T: Config<I>, I: 'static> Create<<T as SystemConfig>::AccountId> for Pallet<T, I> {

--- a/frame/uniques/src/impl_nonfungibles.rs
+++ b/frame/uniques/src/impl_nonfungibles.rs
@@ -89,9 +89,19 @@ impl<T: Config<I>, I: 'static> Inspect<<T as SystemConfig>::AccountId> for Palle
 
 	/// Returns the `instances`, `instance_metadatas`,  and `attributes` corresponding to `class`.
 	///
-	/// By default this is `None`; class does not exist
-	fn destroy_witness(_class: &Self::ClassId) -> Option<(u32, u32, u32)> {
-		None
+	/// By default returns `None`; class does not exist
+	fn destroy_witness(class: &Self::ClassId) -> Option<(u32, u32, u32)> {
+		let maybe_class_details = Class::<T, I>::get(class);
+
+		if let Some(class_details) = maybe_class_details {
+			Some((
+				class_details.instances,
+				class_details.instance_metadatas,
+				class_details.attributes,
+			))
+		} else {
+			None
+		}
 	}
 }
 

--- a/frame/uniques/src/types.rs
+++ b/frame/uniques/src/types.rs
@@ -58,13 +58,13 @@ pub struct ClassDetails<AccountId, DepositBalance> {
 pub struct DestroyWitness {
 	/// The total number of outstanding instances of this asset class.
 	#[codec(compact)]
-	pub(super) instances: u32,
+	pub instances: u32,
 	/// The total number of outstanding instance metadata of this asset class.
 	#[codec(compact)]
-	pub(super) instance_metadatas: u32,
+	pub instance_metadatas: u32,
 	#[codec(compact)]
 	/// The total number of attributes for this asset class.
-	pub(super) attributes: u32,
+	pub attributes: u32,
 }
 
 impl<AccountId, DepositBalance> ClassDetails<AccountId, DepositBalance> {


### PR DESCRIPTION
We are using `pallet_uniques` as a base NFT pallet and trying to extend it's functionality in our own pallet `(pallet_nft: pallet_uniques)`

The problem arises when you try to destroy an NFT class from `pallet_nft`. In order to do that you need DestroyWitness which holds the info for each class. There is crate visibility set for the pallet storage hence it is necessary to expose a function which provides this info.
For testing purposes it is also solicited to have a constructor with public fields available.