### PR TITLE
Format cargo.toml & upgrade 2021

### DIFF
--- a/bin/node-template/pallets/template/Cargo.toml
+++ b/bin/node-template/pallets/template/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = 'pallet-template'
+name = "pallet-template"
 version = "3.0.0"
 description = "FRAME pallet template for defining custom runtime logic."
-authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
+authors = ["Substrate DevHub <https://github.com/substrate-developer-hub>"]
 homepage = "https://substrate.io/"
-edition = '2018'
+edition = "2021"
 license = "Unlicense"
 publish = false
 repository = "https://github.com/substrate-developer-hub/substrate-node-template/"
@@ -27,13 +27,13 @@ sp-io = { default-features = false, version = "4.0.0-dev", path = "../../../../p
 sp-runtime = { default-features = false, version = "4.0.0-dev", path = "../../../../primitives/runtime" }
 
 [features]
-default = ['std']
+default = ["std"]
 std = [
-	'codec/std',
-	'scale-info/std',
-	'frame-support/std',
-	'frame-system/std',
-	'frame-benchmarking/std',
+	"codec/std",
+	"scale-info/std",
+	"frame-support/std",
+	"frame-system/std",
+	"frame-benchmarking/std",
 ]
 
 runtime-benchmarks = ["frame-benchmarking/runtime-benchmarks"]

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "node-template-runtime"
 version = "3.0.0"
-description = 'A fresh FRAME-based Substrate runtime, ready for hacking.'
+description = "A fresh FRAME-based Substrate runtime, ready for hacking."
 authors = ["Substrate DevHub <https://github.com/substrate-developer-hub>"]
 homepage = "https://substrate.io/"
 edition = "2021"

--- a/frame/transaction-payment/asset-tx-payment/Cargo.toml
+++ b/frame/transaction-payment/asset-tx-payment/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pallet-asset-tx-payment"
 version = "4.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://substrate.io"
 repository = "https://github.com/paritytech/substrate/"


### PR DESCRIPTION
1. use double quotes instead of single quotes(For better matching when replacing batches)
2. upgrade 2021