### PR TITLE
Add `OnPostInherent` Hook (try 2)

### DIFF
--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -366,6 +366,11 @@ impl_runtime_apis! {
 		) -> sp_inherents::CheckInherentsResult {
 			data.check_extrinsics(&block)
 		}
+
+		fn on_post_inherent() {
+			let n = frame_system::Pallet::<Self>::block_number();
+			// SHAWN TODO
+		}
 	}
 
 	impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -368,8 +368,9 @@ impl_runtime_apis! {
 		}
 
 		fn on_post_inherent() {
+			use frame_support::traits::OnPostInherent;
 			let n = frame_system::Pallet::<Self>::block_number();
-			// SHAWN TODO
+			AllPalletsWithSystem::on_post_inherent(n);
 		}
 	}
 

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -368,9 +368,8 @@ impl_runtime_apis! {
 		}
 
 		fn on_post_inherent() {
-			use frame_support::traits::OnPostInherent;
 			let n = frame_system::Pallet::<Self>::block_number();
-			AllPalletsWithSystem::on_post_inherent(n);
+			Executive::on_post_inherent(n);
 		}
 	}
 

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1379,6 +1379,11 @@ impl_runtime_apis! {
 		fn check_inherents(block: Block, data: InherentData) -> CheckInherentsResult {
 			data.check_extrinsics(&block)
 		}
+
+		fn on_post_inherent() {
+			let n = frame_system::Pallet::<Self>::block_number();
+			//AllPalletsWithSystem::<T>::on_post_inherent(n);
+		}
 	}
 
 	impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1381,8 +1381,9 @@ impl_runtime_apis! {
 		}
 
 		fn on_post_inherent() {
+			use frame_support::traits::OnPostInherent;
 			let n = frame_system::Pallet::<Self>::block_number();
-			//AllPalletsWithSystem::<T>::on_post_inherent(n);
+			AllPalletsWithSystem::on_post_inherent(n);
 		}
 	}
 

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1381,9 +1381,8 @@ impl_runtime_apis! {
 		}
 
 		fn on_post_inherent() {
-			use frame_support::traits::OnPostInherent;
 			let n = frame_system::Pallet::<Self>::block_number();
-			AllPalletsWithSystem::on_post_inherent(n);
+			Executive::on_post_inherent(n);
 		}
 	}
 

--- a/client/basic-authorship/src/basic_authorship.rs
+++ b/client/basic-authorship/src/basic_authorship.rs
@@ -335,6 +335,8 @@ where
 			}
 		}
 
+		//TODO SHAWN: call on post inherent
+
 		// proceed with transactions
 		// We calculate soft deadline used only in case we start skipping transactions.
 		let now = (self.now)();

--- a/client/basic-authorship/src/basic_authorship.rs
+++ b/client/basic-authorship/src/basic_authorship.rs
@@ -335,7 +335,8 @@ where
 			}
 		}
 
-		//TODO SHAWN: call on post inherent
+		// Inherents have been processed, so run any on post inherent logic from the runtime.
+		block_builder.on_post_inherent()?;
 
 		// proceed with transactions
 		// We calculate soft deadline used only in case we start skipping transactions.

--- a/client/block-builder/src/lib.rs
+++ b/client/block-builder/src/lib.rs
@@ -295,10 +295,8 @@ where
 	pub fn on_post_inherent(&self) -> Result<(), sp_api::ApiError> {
 		let block_id = &self.block_id;
 
-		self.api.on_post_inherent_with_context(
-			&block_id,
-			ExecutionContext::BlockConstruction,
-		)
+		self.api
+			.on_post_inherent_with_context(&block_id, ExecutionContext::BlockConstruction)
 	}
 }
 

--- a/client/block-builder/src/lib.rs
+++ b/client/block-builder/src/lib.rs
@@ -289,6 +289,17 @@ where
 			size
 		}
 	}
+
+	/// Execute any logic after processing all inherents in the block.
+	// TODO: Check error type
+	pub fn on_post_inherent(&self) -> Result<(), sp_api::ApiError> {
+		let block_id = &self.block_id;
+
+		self.api.on_post_inherent_with_context(
+			&block_id,
+			ExecutionContext::BlockConstruction,
+		)
+	}
 }
 
 #[cfg(test)]

--- a/frame/support/procedural/src/construct_runtime/expand/inherent.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/inherent.rs
@@ -162,12 +162,12 @@ pub fn expand_outer_inherent(
 		}
 
 		impl #scrate::traits::EnsureInherentsAreFirst<#block> for #runtime {
