### PR TITLE
Improve test in frame-support-test

### DIFF
--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -553,7 +553,7 @@ frame_support::construct_runtime!(
 		NodeBlock = Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
-		System: frame_system::{Pallet, Call, Event<T>},
+		System: frame_system::{Call, Event<T>},
 		Example: pallet::{Pallet, Call, Event<T>, Config, Storage, Inherent, Origin<T>, ValidateUnsigned},
 		Example2: pallet2::{Pallet, Call, Event, Config<T>, Storage},
 	}
@@ -1001,52 +1001,6 @@ fn metadata() {
 
 	let pallets = vec![
 		PalletMetadata {
-			index: 0,
-			name: "System",
-			storage: None,
-			calls: Some(meta_type::<frame_system::Call<Runtime>>().into()),
-			event: Some(meta_type::<frame_system::Event<Runtime>>().into()),
-			constants: vec![
-				PalletConstantMetadata {
-					name: "BlockWeights",
-					ty: meta_type::<frame_system::limits::BlockWeights>(),
-					value: vec![],
-					docs: vec![],
-				},
-				PalletConstantMetadata {
-					name: "BlockLength",
-					ty: meta_type::<frame_system::limits::BlockLength>(),
-					value: vec![],
-					docs: vec![],
-				},
-				PalletConstantMetadata {
-					name: "BlockHashCount",
-					ty: meta_type::<u32>(),
-					value: vec![],
-					docs: vec![],
-				},
-				PalletConstantMetadata {
-					name: "DbWeight",
-					ty: meta_type::<frame_support::weights::RuntimeDbWeight>(),
-					value: vec![],
-					docs: vec![],
-				},
-				PalletConstantMetadata {
-					name: "Version",
-					ty: meta_type::<sp_version::RuntimeVersion>(),
-					value: vec![],
-					docs: vec![],
-				},
-				PalletConstantMetadata {
-					name: "SS58Prefix",
-					ty: meta_type::<u16>(),
-					value: vec![],
-					docs: vec![],
-				},
-			],
-			error: Some(meta_type::<frame_system::Error<Runtime>>().into()),
-		},
-		PalletMetadata {
 			index: 1,
 			name: "Example",
 			storage: Some(PalletStorageMetadata {
@@ -1105,214 +1059,6 @@ fn metadata() {
 								StorageHasher::Twox64Concat,
 							],
 							key: meta_type::<(u8, u16)>(),
-						},
-						default: vec![0],
-						docs: vec![],
-					},
-					StorageEntryMetadata {
-						name: "DoubleMap2",
-						modifier: StorageEntryModifier::Optional,
-						ty: StorageEntryType::Map {
-							value: meta_type::<u64>(),
-							key: meta_type::<(u16, u32)>(),
-							hashers: vec![
-								StorageHasher::Twox64Concat,
-								StorageHasher::Blake2_128Concat,
-							],
-						},
-						default: vec![0],
-						docs: vec![],
-					},
-					StorageEntryMetadata {
-						name: "NMap",
-						modifier: StorageEntryModifier::Optional,
-						ty: StorageEntryType::Map {
-							key: meta_type::<u8>(),
-							hashers: vec![StorageHasher::Blake2_128Concat],
-							value: meta_type::<u32>(),
-						},
-						default: vec![0],
-						docs: vec![],
-					},
-					StorageEntryMetadata {
-						name: "NMap2",
-						modifier: StorageEntryModifier::Optional,
-						ty: StorageEntryType::Map {
-							key: meta_type::<(u16, u32)>(),
-							hashers: vec![
-								StorageHasher::Twox64Concat,
-								StorageHasher::Blake2_128Concat,
-							],
-							value: meta_type::<u64>(),
-						},
-						default: vec![0],
-						docs: vec![],
-					},
-					#[cfg(feature = "conditional-storage")]
-					StorageEntryMetadata {
-						name: "ConditionalValue",
-						modifier: StorageEntryModifier::Optional,
-						ty: StorageEntryType::Plain(meta_type::<u32>()),
-						default: vec![0],
-						docs: vec![],
-					},
-					#[cfg(feature = "conditional-storage")]
-					StorageEntryMetadata {
-						name: "ConditionalMap",
-						modifier: StorageEntryModifier::Optional,
-						ty: StorageEntryType::Map {
-							key: meta_type::<u16>(),
-							value: meta_type::<u32>(),
-							hashers: vec![StorageHasher::Twox64Concat],
-						},
-						default: vec![0],
-						docs: vec![],
-					},
-					#[cfg(feature = "conditional-storage")]
-					StorageEntryMetadata {
-						name: "ConditionalDoubleMap",
-						modifier: StorageEntryModifier::Optional,
-						ty: StorageEntryType::Map {
-							value: meta_type::<u32>(),
-							key: meta_type::<(u8, u16)>(),
-							hashers: vec![
-								StorageHasher::Blake2_128Concat,
-								StorageHasher::Twox64Concat,
-							],
-						},
-						default: vec![0],
-						docs: vec![],
-					},
-					#[cfg(feature = "conditional-storage")]
-					StorageEntryMetadata {
-						name: "ConditionalNMap",
-						modifier: StorageEntryModifier::Optional,
-						ty: StorageEntryType::Map {
-							key: meta_type::<(u8, u16)>(),
-							hashers: vec![
-								StorageHasher::Blake2_128Concat,
-								StorageHasher::Twox64Concat,
-							],
-							value: meta_type::<u32>(),
-						},
-						default: vec![0],
-						docs: vec![],
-					},
-					StorageEntryMetadata {
-						name: "RenamedCountedMap",
-						modifier: StorageEntryModifier::Optional,
-						ty: StorageEntryType::Map {
-							hashers: vec![StorageHasher::Twox64Concat],
-							key: meta_type::<u8>(),
-							value: meta_type::<u32>(),
-						},
-						default: vec![0],
-						docs: vec![],
-					},
-					StorageEntryMetadata {
-						name: "CounterForRenamedCountedMap",
-						modifier: StorageEntryModifier::Default,
-						ty: StorageEntryType::Plain(meta_type::<u32>()),
-						default: vec![0, 0, 0, 0],
-						docs: vec!["Counter for the related counted storage map"],
-					},
-				],
-			}),
-			calls: Some(meta_type::<pallet::Call<Runtime>>().into()),
-			event: Some(meta_type::<pallet::Event<Runtime>>().into()),
-			constants: vec![
-				PalletConstantMetadata {
-					name: "MyGetParam",
-					ty: meta_type::<u32>(),
-					value: vec![10, 0, 0, 0],
-					docs: vec![" Some comment", " Some comment"],
-				},
-				PalletConstantMetadata {
-					name: "MyGetParam2",
-					ty: meta_type::<u32>(),
-					value: vec![11, 0, 0, 0],
-					docs: vec![" Some comment", " Some comment"],
-				},
-				PalletConstantMetadata {
-					name: "MyGetParam3",
-					ty: meta_type::<u64>(),
-					value: vec![12, 0, 0, 0, 0, 0, 0, 0],
-					docs: vec![],
-				},
-				PalletConstantMetadata {
-					name: "some_extra",
-					ty: meta_type::<u64>(),
-					value: vec![100, 0, 0, 0, 0, 0, 0, 0],
-					docs: vec![" Some doc", " Some doc"],
-				},
-				PalletConstantMetadata {
-					name: "some_extra_extra",
-					ty: meta_type::<u64>(),
-					value: vec![0, 0, 0, 0, 0, 0, 0, 0],
-					docs: vec![" Some doc"],
-				},
-			],
-			error: Some(PalletErrorMetadata { ty: meta_type::<pallet::Error<Runtime>>() }),
-		},
-		PalletMetadata {
-			index: 1,
-			name: "Example",
-			storage: Some(PalletStorageMetadata {
-				prefix: "Example",
-				entries: vec![
-					StorageEntryMetadata {
-						name: "ValueWhereClause",
-						modifier: StorageEntryModifier::Optional,
-						ty: StorageEntryType::Plain(meta_type::<u64>()),
-						default: vec![0],
-						docs: vec![],
-					},
-					StorageEntryMetadata {
-						name: "Value",
-						modifier: StorageEntryModifier::Optional,
-						ty: StorageEntryType::Plain(meta_type::<u32>()),
-						default: vec![0],
-						docs: vec![],
-					},
-					StorageEntryMetadata {
-						name: "Value2",
-						modifier: StorageEntryModifier::Optional,
-						ty: StorageEntryType::Plain(meta_type::<u64>()),
-						default: vec![0],
-						docs: vec![],
-					},
-					StorageEntryMetadata {
-						name: "Map",
-						modifier: StorageEntryModifier::Default,
-						ty: StorageEntryType::Map {
-							key: meta_type::<u8>(),
-							value: meta_type::<u16>(),
-							hashers: vec![StorageHasher::Blake2_128Concat],
-						},
-						default: vec![4, 0],
-						docs: vec![],
-					},
-					StorageEntryMetadata {
-						name: "Map2",
-						modifier: StorageEntryModifier::Optional,
-						ty: StorageEntryType::Map {
-							key: meta_type::<u16>(),
-							value: meta_type::<u32>(),
-							hashers: vec![StorageHasher::Twox64Concat],
-						},
-						default: vec![0],
-						docs: vec![],
-					},
-					StorageEntryMetadata {
-						name: "DoubleMap",
-						modifier: StorageEntryModifier::Optional,
-						ty: StorageEntryType::Map {
-							value: meta_type::<u32>(),
-							key: meta_type::<(u8, u16)>(),
-							hashers: vec![
-								StorageHasher::Blake2_128Concat,
-								StorageHasher::Twox64Concat,
-							],
 						},
 						default: vec![0],
 						docs: vec![],
@@ -1467,13 +1213,33 @@ fn metadata() {
 			name: "Example2",
 			storage: Some(PalletStorageMetadata {
 				prefix: "Example2",
-				entries: vec![StorageEntryMetadata {
-					name: "SomeValue",
-					modifier: StorageEntryModifier::Optional,
-					ty: StorageEntryType::Plain(meta_type::<Vec<u32>>()),
-					default: vec![0],
-					docs: vec![],
-				}],
+				entries: vec![
+					StorageEntryMetadata {
+						name: "SomeValue",
+						modifier: StorageEntryModifier::Optional,
+						ty: StorageEntryType::Plain(meta_type::<Vec<u32>>()),
+						default: vec![0],
+						docs: vec![],
+					},
+					StorageEntryMetadata {
+						name: "SomeCountedStorageMap",
+						modifier: StorageEntryModifier::Optional,
+						ty: StorageEntryType::Map {
+							hashers: vec![StorageHasher::Twox64Concat],
+							key: meta_type::<u8>(),
+							value: meta_type::<u32>(),
+						},
+						default: vec![0],
+						docs: vec![],
+					},
+					StorageEntryMetadata {
+						name: "CounterForSomeCountedStorageMap",
+						modifier: StorageEntryModifier::Default,
+						ty: StorageEntryType::Plain(meta_type::<u32>()),
+						default: vec![0, 0, 0, 0],
+						docs: vec!["Counter for the related counted storage map"],
+					},
+				],
 			}),
 			calls: Some(meta_type::<pallet2::Call<Runtime>>().into()),
 			event: Some(PalletEventMetadata { ty: meta_type::<pallet2::Event>() }),
@@ -1504,7 +1270,7 @@ fn metadata() {
 		_ => panic!("metadata has been bumped, test needs to be updated"),
 	};
 
-	pretty_assertions::assert_eq!(actual_metadata.pallets[1], expected_metadata.pallets[1]);
+	pretty_assertions::assert_eq!(actual_metadata.pallets, expected_metadata.pallets);
 }
 
 #[test]


### PR DESCRIPTION
Currently if frame-system adds use a new type in some new storage or constant etc... then the test in frame-support-test needs to be updated and give the correct metadata to the system pallet to check.

Instead in this PR I remove the system pallet from the metadata and check the 2 example pallets.