### PR TITLE
Derive Debug for CrateVersion and StorageVersion

### DIFF
--- a/frame/support/src/traits/metadata.rs
+++ b/frame/support/src/traits/metadata.rs
@@ -135,7 +135,7 @@ pub trait GetCallMetadata {
 }
 
 /// The version of a crate.
-#[derive(RuntimeDebug, Eq, PartialEq, Encode, Decode, Clone, Copy, Default)]
+#[derive(Debug, Eq, PartialEq, Encode, Decode, Clone, Copy, Default)]
 pub struct CrateVersion {
 	/// The major version of the crate.
 	pub major: u16,
@@ -175,7 +175,7 @@ pub const STORAGE_VERSION_STORAGE_KEY_POSTFIX: &[u8] = b":__STORAGE_VERSION__:";
 ///
 /// Each storage version of a pallet is stored in the state under a fixed key. See
 /// [`STORAGE_VERSION_STORAGE_KEY_POSTFIX`] for how this key is built.
-#[derive(RuntimeDebug, Eq, PartialEq, Encode, Decode, Ord, Clone, Copy, PartialOrd, Default)]
+#[derive(Debug, Eq, PartialEq, Encode, Decode, Ord, Clone, Copy, PartialOrd, Default)]
 pub struct StorageVersion(u16);
 
 impl StorageVersion {


### PR DESCRIPTION
Derive `Debug` for `StorageVersion` so that logs on runtime migration are informative.

**Motivation:**
It is important to be able to verify that runtime migrations ran correctly, but the nature of runtime migrations makes it difficult to run with native execution, so types marked with `RuntimeDebug` will be stripped. This makes it difficult to verify the storage versions for the involved migrations from the logs.

This PR also derives `Debug` for `CrateVersion` as I see it having similar importance (though not for the motivating example for this PR).

related to #10351 

