### PR TITLE
Reduce noise from running empty doc tests

### DIFF
--- a/bin/node-template/pallets/template/Cargo.toml
+++ b/bin/node-template/pallets/template/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/substrate-developer-hub/substrate-node-template
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [
 	"derive",

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/substrate-developer-hub/substrate-node-template
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -31,6 +31,7 @@ required-features = ["cli"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+doctest = false
 
 [dependencies]
 # third-party dependencies

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/paritytech/substrate/"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 scale-info = { version = "1.0", features = ["derive"] }

--- a/bin/node/inspect/Cargo.toml
+++ b/bin/node/inspect/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/paritytech/substrate/"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 derive_more = "0.99"

--- a/bin/node/primitives/Cargo.toml
+++ b/bin/node/primitives/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/paritytech/substrate/"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [
 	"derive",

--- a/bin/node/rpc/Cargo.toml
+++ b/bin/node/rpc/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/paritytech/substrate/"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 jsonrpc-core = "18.0.0"
 node-primitives = { version = "2.0.0", path = "../primitives" }

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/paritytech/substrate/"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 
 # third-party dependencies

--- a/bin/node/test-runner-example/Cargo.toml
+++ b/bin/node/test-runner-example/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
+[lib]
+doctest = false
+
 [dependencies]
 test-runner = { path = "../../../test-utils/test-runner" }
 

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -12,6 +12,9 @@ publish = true
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sc-service = { version = "0.10.0-dev", features = [
     "test-helpers",

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -16,6 +16,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 path = "src/main.rs"
 name = "subkey"
 
+[lib]
+doctest = false
+
 [dependencies]
 sc-cli = { version = "0.10.0-dev", path = "../../../client/cli" }
 structopt = "0.3.25"

--- a/client/allocator/Cargo.toml
+++ b/client/allocator/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
 sp-wasm-interface = { version = "4.0.0-dev", path = "../../primitives/wasm-interface" }

--- a/client/api/Cargo.toml
+++ b/client/api/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [
     "derive",

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -16,6 +16,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 [build-dependencies]
 prost-build = "0.9"
 
+[lib]
+doctest = false
+
 [dependencies]
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", default-features = false, version = "2.0.0" }

--- a/client/basic-authorship/Cargo.toml
+++ b/client/basic-authorship/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 futures = "0.3.9"

--- a/client/beefy/Cargo.toml
+++ b/client/beefy/Cargo.toml
@@ -7,6 +7,9 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 repository = "https://github.com/paritytech/substrate"
 description = "BEEFY Client gadget for substrate"
 
+[lib]
+doctest = false
+
 [dependencies]
 fnv = "1.0.6"
 futures = "0.3"

--- a/client/beefy/rpc/Cargo.toml
+++ b/client/beefy/rpc/Cargo.toml
@@ -7,6 +7,9 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 repository = "https://github.com/paritytech/substrate"
 description = "RPC for the BEEFY Client gadget for substrate"
 
+[lib]
+doctest = false
+
 [dependencies]
 futures = "0.3.16"
 log = "0.4"

--- a/client/block-builder/Cargo.toml
+++ b/client/block-builder/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-state-machine = { version = "0.10.0-dev", path = "../../primitives/state-machine" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }

--- a/client/chain-spec/Cargo.toml
+++ b/client/chain-spec/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sc-chain-spec-derive = { version = "4.0.0-dev", path = "./derive" }
 impl-trait-for-tuples = "0.2.1"

--- a/client/chain-spec/derive/Cargo.toml
+++ b/client/chain-spec/derive/Cargo.toml
@@ -13,6 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 proc-macro-crate = "1.1.0"

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 log = "0.4.11"
 regex = "1.5.4"

--- a/client/consensus/aura/Cargo.toml
+++ b/client/consensus/aura/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-application-crypto = { version = "4.0.0-dev", path = "../../../primitives/application-crypto" }
 sp-consensus-aura = { version = "0.10.0-dev", path = "../../../primitives/consensus/aura" }

--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", features = [
     "derive",

--- a/client/consensus/babe/rpc/Cargo.toml
+++ b/client/consensus/babe/rpc/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sc-consensus-babe = { version = "0.10.0-dev", path = "../" }
 sc-rpc-api = { version = "0.10.0-dev", path = "../../../rpc-api" }

--- a/client/consensus/common/Cargo.toml
+++ b/client/consensus/common/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 thiserror = "1.0.30"
 libp2p = { version = "0.39.1", default-features = false }

--- a/client/consensus/epochs/Cargo.toml
+++ b/client/consensus/epochs/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
 fork-tree = { version = "3.0.0", path = "../../../utils/fork-tree" }

--- a/client/consensus/manual-seal/Cargo.toml
+++ b/client/consensus/manual-seal/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 derive_more = "0.99.2"
 futures = "0.3.9"

--- a/client/consensus/pow/Cargo.toml
+++ b/client/consensus/pow/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
 sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }

--- a/client/consensus/slots/Cargo.toml
+++ b/client/consensus/slots/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 sc-client-api = { version = "4.0.0-dev", path = "../../api" }

--- a/client/consensus/uncles/Cargo.toml
+++ b/client/consensus/uncles/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sc-client-api = { version = "4.0.0-dev", path = "../../api" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 parking_lot = "0.11.1"
 log = "0.4.8"

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }

--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 derive_more = "0.99.2"
 pwasm-utils = "0.18.2"

--- a/client/executor/runtime-test/Cargo.toml
+++ b/client/executor/runtime-test/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/paritytech/substrate/"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-core = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/io" }

--- a/client/executor/wasmi/Cargo.toml
+++ b/client/executor/wasmi/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 log = "0.4.8"
 wasmi = "0.9.1"

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 libc = "0.2.105"
 cfg-if = "1.0"

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -14,6 +14,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 
+[lib]
+doctest = false
+
 [dependencies]
 derive_more = "0.99.2"
 dyn-clone = "1.0"

--- a/client/finality-grandpa/rpc/Cargo.toml
+++ b/client/finality-grandpa/rpc/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 readme = "README.md"
 
+[lib]
+doctest = false
+
 [dependencies]
 sc-finality-grandpa = { version = "0.10.0-dev", path = "../" }
 sc-rpc = { version = "4.0.0-dev", path = "../../rpc" }

--- a/client/informant/Cargo.toml
+++ b/client/informant/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 ansi_term = "0.12.1"
 futures = "0.3.9"

--- a/client/keystore/Cargo.toml
+++ b/client/keystore/Cargo.toml
@@ -14,6 +14,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 
+[lib]
+doctest = false
+
 [dependencies]
 async-trait = "0.1.50"
 derive_more = "0.99.2"

--- a/client/network-gossip/Cargo.toml
+++ b/client/network-gossip/Cargo.toml
@@ -14,6 +14,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 
+[lib]
+doctest = false
+
 [dependencies]
 futures = "0.3.9"
 futures-timer = "3.0.1"

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -16,6 +16,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 [build-dependencies]
 prost-build = "0.9"
 
+[lib]
+doctest = false
+
 [dependencies]
 async-trait = "0.1"
 async-std = "1.10.0"

--- a/client/network/test/Cargo.toml
+++ b/client/network/test/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/paritytech/substrate/"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 async-std = "1.10.0"
 sc-network = { version = "0.10.0-dev", path = "../" }

--- a/client/offchain/Cargo.toml
+++ b/client/offchain/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 bytes = "1.0"
 codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }

--- a/client/peerset/Cargo.toml
+++ b/client/peerset/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 futures = "0.3.9"
 libp2p = { version = "0.39.1", default-features = false }

--- a/client/proposer-metrics/Cargo.toml
+++ b/client/proposer-metrics/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 log = "0.4.8"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.10.0-dev"}

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 futures = "0.3.16"

--- a/client/rpc-servers/Cargo.toml
+++ b/client/rpc-servers/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 futures = "0.3.16"
 jsonrpc-core = "18.0.0"

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sc-rpc-api = { version = "0.10.0-dev", path = "../rpc-api" }
 sc-client-api = { version = "4.0.0-dev", path = "../api" }

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -21,6 +21,9 @@ wasmtime = ["sc-executor/wasmtime"]
 # exposes the client type
 test-helpers = []
 
+[lib]
+doctest = false
+
 [dependencies]
 thiserror = "1.0.30"
 futures = "0.3.16"

--- a/client/service/test/Cargo.toml
+++ b/client/service/test/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/paritytech/substrate/"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 hex = "0.4"
 hex-literal = "0.3.4"

--- a/client/state-db/Cargo.toml
+++ b/client/state-db/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 parking_lot = "0.11.1"
 log = "0.4.11"

--- a/client/sync-state-rpc/Cargo.toml
+++ b/client/sync-state-rpc/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 thiserror = "1.0.30"
 jsonrpc-core = "18.0.0"

--- a/client/telemetry/Cargo.toml
+++ b/client/telemetry/Cargo.toml
@@ -14,6 +14,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 
+[lib]
+doctest = false
+
 [dependencies]
 parking_lot = "0.11.1"
 futures = "0.3.9"

--- a/client/tracing/Cargo.toml
+++ b/client/tracing/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 ansi_term = "0.12.1"
 atty = "0.2.13"

--- a/client/tracing/proc-macro/Cargo.toml
+++ b/client/tracing/proc-macro/Cargo.toml
@@ -13,6 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 proc-macro-crate = "1.1.0"

--- a/client/transaction-pool/Cargo.toml
+++ b/client/transaction-pool/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 thiserror = "1.0.30"

--- a/client/transaction-pool/api/Cargo.toml
+++ b/client/transaction-pool/api/Cargo.toml
@@ -8,6 +8,9 @@ homepage = "https://substrate.io"
 repository = "https://github.com/paritytech/substrate/"
 description = "Transaction pool client facing API."
 
+[lib]
+doctest = false
+
 [dependencies]
 futures = { version = "0.3.1"  }
 log = { version = "0.4.8" }

--- a/client/utils/Cargo.toml
+++ b/client/utils/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/paritytech/substrate/"
 description = "I/O for Substrate runtimes"
 readme = "README.md"
 
+[lib]
+doctest = false
+
 [dependencies]
 futures = "0.3.9"
 lazy_static = "1.4.0"

--- a/frame/assets/Cargo.toml
+++ b/frame/assets/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/atomic-swap/Cargo.toml
+++ b/frame/atomic-swap/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/aura/Cargo.toml
+++ b/frame/aura/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../../primitives/application-crypto" }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }

--- a/frame/authority-discovery/Cargo.toml
+++ b/frame/authority-discovery/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-authority-discovery = { version = "4.0.0-dev", default-features = false, path = "../../primitives/authority-discovery" }
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../../primitives/application-crypto" }

--- a/frame/authorship/Cargo.toml
+++ b/frame/authorship/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [
 	"derive",

--- a/frame/babe/Cargo.toml
+++ b/frame/babe/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/bags-list/Cargo.toml
+++ b/frame/bags-list/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 # parity
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
@@ -70,4 +73,3 @@ fuzz = [
 	"sp-tracing",
 ]
 try-runtime = [ "frame-support/try-runtime" ]
-

--- a/frame/bags-list/remote-tests/Cargo.toml
+++ b/frame/bags-list/remote-tests/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 # frame
 pallet-staking = { path = "../../staking", version = "4.0.0-dev" }

--- a/frame/balances/Cargo.toml
+++ b/frame/balances/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/beefy-mmr/Cargo.toml
+++ b/frame/beefy-mmr/Cargo.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0"
 description = "BEEFY + MMR runtime utilities"
 repository = "https://github.com/paritytech/substrate"
 
+[lib]
+doctest = false
+
 [dependencies]
 hex = { version = "0.4", optional = true }
 codec = { version = "2.2.0", package = "parity-scale-codec", default-features = false, features = ["derive"] }

--- a/frame/beefy-mmr/primitives/Cargo.toml
+++ b/frame/beefy-mmr/primitives/Cargo.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0"
 repository = "https://github.com/paritytech/substrate"
 description = "A no-std/Substrate compatible library to construct binary merkle tree."
 
+[lib]
+doctest = false
+
 [dependencies]
 hex = { version = "0.4", optional = true, default-features = false }
 log = { version = "0.4", optional = true, default-features = false }

--- a/frame/beefy/Cargo.toml
+++ b/frame/beefy/Cargo.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0"
 repository = "https://github.com/paritytech/substrate"
 description = "BEEFY FRAME pallet"
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { version = "2.2.0", package = "parity-scale-codec", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/benchmarking/Cargo.toml
+++ b/frame/benchmarking/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 linregress = { version = "0.4.4", optional = true }
 paste = "1.0"

--- a/frame/bounties/Cargo.toml
+++ b/frame/bounties/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [
 	"derive",

--- a/frame/collective/Cargo.toml
+++ b/frame/collective/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.14", default-features = false }

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 bitflags = "1.3"
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = [

--- a/frame/contracts/common/Cargo.toml
+++ b/frame/contracts/common/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 bitflags = "1.0"
 codec = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }

--- a/frame/contracts/proc-macro/Cargo.toml
+++ b/frame/contracts/proc-macro/Cargo.toml
@@ -13,6 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 proc-macro2 = "1"

--- a/frame/contracts/rpc/Cargo.toml
+++ b/frame/contracts/rpc/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2" }
 jsonrpc-core = "18.0.0"

--- a/frame/contracts/rpc/runtime-api/Cargo.toml
+++ b/frame/contracts/rpc/runtime-api/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/democracy/Cargo.toml
+++ b/frame/democracy/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [

--- a/frame/election-provider-multi-phase/Cargo.toml
+++ b/frame/election-provider-multi-phase/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 static_assertions = "1.1.0"
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [

--- a/frame/election-provider-support/Cargo.toml
+++ b/frame/election-provider-support/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/elections-phragmen/Cargo.toml
+++ b/frame/elections-phragmen/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [
 	"derive",

--- a/frame/elections/Cargo.toml
+++ b/frame/elections/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [
 	"derive",

--- a/frame/examples/basic/Cargo.toml
+++ b/frame/examples/basic/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 log = { version = "0.4.14", default-features = false }

--- a/frame/examples/offchain-worker/Cargo.toml
+++ b/frame/examples/offchain-worker/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 lite-json = { version = "0.1", default-features = false }

--- a/frame/examples/parallel/Cargo.toml
+++ b/frame/examples/parallel/Cargo.toml
@@ -11,6 +11,9 @@ description = "FRAME example pallet using runtime worker threads"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/executive/Cargo.toml
+++ b/frame/executive/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [
 	"derive",

--- a/frame/gilt/Cargo.toml
+++ b/frame/gilt/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/grandpa/Cargo.toml
+++ b/frame/grandpa/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/identity/Cargo.toml
+++ b/frame/identity/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/im-online/Cargo.toml
+++ b/frame/im-online/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../../primitives/application-crypto" }
 pallet-authorship = { version = "4.0.0-dev", default-features = false, path = "../authorship" }

--- a/frame/indices/Cargo.toml
+++ b/frame/indices/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/lottery/Cargo.toml
+++ b/frame/lottery/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [
 	"derive",

--- a/frame/membership/Cargo.toml
+++ b/frame/membership/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/merkle-mountain-range/Cargo.toml
+++ b/frame/merkle-mountain-range/Cargo.toml
@@ -11,6 +11,9 @@ description = "FRAME Merkle Mountain Range pallet."
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/merkle-mountain-range/primitives/Cargo.toml
+++ b/frame/merkle-mountain-range/primitives/Cargo.toml
@@ -11,6 +11,9 @@ description = "FRAME Merkle Mountain Range primitives."
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 log = { version = "0.4.14", default-features = false }

--- a/frame/merkle-mountain-range/rpc/Cargo.toml
+++ b/frame/merkle-mountain-range/rpc/Cargo.toml
@@ -12,6 +12,9 @@ publish = false
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 jsonrpc-core = "18.0.0"

--- a/frame/multisig/Cargo.toml
+++ b/frame/multisig/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/nicks/Cargo.toml
+++ b/frame/nicks/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/node-authorization/Cargo.toml
+++ b/frame/node-authorization/Cargo.toml
@@ -11,6 +11,9 @@ description = "FRAME pallet for node authorization"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/offences/Cargo.toml
+++ b/frame/offences/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 pallet-balances = { version = "4.0.0-dev", default-features = false, path = "../balances" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }

--- a/frame/offences/benchmarking/Cargo.toml
+++ b/frame/offences/benchmarking/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/proxy/Cargo.toml
+++ b/frame/proxy/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["max-encoded-len"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/randomness-collective-flip/Cargo.toml
+++ b/frame/randomness-collective-flip/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 safe-mix = { version = "1.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }

--- a/frame/recovery/Cargo.toml
+++ b/frame/recovery/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/scheduler/Cargo.toml
+++ b/frame/scheduler/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/paritytech/substrate/"
 description = "FRAME example pallet"
 readme = "README.md"
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/scored-pool/Cargo.toml
+++ b/frame/scored-pool/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/session/Cargo.toml
+++ b/frame/session/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 log = { version = "0.4.0", default-features = false }
 impl-trait-for-tuples = "0.2.1"

--- a/frame/session/benchmarking/Cargo.toml
+++ b/frame/session/benchmarking/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 rand = { version = "0.7.2", default-features = false }
 

--- a/frame/society/Cargo.toml
+++ b/frame/society/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/staking/Cargo.toml
+++ b/frame/staking/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0.126", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [

--- a/frame/staking/reward-curve/Cargo.toml
+++ b/frame/staking/reward-curve/Cargo.toml
@@ -13,6 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 syn = { version = "1.0.81", features = ["full", "visit"] }

--- a/frame/staking/reward-fn/Cargo.toml
+++ b/frame/staking/reward-fn/Cargo.toml
@@ -12,6 +12,7 @@ description = "Reward function for FRAME staking pallet"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [lib]
+doctest = false
 
 [dependencies]
 sp-arithmetic = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/arithmetic" }

--- a/frame/sudo/Cargo.toml
+++ b/frame/sudo/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }

--- a/frame/support/procedural/Cargo.toml
+++ b/frame/support/procedural/Cargo.toml
@@ -13,6 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 frame-support-procedural-tools = { version = "4.0.0-dev", path = "./tools" }

--- a/frame/support/procedural/tools/Cargo.toml
+++ b/frame/support/procedural/tools/Cargo.toml
@@ -11,6 +11,9 @@ description = "Proc macro helpers for procedural macros"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 frame-support-procedural-tools-derive = { version = "3.0.0", path = "./derive" }
 proc-macro2 = "1.0.29"

--- a/frame/support/procedural/tools/derive/Cargo.toml
+++ b/frame/support/procedural/tools/derive/Cargo.toml
@@ -13,6 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 proc-macro2 = "1.0.29"

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/paritytech/substrate/"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0.126", default-features = false, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }

--- a/frame/support/test/compile_pass/Cargo.toml
+++ b/frame/support/test/compile_pass/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/paritytech/substrate/"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/support/test/pallet/Cargo.toml
+++ b/frame/support/test/pallet/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/paritytech/substrate/"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/system/Cargo.toml
+++ b/frame/system/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }

--- a/frame/system/benchmarking/Cargo.toml
+++ b/frame/system/benchmarking/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/system/rpc/runtime-api/Cargo.toml
+++ b/frame/system/rpc/runtime-api/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../../../primitives/api" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }

--- a/frame/timestamp/Cargo.toml
+++ b/frame/timestamp/Cargo.toml
@@ -14,6 +14,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/tips/Cargo.toml
+++ b/frame/tips/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.0", default-features = false }

--- a/frame/transaction-payment/Cargo.toml
+++ b/frame/transaction-payment/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [
 	"derive",

--- a/frame/transaction-payment/asset-tx-payment/Cargo.toml
+++ b/frame/transaction-payment/asset-tx-payment/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 # Substrate dependencies
 sp-core = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/core" }

--- a/frame/transaction-payment/rpc/Cargo.toml
+++ b/frame/transaction-payment/rpc/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 jsonrpc-core = "18.0.0"

--- a/frame/transaction-payment/rpc/runtime-api/Cargo.toml
+++ b/frame/transaction-payment/rpc/runtime-api/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../../../primitives/api" }

--- a/frame/transaction-storage/Cargo.toml
+++ b/frame/transaction-storage/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0.126", optional = true }
 hex-literal = { version = "0.3.4", optional = true }

--- a/frame/treasury/Cargo.toml
+++ b/frame/treasury/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = [
 	"derive",

--- a/frame/try-runtime/Cargo.toml
+++ b/frame/try-runtime/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api", default-features = false }
 sp-std = { version = "4.0.0-dev", path = "../../primitives/std" , default-features = false }

--- a/frame/uniques/Cargo.toml
+++ b/frame/uniques/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/utility/Cargo.toml
+++ b/frame/utility/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/frame/vesting/Cargo.toml
+++ b/frame/vesting/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [
 	"derive",

--- a/primitives/api/Cargo.toml
+++ b/primitives/api/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-api-proc-macro = { version = "4.0.0-dev", path = "proc-macro" }

--- a/primitives/api/proc-macro/Cargo.toml
+++ b/primitives/api/proc-macro/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 quote = "1.0.10"

--- a/primitives/application-crypto/Cargo.toml
+++ b/primitives/application-crypto/Cargo.toml
@@ -14,6 +14,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }

--- a/primitives/application-crypto/test/Cargo.toml
+++ b/primitives/application-crypto/test/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/paritytech/substrate/"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-core = { version = "4.0.0-dev", default-features = false, path = "../../core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../keystore", default-features = false }

--- a/primitives/arithmetic/Cargo.toml
+++ b/primitives/arithmetic/Cargo.toml
@@ -14,6 +14,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [
 	"derive",

--- a/primitives/authority-discovery/Cargo.toml
+++ b/primitives/authority-discovery/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../application-crypto" }
 codec = { package = "parity-scale-codec", default-features = false, version = "2.0.0" }

--- a/primitives/authorship/Cargo.toml
+++ b/primitives/authorship/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../inherents" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }

--- a/primitives/beefy/Cargo.toml
+++ b/primitives/beefy/Cargo.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0"
 repository = "https://github.com/paritytech/substrate"
 description = "Primitives for BEEFY protocol."
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { version = "2.2.0", package = "parity-scale-codec", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/primitives/block-builder/Cargo.toml
+++ b/primitives/block-builder/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }

--- a/primitives/blockchain/Cargo.toml
+++ b/primitives/blockchain/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 log = "0.4.11"
 lru = "0.7.0"

--- a/primitives/consensus/aura/Cargo.toml
+++ b/primitives/consensus/aura/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../../application-crypto" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }

--- a/primitives/consensus/babe/Cargo.toml
+++ b/primitives/consensus/babe/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../../application-crypto" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 async-trait = "0.1.42"
 codec = { package = "parity-scale-codec", version = "2.0.0", features = [

--- a/primitives/consensus/pow/Cargo.toml
+++ b/primitives/consensus/pow/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../api" }
 sp-std = { version = "4.0.0-dev", default-features = false, path = "../../std" }

--- a/primitives/consensus/slots/Cargo.toml
+++ b/primitives/consensus/slots/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/primitives/consensus/vrf/Cargo.toml
+++ b/primitives/consensus/vrf/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
 schnorrkel = { version = "0.9.1", features = ["preaudit_deprecated", "u64_backend"], default-features = false }

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -85,6 +85,7 @@ harness = false
 
 [lib]
 bench = false
+doctest = false
 
 [features]
 default = ["std"]

--- a/primitives/core/hashing/Cargo.toml
+++ b/primitives/core/hashing/Cargo.toml
@@ -12,6 +12,9 @@ documentation = "https://docs.rs/sp-core-hashing"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-std = { version = "4.0.0-dev", default-features = false, path = "../../std" }
 byteorder = { version = "1.3.2", default-features = false }

--- a/primitives/database/Cargo.toml
+++ b/primitives/database/Cargo.toml
@@ -10,7 +10,9 @@ description = "Substrate database trait."
 documentation = "https://docs.rs/sp-database"
 readme = "README.md"
 
+[lib]
+doctest = false
+
 [dependencies]
 parking_lot = "0.11.1"
 kvdb = "0.10.0"
-

--- a/primitives/finality-grandpa/Cargo.toml
+++ b/primitives/finality-grandpa/Cargo.toml
@@ -14,6 +14,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/primitives/inherents/Cargo.toml
+++ b/primitives/inherents/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
-
 [dependencies]
 sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
 sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -14,6 +14,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 hash-db = { version = "0.15.2", default-features = false }

--- a/primitives/keyring/Cargo.toml
+++ b/primitives/keyring/Cargo.toml
@@ -14,6 +14,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-core = { version = "4.0.0-dev", path = "../core" }
 sp-runtime = { version = "4.0.0-dev", path = "../runtime" }

--- a/primitives/keystore/Cargo.toml
+++ b/primitives/keystore/Cargo.toml
@@ -12,6 +12,9 @@ documentation = "https://docs.rs/sp-core"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 async-trait = "0.1.50"
 derive_more = "0.99.2"

--- a/primitives/maybe-compressed-blob/Cargo.toml
+++ b/primitives/maybe-compressed-blob/Cargo.toml
@@ -10,5 +10,8 @@ description = "Handling of blobs, usually Wasm code, which may be compresed"
 documentation = "https://docs.rs/sp-maybe-compressed-blob"
 readme = "README.md"
 
+[lib]
+doctest = false
+
 [dependencies]
 zstd = { version = "0.9.0", default-features = false }

--- a/primitives/offchain/Cargo.toml
+++ b/primitives/offchain/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }

--- a/primitives/panic-handler/Cargo.toml
+++ b/primitives/panic-handler/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 backtrace = "0.3.38"
 regex = "1.5.4"

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1.0.126", features = ["derive"] }
 sp-core = { version = "4.0.0-dev", path = "../core" }

--- a/primitives/runtime-interface/proc-macro/Cargo.toml
+++ b/primitives/runtime-interface/proc-macro/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 syn = { version = "1.0.81", features = ["full", "visit", "fold", "extra-traits"] }

--- a/primitives/runtime-interface/test-wasm-deprecated/Cargo.toml
+++ b/primitives/runtime-interface/test-wasm-deprecated/Cargo.toml
@@ -12,6 +12,9 @@ publish = false
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-runtime-interface = { version = "4.0.0-dev", default-features = false, path = "../" }
 sp-std = { version = "4.0.0-dev", default-features = false, path = "../../std" }

--- a/primitives/runtime-interface/test-wasm/Cargo.toml
+++ b/primitives/runtime-interface/test-wasm/Cargo.toml
@@ -12,6 +12,9 @@ publish = false
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-runtime-interface = { version = "4.0.0-dev", default-features = false, path = "../" }
 sp-std = { version = "4.0.0-dev", default-features = false, path = "../../std" }

--- a/primitives/runtime-interface/test/Cargo.toml
+++ b/primitives/runtime-interface/test/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/paritytech/substrate/"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-runtime-interface = { version = "4.0.0-dev", path = "../" }
 sc-executor = { version = "0.10.0-dev", path = "../../../client/executor" }

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
-
 [dependencies]
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }

--- a/primitives/sandbox/Cargo.toml
+++ b/primitives/sandbox/Cargo.toml
@@ -18,6 +18,9 @@ wasmi = { version = "0.9.1", default-features = false, features = ["core"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 wasmi = "0.9.0"
 
+[lib]
+doctest = false
+
 [dependencies]
 wasmi = { version = "0.9.0", optional = true }
 sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }

--- a/primitives/serializer/Cargo.toml
+++ b/primitives/serializer/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = "1.0.126"
 serde_json = "1.0.68"

--- a/primitives/session/Cargo.toml
+++ b/primitives/session/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/primitives/staking/Cargo.toml
+++ b/primitives/staking/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 log = { version = "0.4.11", optional = true }
 thiserror = { version = "1.0.30", optional = true }

--- a/primitives/storage/Cargo.toml
+++ b/primitives/storage/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }

--- a/primitives/test-primitives/Cargo.toml
+++ b/primitives/test-primitives/Cargo.toml
@@ -11,6 +11,9 @@ publish = false
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../application-crypto" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }

--- a/primitives/timestamp/Cargo.toml
+++ b/primitives/timestamp/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }
 sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }

--- a/primitives/transaction-pool/Cargo.toml
+++ b/primitives/transaction-pool/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }

--- a/primitives/transaction-storage-proof/Cargo.toml
+++ b/primitives/transaction-storage-proof/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../inherents" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -17,6 +17,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 name = "bench"
 harness = false
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }

--- a/primitives/version/Cargo.toml
+++ b/primitives/version/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
-
 [dependencies]
 impl-serde = { version = "0.3.1", optional = true }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }

--- a/primitives/version/proc-macro/Cargo.toml
+++ b/primitives/version/proc-macro/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 quote = "1.0.10"

--- a/primitives/wasm-interface/Cargo.toml
+++ b/primitives/wasm-interface/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 wasmi = { version = "0.9.1", optional = true }
 impl-trait-for-tuples = "0.2.1"

--- a/test-utils/client/Cargo.toml
+++ b/test-utils/client/Cargo.toml
@@ -11,6 +11,9 @@ publish = false
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 futures = "0.3.16"

--- a/test-utils/derive/Cargo.toml
+++ b/test-utils/derive/Cargo.toml
@@ -16,3 +16,4 @@ proc-macro2 = "1.0.29"
 
 [lib]
 proc-macro = true
+doctest = false

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -12,6 +12,9 @@ publish = false
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../../primitives/application-crypto" }
 sp-consensus-aura = { version = "0.10.0-dev", default-features = false, path = "../../primitives/consensus/aura" }

--- a/test-utils/runtime/client/Cargo.toml
+++ b/test-utils/runtime/client/Cargo.toml
@@ -11,6 +11,9 @@ publish = false
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-consensus = { version = "0.10.0-dev", path = "../../../primitives/consensus/common" }
 sc-consensus = { version = "0.10.0-dev", path = "../../../client/consensus/common" }

--- a/test-utils/runtime/transaction-pool/Cargo.toml
+++ b/test-utils/runtime/transaction-pool/Cargo.toml
@@ -11,6 +11,9 @@ publish = false
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 substrate-test-runtime-client = { version = "2.0.0", path = "../client" }
 parking_lot = "0.11.1"

--- a/utils/build-script-utils/Cargo.toml
+++ b/utils/build-script-utils/Cargo.toml
@@ -12,5 +12,8 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 platforms = "1.1"

--- a/utils/fork-tree/Cargo.toml
+++ b/utils/fork-tree/Cargo.toml
@@ -13,5 +13,8 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }

--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 frame-benchmarking = { version = "4.0.0-dev", path = "../../../frame/benchmarking" }
 frame-support = { version = "4.0.0-dev", path = "../../../frame/support" }

--- a/utils/frame/frame-utilities-cli/Cargo.toml
+++ b/utils/frame/frame-utilities-cli/Cargo.toml
@@ -10,6 +10,9 @@ description = "cli interface for FRAME"
 documentation = "https://docs.rs/substrate-frame-cli"
 readme = "README.md"
 
+[lib]
+doctest = false
+
 [dependencies]
 sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
 sc-cli = { version = "0.10.0-dev", path = "../../../client/cli" }

--- a/utils/frame/generate-bags/Cargo.toml
+++ b/utils/frame/generate-bags/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/paritytech/substrate/"
 description = "Bag threshold generation script for pallet-bag-list"
 readme = "README.md"
 
+[lib]
+doctest = false
+
 [dependencies]
 # FRAME
 frame-support = { version = "4.0.0-dev", path = "../../../frame/support" }

--- a/utils/frame/remote-externalities/Cargo.toml
+++ b/utils/frame/remote-externalities/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 jsonrpsee = { version = "0.4.1", features = ["ws-client", "macros"] }
 

--- a/utils/frame/rpc/system/Cargo.toml
+++ b/utils/frame/rpc/system/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 sc-client-api = { version = "4.0.0-dev", path = "../../../../client/api" }
 codec = { package = "parity-scale-codec", version = "2.0.0" }

--- a/utils/prometheus/Cargo.toml
+++ b/utils/prometheus/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[lib]
+doctest = false
+
 [dependencies]
 log = "0.4.8"
 prometheus = { version = "0.13.0", default-features = false }


### PR DESCRIPTION
upside:

- reduces space taken up in the ci logs and terminal.
- takes less ci time as it is not compiling and executing binaries that don't contain any tests.

downside: 

- if someone's writing doc tests for a particular crate they will have to remove the flag first.

Prior art:
We already have some libs with this flag set. This just makes it more comprehensive.