### PR TITLE
Avoid hangs in tests

### DIFF
--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -28,8 +28,10 @@ use std::{
 	pin::Pin,
 	sync::Arc,
 	task::{Context as FutureContext, Poll},
+	time::Duration,
 };
 
+use async_std::future::timeout;
 use futures::{future::BoxFuture, prelude::*};
 use libp2p::{build_multiaddr, PeerId};
 use log::trace;
@@ -1017,10 +1019,13 @@ where
 	/// Blocks the current thread until we are sync'ed.
 	///
 	/// Calls `poll_until_sync` repeatedly.
+	/// (If we've not synced within 3 mins then panic rather than hang.)
 	fn block_until_sync(&mut self) {
-		futures::executor::block_on(futures::future::poll_fn::<(), _>(|cx| {
-			self.poll_until_sync(cx)
-		}));
+		futures::executor::block_on(timeout(
+			Duration::from_secs(180),
+			futures::future::poll_fn::<(), _>(|cx| self.poll_until_sync(cx)),
+		))
+		.expect("sync didn't happen within 3 mins");
 	}
 
 	/// Blocks the current thread until there are no pending packets.


### PR DESCRIPTION
https://gitlab.parity.io/parity/substrate/-/jobs/1161469 hung for 2 hours but should have taken 15 mins. `sync_after_fork_works` was the likely culprit so adding in a timeout. 