### PR TITLE
disambiguate Config trait in #[pallet::constant]

### DIFF
--- a/frame/support/procedural/src/pallet/expand/constants.rs
+++ b/frame/support/procedural/src/pallet/expand/constants.rs
@@ -50,7 +50,8 @@ pub fn expand_constants(def: &mut Def) -> proc_macro2::TokenStream {
 			type_: const_.type_.clone(),
 			doc: const_.doc.clone(),
 			default_byte_impl: quote::quote!(
-				let value = <<T as Config#trait_use_gen>::#ident as #frame_support::traits::Get<#const_type>>::get();
+				let value = <<T as Config#trait_use_gen>::#ident as
+					#frame_support::traits::Get<#const_type>>::get();
 				#frame_support::codec::Encode::encode(&value)
 			),
 		}

--- a/frame/support/procedural/src/pallet/expand/constants.rs
+++ b/frame/support/procedural/src/pallet/expand/constants.rs
@@ -49,7 +49,7 @@ pub fn expand_constants(def: &mut Def) -> proc_macro2::TokenStream {
 			type_: const_.type_.clone(),
 			doc: const_.doc.clone(),
 			default_byte_impl: quote::quote!(
-				let value = <T::#ident as #frame_support::traits::Get<#const_type>>::get();
+				let value = <<T as Config>::#ident as #frame_support::traits::Get<#const_type>>::get();
 				#frame_support::codec::Encode::encode(&value)
 			),
 		}

--- a/frame/support/procedural/src/pallet/expand/constants.rs
+++ b/frame/support/procedural/src/pallet/expand/constants.rs
@@ -35,6 +35,7 @@ pub fn expand_constants(def: &mut Def) -> proc_macro2::TokenStream {
 	let type_impl_gen = &def.type_impl_generics(proc_macro2::Span::call_site());
 	let type_use_gen = &def.type_use_generics(proc_macro2::Span::call_site());
 	let pallet_ident = &def.pallet_struct.pallet;
+	let trait_use_gen = &def.trait_use_generics(proc_macro2::Span::call_site());
 
 	let mut where_clauses = vec![&def.config.where_clause];
 	where_clauses.extend(def.extra_constants.iter().map(|d| &d.where_clause));
@@ -49,7 +50,7 @@ pub fn expand_constants(def: &mut Def) -> proc_macro2::TokenStream {
 			type_: const_.type_.clone(),
 			doc: const_.doc.clone(),
 			default_byte_impl: quote::quote!(
-				let value = <<T as Config>::#ident as #frame_support::traits::Get<#const_type>>::get();
+				let value = <<T as Config#trait_use_gen>::#ident as #frame_support::traits::Get<#const_type>>::get();
 				#frame_support::codec::Encode::encode(&value)
 			),
 		}


### PR DESCRIPTION
When there are two Pallets that have constants with the same name and one pallet directly depends on the other, the `#[pallet::constant]` fails with an ambiguous error. `T::ConstName` could refer to `<T as PalletA>::ConstName` or `<T as PalletB>::ConstName`. Using the qualified name solves this.

The error I got:
```
error[E0221]: ambiguous associated type `Deposit` in bounds of `T`
   --> pallets/attestation/src/lib.rs:90:1
    |
90  | #[frame_support::pallet]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    | |
    | ambiguous associated type `Deposit`
    | help: use fully qualified syntax to disambiguate: `<T as pallet::Config>::Deposit`
...
131 |         type Deposit: Get<BalanceOf<Self>>;
    |         ----------------------------------- ambiguous `Deposit` from `pallet::Config`
```
