### PR TITLE
Add xx network to SS58 registry

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -581,6 +581,8 @@ ss58_address_format!(
 		(49, "picasso", "Composable Canary Network, standard account (*25519).")
 	ComposableAccount =>
 		(50, "composable", "Composable mainnet, standard account (*25519).")
+	XXNetworkAccount =>
+		(55, "xxnetwork", "xx network mainnet, standard account (*25519).")
 	HydraDXAccount =>
 		(63, "hydradx", "HydraDX standard account (*25519).")
 	AventusAccount =>

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -461,6 +461,15 @@
 			"website": "https://composable.finance"
 		},
 		{
+			"prefix": 55,
+			"network": "xxnetwork",
+			"displayName": "xx network",
+			"symbols": ["XX"],
+			"decimals": [9],
+			"standardAccount": "*25519",
+			"website": "https://xx.network"
+		},
+		{
 			"prefix": 63,
 			"network": "hydradx",
 			"displayName": "HydraDX",


### PR DESCRIPTION
This PR adds xx network to the SS58 registry with network ID of 55.

xx network combines a Substrate based blockchain with a mixnet operating on the [cMix](https://xx.network/xxcMixwhitepaper.pdf) protocol.

Website: https://xx.network/

Substrate based node codebase: https://github.com/xx-labs/xxchain
cMix mixnode (and more) codebase: https://gitlab.com/elixxir

Active testnet (using 42 for network ID to avoid confusion): 
explorer: https://explorer.xx.network/#/explorer
telemetry: https://telemetry.polkadot.io/#list/0x895af51ef894d3b96df443714028c4f72f86ba929ae9530f689ebe212d87082f

Socials:
Twitter: https://twitter.com/xx_network
Telegram: https://t.me/xxnetwork
Discord: https://discord.com/invite/Y8pCkbK
Forum: https://forum.xx.network/