### PR TITLE
contracts: Add event field names

### DIFF
--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -660,7 +660,7 @@ where
 				}
 
 				// Deposit an instantiation event.
-				deposit_event::<T>(vec![], Event::Instantiated(self.caller().clone(), account_id));
+				deposit_event::<T>(vec![], Event::Instantiated { deployer: self.caller().clone(), contract: account_id });
 			}
 
 			Ok(output)
@@ -942,10 +942,10 @@ where
 		)?;
 		ContractInfoOf::<T>::remove(&frame.account_id);
 		E::remove_user(info.code_hash, &mut frame.nested_meter)?;
-		Contracts::<T>::deposit_event(Event::Terminated(
-			frame.account_id.clone(),
-			beneficiary.clone(),
-		));
+		Contracts::<T>::deposit_event(Event::Terminated {
+			contract: frame.account_id.clone(),
+			beneficiary: beneficiary.clone(),
+		});
 		Ok(())
 	}
 
@@ -997,7 +997,7 @@ where
 	fn deposit_event(&mut self, topics: Vec<T::Hash>, data: Vec<u8>) {
 		deposit_event::<Self::T>(
 			topics,
-			Event::ContractEmitted(self.top_frame().account_id.clone(), data),
+			Event::ContractEmitted { contract: self.top_frame().account_id.clone(), data },
 		);
 	}
 
@@ -1662,7 +1662,7 @@ mod tests {
 				Storage::<Test>::code_hash(&instantiated_contract_address).unwrap(),
 				dummy_ch
 			);
-			assert_eq!(&events(), &[Event::Instantiated(ALICE, instantiated_contract_address)]);
+			assert_eq!(&events(), &[Event::Instantiated { deployer: ALICE, contract: instantiated_contract_address }]);
 		});
 	}
 
@@ -1751,7 +1751,7 @@ mod tests {
 				Storage::<Test>::code_hash(&instantiated_contract_address).unwrap(),
 				dummy_ch
 			);
-			assert_eq!(&events(), &[Event::Instantiated(BOB, instantiated_contract_address)]);
+			assert_eq!(&events(), &[Event::Instantiated { deployer: BOB, contract: instantiated_contract_address }]);
 		});
 	}
 

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -660,7 +660,10 @@ where
 				}
 
 				// Deposit an instantiation event.
-				deposit_event::<T>(vec![], Event::Instantiated { deployer: self.caller().clone(), contract: account_id });
+				deposit_event::<T>(
+					vec![],
+					Event::Instantiated { deployer: self.caller().clone(), contract: account_id },
+				);
 			}
 
 			Ok(output)
@@ -1662,7 +1665,10 @@ mod tests {
 				Storage::<Test>::code_hash(&instantiated_contract_address).unwrap(),
 				dummy_ch
 			);
-			assert_eq!(&events(), &[Event::Instantiated { deployer: ALICE, contract: instantiated_contract_address }]);
+			assert_eq!(
+				&events(),
+				&[Event::Instantiated { deployer: ALICE, contract: instantiated_contract_address }]
+			);
 		});
 	}
 
@@ -1751,7 +1757,10 @@ mod tests {
 				Storage::<Test>::code_hash(&instantiated_contract_address).unwrap(),
 				dummy_ch
 			);
