### PR TITLE
More lenient mechanism for identifying stash accounts in purge_keys

### DIFF
--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -114,12 +114,6 @@ mod mock;
 mod tests;
 pub mod weights;
 
-use sp_runtime::{
-	traits::{AtLeast32BitUnsigned, Convert, Member, One, OpaqueKeys, Zero},
-	ConsensusEngineId, KeyTypeId, Permill, RuntimeAppPublic,
-};
-use sp_staking::SessionIndex;
-use sp_std::{prelude::*, convert::TryFrom, marker::PhantomData, ops::{Rem, Sub}};
 use frame_support::{
 	codec::{Decode, MaxEncodedLen},
 	dispatch::{DispatchError, DispatchResult},
@@ -130,6 +124,17 @@ use frame_support::{
 	},
 	weights::Weight,
 	Parameter,
+};
+use sp_runtime::{
+	traits::{AtLeast32BitUnsigned, Convert, Member, One, OpaqueKeys, Zero},
+	ConsensusEngineId, KeyTypeId, Permill, RuntimeAppPublic,
+};
+use sp_staking::SessionIndex;
+use sp_std::{
+	convert::TryFrom,
+	marker::PhantomData,
+	ops::{Rem, Sub},
+	prelude::*,
 };
 
 pub use pallet::*;
@@ -372,7 +377,10 @@ pub mod pallet {
 		type Event: From<Event> + IsType<<Self as frame_system::Config>::Event>;
 
 		/// A stable ID for a validator.
-		type ValidatorId: Member + Parameter + MaybeSerializeDeserialize + MaxEncodedLen
+		type ValidatorId: Member
+			+ Parameter
+			+ MaybeSerializeDeserialize
+			+ MaxEncodedLen
 			+ TryFrom<Self::AccountId>;
 
 		/// A conversion from account ID to validator ID.
@@ -591,7 +599,7 @@ pub mod pallet {
 		}
 
 		/// Removes any session key(s) of the function caller.
-		/// 
+		///
 		/// This doesn't take effect until the next session.
 		///
 		/// The dispatch origin of this function must be Signed and the account must be either be

--- a/frame/session/src/mock.rs
+++ b/frame/session/src/mock.rs
@@ -22,8 +22,7 @@ use crate as pallet_session;
 #[cfg(feature = "historical")]
 use crate::historical as pallet_session_historical;
 
-use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::{cell::RefCell, collections::BTreeMap};
 
 use sp_core::{crypto::key_types::DUMMY, H256};
 use sp_runtime::{

--- a/frame/session/src/tests.rs
+++ b/frame/session/src/tests.rs
@@ -21,8 +21,8 @@ use super::*;
 use crate::mock::{
 	authorities, before_session_end_called, force_new_session, new_test_ext,
 	reset_before_session_end_called, session_changed, set_next_validators, set_session_length,
-	Origin, PreUpgradeMockSessionKeys, Session, System, Test, SESSION_CHANGED,
-	TEST_SESSION_CHANGED, TestValidatorIdOf,
+	Origin, PreUpgradeMockSessionKeys, Session, System, Test, TestValidatorIdOf, SESSION_CHANGED,
+	TEST_SESSION_CHANGED,
 };
 
 use codec::Decode;


### PR DESCRIPTION
Provides a fallback so a stash account can be provided as well as a controller account to identify a validator for key purging. This is because key purging should be able to happen after the staking controller/stash pair has been removed. Right now that's impossible.