### PR TITLE
Speed up big chainspec json(~1.5 GB) load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1648,7 +1648,7 @@ checksum = "42276e3f205fe63887cca255aa9a65a63fb72764c30b9a6252a7c7e46994f689"
 dependencies = [
  "byteorder",
  "dynasm",
- "memmap2",
+ "memmap2 0.2.1",
 ]
 
 [[package]]
@@ -4098,6 +4098,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4647a11b578fead29cdbb34d4adef8dd3dc35b876c9c6d5240d83f205abfe96e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6174,7 +6183,7 @@ dependencies = [
  "libc",
  "log 0.4.14",
  "lz4",
- "memmap2",
+ "memmap2 0.2.1",
  "parking_lot 0.11.1",
  "rand 0.8.4",
  "snap",
@@ -7503,6 +7512,7 @@ name = "sc-chain-spec"
 version = "4.0.0-dev"
 dependencies = [
  "impl-trait-for-tuples",
+ "memmap2 0.5.0",
  "parity-scale-codec",
  "sc-chain-spec-derive",
  "sc-network",
@@ -11283,7 +11293,7 @@ dependencies = [
  "backtrace",
  "bincode",
  "lazy_static",
- "memmap2",
+ "memmap2 0.2.1",
  "more-asserts",
  "rustc-demangle",
  "serde",

--- a/client/chain-spec/Cargo.toml
+++ b/client/chain-spec/Cargo.toml
@@ -22,3 +22,4 @@ serde_json = "1.0.68"
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sc-telemetry = { version = "4.0.0-dev", path = "../telemetry" }
 codec = { package = "parity-scale-codec", version = "2.0.0" }
+memmap2 = "0.5.0"

--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -285,9 +285,17 @@ impl<G, E: serde::de::DeserializeOwned> ChainSpec<G, E> {
 
 	/// Parse json file into a `ChainSpec`
 	pub fn from_json_file(path: PathBuf) -> Result<Self, String> {
-		// We read the entire file into memory first, as this is *a lot* faster than using
+		// We mmap the file into memory first, as this is *a lot* faster than using
 		// `serde_json::from_reader`. See https://github.com/serde-rs/json/issues/160
-		let bytes = std::fs::read(&path).map_err(|e| format!("Error reading spec file: {}", e))?;
+		let file = File::open(&path)
+			.map_err(|e| format!("Error opening spec file `{}`: {}", path.display(), e))?;
+
+		// SAFETY: `mmap` is fundamentally unsafe since technically the file can change
+		//         underneath us while it is mapped; in practice it's unlikely to be a problem
+		let bytes = unsafe {
+			memmap2::Mmap::map(&file)
+				.map_err(|e| format!("Error mmaping spec file `{}`: {}", path.display(), e))?
+		};
 
 		let client_spec =
 			json::from_slice(&bytes).map_err(|e| format!("Error parsing spec file: {}", e))?;

--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -294,7 +294,7 @@ impl<G, E: serde::de::DeserializeOwned> ChainSpec<G, E> {
 		// We read the entire file into memory first, as this is *a lot* faster than using
 		// `serde_json::from_reader`. See https://github.com/serde-rs/json/issues/160
 		file.read_to_end(&mut bytes)
-			.map_err(|e| format!("Error read spec file: {}", e))?;
+			.map_err(|e| format!("Error reading spec file: {}", e))?;
 
 		let client_spec =
 			json::from_slice(&bytes).map_err(|e| format!("Error parsing spec file: {}", e))?;

--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -285,10 +285,19 @@ impl<G, E: serde::de::DeserializeOwned> ChainSpec<G, E> {
 
 	/// Parse json file into a `ChainSpec`
 	pub fn from_json_file(path: PathBuf) -> Result<Self, String> {
-		let file = File::open(&path)
+		use std::io::Read;
+		let mut bytes = Vec::new();
+
+		let mut file = File::open(&path)
 			.map_err(|e| format!("Error opening spec file `{}`: {}", path.display(), e))?;
+
+		// We read the entire file into memory first, as this is *a lot* faster than using
+		// `serde_json::from_reader`. See https://github.com/serde-rs/json/issues/160
+		file.read_to_end(&mut bytes)
+			.map_err(|e| format!("Error read spec file: {}", e))?;
+
 		let client_spec =
-			json::from_reader(file).map_err(|e| format!("Error parsing spec file: {}", e))?;
+			json::from_slice(&bytes).map_err(|e| format!("Error parsing spec file: {}", e))?;
 		Ok(ChainSpec { client_spec, genesis: GenesisSource::File(path) })
 	}
 }

--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -287,8 +287,7 @@ impl<G, E: serde::de::DeserializeOwned> ChainSpec<G, E> {
 	pub fn from_json_file(path: PathBuf) -> Result<Self, String> {
 		// We read the entire file into memory first, as this is *a lot* faster than using
 		// `serde_json::from_reader`. See https://github.com/serde-rs/json/issues/160
-		let bytes = std::fs::read(path)
-			.map_err(|e| format!("Error reading spec file: {}", e))?;
+		let bytes = std::fs::read(&path).map_err(|e| format!("Error reading spec file: {}", e))?;
 
 		let client_spec =
 			json::from_slice(&bytes).map_err(|e| format!("Error parsing spec file: {}", e))?;

--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -285,15 +285,9 @@ impl<G, E: serde::de::DeserializeOwned> ChainSpec<G, E> {
 
 	/// Parse json file into a `ChainSpec`
 	pub fn from_json_file(path: PathBuf) -> Result<Self, String> {
-		use std::io::Read;
-		let mut bytes = Vec::new();
-
-		let mut file = File::open(&path)
-			.map_err(|e| format!("Error opening spec file `{}`: {}", path.display(), e))?;
-
 		// We read the entire file into memory first, as this is *a lot* faster than using
 		// `serde_json::from_reader`. See https://github.com/serde-rs/json/issues/160
-		file.read_to_end(&mut bytes)
+		let bytes = std::fs::read(path)
 			.map_err(|e| format!("Error reading spec file: {}", e))?;
 
 		let client_spec =


### PR DESCRIPTION
We export our chainspec to `fork.json` by `export-state` of substrate sub cmd, 
The `fork.json` is a 1.5GB json file.
In `ChainSpec::from_json_file`, 
First `use serde_json::from_file`, load `fork.json`, takes `~15 minutes`.
While using `serde_json::from_slice`, only takes `~2 s`, 

See https://github.com/serde-rs/json/issues/160