### PR TITLE
Offchain-worker: Update example-offchain-worker with implementation for TestAuthId

### DIFF
--- a/frame/example-offchain-worker/src/lib.rs
+++ b/frame/example-offchain-worker/src/lib.rs
@@ -86,7 +86,7 @@ pub mod crypto {
 	use sp_runtime::{
 		app_crypto::{app_crypto, sr25519},
 		traits::Verify,
-		MultiSigner, MultiSignature,
+		MultiSignature, MultiSigner,
 	};
 	app_crypto!(sr25519, KEY_TYPE);
 


### PR DESCRIPTION
i tried to incorporate the off-chain worker callback demo as a custom pallet of my own Substrate-based blockchain implementation that's provided at the following links
* https://www.parity.io/blog/substrate-off-chain-workers-secure-and-efficient-computing-intensive-tasks/
* https://gnunicorn.github.io/substrate-offchain-cb/
but when i build the code with `cargo build --release`, it gave me an error:
```
error[E0277]: the trait bound `AuthorityId: AppCrypto<MultiSigner, MultiSignature>` is not satisfied
--> /Users/me/my_repo/node/runtime/src/lib.rs:1172:5
|
1172 |     type AuthorityId = AuthorityId;
|     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AppCrypto<MultiSigner, MultiSignature>` is not implemented for `AuthorityId`
|
note: required by a bound in `offchaincb::Config::AuthorityId`
--> /Users/me/my_repo/node/pallets/offchaincb/src/lib.rs:169:21
|
169  |         type AuthorityId: AppCrypto<Self::Public, Self::Signature>;
|                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `offchaincb::Config::AuthorityId`
```

where in my custom pallet i have:

pallets/offchaincb/src/lib.rs

```
...

use offchaincb::{
    crypto::{
        TestAuthId,
    },
};

...

parameter_types! {
	pub const GracePeriod: BlockNumber = 1 * MINUTES;
	pub const UnsignedInterval: BlockNumber = 1 * MINUTES;
        pub const UnsignedPriority: BlockNumber = 1 * MINUTES;
}

impl offchaincb::Config for Runtime {
    type AuthorityId = TestAuthId;
    type Call = Call;
    type Currency = Balances;
    type Event = Event;
    type GracePeriod = GracePeriod;
    type UnsignedInterval = UnsignedInterval;
    type UnsignedPriority = UnsignedPriority;
}

...
```

then i found another different off-chain workers Substrate Recipe demo from Jimmy Chu @jimmychu0807 https://github.com/jimmychu0807/recipes/blob/master/pallets/ocw-demo/src/lib.rs#L73 which had an extra implementation for TestAuthId here https://github.com/jimmychu0807/recipes/blob/master/pallets/ocw-demo/src/lib.rs#L73, and when i added that it overcame the error.

so i think this change should be included in the Substrate repository