### PR TITLE
remove dep on unmaintained difference crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,9 +156,9 @@ checksum = "9d6e24d2cce90c53b948c46271bfb053e4bdc2db9b5d3f65e20f8cf28a1b7fc3"
 
 [[package]]
 name = "assert_cmd"
-version = "1.0.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2475b58cd94eb4f70159f4fd8844ba3b807532fe3131b3373fae060bbe30396"
+checksum = "b800c4403e8105d959595e1f88119e78bc12bc874c4336973658b648a746ba93"
 dependencies = [
  "bstr",
  "doc-comment",
@@ -1500,10 +1500,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
-name = "difference"
-version = "2.0.0"
+name = "difflib"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -2048,7 +2048,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "paste 1.0.4",
- "pretty_assertions 0.6.1",
+ "pretty_assertions",
  "scale-info",
  "serde",
  "smallvec 1.7.0",
@@ -2102,7 +2102,7 @@ dependencies = [
  "frame-support-test-pallet",
  "frame-system",
  "parity-scale-codec",
- "pretty_assertions 0.6.1",
+ "pretty_assertions",
  "rustversion",
  "scale-info",
  "serde",
@@ -5315,7 +5315,7 @@ dependencies = [
  "pallet-timestamp",
  "pallet-utility",
  "parity-scale-codec",
- "pretty_assertions 0.7.2",
+ "pretty_assertions",
  "pwasm-utils",
  "rand 0.7.3",
  "rand_pcg 0.2.1",
@@ -6635,11 +6635,12 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "predicates"
-version = "1.0.7"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb433456c1a57cc93554dea3ce40b4c19c4057e41c55d4a0f3d84ea71c325aa"
+checksum = "c143348f141cc87aab5b950021bac6145d0e5ae754b0591de23244cee42c9308"
 dependencies = [
- "difference",
+ "difflib",
+ "itertools 0.10.0",
  "predicates-core",
 ]
 
@@ -6661,21 +6662,9 @@ dependencies = [
 
 [[package]]
 name = "pretty_assertions"
-version = "0.6.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
-dependencies = [
- "ansi_term 0.11.0",
- "ctor",
- "difference",
- "output_vt100",
-]
-
-[[package]]
-name = "pretty_assertions"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
+checksum = "ec0cfe1b2403f172ba0f234e500906ee0a3e493fb81092dac23ebefe129301cc"
 dependencies = [
  "ansi_term 0.12.1",
  "ctor",
@@ -9701,7 +9690,7 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.11.1",
- "pretty_assertions 0.6.1",
+ "pretty_assertions",
  "rand 0.7.3",
  "smallvec 1.7.0",
  "sp-core",

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -117,7 +117,7 @@ sc-service-test = { version = "2.0.0", path = "../../../client/service/test" }
 sp-tracing = { version = "4.0.0-dev", path = "../../../primitives/tracing" }
 futures = "0.3.16"
 tempfile = "3.1.0"
-assert_cmd = "1.0"
+assert_cmd = "2.0.1"
 nix = "0.19"
 serde_json = "1.0"
 regex = "1"

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -47,7 +47,7 @@ sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primit
 [dev-dependencies]
 assert_matches = "1"
 hex-literal = "0.3"
-pretty_assertions = "0.7"
+pretty_assertions = "1.0.0"
 wat = "1"
 
 # Substrate Dependencies

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -36,7 +36,7 @@ log = { version = "0.4.14", default-features = false }
 
 [dev-dependencies]
 assert_matches = "1.3.0"
-pretty_assertions = "0.6.1"
+pretty_assertions = "1.0.0"
 frame-system = { version = "4.0.0-dev", path = "../system" }
 parity-util-mem = { version = "0.10.0", default-features = false, features = ["primitive-types"] }
 

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -24,7 +24,7 @@ sp-core = { version = "4.0.0-dev", default-features = false, path = "../../../pr
 sp-std = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/std" }
 sp-version = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/version" }
 trybuild = "1.0.43"
-pretty_assertions = "0.6.1"
+pretty_assertions = "1.0.0"
 rustversion = "1.0.0"
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system" }
 # The "std" feature for this pallet is never activated on purpose, in order to test construct_runtime error message

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -34,7 +34,7 @@ tracing = { version = "0.1.22", optional = true }
 [dev-dependencies]
 hex-literal = "0.3.1"
 sp-runtime = { version = "4.0.0-dev", path = "../runtime" }
-pretty_assertions = "0.6.1"
+pretty_assertions = "1.0.0"
 rand = "0.7.2"
 
 [features]


### PR DESCRIPTION
This consolidates two versions of `pretty_assertions` to the 1.0 version as well as removing references to the unmaintained `difference` crate.