### PR TITLE
pallet-utility: Fix possible mismatch between native/wasm

### DIFF
--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -112,22 +112,35 @@ pub mod pallet {
 		ItemCompleted,
 	}
 
+	// Align the call size to 1KB. As we are currently compiling the runtime for native/wasm
+	// the `size_of` of the `Call` can be different. To ensure that this don't leads to
+	// mismatches between native/wasm or to different metadata for the same runtime, we
+	// algin the call size. The value is choosen big enough to hopefully never reach it.
+	const CALL_ALIGN: u32 = 1024;
+
 	#[pallet::extra_constants]
 	impl<T: Config> Pallet<T> {
 		/// The limit on the number of batched calls.
 		fn batched_calls_limit() -> u32 {
 			let allocator_limit = sp_core::MAX_POSSIBLE_ALLOCATION;
-			// Align the call size to 1KB. As we are currently compiling the runtime for native/wasm
-			// the `size_of` of the `Call` can be different. To ensure that this don't leads to
-			// mismatches between native/wasm or to different metadata for the same runtime, we
-			// algin the call size. The value is choosen big enough to hopefully never reach it.
-			let call_align = 1024;
-			let call_size = ((core::mem::size_of::<<T as Config>::Call>() as u32 + call_align - 1) /
-				call_align) * call_align;
+			let call_size = ((sp_std::mem::size_of::<<T as Config>::Call>() as u32 + CALL_ALIGN -
+				1) / CALL_ALIGN) * CALL_ALIGN;
 			// The margin to take into account vec doubling capacity.
 			let margin_factor = 3;
 
 			allocator_limit / margin_factor / call_size
+		}
+	}
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn integrity_test() {
+			// If you hit this error, you need to try to `Box` big dispatchable parameters.
+			assert!(
+				sp_std::mem::size_of::<<T as Config>::Call>() as u32 <= CALL_ALIGN,
+				"Call enum size should be smaller than {} bytes.",
+				CALL_ALIGN,
+			);
 		}
 	}
 

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -117,7 +117,13 @@ pub mod pallet {
 		/// The limit on the number of batched calls.
 		fn batched_calls_limit() -> u32 {
 			let allocator_limit = sp_core::MAX_POSSIBLE_ALLOCATION;
-			let call_size = core::mem::size_of::<<T as Config>::Call>() as u32;
+			// Align the call size to 1KB. As we are currently compiling the runtime for native/wasm
+			// the `size_of` of the `Call` can be different. To ensure that this don't leads to
+			// mismatches between native/wasm or to different metadata for the same runtime, we
+			// algin the call size. The value is choosen big enough to hopefully never reach it.
+			let call_align = 1024;
+			let call_size = ((core::mem::size_of::<<T as Config>::Call>() as u32 + call_align - 1) /
+				call_align) * call_align;
 			// The margin to take into account vec doubling capacity.
 			let margin_factor = 3;
 


### PR DESCRIPTION
The `batched_calls_limit` constant value includes the `size_of` of the runtime `Call`. As we compile
the runtime for native/wasm, we need to align the call size to ensure that it is the same on
wasm/native. This also solves the problem of different metadata outputs for the same runtime.

Progress on: https://github.com/paritytech/polkadot/issues/4015

CC @Slesarew 