### PR TITLE
 Offchain-worker: enable http2 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,6 +2515,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
+dependencies = [
+ "bytes 1.0.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2731,6 +2750,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",

--- a/client/offchain/Cargo.toml
+++ b/client/offchain/Cargo.toml
@@ -31,7 +31,7 @@ sp-offchain = { version = "4.0.0-dev", path = "../../primitives/offchain" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sc-utils = { version = "4.0.0-dev", path = "../utils" }
 threadpool = "1.7"
-hyper = "0.14.11"
+hyper = { version = "0.14.11", features = ["client", "http1", "http2"] }
 hyper-rustls = "0.22.1"
 
 [dev-dependencies]


### PR DESCRIPTION
 Without this, the request will fail after the protocol is upgraded.

And can this change backport to v0.9.12?