### PR TITLE
Pallet Safe Mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5861,6 +5861,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-safe-mode"
+version = "4.0.0-dev"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4702,6 +4702,7 @@ dependencies = [
  "pallet-proxy",
  "pallet-randomness-collective-flip",
  "pallet-recovery",
+ "pallet-safe-mode",
  "pallet-scheduler",
  "pallet-session",
  "pallet-session-benchmarking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ members = [
 	"frame/proxy",
 	"frame/randomness-collective-flip",
 	"frame/recovery",
+	"frame/safe-mode",
 	"frame/scheduler",
 	"frame/scored-pool",
 	"frame/session",

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -79,6 +79,7 @@ pallet-offences-benchmarking = { version = "4.0.0-dev", path = "../../../frame/o
 pallet-proxy = { version = "4.0.0-dev", default-features = false, path = "../../../frame/proxy" }
 pallet-randomness-collective-flip = { version = "4.0.0-dev", default-features = false, path = "../../../frame/randomness-collective-flip" }
 pallet-recovery = { version = "4.0.0-dev", default-features = false, path = "../../../frame/recovery" }
+pallet-safe-mode = { version = "4.0.0-dev", default-features = false, path = "../../../frame/safe-mode" }
 pallet-session = { version = "4.0.0-dev", features = [
 	"historical",
 ], path = "../../../frame/session", default-features = false }

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -196,7 +196,7 @@ parameter_types! {
 const_assert!(NORMAL_DISPATCH_RATIO.deconstruct() >= AVERAGE_ON_INITIALIZE_RATIO.deconstruct());
 
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = Everything;
+	type BaseCallFilter = SafeMode;
 	type BlockWeights = RuntimeBlockWeights;
 	type BlockLength = RuntimeBlockLength;
 	type DbWeight = RocksDbWeight;
@@ -1243,6 +1243,22 @@ impl pallet_transaction_storage::Config for Runtime {
 	type WeightInfo = pallet_transaction_storage::weights::SubstrateWeight<Runtime>;
 }
 
+parameter_types! {
+	pub const SafeModeBurnAmount: Balance = 1_000_000 * DOLLARS;
+	pub SafeModeBurnDestination: AccountId = [0u8; 32].into();
+}
+
+impl pallet_safe_mode::Config for Runtime {
+	type Event = Event;
+	type BaseCallFilter = Everything;
+	// Should be a lesser filter.
+	type SafeModeCallFilter = Everything;
+	type Currency = Balances;
+	type BurnAmount = SafeModeBurnAmount;
+	type BurnDestination = SafeModeBurnDestination;
+	type DisableOrigin = EnsureRoot<AccountId>;
+}
+
 construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
@@ -1290,6 +1306,7 @@ construct_runtime!(
 		Uniques: pallet_uniques,
 		TransactionStorage: pallet_transaction_storage,
 		BagsList: pallet_bags_list,
+		SafeMode: pallet_safe_mode,
 	}
 );
 

--- a/frame/safe-mode/Cargo.toml
+++ b/frame/safe-mode/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "pallet-safe-mode"
+version = "4.0.0-dev"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+license = "Apache-2.0"
+homepage = "https://substrate.io"
+repository = "https://github.com/paritytech/substrate/"
+description = "FRAME pallet for sudo"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+scale-info = { version = "1.0", default-features = false, features = ["derive"] }
+sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
+
+[dev-dependencies]
+sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"scale-info/std",
+	"sp-std/std",
+	"sp-io/std",
+	"sp-runtime/std",
+	"frame-support/std",
+	"frame-system/std",
+]
+try-runtime = ["frame-support/try-runtime"]

--- a/frame/safe-mode/src/lib.rs
+++ b/frame/safe-mode/src/lib.rs
@@ -1,0 +1,146 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2017-2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Safe Mode Pallet
+//!
+//! - [`Config`]
+//! - [`Call`]
+//!
+//! ## Overview
+//!
+//! The Safe Mode pallet allows a chain to halt specified transactions for a period of time in case
+//! some problem or vulnerability was found on the network which could cause problems.
+//!
+//! Safe mode can be enabled by any user, as long as they are willing to pay the costs required to
+//! enable it. Returning funds for st
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use sp_runtime::DispatchResult;
+
+use frame_support::traits::{Contains, Currency, LockableCurrency, ExistenceRequirement};
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+pub use pallet::*;
+
+type BalanceOf<T> =
+	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+pub type NegativeImbalanceOf<T> = <<T as Config>::Currency as Currency<
+	<T as frame_system::Config>::AccountId,
+>>::NegativeImbalance;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::{DispatchResult, *};
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// The overarching event type.
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+		/// The default call filter that will be used by the chain when things are running normally.
+		type BaseCallFilter: Contains<Self::Call>;
+
+		/// The safe call filter that will be used by the chain when safe mode is enabled.
+		type SafeModeCallFilter: Contains<Self::Call>;
+
+		/// The currency mechanism.
+		type Currency: LockableCurrency<Self::AccountId>;
+
+		/// The amount of currency that needs to be "burned" to enable safe mode.
+		type BurnAmount: Get<BalanceOf<Self>>;
+
+		/// The location where burned funds go.
+		type BurnDestination: Get<Self::AccountId>;
+
+		/// An origin to disable safemode. Most often some governance.
+		type DisableOrigin: EnsureOrigin<Self::Origin>;
+	}
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	#[pallet::generate_storage_info]
+	pub struct Pallet<T>(PhantomData<T>);
+
+	/// The `AccountId` of the sudo key.
+	#[pallet::storage]
+	pub(super) type Enabled<T: Config> = StorageValue<_, bool, ValueQuery>;
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// Safe mode has just been enabled by a user.
+		SafeModeEnabled { who: T::AccountId },
+		/// Safe mode disabled.
+		SafeModeDisabled,
+	}
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_initialize(_n: T::BlockNumber) -> Weight {
+			// TODO: Potentially disable safe mode after some period of time?
+			0
+		}
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+
+		/// Enable safemode
+		#[pallet::weight(0)]
+		pub fn enable_safemode(
+			origin: OriginFor<T>,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			let burn_account = T::BurnDestination::get();
+			let burn_amount = T::BurnAmount::get();
+
+			T::Currency::transfer(&who, &burn_account, burn_amount, ExistenceRequirement::AllowDeath)?;
+
+			Enabled::<T>::set(true);
+			Self::deposit_event(Event::SafeModeEnabled { who });
+			Ok(())
+		}
+
+		/// Disable safemode
+		#[pallet::weight(0)]
+		pub fn disable_safemode(
+			origin: OriginFor<T>,
+		) -> DispatchResult {
+			T::DisableOrigin::ensure_origin(origin)?;
+			Enabled::<T>::set(false);
+			Self::deposit_event(Event::SafeModeDisabled);
+			Ok(())
+		}
+
+	}
+}
+
+impl<T: Config> Contains<T::Call> for Pallet<T> {
+	fn contains(call: &T::Call) -> bool {
+		if Enabled::<T>::get() {
+			T::SafeModeCallFilter::contains(call)
+		} else {
+			<T as Config>::BaseCallFilter::contains(call)
+		}
+	}
+}


### PR DESCRIPTION
In progress...

- [ ] Use check + burn instead of transfer?
    - [ ] Send burn funds to treasury?
- [ ] Allow safemode with infinite lock.
    - [ ] Unlock funds with origin.
- [ ]   Automatically disable safe mode after some period of time?
    - [ ] Maybe a curve to burn more funds to trigger safe mode for a longer period of time? 
- [ ] Expose trait telling other pallets we are in safe mode
- [ ] Implement check in XCM which will queue messages rather than dispatch them.