### PR TITLE
Create attribute macro for defining common defaults for config associated types

### DIFF
--- a/frame/support/procedural/src/default_config.rs
+++ b/frame/support/procedural/src/default_config.rs
@@ -17,7 +17,10 @@
 
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use syn::{Ident, ItemImpl, Path, PathArguments, PathSegment, Result, Token, parse::Parser, punctuated::Punctuated, spanned::Spanned};
+use syn::{
+	parse::Parser, punctuated::Punctuated, spanned::Spanned, Ident, ItemImpl, Path, PathArguments,
+	PathSegment, Result, Token,
+};
 
 pub fn use_default_config_for(attr: TokenStream, input: TokenStream) -> Result<TokenStream> {
 	let config_impl: ItemImpl = syn::parse(input)?;
@@ -28,11 +31,13 @@ pub fn use_default_config_for(attr: TokenStream, input: TokenStream) -> Result<T
 	})?;
 	let ItemImpl { attrs, generics, self_ty, items, .. } = config_impl;
 	let config_opts = Punctuated::<Ident, Token![,]>::parse_terminated.parse(attr)?;
-	let default_items = config_opts.iter().map(|config_item_ident| {
-		let path = construct_path_to_macro(&config_trait);
-		quote!(#path::use_default_config_for!(#config_item_ident);)
-	})
-	.collect::<Vec<_>>();
+	let default_items = config_opts
+		.iter()
+		.map(|config_item_ident| {
+			let path = construct_path_to_macro(&config_trait);
+			quote!(#path::use_default_config_for!(#config_item_ident);)
+		})
+		.collect::<Vec<_>>();
 
 	Ok(quote! {
 		#(#attrs)*
@@ -40,7 +45,8 @@ pub fn use_default_config_for(attr: TokenStream, input: TokenStream) -> Result<T
 			#(#items)*
 			#(#default_items)*
 		}
-	}.into())
+	}
+	.into())
 }
 
 fn construct_path_to_macro(config_trait: &Path) -> Path {

--- a/frame/support/procedural/src/default_config.rs
+++ b/frame/support/procedural/src/default_config.rs
@@ -19,8 +19,11 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::{format_ident, quote};
 use syn::{
-	parse::Parser, punctuated::Punctuated, spanned::Spanned, token::{Bang, For}, Ident, ItemImpl, Path, PathArguments,
-	PathSegment, Result, Token,
+	parse::Parser,
+	punctuated::Punctuated,
+	spanned::Spanned,
+	token::{Bang, For},
+	Ident, ItemImpl, Path, PathArguments, PathSegment, Result, Token,
 };
 
 pub fn use_default_config_for(attr: TokenStream, input: TokenStream) -> Result<TokenStream> {
@@ -55,7 +58,7 @@ fn extract_config_trait(trait_: Option<(Option<Bang>, Path, For)>, span: Span) -
 	let (_, config_trait, _) = trait_.ok_or_else(make_err)?;
 
 	match config_trait.segments.last() {
-		Some(seg) if seg.ident == "Config" => {}
+		Some(seg) if seg.ident == "Config" => (),
 		_ => return Err(make_err()),
 	}
 	Ok(config_trait)

--- a/frame/support/procedural/src/default_config.rs
+++ b/frame/support/procedural/src/default_config.rs
@@ -1,0 +1,54 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{Ident, ItemImpl, Path, PathArguments, PathSegment, Result, Token, parse::Parser, punctuated::Punctuated, spanned::Spanned};
+
+pub fn use_default_config_for(attr: TokenStream, input: TokenStream) -> Result<TokenStream> {
+	let config_impl: ItemImpl = syn::parse(input)?;
+	let config_impl_span = config_impl.span();
+	let (_, config_trait, _) = config_impl.trait_.ok_or_else(|| {
+		let msg = "impl block does not implement a pallet Config trait";
+		syn::Error::new(config_impl_span, msg)
+	})?;
+	let ItemImpl { attrs, generics, self_ty, items, .. } = config_impl;
+	let config_opts = Punctuated::<Ident, Token![,]>::parse_terminated.parse(attr)?;
+	let default_items = config_opts.iter().map(|config_item_ident| {
+		let path = construct_path_to_macro(&config_trait);
+		quote!(#path::use_default_config_for!(#config_item_ident);)
+	})
+	.collect::<Vec<_>>();
+
+	Ok(quote! {
+		#(#attrs)*
+		impl<#generics> #config_trait for #self_ty {
+			#(#items)*
+			#(#default_items)*
+		}
+	}.into())
+}
+
+fn construct_path_to_macro(config_trait: &Path) -> Path {
+	let mut path = config_trait.clone();
+	path.segments.pop();
+	path.segments.push(PathSegment {
+		ident: format_ident!("__substrate_config_defaults"),
+		arguments: PathArguments::None,
+	});
+	path
+}

--- a/frame/support/procedural/src/lib.rs
+++ b/frame/support/procedural/src/lib.rs
@@ -23,6 +23,7 @@ mod clone_no_bound;
 mod construct_runtime;
 mod crate_version;
 mod debug_no_bound;
+mod default_config;
 mod default_no_bound;
 mod dummy_part_checker;
 mod key_prefix;
@@ -497,4 +498,11 @@ pub fn impl_key_prefix_for_tuples(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn __generate_dummy_part_checker(input: TokenStream) -> TokenStream {
 	dummy_part_checker::generate_dummy_part_checker(input)
+}
+
+/// Macro used for declaring that defaults should be used for the specified config items.
+#[proc_macro_attribute]
+pub fn use_default_config_for(attr: TokenStream, input: TokenStream) -> TokenStream {
+	default_config::use_default_config_for(attr, input)
+		.unwrap_or_else(|e| e.to_compile_error().into())
 }

--- a/frame/support/procedural/src/pallet/expand/config.rs
+++ b/frame/support/procedural/src/pallet/expand/config.rs
@@ -41,17 +41,19 @@ pub fn expand_config(def: &mut Def) -> proc_macro2::TokenStream {
 		));
 	}
 
-	let (config_type_names, config_type_defaults) = config
-		.defaults_metadata
-		.iter()
-		.fold((Vec::new(), Vec::new()), |mut acc, metadata| {
-			acc.0.push(metadata.ident.clone());
-			acc.1.push(metadata.default.clone());
-			acc
-		});
+	let (config_type_names, config_type_defaults) =
+		config
+			.defaults_metadata
+			.iter()
+			.fold((Vec::new(), Vec::new()), |mut acc, metadata| {
+				acc.0.push(metadata.ident.clone());
+				acc.1.push(metadata.default.clone());
+				acc
+			});
 
 	let count = COUNTER.with(|counter| counter.borrow_mut().inc());
-	let macro_ident = syn::Ident::new(&format!("__use_default_config_for_{}", count), config.attr_span);
+	let macro_ident =
+		syn::Ident::new(&format!("__use_default_config_for_{}", count), config.attr_span);
 
 	quote::quote! {
 		#[doc(hidden)]

--- a/frame/support/procedural/src/pallet/parse/config.rs
+++ b/frame/support/procedural/src/pallet/parse/config.rs
@@ -155,7 +155,7 @@ impl syn::parse::Parse for TypeAttr {
 		syn::bracketed!(content in input);
 		content.parse::<syn::Ident>()?;
 		content.parse::<syn::Token![::]>()?;
-		
+
 		let lookahead = content.lookahead1();
 
 		if lookahead.peek(keyword::constant) {
@@ -372,7 +372,8 @@ impl ConfigDef {
 				type_attrs.into_iter().partition(|attr| matches!(attr, TypeAttr::Constant(_)));
 
 			if type_attrs_const.len() > 1 {
-				let msg = "Invalid attribute in pallet::config, only one pallet::constant is expected";
+				let msg =
+					"Invalid attribute in pallet::config, only one pallet::constant is expected";
 				return Err(syn::Error::new(type_attrs_const[1].span(), msg))
 			}
 

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -573,7 +573,7 @@ pub fn debug(data: &impl sp_std::fmt::Debug) {
 
 #[doc(inline)]
 pub use frame_support_procedural::{
-	construct_runtime, decl_storage, transactional, RuntimeDebugNoBound,
+	construct_runtime, decl_storage, transactional, use_default_config_for, RuntimeDebugNoBound,
 };
 
 #[doc(hidden)]

--- a/frame/support/test/tests/construct_runtime_ui.rs
+++ b/frame/support/test/tests/construct_runtime_ui.rs
@@ -25,5 +25,5 @@ fn ui() {
 	env::set_var("SKIP_WASM_BUILD", "1");
 
 	let t = trybuild::TestCases::new();
-	t.compile_fail("tests/construct_runtime_ui/*.rs");
+	t.compile_fail("tests/construct_runtime_ui/default_config_non_config_impl.rs");
 }

--- a/frame/support/test/tests/construct_runtime_ui.rs
+++ b/frame/support/test/tests/construct_runtime_ui.rs
@@ -25,5 +25,5 @@ fn ui() {
 	env::set_var("SKIP_WASM_BUILD", "1");
 
 	let t = trybuild::TestCases::new();
-	t.compile_fail("tests/construct_runtime_ui/undefined_default_type.rs");
+	t.compile_fail("tests/construct_runtime_ui/*.rs");
 }

--- a/frame/support/test/tests/construct_runtime_ui.rs
+++ b/frame/support/test/tests/construct_runtime_ui.rs
@@ -25,5 +25,5 @@ fn ui() {
 	env::set_var("SKIP_WASM_BUILD", "1");
 
 	let t = trybuild::TestCases::new();
-	t.compile_fail("tests/construct_runtime_ui/*.rs");
+	t.compile_fail("tests/construct_runtime_ui/undefined_default_type.rs");
 }

--- a/frame/support/test/tests/construct_runtime_ui/default_config_non_config_impl.rs
+++ b/frame/support/test/tests/construct_runtime_ui/default_config_non_config_impl.rs
@@ -1,0 +1,26 @@
+use frame_support::construct_runtime;
+use sp_runtime::{generic, traits::BlakeTwo256};
+use sp_core::sr25519;
+
+pub type Signature = sr25519::Signature;
+pub type BlockNumber = u64;
+pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, ()>;
+
+trait Foo {
+	type Block;
+}
+
+#[frame_support::use_default_config_for(Block)]
+impl Foo for Runtime {}
+
+construct_runtime! {
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic
+	{}
+}
+
+fn main() {}

--- a/frame/support/test/tests/construct_runtime_ui/default_config_non_config_impl.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/default_config_non_config_impl.stderr
@@ -1,0 +1,26 @@
+error: impl block does not implement a pallet Config trait
+  --> $DIR/default_config_non_config_impl.rs:16:1
+   |
+16 | impl Foo for Runtime {}
+   | ^^^^
+
+error: `System` pallet declaration is missing. Please add this line: `System: frame_system::{Pallet, Call, Storage, Config, Event<T>},`
+  --> $DIR/default_config_non_config_impl.rs:23:2
+   |
+23 |     {}
+   |     ^^
+
+error[E0412]: cannot find type `Call` in this scope
+ --> $DIR/default_config_non_config_impl.rs:9:64
+  |
+9 | pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, ()>;
+  |                                                                ^^^^ not found in this scope
+  |
+help: consider importing one of these items
+  |
+1 | use frame_support_test::Call;
+  |
+1 | use frame_system::Call;
+  |
+1 | use test_pallet::Call;
+  |

--- a/frame/support/test/tests/construct_runtime_ui/undefined_default_type.rs
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_default_type.rs
@@ -1,0 +1,37 @@
+use frame_support::construct_runtime;
+use sp_runtime::{generic, traits::BlakeTwo256};
+use sp_core::sr25519;
+
+#[frame_support::pallet]
+mod pallet {
+    use frame_support::pallet_prelude::*;
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+        type Balance: Parameter;
+    }
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+}
+
+pub type Signature = sr25519::Signature;
+pub type BlockNumber = u64;
+pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, ()>;
+
+#[frame_support::use_default_config_for(Balance)]
+impl pallet::Config for Runtime {}
+
+construct_runtime! {
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic
+	{
+		System: system::{Pallet, Call, Storage, Config, Event<T>},
+		Pallet: pallet::{Pallet},
+	}
+}
+
+fn main() {}

--- a/frame/support/test/tests/construct_runtime_ui/undefined_default_type.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_default_type.stderr
@@ -1,0 +1,64 @@
+error: associated type `Balance` does not have a default type specified, or does not exist
+ --> $DIR/undefined_default_type.rs:5:1
+  |
+5 | #[frame_support::pallet]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `pallet::__substrate_config_defaults::use_default_config_for` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0433]: failed to resolve: use of undeclared crate or module `system`
+  --> $DIR/undefined_default_type.rs:32:11
+   |
+32 |         System: system::{Pallet, Call, Storage, Config, Event<T>},
+   |                 ^^^^^^ use of undeclared crate or module `system`
+
+error[E0433]: failed to resolve: use of undeclared crate or module `system`
+  --> $DIR/undefined_default_type.rs:26:1
+   |
+26 | / construct_runtime! {
+27 | |     pub enum Runtime where
+28 | |         Block = Block,
+29 | |         NodeBlock = Block,
+...  |
+34 | |     }
+35 | | }
+   | |_^ not found in `system`
+   |
+   = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this enum
+   |
+1  | use frame_system::RawOrigin;
+   |
+
+error[E0433]: failed to resolve: use of undeclared crate or module `system`
+  --> $DIR/undefined_default_type.rs:26:1
+   |
+26 | / construct_runtime! {
+27 | |     pub enum Runtime where
+28 | |         Block = Block,
+29 | |         NodeBlock = Block,
+...  |
+34 | |     }
+35 | | }
+   | |_^ not found in `system`
+   |
+   = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing one of these items
+   |
+1  | use crate::pallet::Pallet;
+   |
+1  | use frame_support_test::Pallet;
+   |
+1  | use frame_system::Pallet;
+   |
+1  | use test_pallet::Pallet;
+   |
+
+error[E0277]: the trait bound `Runtime: frame_system::Config` is not satisfied
+  --> $DIR/undefined_default_type.rs:24:6
+   |
+9  |     pub trait Config: frame_system::Config {
+   |                       -------------------- required by this bound in `pallet::Config`
+...
+24 | impl pallet::Config for Runtime {}
+   |      ^^^^^^^^^^^^^^ the trait `frame_system::Config` is not implemented for `Runtime`

--- a/frame/support/test/tests/construct_runtime_ui/undefined_default_type.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_default_type.stderr
@@ -1,18 +1,17 @@
 error: associated type `Balance` does not have a default type specified, or does not exist
-  --> $DIR/undefined_default_type.rs:5:1
-   |
-5  | #[frame_support::pallet]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
-...
-23 | #[frame_support::use_default_config_for(Balance)]
-   | ------------------------------------------------- in this procedural macro expansion
-   |
-   = note: this error originates in the macro `pallet::__substrate_config_defaults::use_default_config_for` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> $DIR/undefined_default_type.rs:5:1
+  |
+5 | #[frame_support::pallet]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `pallet::__substrate_config_defaults::use_default_config_for` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0433]: failed to resolve: use of undeclared crate or module `system`
   --> $DIR/undefined_default_type.rs:32:11
    |
 32 |         System: system::{Pallet, Call, Storage, Config, Event<T>},
    |                 ^^^^^^ use of undeclared crate or module `system`
+
 error[E0433]: failed to resolve: use of undeclared crate or module `system`
   --> $DIR/undefined_default_type.rs:26:1
    |
@@ -30,6 +29,7 @@ help: consider importing this enum
    |
 1  | use frame_system::RawOrigin;
    |
+
 error[E0433]: failed to resolve: use of undeclared crate or module `system`
   --> $DIR/undefined_default_type.rs:26:1
    |
@@ -53,6 +53,7 @@ help: consider importing one of these items
    |
 1  | use test_pallet::Pallet;
    |
+
 error[E0277]: the trait bound `Runtime: frame_system::Config` is not satisfied
   --> $DIR/undefined_default_type.rs:24:6
    |

--- a/frame/support/test/tests/construct_runtime_ui/undefined_default_type.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_default_type.stderr
@@ -1,10 +1,13 @@
 error: associated type `Balance` does not have a default type specified, or does not exist
- --> $DIR/undefined_default_type.rs:5:1
-  |
-5 | #[frame_support::pallet]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the macro `pallet::__substrate_config_defaults::use_default_config_for` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $DIR/undefined_default_type.rs:5:1
+   |
+5  | #[frame_support::pallet]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+...
+23 | #[frame_support::use_default_config_for(Balance)]
+   | ------------------------------------------------- in this procedural macro expansion
+   |
+   = note: this error originates in the macro `pallet::__substrate_config_defaults::use_default_config_for` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0433]: failed to resolve: use of undeclared crate or module `system`
   --> $DIR/undefined_default_type.rs:32:11
@@ -57,8 +60,11 @@ help: consider importing one of these items
 error[E0277]: the trait bound `Runtime: frame_system::Config` is not satisfied
   --> $DIR/undefined_default_type.rs:24:6
    |
-9  |     pub trait Config: frame_system::Config {
-   |                       -------------------- required by this bound in `pallet::Config`
-...
 24 | impl pallet::Config for Runtime {}
    |      ^^^^^^^^^^^^^^ the trait `frame_system::Config` is not implemented for `Runtime`
+   |
+note: required by a bound in `pallet::Config`
+  --> $DIR/undefined_default_type.rs:9:20
+   |
+9  |     pub trait Config: frame_system::Config {
+   |                       ^^^^^^^^^^^^^^^^^^^^ required by this bound in `pallet::Config`

--- a/frame/support/test/tests/construct_runtime_ui/undefined_default_type.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_default_type.stderr
@@ -1,17 +1,18 @@
 error: associated type `Balance` does not have a default type specified, or does not exist
- --> $DIR/undefined_default_type.rs:5:1
-  |
-5 | #[frame_support::pallet]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the macro `pallet::__substrate_config_defaults::use_default_config_for` (in Nightly builds, run with -Z macro-backtrace for more info)
-
+  --> $DIR/undefined_default_type.rs:5:1
+   |
+5  | #[frame_support::pallet]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+...
+23 | #[frame_support::use_default_config_for(Balance)]
+   | ------------------------------------------------- in this procedural macro expansion
+   |
+   = note: this error originates in the macro `pallet::__substrate_config_defaults::use_default_config_for` (in Nightly builds, run with -Z macro-backtrace for more info)
 error[E0433]: failed to resolve: use of undeclared crate or module `system`
   --> $DIR/undefined_default_type.rs:32:11
    |
 32 |         System: system::{Pallet, Call, Storage, Config, Event<T>},
    |                 ^^^^^^ use of undeclared crate or module `system`
-
 error[E0433]: failed to resolve: use of undeclared crate or module `system`
   --> $DIR/undefined_default_type.rs:26:1
    |
@@ -29,7 +30,6 @@ help: consider importing this enum
    |
 1  | use frame_system::RawOrigin;
    |
-
 error[E0433]: failed to resolve: use of undeclared crate or module `system`
   --> $DIR/undefined_default_type.rs:26:1
    |
@@ -53,7 +53,6 @@ help: consider importing one of these items
    |
 1  | use test_pallet::Pallet;
    |
-
 error[E0277]: the trait bound `Runtime: frame_system::Config` is not satisfied
   --> $DIR/undefined_default_type.rs:24:6
    |

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -126,6 +126,7 @@ pub mod pallet {
 		#[pallet::constant]
 		type MyGetParam3: Get<<Self::AccountId as SomeAssociation1>::_1>;
 
+		#[pallet::default_type(u64)]
 		type Balance: Parameter + Default + TypeInfo;
 
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
@@ -438,6 +439,7 @@ pub mod pallet2 {
 	where
 		<Self as frame_system::Config>::AccountId: From<SomeType1> + SomeAssociation1,
 	{
+		#[pallet::default_type(Event)]
 		type Event: From<Event> + IsType<<Self as frame_system::Config>::Event>;
 	}
 
@@ -535,17 +537,17 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = ();
 	type OnSetCode = ();
 }
+
+#[frame_support::use_default_config_for(Balance)]
 impl pallet::Config for Runtime {
 	type Event = Event;
 	type MyGetParam = MyGetParam;
 	type MyGetParam2 = MyGetParam2;
 	type MyGetParam3 = MyGetParam3;
-	type Balance = u64;
 }
 
-impl pallet2::Config for Runtime {
-	type Event = Event;
-}
+#[frame_support::use_default_config_for(Event)]
+impl pallet2::Config for Runtime {}
 
 pub type Header = sp_runtime::generic::Header<u32, sp_runtime::traits::BlakeTwo256>;
 pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;

--- a/frame/support/test/tests/pallet_ui/duplicate_default_type.rs
+++ b/frame/support/test/tests/pallet_ui/duplicate_default_type.rs
@@ -1,0 +1,18 @@
+#[frame_support::pallet]
+mod pallet {
+	use frame_support::pallet_prelude::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+        #[pallet::default_type(u64)]
+        #[pallet::default_type(u128)]
+        type Balance: Parameter;
+    }
+
+	#[pallet::pallet]
+	#[pallet::generate_store(trait Store)]
+	pub struct Pallet<T>(core::marker::PhantomData<T>);
+}
+
+fn main() {
+}

--- a/frame/support/test/tests/pallet_ui/duplicate_default_type.stderr
+++ b/frame/support/test/tests/pallet_ui/duplicate_default_type.stderr
@@ -1,0 +1,5 @@
+error: Invalid attribute in pallet::config, only one pallet::default_type is expected
+ --> $DIR/duplicate_default_type.rs:8:19
+  |
+8 |         #[pallet::default_type(u128)]
+  |                   ^^^^^^^^^^^^


### PR DESCRIPTION
May potentially fix #3335.

This PR introduces two new attributes, `#[pallet::default_type]` and `#[frame_support::use_default_config_for]`, for the purpose of simplifying the setup of commonly used types for the associated types in a pallet's `Config` trait.

`#[pallet::default_type(type)]` can be put before a `Config` trait associated type to indicate the default value that the associated type should have. Note that the type provided to the attribute does not get evaluated during pallet construction and only during runtime construction. This means the following is possible:

```rust
// pallet.rs
trait Config: frame_system::Config {
    #[pallet::default_type(Call)] // can be used here even though `Call` is not defined in this pallet
    type Call: Parameter + GetDispatchInfo;
}

// runtime.rs
#[frame_support::use_default_config_for(Call)]
impl pallet::Config for Runtime {}

construct_runtime! {
    // ...
}
```

`#[frame_support::use_default_config_for(ident)]` can only be put on trait impl items that implement the `Config` trait for pallets. The type names provided to the attribute must exist in the `Config` trait definition as associated type items and must also have a `#[pallet::default_type]` declared, otherwise the compiler will emit the following error:

```
error: associated type `YourTypeNameHere` does not have a default type specified, or does not exist
```

If this is a desired change, we could then begin documenting `Config` associated type items and explaining what the default types are and how they behave.