### PR TITLE
AssetId trait should also contain TypeInfo bound

### DIFF
--- a/frame/support/src/traits/tokens/misc.rs
+++ b/frame/support/src/traits/tokens/misc.rs
@@ -161,8 +161,8 @@ impl WithdrawReasons {
 }
 
 /// Simple amalgamation trait to collect together properties for an AssetId under one roof.
-pub trait AssetId: FullCodec + Copy + Eq + PartialEq + Debug {}
-impl<T: FullCodec + Copy + Eq + PartialEq + Debug> AssetId for T {}
+pub trait AssetId: FullCodec + Copy + Eq + PartialEq + Debug + scale_info::TypeInfo {}
+impl<T: FullCodec + Copy + Eq + PartialEq + Debug + scale_info::TypeInfo> AssetId for T {}
 
 /// Simple amalgamation trait to collect together properties for a Balance under one roof.
 pub trait Balance:


### PR DESCRIPTION
apprently I was changing in the wrong place in https://github.com/paritytech/substrate/pull/10031, so it didn't fix `AssetIdOf` but just limited pallet_assets' Config. This pr should fix it, please backport it to polkadot-v0.9.11.

cc. @bkchr @ascjones 

Appreciate for your help!