### PR TITLE
Cli: Introduce `--detailed-log-output` flag

### DIFF
--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -547,6 +547,11 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		Ok(self.shared_params().log_filters().join(","))
 	}
 
+	/// Should the detailed log output be enabled.
+	fn detailed_log_output(&self) -> Result<bool> {
+		Ok(self.shared_params().detailed_log_output())
+	}
+
 	/// Is log reloading enabled?
 	fn enable_log_reloading(&self) -> Result<bool> {
 		Ok(self.shared_params().enable_log_reloading())
@@ -568,7 +573,9 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		sp_panic_handler::set(&C::support_url(), &C::impl_version());
 
 		let mut logger = LoggerBuilder::new(self.log_filters()?);
-		logger.with_log_reloading(self.enable_log_reloading()?);
+		logger
+			.with_log_reloading(self.enable_log_reloading()?)
+			.with_detailed_output(self.detailed_log_output()?);
 
 		if let Some(tracing_targets) = self.tracing_targets()? {
 			let tracing_receiver = self.tracing_receiver()?;

--- a/client/cli/src/params/shared_params.rs
+++ b/client/cli/src/params/shared_params.rs
@@ -49,6 +49,14 @@ pub struct SharedParams {
 	#[structopt(short = "l", long, value_name = "LOG_PATTERN")]
 	pub log: Vec<String>,
 
+	/// Enable detailed log output.
+	///
+	/// This includes displaying the log target, log level and thread name.
+	///
+	/// This is automatically enabled when something is logged with any higher level than `info`.
+	#[structopt(long)]
+	pub detailed_log_output: bool,
+
 	/// Disable log color output.
 	#[structopt(long)]
 	pub disable_log_color: bool,
@@ -105,6 +113,11 @@ impl SharedParams {
 	/// Get the filters for the logging
 	pub fn log_filters(&self) -> &[String] {
 		&self.log
+	}
+
+	/// Should the detailed log output be enabled.
+	pub fn detailed_log_output(&self) -> bool {
+		self.detailed_log_output
 	}
 
 	/// Should the log color output be disabled?

--- a/client/tracing/src/logging/mod.rs
+++ b/client/tracing/src/logging/mod.rs
@@ -95,6 +95,7 @@ fn prepare_subscriber<N, E, F, W>(
 	directives: &str,
 	profiling_targets: Option<&str>,
 	force_colors: Option<bool>,
+	detailed_output: bool,
 	builder_hook: impl Fn(
 		SubscriberBuilder<format::DefaultFields, EventFormat, EnvFilter, DefaultLogger>,
 	) -> SubscriberBuilder<N, E, F, W>,
@@ -157,19 +158,19 @@ where
 	tracing_log::LogTracer::builder().with_max_level(max_level).init()?;
 
 	// If we're only logging `INFO` entries then we'll use a simplified logging format.
-	let simple = match max_level_hint {
-		Some(level) if level <= tracing_subscriber::filter::LevelFilter::INFO => true,
-		_ => false,
-	};
+	let detailed_output = match max_level_hint {
+		Some(level) if level <= tracing_subscriber::filter::LevelFilter::INFO => false,
+		_ => true,
+	} || detailed_output;
 
 	let enable_color = force_colors.unwrap_or_else(|| atty::is(atty::Stream::Stderr));
-	let timer = fast_local_time::FastLocalTime { with_fractional: !simple };
+	let timer = fast_local_time::FastLocalTime { with_fractional: detailed_output };
 
 	let event_format = EventFormat {
 		timer,
-		display_target: !simple,
-		display_level: !simple,
-		display_thread_name: !simple,
+		display_target: detailed_output,
+		display_level: detailed_output,
+		display_thread_name: detailed_output,
 		enable_color,
 		dup_to_stdout: !atty::is(atty::Stream::Stderr) && atty::is(atty::Stream::Stdout),
 	};
@@ -194,6 +195,7 @@ pub struct LoggerBuilder {
 	profiling: Option<(crate::TracingReceiver, String)>,
 	log_reloading: bool,
 	force_colors: Option<bool>,
+	detailed_output: bool,
 }
 
 impl LoggerBuilder {
@@ -204,6 +206,7 @@ impl LoggerBuilder {
 			profiling: None,
 			log_reloading: false,
 			force_colors: None,
+			detailed_output: false,
 		}
 	}
 
@@ -223,6 +226,17 @@ impl LoggerBuilder {
 		self
 	}
 
+	/// Wether detailed log output should be enabled.
+	///
+	/// This includes showing the log target, log level and thread name.
+	///
+	/// This will be automatically enabled when there is a log level enabled that is higher than
+	/// `info`.
+	pub fn with_detailed_output(&mut self, detailed: bool) -> &mut Self {
+		self.detailed_output = detailed;
+		self
+	}
+
 	/// Force enable/disable colors.
 	pub fn with_colors(&mut self, enable: bool) -> &mut Self {
 		self.force_colors = Some(enable);
@@ -239,6 +253,7 @@ impl LoggerBuilder {
 					&self.directives,
 					Some(&profiling_targets),
 					self.force_colors,
+					self.detailed_output,
 					|builder| enable_log_reloading!(builder),
 				)?;
 				let profiling = crate::ProfilingLayer::new(tracing_receiver, &profiling_targets);
@@ -251,6 +266,7 @@ impl LoggerBuilder {
 					&self.directives,
 					Some(&profiling_targets),
 					self.force_colors,
+					self.detailed_output,
 					|builder| builder,
 				)?;
 				let profiling = crate::ProfilingLayer::new(tracing_receiver, &profiling_targets);
@@ -261,19 +277,25 @@ impl LoggerBuilder {
 			}
 		} else {
 			if self.log_reloading {
-				let subscriber =
-					prepare_subscriber(&self.directives, None, self.force_colors, |builder| {
-						enable_log_reloading!(builder)
-					})?;
+				let subscriber = prepare_subscriber(
+					&self.directives,
+					None,
+					self.force_colors,
+					self.detailed_output,
+					|builder| enable_log_reloading!(builder),
+				)?;
 
 				tracing::subscriber::set_global_default(subscriber)?;
 
 				Ok(())
 			} else {
-				let subscriber =
-					prepare_subscriber(&self.directives, None, self.force_colors, |builder| {
-						builder
-					})?;
+				let subscriber = prepare_subscriber(
+					&self.directives,
+					None,
+					self.force_colors,
+					self.detailed_output,
+					|builder| builder,
+				)?;
 
 				tracing::subscriber::set_global_default(subscriber)?;
 

--- a/client/tracing/src/logging/mod.rs
+++ b/client/tracing/src/logging/mod.rs
@@ -226,7 +226,7 @@ impl LoggerBuilder {
 		self
 	}
 
-	/// Wether detailed log output should be enabled.
+	/// Whether detailed log output should be enabled.
 	///
 	/// This includes showing the log target, log level and thread name.
 	///


### PR DESCRIPTION
If this CLI flag is given, detailed log output will be enabled. This includes the log level, log
target ad the thread name. Before this was only enabled when a log level higher than `info` should
be logged.

