### PR TITLE
Regression: unsafe block needed

### DIFF
--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -1484,7 +1484,7 @@ mod allocator_impl {
 pub fn panic(info: &core::panic::PanicInfo) -> ! {
 	let message = sp_std::alloc::format!("{}", info);
 	logging::log(LogLevel::Error, "runtime", message.as_bytes());
-	core::arch::wasm32::unreachable();
+	unsafe { core::arch::wasm32::unreachable() };
 }
 
 /// A default OOM handler for WASM environment.
@@ -1492,7 +1492,7 @@ pub fn panic(info: &core::panic::PanicInfo) -> ! {
 #[alloc_error_handler]
 pub fn oom(_: core::alloc::Layout) -> ! {
 	logging::log(LogLevel::Error, "runtime", b"Runtime memory exhausted. Aborting");
-	core::arch::wasm32::unreachable();
+	unsafe { core::arch::wasm32::unreachable() };
 }
 
 /// Type alias for Externalities implementation used in tests.


### PR DESCRIPTION
My compiler suggests that the unsafe blocks around the unsafe unreachable functions are mandatory.

They were removed recently in PR: #9637 so this is just putting them back.