-			assert_eq!(&events(), &[Event::Instantiated { deployer: BOB, contract: instantiated_contract_address }]);
+			assert_eq!(
+				&events(),
+				&[Event::Instantiated { deployer: BOB, contract: instantiated_contract_address }]
+			);
 		});
 	}
 

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -373,37 +373,35 @@ pub mod pallet {
 		Instantiated { deployer: T::AccountId, contract: T::AccountId },
 
 		/// Contract has been removed.
-		/// \[contract, beneficiary\]
-		///
-		/// # Params
-		///
-		/// - `contract`: The contract that was terminated.
-		/// - `beneficiary`: The account that received the contracts remaining balance.
 		///
 		/// # Note
 		///
 		/// The only way for a contract to be removed and emitting this event is by calling
 		/// `seal_terminate`.
-		Terminated { contract: T::AccountId, beneficiary: T::AccountId },
+		Terminated {
+			/// The contract that was terminated.
+			contract: T::AccountId,
+			/// The account that received the contracts remaining balance
+			beneficiary: T::AccountId
+		},
 
 		/// Code with the specified hash has been stored.
 		CodeStored { code_hash: T::Hash },
 
 		/// Triggered when the current schedule is updated.
-		///
-		/// # Params
-		///
-		/// - `version`: The version of the newly set schedule.
-		ScheduleUpdated { version: u32 },
+		ScheduleUpdated {
+			/// The version of the newly set schedule.
+			version: u32
+		},
 
 		/// A custom event emitted by the contract.
-		///
-		/// # Params
-		///
-		/// - `contract`: The contract that emitted the event.
-		/// - `data`: Data supplied by the contract. Metadata generated during contract compilation
-		///   is needed to decode it.
-		ContractEmitted { contract: T::AccountId, data: Vec<u8> },
+		ContractEmitted {
+			/// The contract that emitted the event.
+			contract: T::AccountId,
+			/// Data supplied by the contract. Metadata generated during contract compilation
+			/// is needed to decode it.
+			data: Vec<u8>
+		},
 
 		/// A code with the specified hash was removed.
 		///

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -369,8 +369,8 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
-		/// Contract deployed by address at the specified address. \[deployer, contract\]
-		Instantiated(T::AccountId, T::AccountId),
+		/// Contract deployed by address at the specified address.
+		Instantiated { deployer: T::AccountId, contract: T::AccountId },
 
 		/// Contract has been removed.
 		/// \[contract, beneficiary\]
@@ -384,34 +384,31 @@ pub mod pallet {
 		///
 		/// The only way for a contract to be removed and emitting this event is by calling
 		/// `seal_terminate`.
-		Terminated(T::AccountId, T::AccountId),
+		Terminated { contract: T::AccountId, beneficiary: T::AccountId },
 
-		/// Code with the specified hash has been stored. \[code_hash\]
-		CodeStored(T::Hash),
+		/// Code with the specified hash has been stored.
+		CodeStored { code_hash: T::Hash },
 
 		/// Triggered when the current schedule is updated.
-		/// \[version\]
 		///
 		/// # Params
 		///
 		/// - `version`: The version of the newly set schedule.
-		ScheduleUpdated(u32),
+		ScheduleUpdated { version: u32 },
 
 		/// A custom event emitted by the contract.
-		/// \[contract, data\]
 		///
 		/// # Params
 		///
 		/// - `contract`: The contract that emitted the event.
 		/// - `data`: Data supplied by the contract. Metadata generated during contract compilation
 		///   is needed to decode it.
-		ContractEmitted(T::AccountId, Vec<u8>),
+		ContractEmitted { contract: T::AccountId, data: Vec<u8> },
 
 		/// A code with the specified hash was removed.
-		/// \[code_hash\]
 		///
 		/// This happens when the last contract that uses this code hash was removed.
-		CodeRemoved(T::Hash),
+		CodeRemoved { code_hash: T::Hash },
 	}
 
 	#[pallet::error]

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -382,7 +382,7 @@ pub mod pallet {
 			/// The contract that was terminated.
 			contract: T::AccountId,
 			/// The account that received the contracts remaining balance
-			beneficiary: T::AccountId
+			beneficiary: T::AccountId,
 		},
 
 		/// Code with the specified hash has been stored.
@@ -391,7 +391,7 @@ pub mod pallet {
 		/// Triggered when the current schedule is updated.
 		ScheduleUpdated {
 			/// The version of the newly set schedule.
-			version: u32
+			version: u32,
 		},
 
 		/// A custom event emitted by the contract.
@@ -400,7 +400,7 @@ pub mod pallet {
 			contract: T::AccountId,
 			/// Data supplied by the contract. Metadata generated during contract compilation
 			/// is needed to decode it.
-			data: Vec<u8>
+			data: Vec<u8>,
 		},
 
 		/// A code with the specified hash was removed.

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -478,7 +478,9 @@ fn instantiate_and_call_and_deposit_event() {
 				},
 				EventRecord {
 					phase: Phase::Initialization,
-					event: Event::Contracts(crate::Event::CodeStored { code_hash: code_hash.into() }),
+					event: Event::Contracts(crate::Event::CodeStored {
+						code_hash: code_hash.into()
+					}),
 					topics: vec![],
 				},
 				EventRecord {
@@ -491,7 +493,10 @@ fn instantiate_and_call_and_deposit_event() {
 				},
 				EventRecord {
 					phase: Phase::Initialization,
-					event: Event::Contracts(crate::Event::Instantiated { deployer: ALICE, contract: addr.clone() }),
+					event: Event::Contracts(crate::Event::Instantiated {
+						deployer: ALICE,
+						contract: addr.clone()
+					}),
 					topics: vec![],
 				},
 			]
@@ -769,7 +774,10 @@ fn self_destruct_works() {
 				},
 				EventRecord {
 					phase: Phase::Initialization,
-					event: Event::Contracts(crate::Event::Terminated { contract: addr.clone(), beneficiary: DJANGO }),
+					event: Event::Contracts(crate::Event::Terminated {
+						contract: addr.clone(),
+						beneficiary: DJANGO
+					}),
 					topics: vec![],
 				},
 			],

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -478,20 +478,20 @@ fn instantiate_and_call_and_deposit_event() {
 				},
 				EventRecord {
 					phase: Phase::Initialization,
-					event: Event::Contracts(crate::Event::CodeStored(code_hash.into())),
+					event: Event::Contracts(crate::Event::CodeStored { code_hash: code_hash.into() }),
 					topics: vec![],
 				},
 				EventRecord {
 					phase: Phase::Initialization,
-					event: Event::Contracts(crate::Event::ContractEmitted(
-						addr.clone(),
-						vec![1, 2, 3, 4]
-					)),
+					event: Event::Contracts(crate::Event::ContractEmitted {
+						contract: addr.clone(),
+						data: vec![1, 2, 3, 4]
+					}),
 					topics: vec![],
 				},
 				EventRecord {
 					phase: Phase::Initialization,
-					event: Event::Contracts(crate::Event::Instantiated(ALICE, addr.clone())),
+					event: Event::Contracts(crate::Event::Instantiated { deployer: ALICE, contract: addr.clone() }),
 					topics: vec![],
 				},
 			]
