### PR TITLE
Update node-template  `construct_runtime!` syntax

### DIFF
--- a/bin/node-template/node/src/chain_spec.rs
+++ b/bin/node-template/node/src/chain_spec.rs
@@ -150,5 +150,6 @@ fn testnet_genesis(
 			// Assign network admin rights.
 			key: root_key,
 		},
+		transaction_payment: Default::default(),
 	}
 }

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -286,16 +286,16 @@ construct_runtime!(
 		NodeBlock = opaque::Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
-		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
-		RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage},
-		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
-		Aura: pallet_aura::{Pallet, Config<T>},
-		Grandpa: pallet_grandpa::{Pallet, Call, Storage, Config, Event},
-		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-		TransactionPayment: pallet_transaction_payment::{Pallet, Storage},
-		Sudo: pallet_sudo::{Pallet, Call, Config<T>, Storage, Event<T>},
+		System: frame_system,
+		RandomnessCollectiveFlip: pallet_randomness_collective_flip,
+		Timestamp: pallet_timestamp,
+		Aura: pallet_aura,
+		Grandpa: pallet_grandpa,
+		Balances: pallet_balances,
+		TransactionPayment: pallet_transaction_payment,
+		Sudo: pallet_sudo,
 		// Include the custom logic from the pallet-template in the runtime.
-		TemplateModule: pallet_template::{Pallet, Call, Storage, Event<T>},
+		TemplateModule: pallet_template,
 	}
 );
 


### PR DESCRIPTION
Per #9681, the `construct_runtime!` section can now just specify the pallets, and no need to concretely set the generics they need for the template. 

~~I will create a new tag for this for the downstream template (`monthly-2021-11+1`)~~ 
~~I would like to **move the pre-release tag** (as the build was broken for the tag as it is now) to include it in updating it for the monthly release https://github.com/substrate-developer-hub/substrate-node-template/issues/258~~
No need to change tags, it will just be included in the template downstream :heavy_check_mark: 