### PR TITLE
Forward wasmer-sandbox feature to sp-sandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4758,6 +4758,7 @@ dependencies = [
  "sp-npos-elections",
  "sp-offchain",
  "sp-runtime",
+ "sp-sandbox",
  "sp-session",
  "sp-staking",
  "sp-std",

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -41,6 +41,7 @@ sp-transaction-pool = { version = "4.0.0-dev", default-features = false, path = 
 sp-version = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/version" }
 sp-npos-elections = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/npos-elections" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/io" }
+sp-sandbox = { version = "0.10.0-dev", default-features = false, path = "../../../primitives/sandbox" }
 
 # frame dependencies
 frame-executive = { version = "4.0.0-dev", default-features = false, path = "../../../frame/executive" }
@@ -257,3 +258,8 @@ try-runtime = [
 # Make contract callable functions marked as __unstable__ available. Do not enable
 # on live chains as those are subject to change.
 contracts-unstable-interface = ["pallet-contracts/unstable-interface"]
+# Force `sp-sandbox` to call into the host resident executor. One still need to make sure
+# that `sc-executor` gets the `wasmer-sandbox` feature which happens automatically when
+# specified on the command line.
+# Don't use that on a production chain.
+wasmer-sandbox = ["sp-sandbox/wasmer-sandbox"]


### PR DESCRIPTION
This fixes an issue where the `wasmer-sandbox` feature wasn't properly forwarded to `sp-sandbox`. The effect was that even though `sc-executor` was providing a wasmer sandbox (instead of a wasmi one), it wasn't used because `sp-sandbox` was using the embedded executor (as it should in production use cases to not rely on the sandboxing host functions). The reason why we need this forwarding is because `sp-sandbox` is part of the runtime and features supplied on the CLI are only applied when piped through the `node-runtime` crate.

You can see the effects from it in [this PR](https://github.com/paritytech/substrate/pull/9600) where there is no difference in weight.  The bug was introduced by: https://github.com/paritytech/substrate/pull/9592.

I reran the end-to-end benchmarks on Linux with the following CLI:
```
cargo run --release --features runtime-benchmarks,[wasmer-sandbox] -- --extra --dev --execution=wasm --wasm-execution=compiled -p pallet_contracts -e ink_erc20_transfer
```

The results now clearly indicate that they were run with different execution engines. Unfortunately, it confirmed our suspicion that wasmer is even slower than wasmi on these example contracts. [Weight benchmarks suggest](https://github.com/paritytech/substrate/pull/10266) that slowness of host function calling might be responsible.

```
ink_erc20_transfer, wasmi

Min Squares Analysis
========
-- Extrinsic Time --

Data points distribution:
    g   mean µs  sigma µs       %
    0      5529     5.575    0.1%
    1      8053     6.898    0.0%

Quality and confidence:
param     error
g         1.267

Model:
Time ~=     5529
    + g     2523
              µs



ink_er20_transfer, wasmer

Min Squares Analysis
========
-- Extrinsic Time --

Data points distribution:
    g   mean µs  sigma µs       %
    0      5744     152.7    2.6%
    1     12000     141.7    1.1%

Quality and confidence:
param     error
g         29.76

Model:
Time ~=     5744
    + g     6260
              µs


--------------------------------------------------------------------------------------------------


solang_erc20_transfer, wasmi

Min Squares Analysis
========
-- Extrinsic Time --

Data points distribution:
    g   mean µs  sigma µs       %
    0      1909     8.551    0.4%
    1      2057     10.93    0.5%

Quality and confidence:
param     error
g         1.983

Model:
Time ~=     1909
    + g    147.5
              µs



solang_erc20_transfer, wasmer

Min Squares Analysis
========
-- Extrinsic Time --

Data points distribution:
    g   mean µs  sigma µs       %
    0      3423     121.5    3.5%
    1      3678     61.12    1.6%

Quality and confidence:
param     error
g         19.43

Model:
Time ~=     3423
    + g    255.2
              µs
```