### PR TITLE
Clarify wieght traits needed to impl in example

### DIFF
--- a/frame/example/src/lib.rs
+++ b/frame/example/src/lib.rs
@@ -487,11 +487,11 @@ pub mod pallet {
 		// the chain in a moderate rate.
 		//
 		// The parenthesized value of the `#[pallet::weight(..)]` attribute can be any type that
-		// implements a set of traits, namely [`WeighData`] and [`ClassifyDispatch`].
-		// The former conveys the weight (a numeric representation of pure execution time and
-		// difficulty) of the transaction and the latter demonstrates the [`DispatchClass`] of the
-		// call. A higher weight means a larger transaction (less of which can be placed in a
-		// single block).
+		// implements a set of traits, namely [`WeighData`], [`ClassifyDispatch`], and 
+		// [`PaysFee`]. The former conveys the weight (a numeric representation of pure execution
+		// time and difficulty) of the transaction and the latter demonstrates the 
+		// [`DispatchClass`] of the call. A higher weight means a larger transaction (less of 
+		// which can be placed in a single block).
 		//
 		// The weight for this extrinsic we rely on the auto-generated `WeightInfo` from the
 		// benchmark toolchain.


### PR DESCRIPTION
Discovered inconsistency with devhub here: https://github.com/substrate-developer-hub/substrate-developer-hub.github.io/pull/1125 

Add a required third trait in the docs as evidenced here:
https://github.com/paritytech/substrate/blob/eded99055e32c1b096993b94b38d3f6e04237c18/frame/example/src/lib.rs#L324-L349