### PR TITLE
Update ss58 registry with new Dock POS information

### DIFF
--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -202,7 +202,7 @@
 		{
 			"prefix": 21,
 			"network": "dock-testnet",
-			"displayName": "Dock Testnet",
+			"displayName": "Dock POA Testnet",
 			"symbols": ["DCK"],
 			"decimals": [6],
 			"standardAccount": "*25519",
@@ -211,6 +211,24 @@
 		{
 			"prefix": 22,
 			"network": "dock-mainnet",
+			"displayName": "Dock POA Mainnet",
+			"symbols": ["DCK"],
+			"decimals": [6],
+			"standardAccount": "*25519",
+			"website": "https://dock.io"
+		},
+		{
+			"prefix": 21,
+			"network": "dock-pos-testnet",
+			"displayName": "Dock Testnet",
+			"symbols": ["DCK"],
+			"decimals": [6],
+			"standardAccount": "*25519",
+			"website": "https://dock.io"
+		},
+		{
+			"prefix": 22,
+			"network": "dock-pos-mainnet",
 			"displayName": "Dock Mainnet",
 			"symbols": ["DCK"],
 			"decimals": [6],


### PR DESCRIPTION
This PR updates the old Dock config display name to re-affirm that its the old POA network. Eventually this can be removed, but I'm not sure the effects of changes if I remove them now so I left them. If you feel like they can be removed now, happy to do so.

It also adds the spec names for the current POS network.

Corresponding polkadot PRs:
https://github.com/polkadot-js/common/pull/1136
https://github.com/polkadot-js/apps/pull/6365
