### PR TITLE
Add a `trie_root_hash` variant for chain specs genesis

### DIFF
--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -64,12 +64,12 @@ impl<G: RuntimeGenesis> GenesisSource<G> {
 				let genesis: GenesisContainer<G> = json::from_reader(file)
 					.map_err(|e| format!("Error parsing spec file: {}", e))?;
 				Ok(genesis.genesis)
-			}
+			},
 			Self::Binary(buf) => {
 				let genesis: GenesisContainer<G> = json::from_reader(buf.as_ref())
 					.map_err(|e| format!("Error parsing embedded file: {}", e))?;
 				Ok(genesis.genesis)
-			}
+			},
 			Self::Factory(f) => Ok(Genesis::Runtime(f())),
 			Self::Storage(storage) => {
 				let top = storage
@@ -94,7 +94,7 @@ impl<G: RuntimeGenesis> GenesisSource<G> {
 					.collect();
 
 				Ok(Genesis::Raw(RawGenesis { top, children_default }))
-			}
+			},
 		}
 	}
 }
@@ -120,7 +120,8 @@ impl<G: RuntimeGenesis, E> BuildStorage for ChainSpec<G, E> {
 					.collect(),
 			}),
 			// The `StateRootHash` variant exists as a way to keep note that other clients support
-			// it, but Substrate itself isn't capable of loading chain specs with just a hash at the moment.
+			// it, but Substrate itself isn't capable of loading chain specs with just a hash at the
+			// moment.
 			Genesis::StateRootHash(_) => Err("Genesis storage in hash format not supported".into()),
 		}
 	}
@@ -328,7 +329,7 @@ impl<G: RuntimeGenesis, E: serde::Serialize + Clone + 'static> ChainSpec<G, E> {
 					.collect();
 
 				Genesis::Raw(RawGenesis { top, children_default })
-			}
+			},
 			(_, genesis) => genesis,
 		};
 		Ok(JsonContainer { client_spec: self.client_spec.clone(), genesis })

--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -119,6 +119,7 @@ impl<G: RuntimeGenesis, E> BuildStorage for ChainSpec<G, E> {
 					})
 					.collect(),
 			}),
+			Genesis::Hash(_) => Err("Genesis storage in hash format not supported".into())
 		}
 	}
 
@@ -144,6 +145,7 @@ pub struct RawGenesis {
 enum Genesis<G> {
 	Runtime(G),
 	Raw(RawGenesis),
+	Hash(StorageData),
 }
 
 /// A configuration of a client. Does not include runtime storage initialization.

--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -119,9 +119,9 @@ impl<G: RuntimeGenesis, E> BuildStorage for ChainSpec<G, E> {
 					})
 					.collect(),
 			}),
-			// The `Hash` variant exists as a way to keep note that other clients support it, but
-			// Substrate itself isn't capable of loading chain specs with just a hash.
-			Genesis::Hash(_) => Err("Genesis storage in hash format not supported".into())
+			// The `TrieRootHash` variant exists as a way to keep note that other clients support
+			// it, but Substrate itself isn't capable of loading chain specs with just a hash.
+			Genesis::TrieRootHash(_) => Err("Genesis storage in hash format not supported".into())
 		}
 	}
 
@@ -147,7 +147,8 @@ pub struct RawGenesis {
 enum Genesis<G> {
 	Runtime(G),
 	Raw(RawGenesis),
-	Hash(StorageData),
+	/// State trie root of the genesis storage.
+	TrieRootHash(StorageData),
 }
 
 /// A configuration of a client. Does not include runtime storage initialization.

--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -119,9 +119,9 @@ impl<G: RuntimeGenesis, E> BuildStorage for ChainSpec<G, E> {
 					})
 					.collect(),
 			}),
-			// The `TrieRootHash` variant exists as a way to keep note that other clients support
-			// it, but Substrate itself isn't capable of loading chain specs with just a hash.
-			Genesis::TrieRootHash(_) => Err("Genesis storage in hash format not supported".into())
+			// The `StateRootHash` variant exists as a way to keep note that other clients support
+			// it, but Substrate itself isn't capable of loading chain specs with just a hash at the moment.
+			Genesis::StateRootHash(_) => Err("Genesis storage in hash format not supported".into())
 		}
 	}
 
