### PR TITLE
Improved file not found error message

### DIFF
--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -58,8 +58,9 @@ impl<G: RuntimeGenesis> GenesisSource<G> {
 
 		match self {
 			Self::File(path) => {
-				let file =
-					File::open(path).map_err(|e| format!("Error opening spec file: {}", e))?;
+				let file = File::open(path).map_err(|e| {
+					format!("Error opening spec file at `{}`: {}", &path.to_string_lossy(), e)
+				})?;
 				let genesis: GenesisContainer<G> = json::from_reader(file)
 					.map_err(|e| format!("Error parsing spec file: {}", e))?;
 				Ok(genesis.genesis)
@@ -284,7 +285,8 @@ impl<G, E: serde::de::DeserializeOwned> ChainSpec<G, E> {
 
 	/// Parse json file into a `ChainSpec`
 	pub fn from_json_file(path: PathBuf) -> Result<Self, String> {
-		let file = File::open(&path).map_err(|e| format!("Error opening spec file: {}", e))?;
+		let file = File::open(&path)
+			.map_err(|e| format!("Error opening spec file `{}`: {}", &path.to_string_lossy(), e))?;
 		let client_spec =
 			json::from_reader(file).map_err(|e| format!("Error parsing spec file: {}", e))?;
 		Ok(ChainSpec { client_spec, genesis: GenesisSource::File(path) })

--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -286,7 +286,7 @@ impl<G, E: serde::de::DeserializeOwned> ChainSpec<G, E> {
 	/// Parse json file into a `ChainSpec`
 	pub fn from_json_file(path: PathBuf) -> Result<Self, String> {
 		let file = File::open(&path)
-			.map_err(|e| format!("Error opening spec file `{}`: {}", &path.to_string_lossy(), e))?;
+			.map_err(|e| format!("Error opening spec file `{}`: {}", path.display(), e))?;
 		let client_spec =
 			json::from_reader(file).map_err(|e| format!("Error parsing spec file: {}", e))?;
 		Ok(ChainSpec { client_spec, genesis: GenesisSource::File(path) })

--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -59,7 +59,7 @@ impl<G: RuntimeGenesis> GenesisSource<G> {
 		match self {
 			Self::File(path) => {
 				let file = File::open(path).map_err(|e| {
-					format!("Error opening spec file at `{}`: {}", &path.to_string_lossy(), e)
+					format!("Error opening spec file at `{}`: {}", path.display(), e)
 				})?;
 				let genesis: GenesisContainer<G> = json::from_reader(file)
 					.map_err(|e| format!("Error parsing spec file: {}", e))?;


### PR DESCRIPTION
Previous error message was: `Error: Input("Error opening spec file: No such file or directory (os error 2)")`

Now we say which file we were looking for. (Also the two error messages are not exactly the same now so that they are unique.)