### PR TITLE
frame-benchmarking: Fix `min-square` for `--steps=1`

### DIFF
--- a/frame/benchmarking/src/analysis.rs
+++ b/frame/benchmarking/src/analysis.rs
@@ -199,7 +199,7 @@ impl Analysis {
 	}
 
 	pub fn min_squares_iqr(r: &Vec<BenchmarkResult>, selector: BenchmarkSelector) -> Option<Self> {
-		if r[0].components.is_empty() {
+		if r[0].components.len() <= 1 {
 			return Self::median_value(r, selector)
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/paritytech/substrate/issues/9985