-			fn ensure_inherents_are_first(block: &#block) -> Result<(), u32> {
+			fn ensure_inherents_are_first(block: &#block) -> Result<Option<u32>, u32> {
 				use #scrate::inherent::ProvideInherent;
 				use #scrate::traits::{IsSubType, ExtrinsicCall};
 				use #scrate::sp_runtime::traits::Block as _;
 
-				let mut first_signed_observed = false;
+				let mut first_non_inherent_observed = None;
 
 				for (i, xt) in block.extrinsics().iter().enumerate() {
 					let is_signed = #scrate::inherent::Extrinsic::is_signed(xt).unwrap_or(false);
@@ -188,16 +188,16 @@ pub fn expand_outer_inherent(
 						is_inherent
 					};
 
-					if !is_inherent {
-						first_signed_observed = true;
+					if !is_inherent && first_non_inherent_observed.is_none() {
+						first_non_inherent_observed = Some(i as u32);
 					}
 
-					if first_signed_observed && is_inherent {
+					if first_non_inherent_observed.is_some() && is_inherent {
 						return Err(i as u32)
 					}
 				}
 
-				Ok(())
+				Ok(first_non_inherent_observed)
 			}
 		}
 	}

--- a/frame/support/procedural/src/pallet/expand/hooks.rs
+++ b/frame/support/procedural/src/pallet/expand/hooks.rs
@@ -124,6 +124,24 @@ pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 		}
 
 		impl<#type_impl_gen>
+			#frame_support::traits::OnPostInherent<<T as #frame_system::Config>::BlockNumber>
+			for #pallet_ident<#type_use_gen> #where_clause
+		{
+			fn on_post_inherent(
+				n: <T as #frame_system::Config>::BlockNumber
+			) -> #frame_support::weights::Weight {
+				#frame_support::sp_tracing::enter_span!(
+					#frame_support::sp_tracing::trace_span!("on_post_inherent")
+				);
+				<
+					Self as #frame_support::traits::Hooks<
+						<T as #frame_system::Config>::BlockNumber
+					>
+				>::on_post_inherent(n)
+			}
+		}
+
+		impl<#type_impl_gen>
 			#frame_support::traits::OnRuntimeUpgrade
 			for #pallet_ident<#type_use_gen> #where_clause
 		{

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -1489,6 +1489,11 @@ macro_rules! decl_module {
 				{ $( $impl )* }
 			}
 		}
+		// `on_post_inherent` is not supported with `decl_module`, so we do an empty impl.
+		impl<$trait_instance: $system::Config + $trait_name$(<I>, $instance: $instantiable)?>
+			$crate::traits::OnPostInherent<<$trait_instance as $system::Config>::BlockNumber>
+			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
+		{}
 	};
 
 	(@impl_on_initialize
@@ -1506,6 +1511,11 @@ macro_rules! decl_module {
 				{ $( $impl )* }
 			}
 		}
