### PR TITLE
Migrate Bounded Types to Const Generics

### DIFF
--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -229,12 +229,12 @@ pub mod pallet {
 
 		/// The maximum number of locks that should exist on an account.
 		/// Not strictly enforced, but used for weight estimation.
-		#[pallet::constant]
-		type MaxLocks: Get<u32>;
+		//#[pallet::constant]
+		const MAX_LOCKS: u32;
 
 		/// The maximum number of named reserves that can exist on an account.
-		#[pallet::constant]
-		type MaxReserves: Get<u32>;
+		//#[pallet::constant]
+		const MAX_RESERVES: u32;
 
 		/// The id type for named reserves.
 		type ReserveIdentifier: Parameter + Member + MaxEncodedLen + Ord + Copy;
@@ -495,7 +495,7 @@ pub mod pallet {
 		ExistingVestingSchedule,
 		/// Beneficiary account must pre-exist
 		DeadAccount,
-		/// Number of named reserves exceed MaxReserves
+		/// Number of named reserves exceed MAX_RESERVES
 		TooManyReserves,
 	}
 
@@ -526,7 +526,7 @@ pub mod pallet {
 		_,
 		Blake2_128Concat,
 		T::AccountId,
-		WeakBoundedVec<BalanceLock<T::Balance>, T::MaxLocks>,
+		WeakBoundedVec<BalanceLock<T::Balance>, { T::MAX_LOCKS }>,
 		ValueQuery,
 		GetDefault,
 		ConstU32<300_000>,
@@ -539,7 +539,7 @@ pub mod pallet {
 		_,
 		Blake2_128Concat,
 		T::AccountId,
-		BoundedVec<ReserveData<T::ReserveIdentifier, T::Balance>, T::MaxReserves>,
+		BoundedVec<ReserveData<T::ReserveIdentifier, T::Balance>, { T::MAX_RESERVES }>,
 		ValueQuery,
 	>;
 
@@ -942,12 +942,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	/// Update the account entry for `who`, given the locks.
 	fn update_locks(who: &T::AccountId, locks: &[BalanceLock<T::Balance>]) {
-		let bounded_locks = WeakBoundedVec::<_, T::MaxLocks>::force_from(
+		let bounded_locks = WeakBoundedVec::<_, { T::MAX_LOCKS }>::force_from(
 			locks.to_vec(),
 			Some("Balances Update Locks"),
 		);
 
-		if locks.len() as u32 > T::MaxLocks::get() {
+		if locks.len() as u32 > T::MAX_LOCKS {
 			log::warn!(
 				target: "runtime::balances",
 				"Warning: A user has more currency locks than expected. \
@@ -2081,7 +2081,7 @@ where
 {
 	type Moment = T::BlockNumber;
 
-	type MaxLocks = T::MaxLocks;
+	const MAX_LOCKS: u32 = T::MAX_LOCKS;
 
 	// Set a lock on the balance of `who`.
 	// Is a no-op if lock amount is zero or `reasons` `is_none()`.

--- a/frame/balances/src/tests_composite.rs
+++ b/frame/balances/src/tests_composite.rs
@@ -84,18 +84,14 @@ impl pallet_transaction_payment::Config for Test {
 	type FeeMultiplierUpdate = ();
 }
 
-parameter_types! {
-	pub const MaxReserves: u32 = 2;
-}
-
 impl Config for Test {
 	type Balance = u64;
 	type DustRemoval = ();
 	type Event = Event;
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = frame_system::Pallet<Test>;
-	type MaxLocks = ();
-	type MaxReserves = MaxReserves;
+	const MAX_LOCKS: u32 = 50;
+	const MAX_RESERVES: u32 = 2;
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }

--- a/frame/balances/src/tests_local.rs
+++ b/frame/balances/src/tests_local.rs
@@ -85,10 +85,7 @@ impl pallet_transaction_payment::Config for Test {
 	type WeightToFee = IdentityFee<u64>;
 	type FeeMultiplierUpdate = ();
 }
-parameter_types! {
-	pub const MaxLocks: u32 = 50;
-	pub const MaxReserves: u32 = 2;
-}
+
 impl Config for Test {
 	type Balance = u64;
 	type DustRemoval = ();
@@ -96,8 +93,8 @@ impl Config for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore =
 		StorageMapShim<super::Account<Test>, system::Provider<Test>, u64, super::AccountData<u64>>;
-	type MaxLocks = MaxLocks;
-	type MaxReserves = MaxReserves;
+	const MAX_LOCKS: u32 = 50;
+	const MAX_RESERVES: u32 = 2;
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }

--- a/frame/balances/src/tests_reentrancy.rs
+++ b/frame/balances/src/tests_reentrancy.rs
@@ -94,10 +94,7 @@ impl OnUnbalanced<NegativeImbalance<Test>> for OnDustRemoval {
 		assert_ok!(Balances::resolve_into_existing(&1, amount));
 	}
 }
-parameter_types! {
-	pub const MaxLocks: u32 = 50;
-	pub const MaxReserves: u32 = 2;
-}
+
 impl Config for Test {
 	type Balance = u64;
 	type DustRemoval = OnDustRemoval;
@@ -105,8 +102,8 @@ impl Config for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore =
 		StorageMapShim<super::Account<Test>, system::Provider<Test>, u64, super::AccountData<u64>>;
-	type MaxLocks = MaxLocks;
-	type MaxReserves = MaxReserves;
+	const MAX_LOCKS: u32 = 50;
+	const MAX_RESERVES: u32 = 2;
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }

--- a/frame/support/src/storage/bounded_btree_map.rs
+++ b/frame/support/src/storage/bounded_btree_map.rs
@@ -17,12 +17,9 @@
 
 //! Traits, types and structs to support a bounded BTreeMap.
 
-use crate::{storage::StorageDecodeLength};
+use crate::storage::StorageDecodeLength;
 use codec::{Decode, Encode, MaxEncodedLen};
-use sp_std::{
-	borrow::Borrow, collections::btree_map::BTreeMap, convert::TryFrom,
-	ops::Deref,
-};
+use sp_std::{borrow::Borrow, collections::btree_map::BTreeMap, convert::TryFrom, ops::Deref};
 
 /// A bounded map based on a B-Tree.
 ///
@@ -53,8 +50,7 @@ where
 	}
 }
 
-impl<K, V, const S: u32> BoundedBTreeMap<K, V, S>
-{
+impl<K, V, const S: u32> BoundedBTreeMap<K, V, S> {
 	/// Get the bound of the type in `usize`.
 	pub fn bound() -> usize {
 		S as usize
@@ -272,9 +268,7 @@ where
 	type Error = ();
 
 	fn try_from(value: BTreeMap<K, V>) -> Result<Self, Self::Error> {
-		(value.len() <= Self::bound())
-			.then(move || BoundedBTreeMap(value))
-			.ok_or(())
+		(value.len() <= Self::bound()).then(move || BoundedBTreeMap(value)).ok_or(())
 	}
 }
 
@@ -321,7 +315,7 @@ pub mod test {
 	fn boundedmap_from_keys<K, const S: u32>(keys: &[K]) -> BoundedBTreeMap<K, (), S>
 	where
 		K: Ord + Copy,
-		{
+	{
 		map_from_keys(keys).try_into().unwrap()
 	}
 

--- a/frame/support/src/storage/bounded_btree_set.rs
+++ b/frame/support/src/storage/bounded_btree_set.rs
@@ -17,12 +17,9 @@
 
 //! Traits, types and structs to support a bounded `BTreeSet`.
 
-use crate::{storage::StorageDecodeLength};
+use crate::storage::StorageDecodeLength;
 use codec::{Decode, Encode, MaxEncodedLen};
-use sp_std::{
-	borrow::Borrow, collections::btree_set::BTreeSet, convert::TryFrom,
-	ops::Deref,
-};
+use sp_std::{borrow::Borrow, collections::btree_set::BTreeSet, convert::TryFrom, ops::Deref};
 
 /// A bounded set based on a B-Tree.
 ///
@@ -51,8 +48,7 @@ where
 	}
 }
 
-impl<T, const S: u32> BoundedBTreeSet<T, S>
-{
+impl<T, const S: u32> BoundedBTreeSet<T, S> {
 	/// Get the bound of the type in `usize`.
 	pub fn bound() -> usize {
 		S as usize
@@ -255,9 +251,7 @@ where
 	type Error = ();
 
 	fn try_from(value: BTreeSet<T>) -> Result<Self, Self::Error> {
-		(value.len() <= Self::bound())
-			.then(move || BoundedBTreeSet(value))
-			.ok_or(())
+		(value.len() <= Self::bound()).then(move || BoundedBTreeSet(value)).ok_or(())
 	}
 }
 
@@ -272,7 +266,10 @@ impl<T, const S: u32> codec::DecodeLength for BoundedBTreeSet<T, S> {
 
 impl<T, const S: u32> StorageDecodeLength for BoundedBTreeSet<T, S> {}
 
-impl<T, const S: u32> codec::EncodeLike<BTreeSet<T>> for BoundedBTreeSet<T, S> where BTreeSet<T>: Encode {}
+impl<T, const S: u32> codec::EncodeLike<BTreeSet<T>> for BoundedBTreeSet<T, S> where
+	BTreeSet<T>: Encode
+{
+}
 
 #[cfg(test)]
 pub mod test {

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -1226,8 +1226,8 @@ mod private {
 	impl<Hash: Encode> Sealed for Digest<Hash> {}
 	impl<T, const S: u32> Sealed for BoundedVec<T, S> {}
 	impl<T, const S: u32> Sealed for WeakBoundedVec<T, S> {}
-	impl<K, V, S> Sealed for bounded_btree_map::BoundedBTreeMap<K, V, S> {}
-	impl<T, S> Sealed for bounded_btree_set::BoundedBTreeSet<T, S> {}
+	impl<K, V, const S: u32> Sealed for bounded_btree_map::BoundedBTreeMap<K, V, S> {}
+	impl<T, const S: u32> Sealed for bounded_btree_set::BoundedBTreeSet<T, S> {}
 
 	macro_rules! impl_sealed_for_tuple {
 		($($elem:ident),+) => {

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -1224,8 +1224,8 @@ mod private {
 
 	impl<T: Encode> Sealed for Vec<T> {}
 	impl<Hash: Encode> Sealed for Digest<Hash> {}
-	impl<T, S> Sealed for BoundedVec<T, S> {}
-	impl<T, S> Sealed for WeakBoundedVec<T, S> {}
+	impl<T, const S: u32> Sealed for BoundedVec<T, S> {}
+	impl<T, const S: u32> Sealed for WeakBoundedVec<T, S> {}
 	impl<K, V, S> Sealed for bounded_btree_map::BoundedBTreeMap<K, V, S> {}
 	impl<T, S> Sealed for bounded_btree_set::BoundedBTreeSet<T, S> {}
 
@@ -1714,22 +1714,19 @@ mod test {
 		});
 	}
 
-	crate::parameter_types! {
-		pub const Seven: u32 = 7;
-		pub const Four: u32 = 4;
-	}
+	const SEVEN: u32 = 7;
 
-	crate::generate_storage_alias! { Prefix, Foo => Value<WeakBoundedVec<u32, Seven>> }
-	crate::generate_storage_alias! { Prefix, FooMap => Map<(u32, Twox128), BoundedVec<u32, Seven>> }
+	crate::generate_storage_alias! { Prefix, Foo => Value<WeakBoundedVec<u32, SEVEN>> }
+	crate::generate_storage_alias! { Prefix, FooMap => Map<(u32, Twox128), BoundedVec<u32, SEVEN>> }
 	crate::generate_storage_alias! {
 		Prefix,
-		FooDoubleMap => DoubleMap<(u32, Twox128), (u32, Twox128), BoundedVec<u32, Seven>>
+		FooDoubleMap => DoubleMap<(u32, Twox128), (u32, Twox128), BoundedVec<u32, SEVEN>>
 	}
 
 	#[test]
 	fn try_append_works() {
 		TestExternalities::default().execute_with(|| {
-			let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
+			let bounded: WeakBoundedVec<u32, SEVEN> = vec![1, 2, 3].try_into().unwrap();
 			Foo::put(bounded);
 			assert_ok!(Foo::try_append(4));
 			assert_ok!(Foo::try_append(5));
@@ -1740,7 +1737,7 @@ mod test {
 		});
 
 		TestExternalities::default().execute_with(|| {
-			let bounded: BoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
+			let bounded: BoundedVec<u32, SEVEN> = vec![1, 2, 3].try_into().unwrap();
 			FooMap::insert(1, bounded);
 
 			assert_ok!(FooMap::try_append(1, 4));
@@ -1755,17 +1752,17 @@ mod test {
 			assert_ok!(FooMap::try_append(2, 4));
 			assert_eq!(
 				FooMap::get(2).unwrap(),
-				BoundedVec::<u32, Seven>::try_from(vec![4]).unwrap(),
+				BoundedVec::<u32, SEVEN>::try_from(vec![4]).unwrap(),
 			);
 			assert_ok!(FooMap::try_append(2, 5));
 			assert_eq!(
 				FooMap::get(2).unwrap(),
-				BoundedVec::<u32, Seven>::try_from(vec![4, 5]).unwrap(),
+				BoundedVec::<u32, SEVEN>::try_from(vec![4, 5]).unwrap(),
 			);
 		});
 
 		TestExternalities::default().execute_with(|| {
-			let bounded: BoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
+			let bounded: BoundedVec<u32, SEVEN> = vec![1, 2, 3].try_into().unwrap();
 			FooDoubleMap::insert(1, 1, bounded);
 
 			assert_ok!(FooDoubleMap::try_append(1, 1, 4));
@@ -1780,12 +1777,12 @@ mod test {
 			assert_ok!(FooDoubleMap::try_append(2, 1, 4));
 			assert_eq!(
 				FooDoubleMap::get(2, 1).unwrap(),
-				BoundedVec::<u32, Seven>::try_from(vec![4]).unwrap(),
+				BoundedVec::<u32, SEVEN>::try_from(vec![4]).unwrap(),
 			);
 			assert_ok!(FooDoubleMap::try_append(2, 1, 5));
 			assert_eq!(
 				FooDoubleMap::get(2, 1).unwrap(),
-				BoundedVec::<u32, Seven>::try_from(vec![4, 5]).unwrap(),
+				BoundedVec::<u32, SEVEN>::try_from(vec![4, 5]).unwrap(),
 			);
 		});
 	}

--- a/frame/support/src/storage/types/counted_map.rs
+++ b/frame/support/src/storage/types/counted_map.rs
@@ -462,7 +462,6 @@ mod test {
 		hash::*,
 		metadata::{StorageEntryModifier, StorageEntryType, StorageHasher},
 		storage::{bounded_vec::BoundedVec, types::ValueQuery},
-		traits::ConstU32,
 	};
 	use sp_io::{hashing::twox_128, TestExternalities};
 
@@ -947,7 +946,7 @@ mod test {
 
 	#[test]
 	fn try_append_decode_len_works() {
-		type B = CountedStorageMap<Prefix, Twox64Concat, u16, BoundedVec<u32, ConstU32<3u32>>>;
+		type B = CountedStorageMap<Prefix, Twox64Concat, u16, BoundedVec<u32, 3u32>>;
 
 		TestExternalities::default().execute_with(|| {
 			assert_eq!(B::decode_len(0), None);

--- a/frame/support/src/storage/weak_bounded_vec.rs
+++ b/frame/support/src/storage/weak_bounded_vec.rs
@@ -20,14 +20,13 @@
 
 use crate::{
 	storage::{StorageDecodeLength, StorageTryAppend},
-	traits::Get,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use core::{
 	ops::{Deref, Index, IndexMut},
 	slice::SliceIndex,
 };
-use sp_std::{convert::TryFrom, marker::PhantomData, prelude::*};
+use sp_std::{convert::TryFrom, prelude::*};
 
 /// A weakly bounded vector.
 ///
@@ -38,9 +37,9 @@ use sp_std::{convert::TryFrom, marker::PhantomData, prelude::*};
 /// is accepted, and some method allow to bypass the restriction with warnings.
 #[derive(Encode, scale_info::TypeInfo)]
 #[scale_info(skip_type_params(S))]
-pub struct WeakBoundedVec<T, S>(Vec<T>, PhantomData<S>);
+pub struct WeakBoundedVec<T, const S: u32>(Vec<T>);
 
-impl<T: Decode, S: Get<u32>> Decode for WeakBoundedVec<T, S> {
+impl<T: Decode, const S: u32> Decode for WeakBoundedVec<T, S> {
 	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
 		let inner = Vec::<T>::decode(input)?;
 		Ok(Self::force_from(inner, Some("decode")))
@@ -51,10 +50,10 @@ impl<T: Decode, S: Get<u32>> Decode for WeakBoundedVec<T, S> {
 	}
 }
 
-impl<T, S> WeakBoundedVec<T, S> {
+impl<T, const S: u32> WeakBoundedVec<T, S> {
 	/// Create `Self` from `t` without any checks.
 	fn unchecked_from(t: Vec<T>) -> Self {
-		Self(t, Default::default())
+		Self(t)
 	}
 
 	/// Consume self, and return the inner `Vec`. Henceforth, the `Vec<_>` can be altered in an
@@ -99,10 +98,10 @@ impl<T, S> WeakBoundedVec<T, S> {
 	}
 }
 
-impl<T, S: Get<u32>> WeakBoundedVec<T, S> {
+impl<T, const S: u32> WeakBoundedVec<T, S> {
 	/// Get the bound of the type in `usize`.
 	pub fn bound() -> usize {
-		S::get() as usize
+		S as usize
 	}
 
 	/// Create `Self` from `t` without any checks. Logs warnings if the bound is not being
@@ -163,7 +162,7 @@ impl<T, S: Get<u32>> WeakBoundedVec<T, S> {
 	}
 }
 
-impl<T, S> Default for WeakBoundedVec<T, S> {
+impl<T, const S: u32> Default for WeakBoundedVec<T, S> {
 	fn default() -> Self {
 		// the bound cannot be below 0, which is satisfied by an empty vector
 		Self::unchecked_from(Vec::default())
@@ -171,17 +170,16 @@ impl<T, S> Default for WeakBoundedVec<T, S> {
 }
 
 #[cfg(feature = "std")]
-impl<T, S> std::fmt::Debug for WeakBoundedVec<T, S>
+impl<T, const S: u32> std::fmt::Debug for WeakBoundedVec<T, S>
 where
 	T: std::fmt::Debug,
-	S: Get<u32>,
 {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_tuple("WeakBoundedVec").field(&self.0).field(&Self::bound()).finish()
 	}
 }
 
-impl<T, S> Clone for WeakBoundedVec<T, S>
+impl<T, const S: u32> Clone for WeakBoundedVec<T, S>
 where
 	T: Clone,
 {
@@ -191,7 +189,7 @@ where
 	}
 }
 
-impl<T, S: Get<u32>> TryFrom<Vec<T>> for WeakBoundedVec<T, S> {
+impl<T, const S: u32> TryFrom<Vec<T>> for WeakBoundedVec<T, S> {
 	type Error = ();
 	fn try_from(t: Vec<T>) -> Result<Self, Self::Error> {
 		if t.len() <= Self::bound() {
@@ -204,26 +202,26 @@ impl<T, S: Get<u32>> TryFrom<Vec<T>> for WeakBoundedVec<T, S> {
 }
 
 // It is okay to give a non-mutable reference of the inner vec to anyone.
-impl<T, S> AsRef<Vec<T>> for WeakBoundedVec<T, S> {
+impl<T, const S: u32> AsRef<Vec<T>> for WeakBoundedVec<T, S> {
 	fn as_ref(&self) -> &Vec<T> {
 		&self.0
 	}
 }
 
-impl<T, S> AsRef<[T]> for WeakBoundedVec<T, S> {
+impl<T, const S: u32> AsRef<[T]> for WeakBoundedVec<T, S> {
 	fn as_ref(&self) -> &[T] {
 		&self.0
 	}
 }
 
-impl<T, S> AsMut<[T]> for WeakBoundedVec<T, S> {
+impl<T, const S: u32> AsMut<[T]> for WeakBoundedVec<T, S> {
 	fn as_mut(&mut self) -> &mut [T] {
 		&mut self.0
 	}
 }
 
 // will allow for immutable all operations of `Vec<T>` on `WeakBoundedVec<T>`.
-impl<T, S> Deref for WeakBoundedVec<T, S> {
+impl<T, const S: u32> Deref for WeakBoundedVec<T, S> {
 	type Target = Vec<T>;
 
 	fn deref(&self) -> &Self::Target {
@@ -232,7 +230,7 @@ impl<T, S> Deref for WeakBoundedVec<T, S> {
 }
 
 // Allows for indexing similar to a normal `Vec`. Can panic if out of bound.
-impl<T, S, I> Index<I> for WeakBoundedVec<T, S>
+impl<T, I, const S: u32> Index<I> for WeakBoundedVec<T, S>
 where
 	I: SliceIndex<[T]>,
 {
@@ -244,7 +242,7 @@ where
 	}
 }
 
-impl<T, S, I> IndexMut<I> for WeakBoundedVec<T, S>
+impl<T, I, const S: u32> IndexMut<I> for WeakBoundedVec<T, S>
 where
 	I: SliceIndex<[T]>,
 {
@@ -254,7 +252,7 @@ where
 	}
 }
 
-impl<T, S> sp_std::iter::IntoIterator for WeakBoundedVec<T, S> {
+impl<T, const S: u32> sp_std::iter::IntoIterator for WeakBoundedVec<T, S> {
 	type Item = T;
 	type IntoIter = sp_std::vec::IntoIter<T>;
 	fn into_iter(self) -> Self::IntoIter {
@@ -262,7 +260,7 @@ impl<T, S> sp_std::iter::IntoIterator for WeakBoundedVec<T, S> {
 	}
 }
 
-impl<T, S> codec::DecodeLength for WeakBoundedVec<T, S> {
+impl<T, const S: u32> codec::DecodeLength for WeakBoundedVec<T, S> {
 	fn len(self_encoded: &[u8]) -> Result<usize, codec::Error> {
 		// `WeakBoundedVec<T, _>` stored just a `Vec<T>`, thus the length is at the beginning in
 		// `Compact` form, and same implementation as `Vec<T>` can be used.
@@ -273,7 +271,7 @@ impl<T, S> codec::DecodeLength for WeakBoundedVec<T, S> {
 // NOTE: we could also implement this as:
 // impl<T: Value, S1: Get<u32>, S2: Get<u32>> PartialEq<WeakBoundedVec<T, S2>> for WeakBoundedVec<T,
 // S1> to allow comparison of bounded vectors with different bounds.
-impl<T, S> PartialEq for WeakBoundedVec<T, S>
+impl<T, const S: u32> PartialEq for WeakBoundedVec<T, S>
 where
 	T: PartialEq,
 {
@@ -282,33 +280,32 @@ where
 	}
 }
 
-impl<T: PartialEq, S: Get<u32>> PartialEq<Vec<T>> for WeakBoundedVec<T, S> {
+impl<T: PartialEq, const S: u32> PartialEq<Vec<T>> for WeakBoundedVec<T, S> {
 	fn eq(&self, other: &Vec<T>) -> bool {
 		&self.0 == other
 	}
 }
 
-impl<T, S> Eq for WeakBoundedVec<T, S> where T: Eq {}
+impl<T, const S: u32> Eq for WeakBoundedVec<T, S> where T: Eq {}
 
-impl<T, S> StorageDecodeLength for WeakBoundedVec<T, S> {}
+impl<T, const S: u32> StorageDecodeLength for WeakBoundedVec<T, S> {}
 
-impl<T, S: Get<u32>> StorageTryAppend<T> for WeakBoundedVec<T, S> {
+impl<T, const S: u32> StorageTryAppend<T> for WeakBoundedVec<T, S> {
 	fn bound() -> usize {
-		S::get() as usize
+		S as usize
 	}
 }
 
-impl<T, S> MaxEncodedLen for WeakBoundedVec<T, S>
+impl<T, const S: u32> MaxEncodedLen for WeakBoundedVec<T, S>
 where
 	T: MaxEncodedLen,
-	S: Get<u32>,
 	WeakBoundedVec<T, S>: Encode,
 {
 	fn max_encoded_len() -> usize {
 		// WeakBoundedVec<T, S> encodes like Vec<T> which encodes like [T], which is a compact u32
 		// plus each item in the slice:
 		// https://substrate.dev/rustdocs/v3.0.0/src/parity_scale_codec/codec.rs.html#798-808
-		codec::Compact(S::get())
+		codec::Compact(S)
 			.encoded_size()
 			.saturating_add(Self::bound().saturating_mul(T::max_encoded_len()))
 	}
@@ -321,33 +318,31 @@ pub mod test {
 	use sp_io::TestExternalities;
 	use sp_std::convert::TryInto;
 
-	crate::parameter_types! {
-		pub const Seven: u32 = 7;
-		pub const Four: u32 = 4;
-	}
+	const SEVEN: u32 = 7;
+	const FOUR: u32 = 4;
 
-	crate::generate_storage_alias! { Prefix, Foo => Value<WeakBoundedVec<u32, Seven>> }
-	crate::generate_storage_alias! { Prefix, FooMap => Map<(u32, Twox128), WeakBoundedVec<u32, Seven>> }
+	crate::generate_storage_alias! { Prefix, Foo => Value<WeakBoundedVec<u32, SEVEN>> }
+	crate::generate_storage_alias! { Prefix, FooMap => Map<(u32, Twox128), WeakBoundedVec<u32, SEVEN>> }
 	crate::generate_storage_alias! {
 		Prefix,
-		FooDoubleMap => DoubleMap<(u32, Twox128), (u32, Twox128), WeakBoundedVec<u32, Seven>>
+		FooDoubleMap => DoubleMap<(u32, Twox128), (u32, Twox128), WeakBoundedVec<u32, SEVEN>>
 	}
 
 	#[test]
 	fn try_append_is_correct() {
-		assert_eq!(WeakBoundedVec::<u32, Seven>::bound(), 7);
+		assert_eq!(WeakBoundedVec::<u32, SEVEN>::bound(), 7);
 	}
 
 	#[test]
 	fn decode_len_works() {
 		TestExternalities::default().execute_with(|| {
-			let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
+			let bounded: WeakBoundedVec<u32, SEVEN> = vec![1, 2, 3].try_into().unwrap();
 			Foo::put(bounded);
 			assert_eq!(Foo::decode_len().unwrap(), 3);
 		});
 
 		TestExternalities::default().execute_with(|| {
-			let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
+			let bounded: WeakBoundedVec<u32, SEVEN> = vec![1, 2, 3].try_into().unwrap();
 			FooMap::insert(1, bounded);
 			assert_eq!(FooMap::decode_len(1).unwrap(), 3);
 			assert!(FooMap::decode_len(0).is_none());
@@ -355,7 +350,7 @@ pub mod test {
 		});
 
 		TestExternalities::default().execute_with(|| {
-			let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
+			let bounded: WeakBoundedVec<u32, SEVEN> = vec![1, 2, 3].try_into().unwrap();
 			FooDoubleMap::insert(1, 1, bounded);
 			assert_eq!(FooDoubleMap::decode_len(1, 1).unwrap(), 3);
 			assert!(FooDoubleMap::decode_len(2, 1).is_none());
@@ -366,7 +361,7 @@ pub mod test {
 
 	#[test]
 	fn try_insert_works() {
-		let mut bounded: WeakBoundedVec<u32, Four> = vec![1, 2, 3].try_into().unwrap();
+		let mut bounded: WeakBoundedVec<u32, FOUR> = vec![1, 2, 3].try_into().unwrap();
 		bounded.try_insert(1, 0).unwrap();
 		assert_eq!(*bounded, vec![1, 0, 2, 3]);
 
@@ -377,13 +372,13 @@ pub mod test {
 	#[test]
 	#[should_panic(expected = "insertion index (is 9) should be <= len (is 3)")]
 	fn try_inert_panics_if_oob() {
-		let mut bounded: WeakBoundedVec<u32, Four> = vec![1, 2, 3].try_into().unwrap();
+		let mut bounded: WeakBoundedVec<u32, FOUR> = vec![1, 2, 3].try_into().unwrap();
 		bounded.try_insert(9, 0).unwrap();
 	}
 
 	#[test]
 	fn try_push_works() {
-		let mut bounded: WeakBoundedVec<u32, Four> = vec![1, 2, 3].try_into().unwrap();
+		let mut bounded: WeakBoundedVec<u32, FOUR> = vec![1, 2, 3].try_into().unwrap();
 		bounded.try_push(0).unwrap();
 		assert_eq!(*bounded, vec![1, 2, 3, 0]);
 
@@ -392,7 +387,7 @@ pub mod test {
 
 	#[test]
 	fn deref_coercion_works() {
-		let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
+		let bounded: WeakBoundedVec<u32, SEVEN> = vec![1, 2, 3].try_into().unwrap();
 		// these methods come from deref-ed vec.
 		assert_eq!(bounded.len(), 3);
 		assert!(bounded.iter().next().is_some());
@@ -401,7 +396,7 @@ pub mod test {
 
 	#[test]
 	fn try_mutate_works() {
-		let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3, 4, 5, 6].try_into().unwrap();
+		let bounded: WeakBoundedVec<u32, SEVEN> = vec![1, 2, 3, 4, 5, 6].try_into().unwrap();
 		let bounded = bounded.try_mutate(|v| v.push(7)).unwrap();
 		assert_eq!(bounded.len(), 7);
 		assert!(bounded.try_mutate(|v| v.push(8)).is_none());
@@ -409,20 +404,20 @@ pub mod test {
 
 	#[test]
 	fn slice_indexing_works() {
-		let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3, 4, 5, 6].try_into().unwrap();
+		let bounded: WeakBoundedVec<u32, SEVEN> = vec![1, 2, 3, 4, 5, 6].try_into().unwrap();
 		assert_eq!(&bounded[0..=2], &[1, 2, 3]);
 	}
 
 	#[test]
 	fn vec_eq_works() {
-		let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3, 4, 5, 6].try_into().unwrap();
+		let bounded: WeakBoundedVec<u32, SEVEN> = vec![1, 2, 3, 4, 5, 6].try_into().unwrap();
 		assert_eq!(bounded, vec![1, 2, 3, 4, 5, 6]);
 	}
 
 	#[test]
 	fn too_big_succeed_to_decode() {
 		let v: Vec<u32> = vec![1, 2, 3, 4, 5];
-		let w = WeakBoundedVec::<u32, Four>::decode(&mut &v.encode()[..]).unwrap();
+		let w = WeakBoundedVec::<u32, FOUR>::decode(&mut &v.encode()[..]).unwrap();
 		assert_eq!(v, *w);
 	}
 }

--- a/frame/support/src/storage/weak_bounded_vec.rs
+++ b/frame/support/src/storage/weak_bounded_vec.rs
@@ -18,9 +18,7 @@
 //! Traits, types and structs to support putting a bounded vector into storage, as a raw value, map
 //! or a double map.
 
-use crate::{
-	storage::{StorageDecodeLength, StorageTryAppend},
-};
+use crate::storage::{StorageDecodeLength, StorageTryAppend};
 use codec::{Decode, Encode, MaxEncodedLen};
 use core::{
 	ops::{Deref, Index, IndexMut},

--- a/frame/support/src/traits/tokens/currency/lockable.rs
+++ b/frame/support/src/traits/tokens/currency/lockable.rs
@@ -18,7 +18,7 @@
 //! The lockable currency trait and some associated types.
 
 use super::{super::misc::WithdrawReasons, Currency};
-use crate::{dispatch::DispatchResult, traits::misc::Get};
+use crate::{dispatch::DispatchResult};
 
 /// An identifier for a lock. Used for disambiguating different locks so that
 /// they can be individually replaced or removed.
@@ -30,7 +30,7 @@ pub trait LockableCurrency<AccountId>: Currency<AccountId> {
 	type Moment;
 
 	/// The maximum number of locks a user should have on their account.
-	type MaxLocks: Get<u32>;
+	const MAX_LOCKS: u32;
 
 	/// Create a new balance lock on account `who`.
 	///


### PR DESCRIPTION
I believe const generics were not stable when we first introduced bounded types.

Now that they are, we should use them instead of `Get<u32>` which may allow a runtime developer to shoot themselves in the foot by NOT providing a constant value.

This should not be a breaking change other than syntax.