### PR TITLE
Rework Transaction Priority calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.21"
+version = "0.13.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659cd14835e75b64d9dba5b660463506763cf0aa6cb640aeeb0e98d841093490"
+checksum = "9c1cbbfc9a1996c6af82c2b4caf828d2c653af4fcdbb0e5674cc966eee5a4197"
 dependencies = [
  "bitflags",
  "libc",
@@ -3233,9 +3233,9 @@ checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.22+1.1.0"
+version = "0.12.23+1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c53ac117c44f7042ad8d8f5681378dfbc6010e49ec2c0d1f11dfedc7a4a1c3"
+checksum = "29730a445bae719db3107078b46808cc45a5b7a6bae3f31272923af969453356"
 dependencies = [
  "cc",
  "libc",

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -257,11 +257,13 @@ impl pallet_balances::Config for Runtime {
 
 parameter_types! {
 	pub const TransactionByteFee: Balance = 1;
+	pub WeightTipRatio: Balance = BlockWeights::get().max_block as Balance / ExistentialDeposit::get();
 }
 
 impl pallet_transaction_payment::Config for Runtime {
 	type OnChargeTransaction = CurrencyAdapter<Balances, ()>;
 	type TransactionByteFee = TransactionByteFee;
+	type WeightTipRatio = WeightTipRatio;
 	type WeightToFee = IdentityFee<Balance>;
 	type FeeMultiplierUpdate = ();
 }

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -412,6 +412,7 @@ impl pallet_balances::Config for Runtime {
 
 parameter_types! {
 	pub const TransactionByteFee: Balance = 10 * MILLICENTS;
+	pub const WeightTipRatio: Balance = MAXIMUM_BLOCK_WEIGHT as Balance / 1 * DOLLARS;
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
 	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(1, 100_000);
 	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000_000u128);
@@ -420,6 +421,7 @@ parameter_types! {
 impl pallet_transaction_payment::Config for Runtime {
 	type OnChargeTransaction = CurrencyAdapter<Balances, DealWithFees>;
 	type TransactionByteFee = TransactionByteFee;
+	type WeightTipRatio = WeightTipRatio;
 	type WeightToFee = IdentityFee<Balance>;
 	type FeeMultiplierUpdate =
 		TargetedFeeAdjustment<Self, TargetBlockFullness, AdjustmentVariable, MinimumMultiplier>;

--- a/frame/balances/src/tests_composite.rs
+++ b/frame/balances/src/tests_composite.rs
@@ -76,10 +76,12 @@ impl frame_system::Config for Test {
 }
 parameter_types! {
 	pub const TransactionByteFee: u64 = 1;
+	pub const WeightTipRatio: u64 = 1;
 }
 impl pallet_transaction_payment::Config for Test {
 	type OnChargeTransaction = CurrencyAdapter<Pallet<Test>, ()>;
 	type TransactionByteFee = TransactionByteFee;
+	type WeightTipRatio = WeightTipRatio;
 	type WeightToFee = IdentityFee<u64>;
 	type FeeMultiplierUpdate = ();
 }

--- a/frame/balances/src/tests_local.rs
+++ b/frame/balances/src/tests_local.rs
@@ -78,10 +78,12 @@ impl frame_system::Config for Test {
 }
 parameter_types! {
 	pub const TransactionByteFee: u64 = 1;
+	pub const WeightTipRatio: u64 = 1;
 }
 impl pallet_transaction_payment::Config for Test {
 	type OnChargeTransaction = CurrencyAdapter<Pallet<Test>, ()>;
 	type TransactionByteFee = TransactionByteFee;
+	type WeightTipRatio = WeightTipRatio;
 	type WeightToFee = IdentityFee<u64>;
 	type FeeMultiplierUpdate = ();
 }

--- a/frame/balances/src/tests_reentrancy.rs
+++ b/frame/balances/src/tests_reentrancy.rs
@@ -80,10 +80,12 @@ impl frame_system::Config for Test {
 }
 parameter_types! {
 	pub const TransactionByteFee: u64 = 1;
+	pub const WeightTipRatio: u64 = 1;
 }
 impl pallet_transaction_payment::Config for Test {
 	type OnChargeTransaction = CurrencyAdapter<Pallet<Test>, ()>;
 	type TransactionByteFee = TransactionByteFee;
+	type WeightTipRatio = WeightTipRatio;
 	type WeightToFee = IdentityFee<u64>;
 	type FeeMultiplierUpdate = ();
 }

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -1054,8 +1054,6 @@ mod tests {
 		let invalid = TestXt::new(Call::Custom(custom::Call::unallowed_unsigned {}), None);
 		let mut t = new_test_ext(1);
 
-		let mut default_with_prio_3 = ValidTransaction::default();
-		default_with_prio_3.priority = 3;
 		t.execute_with(|| {
 			assert_eq!(
 				Executive::validate_transaction(
@@ -1063,7 +1061,7 @@ mod tests {
 					valid.clone(),
 					Default::default(),
 				),
-				Ok(default_with_prio_3),
+				Ok(ValidTransaction::default()),
 			);
 			assert_eq!(
 				Executive::validate_transaction(

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -775,10 +775,12 @@ mod tests {
 
 	parameter_types! {
 		pub const TransactionByteFee: Balance = 0;
+		pub const WeightTipRatio: Balance = 1;
 	}
 	impl pallet_transaction_payment::Config for Runtime {
 		type OnChargeTransaction = CurrencyAdapter<Balances, ()>;
 		type TransactionByteFee = TransactionByteFee;
+		type WeightTipRatio = WeightTipRatio;
 		type WeightToFee = IdentityFee<Balance>;
 		type FeeMultiplierUpdate = ();
 	}

--- a/frame/support/src/weights.rs
+++ b/frame/support/src/weights.rs
@@ -287,30 +287,6 @@ impl<'a> OneOrMany<DispatchClass> for &'a [DispatchClass] {
 	}
 }
 
-/// Primitives related to priority management of Frame.
-pub mod priority {
-	/// The starting point of all Operational transactions. 3/4 of u64::MAX.
-	pub const LIMIT: u64 = 13_835_058_055_282_163_711_u64;
-
-	/// Wrapper for priority of different dispatch classes.
-	///
-	/// This only makes sure that any value created for the operational dispatch class is
-	/// incremented by [`LIMIT`].
-	pub enum FrameTransactionPriority {
-		Normal(u64),
-		Operational(u64),
-	}
-
-	impl From<FrameTransactionPriority> for u64 {
-		fn from(priority: FrameTransactionPriority) -> Self {
-			match priority {
-				FrameTransactionPriority::Normal(inner) => inner,
-				FrameTransactionPriority::Operational(inner) => inner.saturating_add(LIMIT),
-			}
-		}
-	}
-}
-
 /// A bundle of static information collected from the `#[weight = $x]` attributes.
 #[derive(Clone, Copy, Eq, PartialEq, Default, RuntimeDebug, Encode, Decode, TypeInfo)]
 pub struct DispatchInfo {

--- a/frame/system/src/extensions/check_genesis.rs
+++ b/frame/system/src/extensions/check_genesis.rs
@@ -24,6 +24,11 @@ use sp_runtime::{
 };
 
 /// Genesis hash check to provide replay protection between different networks.
+///
+/// # Transaction Validity
+///
+/// Note that while a transaction with invalid `genesis_hash` will fail to be decoded,
+/// the extension does not affect any other fields of `TransactionValidity` directly.
 #[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
 #[scale_info(skip_type_params(T))]
 pub struct CheckGenesis<T: Config + Send + Sync>(sp_std::marker::PhantomData<T>);

--- a/frame/system/src/extensions/check_mortality.rs
+++ b/frame/system/src/extensions/check_mortality.rs
@@ -27,6 +27,10 @@ use sp_runtime::{
 };
 
 /// Check for transaction mortality.
+///
+/// # Transaction Validity
+///
+/// The extension affects `longevity` of the transaction according to the [`Era`] definition.
 #[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
 #[scale_info(skip_type_params(T))]
 pub struct CheckMortality<T: Config + Send + Sync>(Era, sp_std::marker::PhantomData<T>);

--- a/frame/system/src/extensions/check_nonce.rs
+++ b/frame/system/src/extensions/check_nonce.rs
@@ -30,8 +30,11 @@ use sp_std::vec;
 
 /// Nonce check and increment to give replay protection for transactions.
 ///
-/// Note that this does not set any priority by default. Make sure that AT LEAST one of the signed
-/// extension sets some kind of priority upon validating transactions.
+/// # Transaction Validity
+///
+/// This extension affects `requires` and `provides` tags of validity, but DOES NOT
+/// set the `priority` field. Make sure that AT LEAST one of the signed extension sets
+/// some kind of priority upon validating transactions.
 #[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
 #[scale_info(skip_type_params(T))]
 pub struct CheckNonce<T: Config>(#[codec(compact)] pub T::Index);

--- a/frame/system/src/extensions/check_spec_version.rs
+++ b/frame/system/src/extensions/check_spec_version.rs
@@ -21,6 +21,11 @@ use scale_info::TypeInfo;
 use sp_runtime::{traits::SignedExtension, transaction_validity::TransactionValidityError};
 
 /// Ensure the runtime version registered in the transaction is the same as at present.
+///
+/// # Transaction Validity
+///
+/// The transaction with incorrect `spec_version` are considered invalid. The validity
+/// is not affected in any other way.
 #[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
 #[scale_info(skip_type_params(T))]
 pub struct CheckSpecVersion<T: Config + Send + Sync>(sp_std::marker::PhantomData<T>);

--- a/frame/system/src/extensions/check_tx_version.rs
+++ b/frame/system/src/extensions/check_tx_version.rs
@@ -21,6 +21,11 @@ use scale_info::TypeInfo;
 use sp_runtime::{traits::SignedExtension, transaction_validity::TransactionValidityError};
 
 /// Ensure the transaction version registered in the transaction is the same as at present.
+///
+/// # Transaction Validity
+///
+/// The transaction with incorrect `transaction_version` are considered invalid. The validity
+/// is not affected in any other way.
 #[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
 #[scale_info(skip_type_params(T))]
 pub struct CheckTxVersion<T: Config + Send + Sync>(sp_std::marker::PhantomData<T>);

--- a/frame/system/src/extensions/check_weight.rs
+++ b/frame/system/src/extensions/check_weight.rs
@@ -32,6 +32,16 @@ use sp_runtime::{
 };
 
 /// Block resource (weight) limit check.
+///
+/// # Transaction Validity
+///
+/// The extension affects `priority` field of `TransationValidity`. The priority depends
+/// on the `DispatchClass` and declared `weight`.
+///
+/// Note that usually it's desireable to include some fee payment mechanism and use that
+/// as a primary source of `priority`. Take a look at
+/// [`frame_support::signed_extensions::AdjustPriority`] utility to adjust priority coming
+/// from multiple extensions.
 #[derive(Encode, Decode, Clone, Eq, PartialEq, Default, TypeInfo)]
 #[scale_info(skip_type_params(T))]
 pub struct CheckWeight<T: Config + Send + Sync>(sp_std::marker::PhantomData<T>);

--- a/frame/system/src/extensions/check_weight.rs
+++ b/frame/system/src/extensions/check_weight.rs
@@ -19,14 +19,13 @@ use crate::{limits::BlockWeights, Config, Pallet};
 use codec::{Decode, Encode};
 use frame_support::{
 	traits::Get,
-	weights::{priority::FrameTransactionPriority, DispatchClass, DispatchInfo, PostDispatchInfo},
+	weights::{DispatchClass, DispatchInfo, PostDispatchInfo},
 };
 use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{DispatchInfoOf, Dispatchable, PostDispatchInfoOf, SignedExtension},
 	transaction_validity::{
-		InvalidTransaction, TransactionPriority, TransactionValidity, TransactionValidityError,
-		ValidTransaction,
+		InvalidTransaction, TransactionValidity, TransactionValidityError,
 	},
 	DispatchResult,
 };
@@ -35,13 +34,8 @@ use sp_runtime::{
 ///
 /// # Transaction Validity
 ///
-/// The extension affects `priority` field of `TransationValidity`. The priority depends
-/// on the `DispatchClass` and declared `weight`.
-///
-/// Note that usually it's desireable to include some fee payment mechanism and use that
-/// as a primary source of `priority`. Take a look at
-/// [`frame_support::signed_extensions::AdjustPriority`] utility to adjust priority coming
-/// from multiple extensions.
+/// This extension does not influence any fields of `TransactionValidity` in case the
+/// transaction is valid.
 #[derive(Encode, Decode, Clone, Eq, PartialEq, Default, TypeInfo)]
 #[scale_info(skip_type_params(T))]
 pub struct CheckWeight<T: Config + Send + Sync>(sp_std::marker::PhantomData<T>);
@@ -91,23 +85,6 @@ where
 		}
 	}
 
-	/// Get the priority of an extrinsic denoted by `info`.
-	///
-	/// Operational transaction will be given a fixed initial amount to be fairly distinguished from
-	/// the normal ones.
-	fn get_priority(info: &DispatchInfoOf<T::Call>) -> TransactionPriority {
-		match info.class {
-			// Normal transaction.
-			DispatchClass::Normal => FrameTransactionPriority::Normal(info.weight.into()).into(),
-			// Don't use up the whole priority space, to allow things like `tip` to be taken into
-			// account as well.
-			DispatchClass::Operational =>
-				FrameTransactionPriority::Operational(info.weight.into()).into(),
-			// Mandatory extrinsics are only for inherents; never transactions.
-			DispatchClass::Mandatory => TransactionPriority::min_value(),
-		}
-	}
-
 	/// Creates new `SignedExtension` to check weight of the extrinsic.
 	pub fn new() -> Self {
 		Self(Default::default())
@@ -140,7 +117,7 @@ where
 		// consumption from causing false negatives.
 		Self::check_extrinsic_weight(info)?;
 
-		Ok(ValidTransaction { priority: Self::get_priority(info), ..Default::default() })
+		Ok(Default::default())
 	}
 }
 
@@ -380,10 +357,7 @@ mod tests {
 
 			assert_eq!(
 				CheckWeight::<Test>::do_validate(&okay, len),
-				Ok(ValidTransaction {
-					priority: CheckWeight::<Test>::get_priority(&okay),
-					..Default::default()
-				})
+				Ok(Default::default())
 			);
 			assert_err!(
 				CheckWeight::<Test>::do_validate(&max, len),
@@ -513,30 +487,6 @@ mod tests {
 				InvalidTransaction::ExhaustsResources
 			);
 			assert_ok!(CheckWeight::<Test>(PhantomData).pre_dispatch(&1, CALL, &op, len));
-		})
-	}
-
-	#[test]
-	fn signed_ext_check_weight_works() {
-		new_test_ext().execute_with(|| {
-			let normal =
-				DispatchInfo { weight: 100, class: DispatchClass::Normal, pays_fee: Pays::Yes };
-			let op = DispatchInfo {
-				weight: 100,
-				class: DispatchClass::Operational,
-				pays_fee: Pays::Yes,
-			};
-			let len = 0_usize;
-
-			let priority = CheckWeight::<Test>(PhantomData)
-				.validate(&1, CALL, &normal, len)
-				.unwrap()
-				.priority;
-			assert_eq!(priority, 100);
-
-			let priority =
-				CheckWeight::<Test>(PhantomData).validate(&1, CALL, &op, len).unwrap().priority;
-			assert_eq!(priority, frame_support::weights::priority::LIMIT + 100);
 		})
 	}
 

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -523,6 +523,12 @@ where
 
 /// Require the transactor pay for themselves and maybe include a tip to gain additional priority
 /// in the queue.
+///
+/// # Transaction Validity
+///
+/// This extension sets the `priority` field of `TransactionValidity` depending on the amount
+/// of fee being paid (including the tip) and byte size. Transactions with high per-weight-unit
+/// fee or per-byte fee (depending which is greater) will have higher priority.
 #[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
 #[scale_info(skip_type_params(T))]
 pub struct ChargeTransactionPayment<T: Config>(#[codec(compact)] BalanceOf<T>);


### PR DESCRIPTION
Closes #5672 
Closes #9317 

Alternative take on #9596
(we can leave the adjuster from previous PR, but I don't think it is going to be useful at all, given no extensions change `priority`).

This PR changes the way Transaction Priority is calculated by following `SignedExtensions`:
1. `CheckWeight`
2. `ChargeTransactionPayment`

For `CheckWeight` it removes the `priority` calculation completely, leaving the priority as `0` for all dispatch classes. Please note that this might cause a bit of an havoc on existing chains without any extra signed extension that would alter `priority` (which is discouraged anyway) -  all transactions would end up having the same priority (`0`) and the inclusion might be done at random (i.e. depending on the transaction pool ordering - currently based on the insertion time), note that the requirements (i.e. nonce) would still be respected though.

`ChargeTransactionPayment` is completely reworked and is now a single place responsible for calculating the overall `priority` (all other `SignedExtensions` in this repo do not alter it).
The priority depends on the dispatch class and the amount of tip-per-weight the sender is willing to pay.
Note, this means that without a `tip` all transactions would end up with priority `0` (which means the inclusion would be attempted based on the transaction pool ordering (insertion time)).

`Operational` transactions are getting additional priority bump - not as high as previously (3/4 * u64::max), because that prevents other transactions from getting in front of them in the pool, but now equal to the amount required to pay for a transaction that fills up half of the block.