### PR TITLE
draft: attempt to fix code duplication and AllPallets footgun

### DIFF
--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -148,9 +148,10 @@ pub type OriginOf<E, C> = <CallOf<E, C> as Dispatchable>::Origin;
 /// - `Block`: The block type of the runtime
 /// - `Context`: The context that is used when checking an extrinsic.
 /// - `UnsignedValidator`: The unsigned transaction validator of the runtime.
-/// - `AllPallets`: Tuple that contains all modules. Will be used to call e.g. `on_initialize`.
-/// - `OnRuntimeUpgrade`: Custom logic that should be called after a runtime upgrade. Modules are
-///   already called by `AllPallets`. It will be called before all modules will be called.
+/// - `AllPallets`: Tuple that contains all pallets. Will be used to call e.g. `on_initialize`,
+///    it must include system pallet.
+/// - `OnRuntimeUpgrade`: Custom logic that should be called after a runtime upgrade. Pallets are
+///   already called by `AllPallets`. It will be called before all pallets will be called.
 pub struct Executive<System, Block, Context, UnsignedValidator, AllPallets, OnRuntimeUpgrade = ()>(
 	PhantomData<(System, Block, Context, UnsignedValidator, AllPallets, OnRuntimeUpgrade)>,
 );

--- a/frame/support/procedural/src/construct_runtime/mod.rs
+++ b/frame/support/procedural/src/construct_runtime/mod.rs
@@ -206,32 +206,38 @@ fn decl_all_pallets<'a>(
 	}
 	// Make nested tuple structure like (((Babe, Consensus), Grandpa), ...)
 	// But ignore the system pallet.
-	let all_pallets = names
+	let all_pallets_without_system = names
 		.iter()
 		.filter(|n| **n != SYSTEM_PALLET_NAME)
 		.fold(TokenStream2::default(), |combined, name| quote!((#name, #combined)));
 
-	let all_pallets_with_system = names
+	let all_pallets = names
 		.iter()
 		.fold(TokenStream2::default(), |combined, name| quote!((#name, #combined)));
 
 	quote!(
 		#types
 		/// All pallets included in the runtime as a nested tuple of types.
-		/// Excludes the System pallet.
 		pub type AllPallets = ( #all_pallets );
+
 		/// All pallets included in the runtime as a nested tuple of types.
-		pub type AllPalletsWithSystem = ( #all_pallets_with_system );
+		#[deprecated(note = "use `AllPallets` instead")]
+		pub type AllPalletsWithSystem = AllPallets;
+
+		/// All pallets included in the runtime as a nested tuple of types.
+		/// Excludes the System pallet.
+		pub type AllPalletsWithoutSystem = ( #all_pallets_without_system );
 
 		/// All modules included in the runtime as a nested tuple of types.
 		/// Excludes the System pallet.
 		#[deprecated(note = "use `AllPallets` instead")]
 		#[allow(dead_code)]
-		pub type AllModules = ( #all_pallets );
+		#[allow(deprecated)]
+		pub type AllModules = AllPalletsWithoutSystem;
 		/// All modules included in the runtime as a nested tuple of types.
 		#[deprecated(note = "use `AllPalletsWithSystem` instead")]
 		#[allow(dead_code)]
-		pub type AllModulesWithSystem = ( #all_pallets_with_system );
+		pub type AllModulesWithSystem = AllPallets;
 	)
 }
 

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -942,7 +942,7 @@ fn pallet_hooks_expand() {
 		assert_eq!(AllPallets::on_initialize(1), 10);
 		AllPallets::on_finalize(1);
 
-		assert_eq!(AllPallets::on_runtime_upgrade(), 30);
+		AllPallets::on_runtime_upgrade();
 
 		assert_eq!(
 			frame_system::Pallet::<Runtime>::events()[0].event,
@@ -956,6 +956,8 @@ fn pallet_hooks_expand() {
 			frame_system::Pallet::<Runtime>::events()[2].event,
 			Event::Example(pallet::Event::Something(30)),
 		);
+
+		assert_eq!(Example::on_runtime_upgrade(), 30);
 	})
 }
 

--- a/frame/support/test/tests/pallet_instance.rs
+++ b/frame/support/test/tests/pallet_instance.rs
@@ -513,7 +513,7 @@ fn pallet_hooks_expand() {
 		assert_eq!(AllPallets::on_initialize(1), 21);
 		AllPallets::on_finalize(1);
 
-		assert_eq!(AllPallets::on_runtime_upgrade(), 61);
+		AllPallets::on_runtime_upgrade();
 
 		// The order is indeed reversed due to https://github.com/paritytech/substrate/issues/6280
 		assert_eq!(
@@ -540,6 +540,8 @@ fn pallet_hooks_expand() {
 			frame_system::Pallet::<Runtime>::events()[5].event,
 			Event::Example(pallet::Event::Something(30)),
 		);
+
+		assert_eq!(<(Example, Instance1Example)>::on_runtime_upgrade(), 61);
 	})
 }
 


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/9105

Currently in executive we always handle system pallet manually, instead it should be considered as other pallet.

Also this fix the case where system pallet defines some offchain worker. currently the manual handling of the offchain worker hook for system pallet is missing.

The only usage of `AllPallets` in substrate is for executive type. So this PR changes `AllPallets` type to include frame system pallet. and modify executive in order not to call the hook 2 times for system pallet.