### PR TITLE
Point to nightly that can compile the code.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@ let
       rev = "4a07484cf0e49047f82d83fd119acffbad3b235f";
     });
   nixpkgs = import <nixpkgs> { overlays = [ mozillaOverlay ]; };
-  rust-nightly = with nixpkgs; ((rustChannelOf { date = "2021-07-06"; channel = "nightly"; }).rust.override {
+  rust-nightly = with nixpkgs; ((rustChannelOf { date = "2021-09-10"; channel = "nightly"; }).rust.override {
     extensions = [ "rust-src" ];
     targets = [ "wasm32-unknown-unknown" ];
   });


### PR DESCRIPTION
Update nix shell. ( due to wasm32's unreachable not being an unsafe fn anymore  #9637 )