### PR TITLE
add some bounds on frame-system call associated type

### DIFF
--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -89,8 +89,8 @@ use frame_support::{
 		PalletInfo, SortedMembers, StoredMap,
 	},
 	weights::{
-		extract_actual_weight, DispatchClass, DispatchInfo, PerDispatchClass, RuntimeDbWeight,
-		Weight,
+		extract_actual_weight, DispatchClass, DispatchInfo, GetDispatchInfo, PerDispatchClass,
+		PostDispatchInfo, RuntimeDbWeight, Weight,
 	},
 	Parameter,
 };
@@ -179,7 +179,14 @@ pub mod pallet {
 			+ OriginTrait<Call = Self::Call>;
 
 		/// The aggregated `Call` type.
-		type Call: Dispatchable + Debug;
+		type Call: Debug
+			+ GetDispatchInfo
+			+ FullCodec
+			+ Clone
+			+ Eq
+			+ PartialEq
+			+ scale_info::TypeInfo
+			+ Dispatchable<Origin = Self::Origin, Info = DispatchInfo, PostInfo = PostDispatchInfo>;
 
 		/// Account index (aka nonce) type. This stores the number of previous transactions
 		/// associated with a sender account.


### PR DESCRIPTION
Currently in construct_runtime we always implement the runtime Call with some bounds.

We already require every argument of dispatchable to implement Clone/Eq/PartialEq/FullCodec/.
We implement GetDispatchInfo,
And when we implement Dispatchable we do it with the FRAME concrete types for Info and PostDispatchInfo.

For this reason I think it makes sense to bounds on the Config::Call what is expected to be implemented.

The downside of this is that changing GetDispatchInfo or PostDispatchInfo type might then lead to more breaking change. But actually every user who makes use of dispatchable already bound them by have a new associated type in their pallet.

It seems pallets like the scheduler already create a new associated type, only because frame-system::Config::Call doesn't have the bounds which are expected from FRAME implementation in construct_runtime.
https://github.com/paritytech/substrate/blob/bdf97a350054b882dbe0c1cdcb377b3a9bf2e411/frame/scheduler/src/lib.rs#L149-L153

Maybe it is better to bound everything from the start