+		// `on_post_inherent` is not supported with `decl_module`, so we do an empty impl.
+		impl<$trait_instance: $system::Config + $trait_name$(<I>, $instance: $instantiable)?>
+			$crate::traits::OnPostInherent<<$trait_instance as $system::Config>::BlockNumber>
+			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
+		{}
 	};
 
 	(@impl_on_initialize
@@ -1515,6 +1525,11 @@ macro_rules! decl_module {
 	) => {
 		impl<$trait_instance: $system::Config + $trait_name$(<I>, $instance: $instantiable)?>
 			$crate::traits::OnInitialize<<$trait_instance as $system::Config>::BlockNumber>
+			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
+		{}
+		// `on_post_inherent` is not supported with `decl_module`, so we do an empty impl.
+		impl<$trait_instance: $system::Config + $trait_name$(<I>, $instance: $instantiable)?>
+			$crate::traits::OnPostInherent<<$trait_instance as $system::Config>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{}
 	};

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -72,7 +72,8 @@ mod hooks;
 #[cfg(feature = "std")]
 pub use hooks::GenesisBuild;
 pub use hooks::{
-	Hooks, OnFinalize, OnGenesis, OnIdle, OnInitialize, OnRuntimeUpgrade, OnTimestampSet,
+	Hooks, OnFinalize, OnGenesis, OnIdle, OnInitialize, OnPostInherent, OnRuntimeUpgrade,
+	OnTimestampSet,
 };
 #[cfg(feature = "try-runtime")]
 pub use hooks::{OnRuntimeUpgradeHelpersExt, ON_RUNTIME_UPGRADE_PREFIX};

--- a/frame/support/src/traits/hooks.rs
+++ b/frame/support/src/traits/hooks.rs
@@ -31,8 +31,10 @@ pub trait OnInitialize<BlockNumber> {
 	/// Return the non-negotiable weight consumed in the block.
 	///
 	/// NOTE: This function is called BEFORE ANY extrinsic in a block is applied,
-	/// including inherent extrinsics. Hence for instance, if you runtime includes
+	/// including inherent extrinsics. Hence, for instance, if your runtime includes
 	/// `pallet_timestamp`, the `timestamp` is not yet up to date at this point.
+	///
+	/// If you want to execute something after inherents, implement `OnPostInherent`.
 	fn on_initialize(_n: BlockNumber) -> crate::weights::Weight {
 		0
 	}
@@ -43,6 +45,31 @@ impl<BlockNumber: Clone> OnInitialize<BlockNumber> for Tuple {
 	fn on_initialize(n: BlockNumber) -> crate::weights::Weight {
 		let mut weight = 0;
 		for_tuples!( #( weight = weight.saturating_add(Tuple::on_initialize(n.clone())); )* );
+		weight
+	}
+}
+
+/// The after inherent initialization trait.
+///
+/// Implementing this lets you express what should happen for your pallet when the block is
+/// beginning (right before the first extrinsic is executed).
+pub trait OnPostInherent<BlockNumber> {
+	/// We have finished executing all inherent extrinsics. Implement to have something happen.
+	///
+	/// Return the non-negotiable weight consumed for this behavior.
+	///
+	/// NOTE: Unlike `on_initialize`, this is called after the inherent extrinsics have been
+	/// included, so things like the `timestamp` will be up to date here.
+	fn on_post_inherent(_n: BlockNumber) -> crate::weights::Weight {
+		0
+	}
+}
+
+#[impl_for_tuples(30)]
+impl<BlockNumber: Clone> OnPostInherent<BlockNumber> for Tuple {
+	fn on_post_inherent(n: BlockNumber) -> crate::weights::Weight {
+		let mut weight = 0;
+		for_tuples!( #( weight = weight.saturating_add(Tuple::on_post_inherent(n.clone())); )* );
 		weight
 	}
 }
@@ -231,6 +258,13 @@ pub trait Hooks<BlockNumber> {
 	///
 	/// Return the non-negotiable weight consumed in the block.
 	fn on_initialize(_n: BlockNumber) -> crate::weights::Weight {
+		0
+	}
+
+	/// The inherent extrinsics have been executed. Implement to have something happen.
+	///
+	/// Return the non-negotiable weight consumed in the block.
+	fn on_post_inherent(_n: BlockNumber) -> crate::weights::Weight {
 		0
 	}
 

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -352,8 +352,10 @@ pub trait GetBacking {
 pub trait EnsureInherentsAreFirst<Block> {
 	/// Ensure the position of inherent is correct, i.e. they are before non-inherents.
 	///
+	/// On success, return the index of the first non-inherent (signed) extrinsic if one exists.
+	///
 	/// On error return the index of the inherent with invalid position (counting from 0).
-	fn ensure_inherents_are_first(block: &Block) -> Result<(), u32>;
+	fn ensure_inherents_are_first(block: &Block) -> Result<Option<u32>, u32>;
 }
 
 /// An extrinsic on which we can get access to call.

--- a/primitives/block-builder/src/lib.rs
+++ b/primitives/block-builder/src/lib.rs
@@ -33,7 +33,6 @@ sp_api::decl_runtime_apis! {
 		fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult;
 
 		/// Finish the current block.
-		#[renamed("finalise_block", 3)]
 		fn finalize_block() -> <Block as BlockT>::Header;
 
 		/// Generate inherent extrinsics. The inherent data will vary from chain to chain.
@@ -43,5 +42,8 @@ sp_api::decl_runtime_apis! {
 
 		/// Check that the inherents are valid. The inherent data will vary from chain to chain.
 		fn check_inherents(block: Block, data: InherentData) -> CheckInherentsResult;
+
+		/// Execute some logic after processing the inherents in the block.
+		fn on_post_inherent();
 	}
 }

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -1012,8 +1012,7 @@ cfg_if! {
 				}
 
 				fn on_post_inherent() {
-					let n = frame_system::Pallet::<Self>::block_number();
-					// SHAWN TODO
+					// TODO: Code Reviewers Please Check This
 				}
 			}
 

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -752,6 +752,10 @@ cfg_if! {
 				fn check_inherents(_block: Block, _data: InherentData) -> CheckInherentsResult {
 					CheckInherentsResult::new()
 				}
+
+				fn on_post_inherent() {
+					let n = frame_system::Pallet::<Self>::block_number();
+				}
 			}
 
 			impl self::TestAPI<Block> for Runtime {
@@ -1005,6 +1009,11 @@ cfg_if! {
 
 				fn check_inherents(_block: Block, _data: InherentData) -> CheckInherentsResult {
 					CheckInherentsResult::new()
+				}
+
+				fn on_post_inherent() {
+					let n = frame_system::Pallet::<Self>::block_number();
+					// SHAWN TODO
 				}
 			}
 

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -754,7 +754,7 @@ cfg_if! {
 				}
 
 				fn on_post_inherent() {
-					let n = frame_system::Pallet::<Self>::block_number();
+					// TODO: Code Reviewer Please Check This Is Empty
 				}
 			}
 


### PR DESCRIPTION
Fixes https://github.com/paritytech/substrate/issues/9210
Fixes https://github.com/paritytech/substrate/issues/5757

This PR introduces a new `OnPostInherent` hook within the block builder/execution pipeline.

This allows runtime developers to execute code after all inherent extrinsics have been executed, but before any signed extrinsics.

We introduce this hook only for the `#[pallet]` macro and not for the `decl_module!` macro. (it wouldnt be so hard to enable this if we wanted... but seems we should encourage people to start giving up `decl_module!` for new features.)

This should be completely backwards compatible with existing pallets which do not take advantage of this hook.