### PR TITLE
Fix gitlab command

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -763,12 +763,14 @@ publish-rustdoc:
     - cp README.md /tmp/doc/
     - git checkout gh-pages
     # Remove directories no longer necessary, as specified in $RUSTDOCS_DEPLOY_REFS.
-    # Also ensure $RUSTDOCS_DEPLOY_REFS is non-space
+    # Also ensure $RUSTDOCS_DEPLOY_REFS is not just empty spaces.
+    # Even though this block spans multiple lines, they are concatenated to run as a single line
+    #   command, so note for the semi-colons in the inner-most code block.
     - if [[ ! -z ${RUSTDOCS_DEPLOY_REFS// } ]]; then
         for FILE in *; do
           if [[ ! " $RUSTDOCS_DEPLOY_REFS " =~ " $FILE " ]]; then
-            echo "Removing ${FILE}..."
-            rm -rf $FILE
+            echo "Removing ${FILE}...";
+            rm -rf $FILE;
           fi
         done
       fi


### PR DESCRIPTION
This PR fixes the gitlab command error in the publish-docs CI job failure [as seen here](https://gitlab.parity.io/parity/substrate/-/jobs/1135813).

Would @TriplEight @rcny kindly this. Thanks.