### PR TITLE
Fungibles Create and Destroy Traits + Assets Implementation

### DIFF
--- a/frame/assets/src/functions.rs
+++ b/frame/assets/src/functions.rs
@@ -479,6 +479,36 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Ok(credit)
 	}
 
+	pub(super) fn do_force_create(
+		id: T::AssetId,
+		owner: T::AccountId,
+		is_sufficient: bool,
+		min_balance: T::Balance,
+	) -> DispatchResult {
+		ensure!(!Asset::<T, I>::contains_key(id), Error::<T, I>::InUse);
+		ensure!(!min_balance.is_zero(), Error::<T, I>::MinBalanceZero);
+
+		Asset::<T, I>::insert(
+			id,
+			AssetDetails {
+				owner: owner.clone(),
+				issuer: owner.clone(),
+				admin: owner.clone(),
+				freezer: owner.clone(),
+				supply: Zero::zero(),
+				deposit: Zero::zero(),
+				min_balance,
+				is_sufficient,
+				accounts: 0,
+				sufficients: 0,
+				approvals: 0,
+				is_frozen: false,
+			},
+		);
+		Self::deposit_event(Event::ForceCreated(id, owner));
+		Ok(())
+	}
+
 	pub(super) fn do_destroy(
 		id: T::AssetId,
 		witness: DestroyWitness,

--- a/frame/assets/src/impl_fungibles.rs
+++ b/frame/assets/src/impl_fungibles.rs
@@ -147,3 +147,19 @@ impl<T: Config<I>, I: 'static> fungibles::Unbalanced<T::AccountId> for Pallet<T,
 		}
 	}
 }
+
+impl<T: Config<I>, I: 'static> fungibles::Destroy<T::AccountId> for Pallet<T, I> {
+	type DestroyWitness = DestroyWitness;
+
+	fn get_destroy_witness(asset: T::AssetId) -> Option<Self::DestroyWitness> {
+		Asset::<T, I>::get(asset).map(|asset_details| asset_details.destroy_witness())
+	}
+
+	fn destroy(
+		id: T::AssetId,
+		witness: Self::DestroyWitness,
+		maybe_check_owner: Option<T::AccountId>,
+	) -> DispatchResultWithPostInfo {
+		Self::do_destroy(id, witness, maybe_check_owner)
+	}
+}

--- a/frame/assets/src/impl_fungibles.rs
+++ b/frame/assets/src/impl_fungibles.rs
@@ -148,6 +148,17 @@ impl<T: Config<I>, I: 'static> fungibles::Unbalanced<T::AccountId> for Pallet<T,
 	}
 }
 
+impl<T: Config<I>, I: 'static> fungibles::Create<T::AccountId> for Pallet<T, I> {
+	fn create(
+		id: T::AssetId,
+		admin: T::AccountId,
+		is_sufficient: bool,
+		min_balance: Self::Balance,
+	) -> DispatchResult {
+		Self::do_force_create(id, admin, is_sufficient, min_balance)
+	}
+}
+
 impl<T: Config<I>, I: 'static> fungibles::Destroy<T::AccountId> for Pallet<T, I> {
 	type DestroyWitness = DestroyWitness;
 

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -438,29 +438,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			T::ForceOrigin::ensure_origin(origin)?;
 			let owner = T::Lookup::lookup(owner)?;
