### PR TITLE
Warn about usage of pallet collective set members call.

### DIFF
--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -345,6 +345,13 @@ pub mod pallet {
 		/// NOTE: Does not enforce the expected `MaxMembers` limit on the amount of members, but
 		///       the weight estimations rely on it to estimate dispatchable weight.
 		///
+		/// # WARNING:
+		///
+		/// The pallet collective can also be managed by logic outside of the pallet throught the
+		/// implementation of the trait [`ChangeMembers`].
+		/// Any call to `set_members` must be careful that member set doesn't get out of sync with
+		/// other logic managing the member set.
+		///
 		/// # <weight>
 		/// ## Weight
 		/// - `O(MP + N)` where:

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -347,9 +347,9 @@ pub mod pallet {
 		///
 		/// # WARNING:
 		///
-		/// The pallet collective can also be managed by logic outside of the pallet throught the
+		/// The `pallet-collective` can also be managed by logic outside of the pallet through the
 		/// implementation of the trait [`ChangeMembers`].
-		/// Any call to `set_members` must be careful that member set doesn't get out of sync with
+		/// Any call to `set_members` must be careful that the member set doesn't get out of sync with
 		/// other logic managing the member set.
 		///
 		/// # <weight>

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -349,8 +349,8 @@ pub mod pallet {
 		///
 		/// The `pallet-collective` can also be managed by logic outside of the pallet through the
 		/// implementation of the trait [`ChangeMembers`].
-		/// Any call to `set_members` must be careful that the member set doesn't get out of sync with
-		/// other logic managing the member set.
+		/// Any call to `set_members` must be careful that the member set doesn't get out of sync
+		/// with other logic managing the member set.
 		///
 		/// # <weight>
 		/// ## Weight


### PR DESCRIPTION
Currently the pallet collective allows other pallet to manage the member set through the implementation of `ChangeMembers` but also directly with `set_members` root call.

But both are quite incompatible. Or at least they must stay in sync.
Like currently on kusama if we call `set_members` without modifying the storage of pallet-membership they would get out of sync.
And the next call to `change_members` from pallet-membership will be inaccurate in regards to who are the member in pallet-collective.

I think this call is a bit error prone.