### PR TITLE
Replace is_global to is_private, maybe fixing #9922

### DIFF
--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -512,12 +512,10 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 			list_to_filter.extend(self.mdns.addresses_of_peer(peer_id));
 
 			if !self.allow_private_ipv4 {
-				list_to_filter.retain(|addr| {
-					match addr.iter().next() {
-						Some(Protocol::Ip4(addr)) if !IpNetwork::from(addr).is_global() => false,
-						Some(Protocol::Ip6(addr)) if !IpNetwork::from(addr).is_global() => false,
-						_ => true
-					}
+				list_to_filter.retain(|addr| match addr.iter().next() {
+					Some(Protocol::Ip4(addr)) if !IpNetwork::from(addr).is_global() => false,
+					Some(Protocol::Ip6(addr)) if !IpNetwork::from(addr).is_global() => false,
+					_ => true,
 				});
 			}
 


### PR DESCRIPTION
Replacing is_global to is_private, [probably] fixing the issue of node still connecting to local addresses (ie 100.64.0.0/10) even if --no-private-ipv4 is enabled, like explained in #9922 
