### PR TITLE
Remove broken links in Nicks Pallet

### DIFF
--- a/frame/nicks/src/lib.rs
+++ b/frame/nicks/src/lib.rs
@@ -35,7 +35,6 @@
 //!   taken.
 //! * `clear_name` - Remove an account's associated name; the deposit is returned.
 //! * `kill_name` - Forcibly remove the associated name; the deposit is lost.
-//!
 
 #![cfg_attr(not(feature = "std"), no_std)]
 


### PR DESCRIPTION
Hi there!

I've removed two broken links that led:
1. https://paritytech.github.io/substrate/latest/pallet_nicks/trait.Config.html
2. https://paritytech.github.io/substrate/latest/pallet_nicks/enum.Call.html

[This PR is nominated at RU RustCon Contest](https://rustcon.ru/contest2021)