### PR TITLE
Prevent duplicate gossip to impact peer review

### DIFF
--- a/client/network-gossip/src/state_machine.rs
+++ b/client/network-gossip/src/state_machine.rs
@@ -51,8 +51,6 @@ mod rep {
 	use sc_network::ReputationChange as Rep;
 	/// Reputation change when a peer sends us a gossip message that we didn't know about.
 	pub const GOSSIP_SUCCESS: Rep = Rep::new(1 << 4, "Successfull gossip");
-	/// Reputation change when a peer sends us a gossip message that we already knew about.
-	pub const DUPLICATE_GOSSIP: Rep = Rep::new(-(1 << 2), "Duplicate gossip");
 }
 
 struct PeerConsensus<H> {
@@ -360,7 +358,6 @@ impl<B: BlockT> ConsensusGossip<B> {
 					protocol = %self.protocol,
 					"Ignored already known message",
 				);
-				network.report_peer(who.clone(), rep::DUPLICATE_GOSSIP);
 				continue
 			}
 


### PR DESCRIPTION
This PR prevents the validator to have its peer reputation lowered when submitting duplicated gossip.
Duplicate gossip is currently part of the normal process (more details can be provided by @bkchr ).

With the current code, it leads to validators rejecting other validators because of their reputation going. It can often impact parachains if those validators are responsible for their group.