@@ -147,8 +147,8 @@ pub struct RawGenesis {
 enum Genesis<G> {
 	Runtime(G),
 	Raw(RawGenesis),
-	/// State trie root of the genesis storage.
-	TrieRootHash(StorageData),
+	/// State root hash of the genesis storage.
+	StateRootHash(StorageData),
 }
 
 /// A configuration of a client. Does not include runtime storage initialization.

--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -119,6 +119,8 @@ impl<G: RuntimeGenesis, E> BuildStorage for ChainSpec<G, E> {
 					})
 					.collect(),
 			}),
+			// The `Hash` variant exists as a way to keep note that other clients support it, but
+			// Substrate itself isn't capable of loading chain specs with just a hash.
 			Genesis::Hash(_) => Err("Genesis storage in hash format not supported".into())
 		}
 	}

--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -64,12 +64,12 @@ impl<G: RuntimeGenesis> GenesisSource<G> {
 				let genesis: GenesisContainer<G> = json::from_reader(file)
 					.map_err(|e| format!("Error parsing spec file: {}", e))?;
 				Ok(genesis.genesis)
-			},
+			}
 			Self::Binary(buf) => {
 				let genesis: GenesisContainer<G> = json::from_reader(buf.as_ref())
 					.map_err(|e| format!("Error parsing embedded file: {}", e))?;
 				Ok(genesis.genesis)
-			},
+			}
 			Self::Factory(f) => Ok(Genesis::Runtime(f())),
 			Self::Storage(storage) => {
 				let top = storage
@@ -94,7 +94,7 @@ impl<G: RuntimeGenesis> GenesisSource<G> {
 					.collect();
 
 				Ok(Genesis::Raw(RawGenesis { top, children_default }))
-			},
+			}
 		}
 	}
 }
@@ -121,7 +121,7 @@ impl<G: RuntimeGenesis, E> BuildStorage for ChainSpec<G, E> {
 			}),
 			// The `StateRootHash` variant exists as a way to keep note that other clients support
 			// it, but Substrate itself isn't capable of loading chain specs with just a hash at the moment.
-			Genesis::StateRootHash(_) => Err("Genesis storage in hash format not supported".into())
+			Genesis::StateRootHash(_) => Err("Genesis storage in hash format not supported".into()),
 		}
 	}
 
@@ -328,7 +328,7 @@ impl<G: RuntimeGenesis, E: serde::Serialize + Clone + 'static> ChainSpec<G, E> {
 					.collect();
 
 				Genesis::Raw(RawGenesis { top, children_default })
-			},
+			}
 			(_, genesis) => genesis,
 		};
 		Ok(JsonContainer { client_spec: self.client_spec.clone(), genesis })

--- a/client/chain-spec/src/extension.rs
+++ b/client/chain-spec/src/extension.rs
@@ -107,7 +107,7 @@ impl<T: Fork> Fork for Option<T> {
 			(Some(mut a), Some(b)) => {
 				a.combine_with(b);
 				Some(a)
-			},
+			}
 			(a, b) => a.or(b),
 		};
 	}

--- a/client/chain-spec/src/extension.rs
+++ b/client/chain-spec/src/extension.rs
@@ -107,7 +107,7 @@ impl<T: Fork> Fork for Option<T> {
 			(Some(mut a), Some(b)) => {
 				a.combine_with(b);
 				Some(a)
-			}
+			},
 			(a, b) => a.or(b),
 		};
 	}


### PR DESCRIPTION
Right now, chain specs can look like this:

```json
"genesis": {
  "runtime": { }
}
```

Or like this:

```json
"genesis": {
  "raw": { }
}
```

This PR adds a third variant:

```json
"genesis": {
  "trie_root_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
}
```

Substrate isn't capable of loading chain specs with this `trie_root_hash` variant and will probably not be capable in the near future, but I'm adding this variant anyway because the `chain_spec.rs` file of Substrate is kind of the reference of the format of the chain specs.
I would like to add support for this variant in smoldot (https://github.com/paritytech/smoldot/issues/1566), and this PR will provide a nice error message for people trying to load "smoldot chain specs" into Substrate.

EDIT: changed `trie_root_hash` to `state_root_hash` after review
