### PR TITLE
Bump parity-db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6209,9 +6209,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ccc4a8687027deb53d45c5434a1f1b330c9d1069a59cfe80a62aa9a1da25ae"
+checksum = "7cb5195cb862b13055cf7f7a76c55073dc73885c2a61511e322b8c1666be7332"
 dependencies = [
  "blake2-rfc",
  "crc32fast",

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -33,7 +33,7 @@ sc-state-db = { version = "0.10.0-dev", path = "../state-db" }
 sp-trie = { version = "4.0.0-dev", path = "../../primitives/trie" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sp-database = { version = "4.0.0-dev", path = "../../primitives/database" }
-parity-db = { version = "0.3.3", optional = true }
+parity-db = { version = "0.3.4", optional = true }
 
 [dev-dependencies]
 sp-tracing = { version = "4.0.0-dev", path = "../../primitives/tracing" }


### PR DESCRIPTION
Brings a fix for potential race condition and performance optimizations for MacOS.