### PR TITLE
Use correct db path for parity-db

### DIFF
--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -229,7 +229,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		let paritydb_path = base_path.join("paritydb").join(role_dir);
 		Ok(match database {
 			Database::RocksDb => DatabaseSource::RocksDb { path: rocksdb_path, cache_size },
-			Database::ParityDb => DatabaseSource::ParityDb { path: rocksdb_path },
+			Database::ParityDb => DatabaseSource::ParityDb { path: paritydb_path },
 			Database::Auto => DatabaseSource::Auto { paritydb_path, rocksdb_path, cache_size },
 		})
 	}


### PR DESCRIPTION
This was overseen in: https://github.com/paritytech/substrate/pull/9500

Not sure what we should do regarding a migration? Ignore it or write some external script?