### PR TITLE
Remove `IgnoredIssuance` from metadata constants

### DIFF
--- a/frame/gilt/src/lib.rs
+++ b/frame/gilt/src/lib.rs
@@ -128,7 +128,6 @@ pub mod pallet {
 
 		/// The issuance to ignore. This is subtracted from the `Currency`'s `total_issuance` to get
 		/// the issuance by which we inflate or deflate the gilt.
-		#[pallet::constant]
 		type IgnoredIssuance: Get<BalanceOf<Self>>;
 
 		/// Number of duration queues in total. This sets the maximum duration supported, which is


### PR DESCRIPTION
This value is not really meant to be "constant".

Part of the fix for: https://github.com/paritytech/polkadot/issues/4015