### PR TITLE
Ease of use: Print to stdout a hint on how to turn logging on

### DIFF
--- a/client/cli/src/runner.rs
+++ b/client/cli/src/runner.rs
@@ -198,7 +198,7 @@ impl<C: SubstrateCli> Runner<C> {
 /// (and hint to people who haven't set up logging how to do it)
 pub fn print_node_infos<C: SubstrateCli>(config: &Configuration) {	
 	if log::max_level() == log::LevelFilter::Off {
-		println!("Logging disabled  (to enable typically set env var RUST_LOG=info )");
+		println!("Logging disabled. To enable set the `RUST_LOG` env var to the desired level or use the `--log` option.");
 	}
 	info!("{}", C::impl_name());
 	info!("✌️  version {}", C::impl_version());

--- a/client/cli/src/runner.rs
+++ b/client/cli/src/runner.rs
@@ -198,7 +198,7 @@ impl<C: SubstrateCli> Runner<C> {
 /// (and hint to people who haven't set up logging how to do it)
 pub fn print_node_infos<C: SubstrateCli>(config: &Configuration) {	
 	if log::max_level() == log::LevelFilter::Off {
-		println!("( for logging set env var RUST_LOG=info )");
+		println!("Logging disabled  (to enable typically set env var RUST_LOG=info )");
 	}
 	info!("{}", C::impl_name());
 	info!("✌️  version {}", C::impl_version());

--- a/client/cli/src/runner.rs
+++ b/client/cli/src/runner.rs
@@ -22,7 +22,7 @@ use futures::{future, future::FutureExt, pin_mut, select, Future};
 use log::info;
 use sc_service::{Configuration, Error as ServiceError, TaskManager};
 use sc_utils::metrics::{TOKIO_THREADS_ALIVE, TOKIO_THREADS_TOTAL};
-use std::marker::PhantomData;
+use std::{env, marker::PhantomData};
 
 #[cfg(target_family = "unix")]
 async fn main<F, E>(func: F) -> std::result::Result<(), E>
@@ -195,7 +195,11 @@ impl<C: SubstrateCli> Runner<C> {
 }
 
 /// Log information about the node itself.
+/// (and hint to people who haven't set up logging how to do it)
 pub fn print_node_infos<C: SubstrateCli>(config: &Configuration) {
+	if env::var("RUST_LOG").is_err() {
+		println!("( for logging set env var RUST_LOG=info )");
+	}
 	info!("{}", C::impl_name());
 	info!("✌️  version {}", C::impl_version());
 	info!("❤️  by {}, {}-{}", C::author(), C::copyright_start_year(), Local::today().year());

--- a/client/cli/src/runner.rs
+++ b/client/cli/src/runner.rs
@@ -22,7 +22,7 @@ use futures::{future, future::FutureExt, pin_mut, select, Future};
 use log::info;
 use sc_service::{Configuration, Error as ServiceError, TaskManager};
 use sc_utils::metrics::{TOKIO_THREADS_ALIVE, TOKIO_THREADS_TOTAL};
-use std::{env, marker::PhantomData};
+use std::marker::PhantomData;
 
 #[cfg(target_family = "unix")]
 async fn main<F, E>(func: F) -> std::result::Result<(), E>
@@ -196,8 +196,8 @@ impl<C: SubstrateCli> Runner<C> {
 
 /// Log information about the node itself.
 /// (and hint to people who haven't set up logging how to do it)
-pub fn print_node_infos<C: SubstrateCli>(config: &Configuration) {
-	if env::var("RUST_LOG").is_err() {
+pub fn print_node_infos<C: SubstrateCli>(config: &Configuration) {	
+	if log::max_level() == log::LevelFilter::Off {
 		println!("( for logging set env var RUST_LOG=info )");
 	}
 	info!("{}", C::impl_name());


### PR DESCRIPTION
Sometimes you run substrate and nothing seems to happen. It's happening but the logging's not configured.
I've been tripped up by this and I'm sure it's puzzled a fair few beginners (and probably a few experts from time to time). By just having one line of hint on stdout we can shortcut the head scratching making substrate a little easier to use. Please feel free to bikeshed message!

(There's probably some tests that will squawk due to this that I will have to fix up.)