### PR TITLE
Simple Trait to Inspect Metadata

### DIFF
--- a/frame/assets/src/impl_fungibles.rs
+++ b/frame/assets/src/impl_fungibles.rs
@@ -60,6 +60,25 @@ impl<T: Config<I>, I: 'static> fungibles::Inspect<<T as SystemConfig>::AccountId
 	}
 }
 
+impl<T: Config<I>, I: 'static> fungibles::InspectMetadata<<T as SystemConfig>::AccountId>
+	for Pallet<T, I>
+{
+	/// Return the name of an asset.
+	fn name(asset: &Self::AssetId) -> Vec<u8> {
+		Metadata::<T, I>::get(asset).name.to_vec()
+	}
+
+	/// Return the symbol of an asset.
+	fn symbol(asset: &Self::AssetId) -> Vec<u8> {
+		Metadata::<T, I>::get(asset).symbol.to_vec()
+	}
+
+	/// Return the decimals of an asset.
+	fn decimals(asset: &Self::AssetId) -> u8 {
+		Metadata::<T, I>::get(asset).decimals
+	}
+}
+
 impl<T: Config<I>, I: 'static> fungibles::Mutate<<T as SystemConfig>::AccountId> for Pallet<T, I> {
 	fn mint_into(
 		asset: Self::AssetId,

--- a/frame/support/src/traits/tokens/fungibles.rs
+++ b/frame/support/src/traits/tokens/fungibles.rs
@@ -65,6 +65,18 @@ pub trait Inspect<AccountId> {
 	) -> WithdrawConsequence<Self::Balance>;
 }
 
+/// Trait for reading metadata from a fungible asset.
+pub trait InspectMetadata<AccountId>: Inspect<AccountId> {
+	/// Return the name of an asset.
+	fn name(asset: &Self::AssetId) -> Vec<u8>;
+
+	/// Return the symbol of an asset.
+	fn symbol(asset: &Self::AssetId) -> Vec<u8>;
+
+	/// Return the decimals of an asset.
+	fn decimals(asset: &Self::AssetId) -> u8;
+}
+
 /// Trait for providing a set of named fungible assets which can be created and destroyed.
 pub trait Mutate<AccountId>: Inspect<AccountId> {
 	/// Attempt to increase the `asset` balance of `who` by `amount`.

--- a/frame/support/src/traits/tokens/fungibles.rs
+++ b/frame/support/src/traits/tokens/fungibles.rs
@@ -23,6 +23,7 @@ use super::{
 };
 use crate::dispatch::{DispatchError, DispatchResult};
 use sp_runtime::traits::Saturating;
+use sp_std::vec::Vec;
 
 mod balanced;
 pub use balanced::{Balanced, Unbalanced};


### PR DESCRIPTION
This introduces a very simple trait to inspect the metadata of an asset.

Closes: https://github.com/paritytech/substrate/issues/9877