### PR TITLE
Reserve SS58 prefix 12191 for NFTMart

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -623,6 +623,8 @@ ss58_address_format!(
 		(10041, "basilisk", "Basilisk standard account (*25519).")
 	ContextFree =>
 		(11820, "contextfree", "Automata ContextFree standard account (*25519).")
+	NFTMartAccount =>
+		(12191, "nftmart", "NFTMart standard account (*25519).")
 
 	// Note: 16384 and above are reserved.
 );

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -666,6 +666,15 @@
 			"decimals": [18],
 			"standardAccount": "*25519",
 			"website": "https://ata.network"
+		},
+		{
+			"prefix": 12191,
+			"network": "nftmart",
+			"displayName": "NFTMart",
+			"symbols": ["NMT"],
+			"decimals": [12],
+			"standardAccount": "*25519",
+			"website": "https://nftmart.io"
 		}
 	]
 }


### PR DESCRIPTION
This replaces https://github.com/paritytech/substrate/pull/9346 since prefix 50 is allocated already.