### PR TITLE
Add BabeApi::slot_duration() and clarify BabeApi::configuration()

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1450,6 +1450,10 @@ impl_runtime_apis! {
 			}
 		}
 
+		fn slot_duration() -> sp_consensus_babe::SlotDuration {
+			Babe::slot_duration()
+		}
+
 		fn current_epoch_start() -> sp_consensus_babe::Slot {
 			Babe::current_epoch_start()
 		}

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1450,7 +1450,7 @@ impl_runtime_apis! {
 			}
 		}
 
-		fn slot_duration() -> sp_consensus_babe::SlotDuration {
+		fn slot_duration() -> u64 {
 			Babe::slot_duration()
 		}
 

--- a/primitives/consensus/babe/src/lib.rs
+++ b/primitives/consensus/babe/src/lib.rs
@@ -367,11 +367,22 @@ sp_api::decl_runtime_apis! {
 	#[api_version(2)]
 	pub trait BabeApi {
 		/// Return the genesis configuration for BABE. The configuration is only read on genesis.
+		///
+		/// This method is used to obtain the BABE configuration of epoch #0. Its output is valid
+		/// only when called at the genesis block.
 		fn configuration() -> BabeGenesisConfiguration;
 
 		/// Return the configuration for BABE. Version 1.
+		///
+		/// This method is used to obtain the BABE configuration of epoch #0. Its output is valid
+		/// only when called at the genesis block.
 		#[changed_in(2)]
 		fn configuration() -> BabeGenesisConfigurationV1;
+
+		/// Returns the slot duration for BABE.
+		///
+		/// This value currently never changes.
+		fn slot_duration() -> SlotDuration;
 
 		/// Returns the slot that started the current epoch.
 		fn current_epoch_start() -> Slot;

--- a/primitives/consensus/babe/src/lib.rs
+++ b/primitives/consensus/babe/src/lib.rs
@@ -379,7 +379,7 @@ sp_api::decl_runtime_apis! {
 		#[changed_in(2)]
 		fn configuration() -> BabeGenesisConfigurationV1;
 
-		/// Returns the slot duration for BABE.
+		/// Returns the slot duration for BABE, in milliseconds.
 		///
 		/// This value currently never changes.
 		fn slot_duration() -> u64;

--- a/primitives/consensus/babe/src/lib.rs
+++ b/primitives/consensus/babe/src/lib.rs
@@ -382,7 +382,7 @@ sp_api::decl_runtime_apis! {
 		/// Returns the slot duration for BABE.
 		///
 		/// This value currently never changes.
-		fn slot_duration() -> SlotDuration;
+		fn slot_duration() -> u64;
 
 		/// Returns the slot that started the current epoch.
 		fn current_epoch_start() -> Slot;

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -867,6 +867,10 @@ cfg_if! {
 					}
 				}
 
+				fn slot_duration() -> sp_consensus_babe::SlotDuration {
+					1000
+				}
+
 				fn current_epoch_start() -> Slot {
 					<pallet_babe::Pallet<Runtime>>::current_epoch_start()
 				}
@@ -1123,6 +1127,10 @@ cfg_if! {
 						randomness: <pallet_babe::Pallet<Runtime>>::randomness(),
 						allowed_slots: AllowedSlots::PrimaryAndSecondaryPlainSlots,
 					}
+				}
+
+				fn slot_duration() -> sp_consensus_babe::SlotDuration {
+					1000
 				}
 
 				fn current_epoch_start() -> Slot {

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -867,7 +867,7 @@ cfg_if! {
 					}
 				}
 
-				fn slot_duration() -> sp_consensus_babe::SlotDuration {
+				fn slot_duration() -> u64 {
 					1000
 				}
 
@@ -1129,7 +1129,7 @@ cfg_if! {
 					}
 				}
 
-				fn slot_duration() -> sp_consensus_babe::SlotDuration {
+				fn slot_duration() -> u64 {
 					1000
 				}
 


### PR DESCRIPTION
At the moment, the only way to obtain the Babe slot duration is to call `BabeApi_configuration`.
However, the `BabeApi_configuration` function returns nonsensical data when called against any block other than the genesis block (it mixes the genesis config and non-genesis config).

This PR:

- Clarifies the API of the `BabeApi_configuration` runtime entry point, mentioning that it's supposed to be called only on the genesis block.
- Adds a new `BabeApi_slot_duration` entry point to return just the Babe slot duration. This new entry point can be called on any block.

This makes it possible to obtain the Babe slot duration without access to the genesis block state.

polkadot companion: https://github.com/paritytech/polkadot/pull/4206
