### PR TITLE
`--dev` implies `--tmp`

### DIFF
--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -242,7 +242,7 @@ pub struct RunCmd {
 	/// Note: the directory is random per process execution. This directory is used as base path
 	/// which includes: database, node key and keystore.
 	///
-	/// When `--dev` is given and no explicit `--base-path`, this is option is implied.
+	/// When `--dev` is given and no explicit `--base-path`, this option is implied.
 	#[structopt(long, conflicts_with = "base-path")]
 	pub tmp: bool,
 }

--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -241,6 +241,8 @@ pub struct RunCmd {
 	///
 	/// Note: the directory is random per process execution. This directory is used as base path
 	/// which includes: database, node key and keystore.
+	///
+	/// When `--dev` is given and no explicit `--base-path`, this is option is implied.
 	#[structopt(long, conflicts_with = "base-path")]
 	pub tmp: bool,
 }
@@ -444,7 +446,12 @@ impl CliConfiguration for RunCmd {
 		Ok(if self.tmp {
 			Some(BasePath::new_temp_dir()?)
 		} else {
-			self.shared_params().base_path()
+			match self.shared_params().base_path() {
+				Some(r) => Some(r),
+				// If `dev` is enabled, we use the temp base path.
+				None if self.shared_params().is_dev() => Some(BasePath::new_temp_dir()?),
+				None => None,
+			}
 		})
 	}
 }


### PR DESCRIPTION
This changes `--dev` to imply `--tmp` when no explicit `--base-path` is provided.
