### PR TITLE
Update staking `InsufficientBond` erorr doc.

### DIFF
--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -608,7 +608,9 @@ pub mod pallet {
 		DuplicateIndex,
 		/// Slash record index out of bounds.
 		InvalidSlashIndex,
-		/// Can not bond with value less than minimum required.
+		/// Cannot have a validator or nominator role, with value less than the minimum defined by
+		/// governance (see `MinValidatorBond` and `MinNominatorBond`). If unbonding is the
+		/// intention, `chill` first to remove one's role as validator/nominator.
 		InsufficientBond,
 		/// Can not schedule more unlock chunks.
 		NoMoreChunks,


### PR DESCRIPTION
As many people are unbonding, I've had to explain this to a handful of people recently. This improves the error message a bit and puts it in the error description, so that it is shown in the front page of all explorers if `unbond` fails, hopefully making it clear.

