### PR TITLE
Handle doc on type_value item in pallet macro

### DIFF
--- a/frame/support/procedural/src/pallet/expand/type_value.rs
+++ b/frame/support/procedural/src/pallet/expand/type_value.rs
@@ -59,7 +59,10 @@ pub fn expand_type_values(def: &mut Def) -> proc_macro2::TokenStream {
 			(Default::default(), Default::default())
 		};
 
+		let docs = &type_value.docs;
+
 		expand.extend(quote::quote_spanned!(type_value.attr_span =>
+			#( #[doc = #docs] )*
 			#vis struct #ident<#struct_use_gen>(core::marker::PhantomData<((), #struct_use_gen)>);
 			impl<#struct_impl_gen> #frame_support::traits::Get<#type_> for #ident<#struct_use_gen>
 			#where_clause

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -262,6 +262,7 @@ pub mod pallet {
 	#[pallet::storage_prefix = "Value2"]
 	pub type RenamedValue<T> = StorageValue<Value = u64>;
 
+	/// Test some doc
 	#[pallet::type_value]
 	pub fn MyDefault<T: Config>() -> u16
 	where


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/10131#event-5545192992

Before doc attribute on the type_value item was unsupported, now it is handled, and doc are written on the generated struct.