### PR TITLE
Vesting: Fix `post_migration` check

### DIFF
--- a/frame/vesting/src/migrations.rs
+++ b/frame/vesting/src/migrations.rs
@@ -70,7 +70,7 @@ pub(crate) mod v1 {
 
 		for (_key, schedules) in Vesting::<T>::iter() {
 			assert!(
-				schedules.len() == 1,
+				schedules.len() => 1,
 				"A bounded vec with incorrect count of items was created."
 			);
 

--- a/frame/vesting/src/migrations.rs
+++ b/frame/vesting/src/migrations.rs
@@ -70,7 +70,7 @@ pub(crate) mod v1 {
 
 		for (_key, schedules) in Vesting::<T>::iter() {
 			assert!(
-				schedules.len() => 1,
+				schedules.len() >= 1,
 				"A bounded vec with incorrect count of items was created."
 			);
 


### PR DESCRIPTION
As the vesting migration could already have been done, people could already have started to merge schedules.

CC @koushiro 

Fixes: https://github.com/paritytech/substrate/issues/10275