### PR TITLE
Put back consensus_engine, only accept its absence

### DIFF
--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -168,7 +168,9 @@ struct ClientSpec<E> {
 	#[serde(flatten)]
 	extensions: E,
 	// Never used, left only for backward compatibility.
-	#[serde(default, skip_serializing)]
+	// In a future version, a `skip_serializing` attribute should be added in order to no longer
+	// generate chain specs with this field.
+	#[serde(default)]
 	consensus_engine: (),
 	#[serde(skip_serializing)]
 	#[allow(unused)]


### PR DESCRIPTION
Continuation of https://github.com/paritytech/substrate/pull/10303#issuecomment-975760198

Substrate will now accept when the field is missing, but still generate chain specs with this field.
We'll remove the field in a later version.