@@ -764,12 +764,12 @@ fn self_destruct_works() {
 				},
 				EventRecord {
 					phase: Phase::Initialization,
-					event: Event::Contracts(crate::Event::CodeRemoved(code_hash)),
+					event: Event::Contracts(crate::Event::CodeRemoved { code_hash }),
 					topics: vec![],
 				},
 				EventRecord {
 					phase: Phase::Initialization,
-					event: Event::Contracts(crate::Event::Terminated(addr.clone(), DJANGO)),
+					event: Event::Contracts(crate::Event::Terminated { contract: addr.clone(), beneficiary: DJANGO }),
 					topics: vec![],
 				},
 			],

--- a/frame/contracts/src/wasm/code_cache.rs
+++ b/frame/contracts/src/wasm/code_cache.rs
@@ -59,7 +59,7 @@ where
 		Some(module) => increment_64(&mut module.refcount),
 		None => {
 			*existing = Some(prefab_module);
-			Contracts::<T>::deposit_event(Event::CodeStored(code_hash))
+			Contracts::<T>::deposit_event(Event::CodeStored { code_hash })
 		},
 	});
 }
@@ -170,7 +170,7 @@ where
 	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
 {
 	<PristineCode<T>>::remove(code_hash);
-	Contracts::<T>::deposit_event(Event::CodeRemoved(code_hash))
+	Contracts::<T>::deposit_event(Event::CodeRemoved { code_hash })
 }
 
 /// Increment the refcount panicking if it should ever overflow (which will not happen).


### PR DESCRIPTION
Use struct variants with field names for `Event`, instead of unnamed tuple variants. This will be automatically reflected (via the `TypeInfo` derive) in the metadata with variant fields having names attached.

Motivated by my having wasted a lot of time when I mixed up these fields `Instantiated(T::AccountId, T::AccountId)`

If this is acceptable then we can convert other pallet `Event`s to this style.