### PR TITLE
No longer include :code and :heappages in execution proofs

### DIFF
--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -1085,15 +1085,6 @@ where
 		method: &str,
 		call_data: &[u8],
 	) -> sp_blockchain::Result<(Vec<u8>, StorageProof)> {
-		// Make sure we include the `:code` and `:heap_pages` in the execution proof to be
-		// backwards compatible.
-		//
-		// TODO: Remove when solved: https://github.com/paritytech/substrate/issues/5047
-		let code_proof = self.read_proof(
-			id,
-			&mut [well_known_keys::CODE, well_known_keys::HEAP_PAGES].iter().map(|v| *v),
-		)?;
-
 		self.executor
 			.prove_execution(id, method, call_data)
 			.map(|(r, p)| (r, StorageProof::merge(vec![p, code_proof])))

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -1087,7 +1087,6 @@ where
 	) -> sp_blockchain::Result<(Vec<u8>, StorageProof)> {
 		self.executor
 			.prove_execution(id, method, call_data)
-			.map(|(r, p)| (r, StorageProof::merge(vec![p, code_proof])))
 	}
 
 	fn read_proof_collection(

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -1085,8 +1085,7 @@ where
 		method: &str,
 		call_data: &[u8],
 	) -> sp_blockchain::Result<(Vec<u8>, StorageProof)> {
-		self.executor
-			.prove_execution(id, method, call_data)
+		self.executor.prove_execution(id, method, call_data)
 	}
 
 	fn read_proof_collection(


### PR DESCRIPTION
So I'm opening this PR very naively. I don't really understand the design of the code of the client, but if I'm not mistaken this should remove the fact that right now `:code` and `:heappages` are included in every execution proof.

This was the case because the Substrate light client is incapable of caching the runtime code. Smoldot, however, is completely capable of doing that. Now that the Substrate light client is dead, there's no reason to keep that behavior.

This should reduce by a few megabytes the size of execution proofs.

Close https://github.com/paritytech/substrate/issues/5047