### PR TITLE
`Beefy`: impl Default for ValidatorSet

### DIFF
--- a/primitives/beefy/src/lib.rs
+++ b/primitives/beefy/src/lib.rs
@@ -93,6 +93,11 @@ impl<AuthorityId> ValidatorSet<AuthorityId> {
 	}
 }
 
+impl<AuthorityId> Default for ValidatorSet<AuthorityId> {
+	fn default() -> Self {
+		Self::empty()
+	}
+}
 /// The index of an authority.
 pub type AuthorityIndex = u32;
 


### PR DESCRIPTION
Implement `Default` for `ValidatorSet` for downstream crate ease-of-life.

`default()` has been implemented in terms of `empty()` to highlight semantic equivalence of both methods.