### PR TITLE
Remove unidiomatic implementation

### DIFF
--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -450,7 +450,7 @@ impl<T: TypeInfo + 'static> TypeInfo for WrapperOpaque<T> {
 			.type_params(vec![TypeParameter::new("T", Some(meta_type::<T>()))])
 			.composite(
 				Fields::unnamed()
-					.field(|f| f.compact::<u32>().type_name("EncodedLengthOfT"))
+					.field(|f| f.compact::<u32>())
 					.field(|f| f.ty::<T>().type_name("T")),
 			)
 	}


### PR DESCRIPTION
the type_name is generally used as a hint for generic type of a type. Here the `compact<u32>` is not generic for WrapperOpaque, thus we should just give no name:
https://github.com/paritytech/substrate/pull/9881#discussion_r718293534