-
-			ensure!(!Asset::<T, I>::contains_key(id), Error::<T, I>::InUse);
-			ensure!(!min_balance.is_zero(), Error::<T, I>::MinBalanceZero);
-
-			Asset::<T, I>::insert(
-				id,
-				AssetDetails {
-					owner: owner.clone(),
-					issuer: owner.clone(),
-					admin: owner.clone(),
-					freezer: owner.clone(),
-					supply: Zero::zero(),
-					deposit: Zero::zero(),
-					min_balance,
-					is_sufficient,
-					accounts: 0,
-					sufficients: 0,
-					approvals: 0,
-					is_frozen: false,
-				},
-			);
-			Self::deposit_event(Event::ForceCreated(id, owner));
-			Ok(())
+			Self::do_force_create(id, owner, is_sufficient, min_balance)
 		}
 
 		/// Destroy a class of fungible assets.

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -143,6 +143,7 @@ use codec::HasCompact;
 use frame_support::{
 	dispatch::{DispatchError, DispatchResult},
 	ensure,
+	pallet_prelude::DispatchResultWithPostInfo,
 	traits::{
 		tokens::{fungibles, DepositConsequence, WithdrawConsequence},
 		BalanceStatus::Reserved,
@@ -494,39 +495,7 @@ pub mod pallet {
 				Ok(_) => None,
 				Err(origin) => Some(ensure_signed(origin)?),
 			};
-			Asset::<T, I>::try_mutate_exists(id, |maybe_details| {
-				let mut details = maybe_details.take().ok_or(Error::<T, I>::Unknown)?;
-				if let Some(check_owner) = maybe_check_owner {
-					ensure!(details.owner == check_owner, Error::<T, I>::NoPermission);
-				}
-				ensure!(details.accounts <= witness.accounts, Error::<T, I>::BadWitness);
-				ensure!(details.sufficients <= witness.sufficients, Error::<T, I>::BadWitness);
-				ensure!(details.approvals <= witness.approvals, Error::<T, I>::BadWitness);
-
-				for (who, v) in Account::<T, I>::drain_prefix(id) {
-					Self::dead_account(id, &who, &mut details, v.sufficient);
-				}
-				debug_assert_eq!(details.accounts, 0);
-				debug_assert_eq!(details.sufficients, 0);
-
-				let metadata = Metadata::<T, I>::take(&id);
-				T::Currency::unreserve(
-					&details.owner,
-					details.deposit.saturating_add(metadata.deposit),
-				);
-
-				for ((owner, _), approval) in Approvals::<T, I>::drain_prefix((&id,)) {
-					T::Currency::unreserve(&owner, approval.deposit);
-				}
-				Self::deposit_event(Event::Destroyed(id));
-
-				Ok(Some(T::WeightInfo::destroy(
-					details.accounts.saturating_sub(details.sufficients),
-					details.sufficients,
-					details.approvals,
-				))
-				.into())
-			})
+			Self::do_destroy(id, witness, maybe_check_owner)
 		}
 
 		/// Mint assets of a particular class.

--- a/frame/support/src/traits/tokens/fungibles.rs
+++ b/frame/support/src/traits/tokens/fungibles.rs
@@ -231,7 +231,12 @@ impl<AccountId, T: Balanced<AccountId> + MutateHold<AccountId>> BalancedHold<Acc
 /// Trait for providing the ability to create new fungible assets.
 pub trait Create<AccountId>: Inspect<AccountId> {
 	/// Create a new fungible asset.
-	fn create(id: Self::AssetId, admin: AccountId, min_balance: Self::Balance) -> DispatchResult;
+	fn create(
+		id: Self::AssetId,
+		admin: AccountId,
+		is_sufficient: bool,
+		min_balance: Self::Balance,
+	) -> DispatchResult;
 }
 
 /// Trait for providing the ability to destroy existing fungible assets.

--- a/frame/support/src/traits/tokens/fungibles.rs
+++ b/frame/support/src/traits/tokens/fungibles.rs
@@ -21,7 +21,7 @@ use super::{
 	misc::{AssetId, Balance},
 	*,
 };
-use crate::dispatch::{DispatchError, DispatchResult};
+use crate::dispatch::{DispatchError, DispatchResult, DispatchResultWithPostInfo};
 use sp_runtime::traits::Saturating;
 
 mod balanced;
@@ -226,4 +226,32 @@ impl<AccountId, T: Balanced<AccountId> + MutateHold<AccountId>> BalancedHold<Acc
 		};
 		<Self as fungibles::Balanced<AccountId>>::slash(asset, who, actual)
 	}
+}
+
+/// Trait for providing the ability to create new fungible assets.
+pub trait Create<AccountId>: Inspect<AccountId> {
+	/// Create a new fungible asset.
+	fn create(id: Self::AssetId, admin: AccountId, min_balance: Self::Balance) -> DispatchResult;
+}
+
+/// Trait for providing the ability to destroy existing fungible assets.
+pub trait Destroy<AccountId>: Inspect<AccountId> {
+	/// The witness data needed to destroy an asset.
+	type DestroyWitness;
+
+	/// Provide the appropriate witness data needed to destroy an asset.
+	fn get_destroy_witness(id: Self::AssetId) -> Option<Self::DestroyWitness>;
+
+	/// Destroy an existing fungible asset.
+	/// * `id`: The `AssetId` to be destroyed.
+	/// * `witness`: Any witness data that needs to be provided to complete the operation
+	///   successfully.
+	/// * `maybe_check_owner`: An optional account id that can be used to authorize the destroy
+	///   command. If not provided, we will not do any authorization checks before destroying the
+	///   asset.
+	fn destroy(
+		id: Self::AssetId,
+		witness: Self::DestroyWitness,
+		maybe_check_owner: Option<AccountId>,
+	) -> DispatchResultWithPostInfo;
 }


### PR DESCRIPTION
This PR introduces the traits `Create` and `Destroy` to the overarching `fungibles` definition.

These traits, as they sound, allow you to create and destroy fungible assets within some pallet which manages multiple fungible assets.

We implement this trait in the Assets pallet by doing a trivial refactor of the logic in the `destroy` and `force_create` extrinsic, and then using that logic for the trait.

This should help other developers who want to build on top of the Assets pallet as a basis for managing fungible tokens in their runtime.