### PR TITLE
Remove unnecessary mut reference in `handle_justification`

### DIFF
--- a/client/consensus/common/src/block_import.rs
+++ b/client/consensus/common/src/block_import.rs
@@ -74,7 +74,7 @@ impl ImportResult {
 		&self,
 		hash: &B::Hash,
 		number: NumberFor<B>,
-		justification_sync_link: &mut dyn JustificationSyncLink<B>,
+		justification_sync_link: &dyn JustificationSyncLink<B>,
 	) where
 		B: BlockT,
 	{


### PR DESCRIPTION
This is split out of #9698 since it looks that that PR will take some time to review.

Remove an unnecessary mut ref that is just not needed.