### PR TITLE
Remove useless WeightInfo in pallet-offences

### DIFF
--- a/frame/offences/src/lib.rs
+++ b/frame/offences/src/lib.rs
@@ -43,28 +43,6 @@ type OpaqueTimeSlot = Vec<u8>;
 /// A type alias for a report identifier.
 type ReportIdOf<T> = <T as frame_system::Config>::Hash;
 
-pub trait WeightInfo {
-	fn report_offence_im_online(r: u32, o: u32, n: u32) -> Weight;
-	fn report_offence_grandpa(r: u32, n: u32) -> Weight;
-	fn report_offence_babe(r: u32, n: u32) -> Weight;
-	fn on_initialize(d: u32) -> Weight;
-}
-
-impl WeightInfo for () {
-	fn report_offence_im_online(_r: u32, _o: u32, _n: u32) -> Weight {
-		1_000_000_000
-	}
-	fn report_offence_grandpa(_r: u32, _n: u32) -> Weight {
-		1_000_000_000
-	}
-	fn report_offence_babe(_r: u32, _n: u32) -> Weight {
-		1_000_000_000
-	}
-	fn on_initialize(_d: u32) -> Weight {
-		1_000_000_000
-	}
-}
-
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;


### PR DESCRIPTION
I guess this is missed when removing the `WeightInfo` type in Offences in https://github.com/paritytech/substrate/pull/7136.