### PR TITLE
Resolve package versioning problem

### DIFF
--- a/primitives/finality-grandpa/Cargo.toml
+++ b/primitives/finality-grandpa/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-grandpa = { package = "finality-grandpa", version = "0.14.1", default-features = false, features = ["derive-codec"] }
+grandpa = { package = "finality-grandpa", version = "0.14.4", default-features = false, features = ["derive-codec"] }
 log = { version = "0.4.8", optional = true }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }


### PR DESCRIPTION
After update #8615 I ran into the build error:
```shell
error[E0432]: unresolved import `scale_info`
  --> /Users/breathx/.cargo/git/checkouts/substrate-7e08433d4c370a21/852bab0/frame/system/src/lib.rs:97:5
   |
97 | use scale_info::TypeInfo;
   |     ^^^^^^^^^^ use of undeclared crate or module `scale_info`

error: cannot determine resolution for the derive macro `TypeInfo`
   --> /Users/breathx/.cargo/git/checkouts/substrate-7e08433d4c370a21/852bab0/frame/system/src/lib.rs:761:40
    |
761 | #[derive(Encode, Decode, RuntimeDebug, TypeInfo)]
    |                                        ^^^^^^^^
    |
    = note: import resolution is stuck, try simplifying macro imports

error: cannot determine resolution for the derive macro `TypeInfo`
   --> /Users/breathx/.cargo/git/checkouts/substrate-7e08433d4c370a21/852bab0/frame/system/src/lib.rs:779:40
    |
779 | #[derive(Encode, Decode, RuntimeDebug, TypeInfo)]
    |                                        ^^^^^^^^
    |
    = note: import resolution is stuck, try simplifying macro imports

error: cannot determine resolution for the derive macro `TypeInfo`
   --> /Users/breathx/.cargo/git/checkouts/substrate-7e08433d4c370a21/852bab0/frame/system/src/lib.rs:791:62
    |
791 | #[derive(PartialEq, Eq, Clone, RuntimeDebug, Encode, Decode, TypeInfo)]
    |                                                              ^^^^^^^^
    |
    = note: import resolution is stuck, try simplifying macro imports

error: cannot determine resolution for the derive macro `TypeInfo`
   --> /Users/breathx/.cargo/git/checkouts/substrate-7e08433d4c370a21/852bab0/frame/system/src/lib.rs:831:71
    |
831 | #[derive(Clone, Eq, PartialEq, Default, RuntimeDebug, Encode, Decode, TypeInfo)]
    |                                                                       ^^^^^^^^
    |
    = note: import resolution is stuck, try simplifying macro imports

error: cannot determine resolution for the derive macro `TypeInfo`
   --> /Users/breathx/.cargo/git/checkouts/substrate-7e08433d4c370a21/852bab0/frame/system/src/lib.rs:851:52
    |
851 | #[derive(sp_runtime::RuntimeDebug, Encode, Decode, TypeInfo)]
    |                                                    ^^^^^^^^
    |
    = note: import resolution is stuck, try simplifying macro imports
```
I assumed it was due to versioning of some packages and find out that everywhere used `finality-grandpa` v0.14.4 and only here v0.14.1, which depends on `scale-info` v0.10.0 (and `scale-info-derive` v0.7.0) instead of v1.0.0 (and v1.0.0) what might lead to that kind collision.