### PR TITLE
don't panic if already migrated

### DIFF
--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -199,11 +199,7 @@ pub mod pallet {
 
 		#[cfg(feature = "try-runtime")]
 		fn post_upgrade() -> Result<(), &'static str> {
-			if StorageVersion::<T>::get() == Releases::V1 {
-				migrations::v1::post_migrate::<T>()
-			} else {
-				Ok(())
-			}
+			migrations::v1::post_migrate::<T>()
 		}
 
 		fn integrity_test() {

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -181,7 +181,11 @@ pub mod pallet {
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		#[cfg(feature = "try-runtime")]
 		fn pre_upgrade() -> Result<(), &'static str> {
-			migrations::v1::pre_migrate::<T>()
+			if StorageVersion::<T>::get() == Releases::V0 {
+				migrations::v1::pre_migrate::<T>()
+			} else {
+				Ok(())
+			}
 		}
 
 		fn on_runtime_upgrade() -> Weight {
@@ -195,7 +199,11 @@ pub mod pallet {
 
 		#[cfg(feature = "try-runtime")]
 		fn post_upgrade() -> Result<(), &'static str> {
-			migrations::v1::post_migrate::<T>()
+			if StorageVersion::<T>::get() == Releases::V1 {
+				migrations::v1::post_migrate::<T>()
+			} else {
+				Ok(())
+			}
 		}
 
 		fn integrity_test() {


### PR DESCRIPTION
When testing a runtime upgrade using the `try-runtime` utility the vesting pallet panics because it's already migrated on our chain. This prevents us from testing our next runtime upgrade without messing around with the vesting pallet.

Could this get cherry-picked to the `polkadot-0.9.12` branch?