### PR TITLE
Better error message for an easy mistake to make

### DIFF
--- a/primitives/api/proc-macro/src/impl_runtime_apis.rs
+++ b/primitives/api/proc-macro/src/impl_runtime_apis.rs
@@ -634,6 +634,14 @@ fn generate_runtime_api_versions(impls: &[ItemImpl]) -> Result<TokenStream> {
 			.into_value()
 			.ident;
 
+		if &trait_.to_string() == "Config" {
+			let span = trait_.span();
+			return Err(Error::new(
+				span,
+				"Config trait implementations should be outside the impl_untime_apis! macro.",
+			))
+		}
+
 		let span = trait_.span();
 		if !processed_traits.insert(trait_) {
 			return Err(Error::new(


### PR DESCRIPTION
If people put the `impl pallet_xxx::Config for Runtime`s in `impl_runtime_apis!` then at the moment there's an error saying to rename Config trait so that the ids do not clash, but the Config traits should not be in there, so this error message makes it clear what mistake the user has made and how to fix it:

```
Compiling test-runtime v0.1.0 (/Users/bit/p/substrate/test/runtime)
  error: Config trait implementations should be outside the impl_untime_apis! macro.
     --> /Users/bit/p/substrate/test/runtime/src/lib.rs:569:23
      |
  569 | impl pallet_offences::Config<Block> for Runtime {
      |                       ^^^^^^
```