### PR TITLE
make npos crates accept non-default account

### DIFF
--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -313,8 +313,9 @@ impl<AId> SessionHandler<AId> for Tuple {
 			#(
 				let our_keys: Box<dyn Iterator<Item=_>> = Box::new(validators.iter()
 					.filter_map(|k|
-						(&k.0, k.1.get::<Tuple::Key>(<Tuple::Key as RuntimeAppPublic>::ID)))
-					);
+						k.1.get::<Tuple::Key>(<Tuple::Key as RuntimeAppPublic>::ID).map(|k1| (&k.0, k1))
+					)
+				);
 
 				Tuple::on_genesis_session(our_keys);
 			)*
@@ -330,12 +331,12 @@ impl<AId> SessionHandler<AId> for Tuple {
 			#(
 				let our_keys: Box<dyn Iterator<Item=_>> = Box::new(validators.iter()
 					.filter_map(|k|
-						(&k.0, k.1.get::<Tuple::Key>(<Tuple::Key as RuntimeAppPublic>::ID)))
-					);
+						k.1.get::<Tuple::Key>(<Tuple::Key as RuntimeAppPublic>::ID).map(|k1| (&k.0, k1))
+					));
 				let queued_keys: Box<dyn Iterator<Item=_>> = Box::new(queued_validators.iter()
 					.filter_map(|k|
-						(&k.0, k.1.get::<Tuple::Key>(<Tuple::Key as RuntimeAppPublic>::ID)))
-					);
+						k.1.get::<Tuple::Key>(<Tuple::Key as RuntimeAppPublic>::ID).map(|k1| (&k.0, k1))
+					));
 				Tuple::on_new_session(changed, our_keys, queued_keys);
 			)*
 		)

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -364,12 +364,18 @@ pub struct ActiveEraInfo {
 /// Reward points of an era. Used to split era total payout between validators.
 ///
 /// This points will be used to reward validators and their respective nominators.
-#[derive(PartialEq, Encode, Decode, Default, RuntimeDebug, TypeInfo)]
+#[derive(PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
 pub struct EraRewardPoints<AccountId: Ord> {
 	/// Total number of points. Equals the sum of reward points for each validator.
 	total: RewardPoint,
 	/// The reward points earned by a given validator.
 	individual: BTreeMap<AccountId, RewardPoint>,
+}
+
+impl<AccountId: Ord> Default for EraRewardPoints<AccountId> {
+	fn default() -> Self {
+		EraRewardPoints { total: Default::default(), individual: BTreeMap::new() }
+	}
 }
 
 /// Indicates the initial status of the staker.
@@ -593,9 +599,7 @@ pub struct IndividualExposure<AccountId, Balance: HasCompact> {
 }
 
 /// A snapshot of the stake backing a single validator in the system.
-#[derive(
-	PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Default, RuntimeDebug, TypeInfo,
-)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
 pub struct Exposure<AccountId, Balance: HasCompact> {
 	/// The total balance backing this validator.
 	#[codec(compact)]
@@ -605,6 +609,12 @@ pub struct Exposure<AccountId, Balance: HasCompact> {
 	pub own: Balance,
 	/// The portions of nominators stashes that are exposed.
 	pub others: Vec<IndividualExposure<AccountId, Balance>>,
+}
+
+impl<AccountId, Balance: Default + HasCompact> Default for Exposure<AccountId, Balance> {
+	fn default() -> Self {
+		Self { total: Default::default(), own: Default::default(), others: vec![] }
+	}
 }
 
 /// A pending slash record. The value of the slash has been computed but not applied yet,

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -1108,9 +1108,12 @@ where
 	fn note_author(author: T::AccountId) {
 		Self::reward_by_ids(vec![(author, 20)])
 	}
-	fn note_uncle(author: T::AccountId, _age: T::BlockNumber) {
-		if let Some(author) = <pallet_authorship::Pallet<T>>::author() {
-			Self::reward_by_ids(vec![(author, 2), (author, 1)])
+	fn note_uncle(uncle_author: T::AccountId, _age: T::BlockNumber) {
+		// defensive-only: block author must exist.
+		if let Some(block_author) = <pallet_authorship::Pallet<T>>::author() {
+			Self::reward_by_ids(vec![(block_author, 2), (uncle_author, 1)])
+		} else {
+			crate::log!(warn, "block author not set, this should never happen");
 		}
 	}
 }

--- a/primitives/npos-elections/src/lib.rs
+++ b/primitives/npos-elections/src/lib.rs
@@ -193,6 +193,15 @@ pub struct Edge<AccountId> {
 	weight: ExtendedBalance,
 }
 
+#[cfg(test)]
+impl<AccountId: Clone> Edge<AccountId> {
+	fn new(candidate: Candidate<AccountId>, weight: ExtendedBalance) -> Self {
+		let who = candidate.who.clone();
+		let candidate = Rc::new(RefCell::new(candidate));
+		Self { weight, who, candidate, load: Default::default() }
+	}
+}
+
 #[cfg(feature = "std")]
 impl<A: IdentifierT> sp_std::fmt::Debug for Edge<A> {
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
@@ -223,7 +232,12 @@ impl<A: IdentifierT> std::fmt::Debug for Voter<A> {
 impl<AccountId: IdentifierT> Voter<AccountId> {
 	/// Create a new `Voter`.
 	pub fn new(who: AccountId) -> Self {
-		Self { who, edges: Default::default(), budget: Default::default(), load: Default::default() }
+		Self {
+			who,
+			edges: Default::default(),
+			budget: Default::default(),
+			load: Default::default(),
+		}
 	}
 
 	/// Returns `true` if `self` votes for `target`.
@@ -350,10 +364,7 @@ pub struct Support<AccountId> {
 
 impl<AccountId> Default for Support<AccountId> {
 	fn default() -> Self {
-		Self {
-			total: Default::default(),
-			voters: vec![],
-		}
+		Self { total: Default::default(), voters: vec![] }
 	}
 }
 
@@ -477,7 +488,8 @@ pub fn setup_inputs<AccountId: IdentifierT>(
 				backed_stake: Default::default(),
 				elected: Default::default(),
 				round: Default::default(),
-			}.to_ptr()
+			}
+			.to_ptr()
 		})
 		.collect::<Vec<CandidatePtr<AccountId>>>();
 

--- a/primitives/npos-elections/src/tests.rs
+++ b/primitives/npos-elections/src/tests.rs
@@ -199,9 +199,9 @@ fn voter_normalize_ops_works() {
 		let c2 = Candidate { who: 20, elected: false, ..Default::default() };
 		let c3 = Candidate { who: 30, elected: false, ..Default::default() };
 
-		let e1 = Edge { candidate: Rc::new(RefCell::new(c1)), weight: 30, ..Default::default() };
-		let e2 = Edge { candidate: Rc::new(RefCell::new(c2)), weight: 33, ..Default::default() };
-		let e3 = Edge { candidate: Rc::new(RefCell::new(c3)), weight: 30, ..Default::default() };
+		let e1 = Edge::new(c1, 30);
+		let e2 = Edge::new(c2, 33);
+		let e3 = Edge::new(c3, 30);
 
 		let mut v = Voter { who: 1, budget: 100, edges: vec![e1, e2, e3], ..Default::default() };
 
@@ -214,9 +214,9 @@ fn voter_normalize_ops_works() {
 		let c2 = Candidate { who: 20, elected: true, ..Default::default() };
 		let c3 = Candidate { who: 30, elected: true, ..Default::default() };
 
-		let e1 = Edge { candidate: Rc::new(RefCell::new(c1)), weight: 30, ..Default::default() };
-		let e2 = Edge { candidate: Rc::new(RefCell::new(c2)), weight: 33, ..Default::default() };
-		let e3 = Edge { candidate: Rc::new(RefCell::new(c3)), weight: 30, ..Default::default() };
+		let e1 = Edge::new(c1, 30);
+		let e2 = Edge::new(c2, 33);
+		let e3 = Edge::new(c3, 30);
 
 		let mut v = Voter { who: 1, budget: 100, edges: vec![e1, e2, e3], ..Default::default() };
 


### PR DESCRIPTION
- makes sure that all staking/npos pallets compile (`check` and `test`)
- makes `reduce.rs` play a bit nicer with non-default account id types. 


ref: https://github.com/paritytech/substrate/pull/10403