### PR TITLE
Update requirement for pwasm-utils

### DIFF
--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 derive_more = "0.99.2"
-pwasm-utils = "0.18.0"
+pwasm-utils = "0.18.2"
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 wasmi = "0.9.1"
 sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }


### PR DESCRIPTION
Even though the Cargo.lock has 0.18.2, we update the required version of pwasm-utils Cargo.toml for sc-executor-common. See [this](https://github.com/paritytech/polkadot/pull/4267) for the reason.
