### PR TITLE
run simnet quck test for every commit 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -852,6 +852,7 @@ deploy-prometheus-alerting-rules:
 # checking values from metrics exposed by the app.
 # A "long" test is the load testing where we send 50K transactions into the 
 # network and check if all completed successfully
+
 simnet-tests:
   stage:                           deploy
   image:                           docker.io/paritytech/simnet:${SIMNET_REF}
@@ -880,3 +881,4 @@ simnet-tests:
   retry: 2
   tags:
     - parity-simnet
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -558,6 +558,7 @@ build-linux-substrate:             &build-binary
   <<:                              *collect-artifacts
   <<:                              *docker-env
   <<:                              *build-refs
+  <<:                              *test-refs-no-trigger-prs-only
   needs:
     - job:                         test-linux-stable
       artifacts:                   false
@@ -881,4 +882,3 @@ simnet-tests:
   retry: 2
   tags:
     - parity-simnet
-


### PR DESCRIPTION
Run simnet quick test after every commit

Intention of changes in this PR are to add proper rules and values for variables to build docker image after every commit on any
PR and then run simnet "quick" test. Quick test is a smoke test that assures a network spawned with the substrate docker image
has a minimum amount of nodes connected and that they can produce blocks


