### PR TITLE
Tips Benchmarking to be Runtime Agnostic

### DIFF
--- a/frame/bounties/src/benchmarking.rs
+++ b/frame/bounties/src/benchmarking.rs
@@ -81,11 +81,9 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
 	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 
-const MAX_BYTES: u32 = 16384;
-
 benchmarks! {
 	propose_bounty {
-		let d in 0 .. MAX_BYTES;
+		let d in 0 .. T::MaximumumReasonLenght:get();
 
 		let (caller, curator, fee, value, description) = setup_bounty::<T>(0, d);
 	}: _(RawOrigin::Signed(caller), value, description)

--- a/frame/bounties/src/benchmarking.rs
+++ b/frame/bounties/src/benchmarking.rs
@@ -33,7 +33,8 @@ const SEED: u32 = 0;
 // Create bounties that are approved for use in `on_initialize`.
 fn create_approved_bounties<T: Config>(n: u32) -> Result<(), &'static str> {
 	for i in 0..n {
-		let (caller, _curator, _fee, value, reason) = setup_bounty::<T>(i, MAX_BYTES);
+		let (caller, _curator, _fee, value, reason) =
+			setup_bounty::<T>(i, T::MaximumReasonLength::get());
 		Bounties::<T>::propose_bounty(RawOrigin::Signed(caller).into(), value, reason)?;
 		let bounty_id = BountyCount::<T>::get() - 1;
 		Bounties::<T>::approve_bounty(RawOrigin::Root.into(), bounty_id)?;
@@ -50,7 +51,8 @@ fn setup_bounty<T: Config>(
 	let caller = account("caller", u, SEED);
 	let value: BalanceOf<T> = T::BountyValueMinimum::get().saturating_mul(100u32.into());
 	let fee = value / 2u32.into();
-	let deposit = T::BountyDepositBase::get() + T::DataDepositPerByte::get() * MAX_BYTES.into();
+	let deposit = T::BountyDepositBase::get() +
+		T::DataDepositPerByte::get() * T::MaximumReasonLength::get().into();
 	let _ = T::Currency::make_free_balance_be(&caller, deposit);
 	let curator = account("curator", u, SEED);
 	let _ = T::Currency::make_free_balance_be(&curator, fee / 2u32.into());
@@ -60,7 +62,7 @@ fn setup_bounty<T: Config>(
 
 fn create_bounty<T: Config>(
 ) -> Result<(<T::Lookup as StaticLookup>::Source, BountyIndex), &'static str> {
-	let (caller, curator, fee, value, reason) = setup_bounty::<T>(0, MAX_BYTES);
+	let (caller, curator, fee, value, reason) = setup_bounty::<T>(0, T::MaximumReasonLength::get());
 	let curator_lookup = T::Lookup::unlookup(curator.clone());
 	Bounties::<T>::propose_bounty(RawOrigin::Signed(caller).into(), value, reason)?;
 	let bounty_id = BountyCount::<T>::get() - 1;
@@ -83,20 +85,20 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
 
 benchmarks! {
 	propose_bounty {
-		let d in 0 .. T::MaximumumReasonLenght:get();
+		let d in 0 .. T::MaximumReasonLength::get();
 
 		let (caller, curator, fee, value, description) = setup_bounty::<T>(0, d);
 	}: _(RawOrigin::Signed(caller), value, description)
 
 	approve_bounty {
-		let (caller, curator, fee, value, reason) = setup_bounty::<T>(0, MAX_BYTES);
+		let (caller, curator, fee, value, reason) = setup_bounty::<T>(0, T::MaximumReasonLength::get());
 		Bounties::<T>::propose_bounty(RawOrigin::Signed(caller).into(), value, reason)?;
 		let bounty_id = BountyCount::<T>::get() - 1;
 	}: _(RawOrigin::Root, bounty_id)
 
 	propose_curator {
 		setup_pot_account::<T>();
-		let (caller, curator, fee, value, reason) = setup_bounty::<T>(0, MAX_BYTES);
+		let (caller, curator, fee, value, reason) = setup_bounty::<T>(0, T::MaximumReasonLength::get());
 		let curator_lookup = T::Lookup::unlookup(curator.clone());
 		Bounties::<T>::propose_bounty(RawOrigin::Signed(caller).into(), value, reason)?;
 		let bounty_id = BountyCount::<T>::get() - 1;
@@ -116,7 +118,7 @@ benchmarks! {
 
 	accept_curator {
 		setup_pot_account::<T>();
-		let (caller, curator, fee, value, reason) = setup_bounty::<T>(0, MAX_BYTES);
+		let (caller, curator, fee, value, reason) = setup_bounty::<T>(0, T::MaximumReasonLength::get());
 		let curator_lookup = T::Lookup::unlookup(curator.clone());
 		Bounties::<T>::propose_bounty(RawOrigin::Signed(caller).into(), value, reason)?;
 		let bounty_id = BountyCount::<T>::get() - 1;

--- a/frame/bounties/src/lib.rs
+++ b/frame/bounties/src/lib.rs
@@ -195,6 +195,8 @@ pub mod pallet {
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 
 		/// Maximum acceptable reason length.
+		///
+		/// Benchmarks depend on this value, be sure to update weights file when changing this value
 		#[pallet::constant]
 		type MaximumReasonLength: Get<u32>;
 

--- a/frame/tips/src/benchmarking.rs
+++ b/frame/tips/src/benchmarking.rs
@@ -84,12 +84,9 @@ fn setup_pot_account<T: Config>() {
 	let _ = T::Currency::make_free_balance_be(&pot_account, value);
 }
 
-const MAX_BYTES: u32 = 16384;
-const MAX_TIPPERS: u32 = 100;
-
 benchmarks! {
 	report_awesome {
-		let r in 0 .. MAX_BYTES;
+		let r in 0 .. T::MaximumReasonLength::get();
 		let (caller, reason, awesome_person) = setup_awesome::<T>(r);
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
@@ -97,7 +94,7 @@ benchmarks! {
 	}: _(RawOrigin::Signed(caller), reason, awesome_person)
 
 	retract_tip {
-		let r = MAX_BYTES;
+		let r = T::MaximumReasonLength::get();
 		let (caller, reason, awesome_person) = setup_awesome::<T>(r);
 		TipsMod::<T>::report_awesome(
 			RawOrigin::Signed(caller.clone()).into(),
@@ -112,8 +109,8 @@ benchmarks! {
 	}: _(RawOrigin::Signed(caller), hash)
 
 	tip_new {
-		let r in 0 .. MAX_BYTES;
-		let t in 1 .. MAX_TIPPERS;
+		let r in 0 .. T::MaximumReasonLength::get();
+		let t in 1 .. T::Tippers::max_len() as u32;
 
 		let (caller, reason, beneficiary, value) = setup_tip::<T>(r, t)?;
 		// Whitelist caller account from further DB operations.
@@ -122,7 +119,7 @@ benchmarks! {
 	}: _(RawOrigin::Signed(caller), reason, beneficiary, value)
 
 	tip {
-		let t in 1 .. MAX_TIPPERS;
+		let t in 1 .. T::Tippers::max_len() as u32;
 		let (member, reason, beneficiary, value) = setup_tip::<T>(0, t)?;
 		let value = T::Currency::minimum_balance().saturating_mul(100u32.into());
 		TipsMod::<T>::tip_new(
@@ -142,7 +139,7 @@ benchmarks! {
 	}: _(RawOrigin::Signed(caller), hash, value)
 
 	close_tip {
-		let t in 1 .. MAX_TIPPERS;
+		let t in 1 .. T::Tippers::max_len() as u32;
 
 		// Make sure pot is funded
 		setup_pot_account::<T>();
@@ -171,7 +168,7 @@ benchmarks! {
 	}: _(RawOrigin::Signed(caller), hash)
 
 	slash_tip {
-		let t in 1 .. MAX_TIPPERS;
+		let t in 1 .. T::Tippers::max_len() as u32;
 
 		// Make sure pot is funded
 		setup_pot_account::<T>();

--- a/frame/tips/src/lib.rs
+++ b/frame/tips/src/lib.rs
@@ -128,6 +128,8 @@ pub mod pallet {
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 
 		/// Maximum acceptable reason length.
+		///
+		/// Benchmarks depend on this value, be sure to update weights file when changing this value
 		#[pallet::constant]
 		type MaximumReasonLength: Get<u32>;
 
@@ -150,7 +152,8 @@ pub mod pallet {
 		/// Origin from which tippers must come.
 		///
 		/// `ContainsLengthBound::max_len` must be cost free (i.e. no storage read or heavy
-		/// operation).
+		/// operation). Benchmarks depend on the value of `ContainsLengthBound::max_len` be sure to
+		/// update weights file when altering this method.
 		type Tippers: SortedMembers<Self::AccountId> + ContainsLengthBound;
 
 		/// Weight information for extrinsics in this pallet.


### PR DESCRIPTION
Use the generic config traits in benchmarking instead of hard-coded constants so any runtime configuration can benchmark `pallet_tips` and `pallet bounties`
