### PR TITLE
upgrade ss58-registry with additional networks.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9994,9 +9994,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "ss58-registry"
-version = "1.0.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2413ecc7946ca99368862851dc1359f1477bc654ecfb135cf3efcb85ceca5f"
+checksum = "c66cd4c4bb7ee41dc5b0c13d600574ae825d3a02e8f31326b17ac71558f2c836"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -125,6 +125,7 @@ std = [
 	"sp-externalities",
 	"sp-storage/std",
 	"sp-runtime-interface/std",
+	"ss58-registry/std",
 	"zeroize/alloc",
 	"secrecy/alloc",
 	"futures",

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -68,7 +68,7 @@ twox-hash = { version = "1.6.1", default-features = false, optional = true }
 libsecp256k1 = { version = "0.6", default-features = false, features = ["hmac", "static-context"], optional = true }
 sp-core-hashing = { version = "4.0.0-dev", path = "./hashing", default-features = false, optional = true }
 merlin = { version = "2.0", default-features = false, optional = true }
-ss58-registry = "1.5.0"
+ss58-registry = { version = "1.5.0", default-features = false }
 sp-runtime-interface = { version = "4.0.0-dev", default-features = false, path = "../runtime-interface" }
 
 [dev-dependencies]

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -68,7 +68,7 @@ twox-hash = { version = "1.6.1", default-features = false, optional = true }
 libsecp256k1 = { version = "0.6", default-features = false, features = ["hmac", "static-context"], optional = true }
 sp-core-hashing = { version = "4.0.0-dev", path = "./hashing", default-features = false, optional = true }
 merlin = { version = "2.0", default-features = false, optional = true }
-ss58-registry = "1.0.0"
+ss58-registry = "1.5.0"
 sp-runtime-interface = { version = "4.0.0-dev", default-features = false, path = "../runtime-interface" }
 
 [dev-dependencies]


### PR DESCRIPTION
(also includes explicitly being a no_std crate when std feature not enabled).