### PR TITLE
Remove unused `sp-maybe-compressed-blob` from `sp-io`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9263,7 +9263,6 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-keystore",
- "sp-maybe-compressed-blob",
  "sp-runtime-interface",
  "sp-state-machine",
  "sp-std",

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -24,7 +24,6 @@ libsecp256k1 = { version = "0.6", optional = true }
 sp-state-machine = { version = "0.10.0-dev", optional = true, path = "../state-machine" }
 sp-wasm-interface = { version = "4.0.0-dev", path = "../wasm-interface", default-features = false }
 sp-runtime-interface = { version = "4.0.0-dev", default-features = false, path = "../runtime-interface" }
-sp-maybe-compressed-blob = { version = "4.0.0-dev", optional = true, path = "../maybe-compressed-blob" }
 sp-trie = { version = "4.0.0-dev", optional = true, path = "../trie" }
 sp-externalities = { version = "0.10.0-dev", optional = true, path = "../externalities" }
 sp-tracing = { version = "4.0.0-dev", default-features = false, path = "../tracing" }
@@ -48,7 +47,6 @@ std = [
 	"sp-runtime-interface/std",
 	"sp-externalities",
 	"sp-wasm-interface/std",
-	"sp-maybe-compressed-blob",
 	"sp-tracing/std",
 	"tracing/std",
 	"tracing-core/std",


### PR DESCRIPTION
This dependency is unused and brings in the very heavy `zstd` along with it.