### PR TITLE
Do not propagate host RUSTFLAGS when checking for WASM toolchain

### DIFF
--- a/utils/wasm-builder/src/prerequisites.rs
+++ b/utils/wasm-builder/src/prerequisites.rs
@@ -140,10 +140,10 @@ fn check_wasm_toolchain_installed(
 
 	// Make sure the host's flags aren't used here, e.g. if an alternative linker is specified
 	// in the RUSTFLAGS then the check we do here will break unless we clear these.
-	build_cmd.env("CARGO_ENCODED_RUSTFLAGS", "");
-	run_cmd.env("CARGO_ENCODED_RUSTFLAGS", "");
-	build_cmd.env("RUSTFLAGS", "");
-	run_cmd.env("RUSTFLAGS", "");
+	build_cmd.env_remove("CARGO_ENCODED_RUSTFLAGS");
+	run_cmd.env_remove("CARGO_ENCODED_RUSTFLAGS");
+	build_cmd.env_remove("RUSTFLAGS");
+	run_cmd.env_remove("RUSTFLAGS");
 
 	build_cmd.output().map_err(|_| err_msg.clone()).and_then(|s| {
 		if s.status.success() {

--- a/utils/wasm-builder/src/prerequisites.rs
+++ b/utils/wasm-builder/src/prerequisites.rs
@@ -138,6 +138,11 @@ fn check_wasm_toolchain_installed(
 	build_cmd.env_remove("CARGO_TARGET_DIR");
 	run_cmd.env_remove("CARGO_TARGET_DIR");
 
+	// Make sure the host's flags aren't used here, e.g. if an alternative linker is specified
+	// in the RUSTFLAGS then the check we do here will break unless we clear these.
+	build_cmd.env("CARGO_ENCODED_RUSTFLAGS", "");
+	run_cmd.env("CARGO_ENCODED_RUSTFLAGS", "");
+
 	build_cmd.output().map_err(|_| err_msg.clone()).and_then(|s| {
 		if s.status.success() {
 			let version = run_cmd.output().ok().and_then(|o| String::from_utf8(o.stdout).ok());

--- a/utils/wasm-builder/src/prerequisites.rs
+++ b/utils/wasm-builder/src/prerequisites.rs
@@ -142,6 +142,8 @@ fn check_wasm_toolchain_installed(
 	// in the RUSTFLAGS then the check we do here will break unless we clear these.
 	build_cmd.env("CARGO_ENCODED_RUSTFLAGS", "");
 	run_cmd.env("CARGO_ENCODED_RUSTFLAGS", "");
+	build_cmd.env("RUSTFLAGS", "");
+	run_cmd.env("RUSTFLAGS", "");
 
 	build_cmd.output().map_err(|_| err_msg.clone()).and_then(|s| {
 		if s.status.success() {


### PR DESCRIPTION
I usually export `RUSTFLAGS` with an alternative linker ([mold](https://github.com/rui314/mold)) to speed up the compilation for development builds; unfortunately the check for the WASM toolchain fails when you do this as it then tries to use this linker for `wasm32-unknown-unknown` which obviously doesn't work. This PR fixes this issue by simply clearing RUSTFLAGS beforehand.