### PR TITLE
REAL fix for `min-square` for `--steps=1 --repeats=1` (#10323)

### DIFF
--- a/frame/benchmarking/src/analysis.rs
+++ b/frame/benchmarking/src/analysis.rs
@@ -199,7 +199,7 @@ impl Analysis {
 	}
 
 	pub fn min_squares_iqr(r: &Vec<BenchmarkResult>, selector: BenchmarkSelector) -> Option<Self> {
-		if r[0].components.is_empty() {
+		if r[0].components.is_empty() || r.len() <= 2 {
 			return Self::median_value(r, selector)
 		}
 

--- a/frame/benchmarking/src/analysis.rs
+++ b/frame/benchmarking/src/analysis.rs
@@ -199,7 +199,7 @@ impl Analysis {
 	}
 
 	pub fn min_squares_iqr(r: &Vec<BenchmarkResult>, selector: BenchmarkSelector) -> Option<Self> {
-		if r[0].components.len() <= 1 {
+		if r[0].components.is_empty() {
 			return Self::median_value(r, selector)
 		}
 


### PR DESCRIPTION
This reverts commit fe7c02941122bbe4a7956aff53739b62f575240d.

And actually fixes the underlying issue. Basically, when there are only two or less data points for min squares, we fallback to median value.