### PR TITLE
Fix basic authorship flaky test

### DIFF
--- a/client/basic-authorship/src/basic_authorship.rs
+++ b/client/basic-authorship/src/basic_authorship.rs
@@ -718,7 +718,7 @@ mod tests {
 			);
 
 			// when
-			let deadline = time::Duration::from_secs(9);
+			let deadline = time::Duration::from_secs(900);
 			let block =
 				block_on(proposer.propose(Default::default(), Default::default(), deadline, None))
 					.map(|r| r.block)


### PR DESCRIPTION
The test is flaky because sometimes we hit the 9 seconds deadline when
the CI was probably on high load. To "solve" this we just use an huge
deadline that should never be triggered. The deadline isn't required anyway.

