### PR TITLE
Don't generate the consensusEngine field in chain specs

### DIFF
--- a/client/chain-spec/res/chain_spec.json
+++ b/client/chain-spec/res/chain_spec.json
@@ -19,7 +19,6 @@
 		["wss://telemetry.polkadot.io/submit/", 0]
 	],
 	"protocolId": "fir",
-	"consensusEngine": null,
 	"genesis": {
 		"raw": [
 			{

--- a/client/chain-spec/res/chain_spec2.json
+++ b/client/chain-spec/res/chain_spec2.json
@@ -19,7 +19,6 @@
 		["wss://telemetry.polkadot.io/submit/", 0]
 	],
 	"protocolId": "fir",
-	"consensusEngine": null,
 	"myProperty": "Test Extension",
 	"genesis": {
 		"raw": [

--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -168,6 +168,7 @@ struct ClientSpec<E> {
 	#[serde(flatten)]
 	extensions: E,
 	// Never used, left only for backward compatibility.
+	#[serde(default, skip_serializing)]
 	consensus_engine: (),
 	#[serde(skip_serializing)]
 	#[allow(unused)]


### PR DESCRIPTION
The `consensusEngine` field of chain specs hasn't been used in years. Let's no longer generate it, and allow decoding chain specs that don't have this field.