### PR TITLE
Remove ability to implement on_runtime_upgrade in pallets from macros

### DIFF
--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -87,7 +87,7 @@
 mod gas;
 mod benchmarking;
 mod exec;
-mod migration;
+pub mod migration;
 mod schedule;
 mod storage;
 mod wasm;

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -244,10 +244,6 @@ pub mod pallet {
 			Storage::<T>::process_deletion_queue_batch(weight_limit)
 				.saturating_add(T::WeightInfo::on_initialize())
 		}
-
-		fn on_runtime_upgrade() -> Weight {
-			migration::migrate::<T>()
-		}
 	}
 
 	#[pallet::call]

--- a/frame/offences/src/lib.rs
+++ b/frame/offences/src/lib.rs
@@ -110,13 +110,6 @@ pub mod pallet {
 		/// \[kind, timeslot\].
 		Offence { kind: Kind, timeslot: OpaqueTimeSlot },
 	}
-
-	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		fn on_runtime_upgrade() -> Weight {
-			migration::remove_deferred_storage::<T>()
-		}
-	}
 }
 
 impl<T: Config, O: Offence<T::IdentificationTuple>>

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -672,23 +672,6 @@ pub mod pallet {
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		fn on_runtime_upgrade() -> Weight {
-			if StorageVersion::<T>::get() == Releases::V6_0_0 {
-				migrations::v7::migrate::<T>()
-			} else {
-				T::DbWeight::get().reads(1)
-			}
-		}
-
-		#[cfg(feature = "try-runtime")]
-		fn pre_upgrade() -> Result<(), &'static str> {
-			if StorageVersion::<T>::get() == Releases::V6_0_0 {
-				migrations::v7::pre_migrate::<T>()
-			} else {
-				Ok(())
-			}
-		}
-
 		fn on_initialize(_now: BlockNumberFor<T>) -> Weight {
 			// just return the weight of the on_finalize.
 			T::DbWeight::get().reads(1)

--- a/frame/support/procedural/src/pallet/parse/hooks.rs
+++ b/frame/support/procedural/src/pallet/parse/hooks.rs
@@ -28,8 +28,6 @@ pub struct HooksDef {
 	pub where_clause: Option<syn::WhereClause>,
 	/// The span of the pallet::hooks attribute.
 	pub attr_span: proc_macro2::Span,
-	/// Boolean flag, set to true if the `on_runtime_upgrade` method of hooks was implemented.
-	pub has_runtime_upgrade: bool,
 }
 
 impl HooksDef {
@@ -69,16 +67,10 @@ impl HooksDef {
 			return Err(syn::Error::new(item_trait.span(), msg))
 		}
 
-		let has_runtime_upgrade = item.items.iter().any(|i| match i {
-			syn::ImplItem::Method(method) => method.sig.ident == "on_runtime_upgrade",
-			_ => false,
-		});
-
 		Ok(Self {
 			attr_span,
 			index,
 			instances,
-			has_runtime_upgrade,
 			where_clause: item.generics.where_clause.clone(),
 		})
 	}

--- a/frame/support/procedural/src/pallet/parse/hooks.rs
+++ b/frame/support/procedural/src/pallet/parse/hooks.rs
@@ -67,11 +67,6 @@ impl HooksDef {
 			return Err(syn::Error::new(item_trait.span(), msg))
 		}
 
-		Ok(Self {
-			attr_span,
-			index,
-			instances,
-			where_clause: item.generics.where_clause.clone(),
-		})
+		Ok(Self { attr_span, index, instances, where_clause: item.generics.where_clause.clone() })
 	}
 }

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -2514,7 +2514,6 @@ mod tests {
 				7
 			}
 			fn on_finalize(n: T::BlockNumber,) { if n.into() == 42 { panic!("on_finalize") } }
-			fn on_runtime_upgrade() -> Weight { 10 }
 			fn offchain_worker() {}
 			/// Some doc
 			fn integrity_test() { panic!("integrity_test") }
@@ -2690,7 +2689,7 @@ mod tests {
 	#[test]
 	fn on_runtime_upgrade_should_work() {
 		sp_io::TestExternalities::default().execute_with(|| {
-			assert_eq!(<Module<TraitImpl> as OnRuntimeUpgrade>::on_runtime_upgrade(), 10)
+			assert_eq!(<Module<TraitImpl> as OnRuntimeUpgrade>::on_runtime_upgrade(), 0)
 		});
 	}
 

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -289,12 +289,6 @@ impl<T> Parameter for T where T: Codec + EncodeLike + Clone + Eq + fmt::Debug + 
 /// The following reserved functions also take the block number (with type `T::BlockNumber`) as an
 /// optional input:
 ///
-/// * `on_runtime_upgrade`: Executes at the beginning of a block prior to on_initialize when there
-/// is a runtime upgrade. This allows each module to upgrade its storage before the storage items
-/// are used. As such, **calling other modules must be avoided**!! Using this function will
-/// implement the [`OnRuntimeUpgrade`](../sp_runtime/traits/trait.OnRuntimeUpgrade.html) trait.
-/// Function signature must be `fn on_runtime_upgrade() -> frame_support::weights::Weight`.
-///
 /// * `on_initialize`: Executes at the beginning of a block. Using this function will
 /// implement the [`OnInitialize`](./trait.OnInitialize.html) trait.
 /// Function signature can be either:
@@ -348,7 +342,6 @@ macro_rules! decl_module {
 			{}
 			{}
 			{}
-			{}
 			[]
 			$($t)*
 		);
@@ -385,7 +378,6 @@ macro_rules! decl_module {
 			{}
 			{}
 			{}
-			{}
 			[]
 			$($t)*
 		);
@@ -399,7 +391,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{}
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -419,7 +410,6 @@ macro_rules! decl_module {
 			{ $( $other_where_bounds )* }
 			{ $vis fn deposit_event() = default; }
 			{ $( $on_initialize )* }
-			{ $( $on_runtime_upgrade )* }
 			{ $( $on_idle )* }
 			{ $( $on_finalize )* }
 			{ $( $offchain )* }
@@ -438,7 +428,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{}
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -465,7 +454,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )+ }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -488,7 +476,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{}
 		{ $( $offchain:tt )* }
@@ -508,7 +495,6 @@ macro_rules! decl_module {
 			{ $( $other_where_bounds )* }
 			{ $( $deposit_event )* }
 			{ $( $on_initialize )* }
-			{ $( $on_runtime_upgrade )* }
 			{ $( $on_idle )* }
 			{
 				fn on_finalize( $( $param_name : $param ),* ) { $( $impl )* }
@@ -530,7 +516,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{}
 		{ $( $offchain:tt )* }
@@ -546,7 +531,7 @@ macro_rules! decl_module {
 	) => {
 		compile_error!(
 			"`on_finalize` can't be given weight attribute anymore, weight must be returned by \
-			`on_initialize` or `on_runtime_upgrade` instead"
+			`on_initialize` instead"
 		);
 	};
 	// Compile error on `on_finalize` being added a second time.
@@ -559,7 +544,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )+ }
 		{ $( $offchain:tt )* }
@@ -584,7 +568,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{}
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -604,7 +587,6 @@ macro_rules! decl_module {
 			{ $( $other_where_bounds )* }
 			{ $( $deposit_event )* }
 			{ $( $on_initialize )* }
-			{ $( $on_runtime_upgrade )* }
 			{
 				fn on_idle( $param_name1: $param1, $param_name2: $param2 ) -> $return { $( $impl )* }
 			}
@@ -628,7 +610,7 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
+		{}
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
 		{ $( $constants:tt )* }
@@ -654,7 +636,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{}
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -668,7 +649,8 @@ macro_rules! decl_module {
 		$($rest:tt)*
 	) => {
 		compile_error!(
-			"`on_runtime_upgrade` must return Weight, signature has changed."
+			"`on_runtime_upgrade` can't be implemented anymore. The runtime upgrade must be \
+			defined at the runtime level."
 		);
 	};
 	// compile_error on_runtime_upgrade, given weight removed syntax.
@@ -681,7 +663,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{}
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -696,11 +677,11 @@ macro_rules! decl_module {
 		$($rest:tt)*
 	) => {
 		compile_error!(
-			"`on_runtime_upgrade` can't be given weight attribute anymore, weight must be returned \
-			by the function directly."
+			"`on_runtime_upgrade` can't be implemented anymore. The runtime upgrade must be \
+			defined at the runtime level."
 		);
 	};
-	// Add on_runtime_upgrade
+	// Compile_error on_runtime_upgrade is no longer implementable.
 	(@normalize
 		$(#[$attr:meta])*
 		pub struct $mod_type:ident<
@@ -710,7 +691,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{}
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -720,28 +700,12 @@ macro_rules! decl_module {
 		{ $( $storage_version:tt )* }
 		[ $( $dispatchables:tt )* ]
 		$(#[doc = $doc_attr:tt])*
-		fn on_runtime_upgrade( $( $param_name:ident : $param:ty ),* $(,)? ) -> $return:ty { $( $impl:tt )* }
+		fn on_runtime_upgrade
 		$($rest:tt)*
 	) => {
-		$crate::decl_module!(@normalize
-			$(#[$attr])*
-			pub struct $mod_type<$trait_instance: $trait_name$(<I>, I: $instantiable $(= $module_default_instance)?)?>
-			for enum $call_type where origin: $origin_type, system = $system
-			{ $( $other_where_bounds )* }
-			{ $( $deposit_event )* }
-			{ $( $on_initialize )* }
-			{
-				fn on_runtime_upgrade( $( $param_name : $param ),* ) -> $return { $( $impl )* }
-			}
-			{ $( $on_idle )* }
-			{ $( $on_finalize )* }
-			{ $( $offchain )* }
-			{ $( $constants )* }
-			{ $( $error_type )* }
-			{ $( $integrity_test )* }
-			{ $( $storage_version )* }
-			[ $( $dispatchables )* ]
-			$($rest)*
+		compile_error!(
+			"`on_runtime_upgrade` can't be implemented anymore. The runtime upgrade must be \
+			defined at the runtime level."
 		);
 	};
 	// Compile error on `on_runtime_upgrade` being added a second time.
@@ -754,7 +718,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )+ }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -767,7 +730,10 @@ macro_rules! decl_module {
 		fn on_runtime_upgrade( $( $param_name:ident : $param:ty ),* $(,)? ) -> $return:ty { $( $impl:tt )* }
 		$($rest:tt)*
 	) => {
-		compile_error!("`on_runtime_upgrade` can only be passed once as input.");
+		compile_error!(
+			"`on_runtime_upgrade` can't be implemented anymore. The runtime upgrade must be \
+			defined at the runtime level."
+		);
 	};
 	// Add integrity_test
 	(@normalize
@@ -779,7 +745,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -799,7 +764,6 @@ macro_rules! decl_module {
 			{ $( $other_where_bounds )* }
 			{ $( $deposit_event )* }
 			{ $( $on_initialize )* }
-			{ $( $on_runtime_upgrade )* }
 			{ $( $on_idle )* }
 			{ $( $on_finalize )* }
 			{ $( $offchain )* }
@@ -824,7 +788,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -849,7 +812,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{}
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -876,7 +838,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{}
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -905,7 +866,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{}
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -927,7 +887,6 @@ macro_rules! decl_module {
 			{
 				fn on_initialize( $( $param_name : $param ),* ) -> $return { $( $impl )* }
 			}
-			{ $( $on_runtime_upgrade )* }
 			{ $( $on_idle )* }
 			{ $( $on_finalize )* }
 			{ $( $offchain )* }
@@ -949,7 +908,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )+ }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -974,7 +932,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ }
@@ -996,7 +953,6 @@ macro_rules! decl_module {
 			{ $( $other_where_bounds )* }
 			{ $( $deposit_event )* }
 			{ $( $on_initialize )* }
-			{ $( $on_runtime_upgrade )* }
 			{ $( $on_idle )* }
 			{ $( $on_finalize )* }
 			{ fn offchain_worker( $( $param_name : $param ),* ) { $( $impl )* } }
@@ -1018,7 +974,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )+ }
@@ -1044,7 +999,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -1067,7 +1021,6 @@ macro_rules! decl_module {
 			{ $( $other_where_bounds )* }
 			{ $( $deposit_event )* }
 			{ $( $on_initialize )* }
-			{ $( $on_runtime_upgrade )* }
 			{ $( $on_idle )* }
 			{ $( $on_finalize )* }
 			{ $( $offchain )* }
@@ -1095,7 +1048,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -1117,7 +1069,6 @@ macro_rules! decl_module {
 			{ $( $other_where_bounds )* }
 			{ $( $deposit_event )* }
 			{ $( $on_initialize )* }
-			{ $( $on_runtime_upgrade )* }
 			{ $( $on_idle )* }
 			{ $( $on_finalize )* }
 			{ $( $offchain )* }
@@ -1140,7 +1091,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -1160,7 +1110,6 @@ macro_rules! decl_module {
 			{ $( $other_where_bounds )* }
 			{ $( $deposit_event )* }
 			{ $( $on_initialize )* }
-			{ $( $on_runtime_upgrade )* }
 			{ $( $on_idle )* }
 			{ $( $on_finalize )* }
 			{ $( $offchain )* }
@@ -1184,7 +1133,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -1206,7 +1154,6 @@ macro_rules! decl_module {
 			{ $( $other_where_bounds )* }
 			{ $( $deposit_event )* }
 			{ $( $on_initialize )* }
-			{ $( $on_runtime_upgrade )* }
 			{ $( $on_idle )* }
 			{ $( $on_finalize )* }
 			{ $( $offchain )* }
@@ -1230,7 +1177,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -1256,7 +1202,6 @@ macro_rules! decl_module {
 			{ $( $other_where_bounds )* }
 			{ $( $deposit_event )* }
 			{ $( $on_initialize )* }
-			{ $( $on_runtime_upgrade )* }
 			{ $( $on_idle )* }
 			{ $( $on_finalize )* }
 			{ $( $offchain )* }
@@ -1288,7 +1233,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -1318,7 +1262,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -1348,7 +1291,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -1378,7 +1320,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -1409,7 +1350,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -1428,7 +1368,6 @@ macro_rules! decl_module {
 			{ $( $other_where_bounds )* }
 			{ $( $deposit_event )* }
 			{ $( $on_initialize )* }
-			{ $( $on_runtime_upgrade )* }
 			{ $( $on_idle )* }
 			{ $( $on_finalize )* }
 			{ $( $offchain )* }
@@ -1519,48 +1458,7 @@ macro_rules! decl_module {
 		{}
 	};
 
-	(@impl_on_runtime_upgrade
-		{ $system:ident }
-		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
-		{ $( $other_where_bounds:tt )* }
-		fn on_runtime_upgrade() -> $return:ty { $( $impl:tt )* }
-	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::traits::OnRuntimeUpgrade
-			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
-		{
-			fn on_runtime_upgrade() -> $return {
-				$crate::sp_tracing::enter_span!($crate::sp_tracing::trace_span!("on_runtime_upgrade"));
-				let pallet_name = <<
-					$trait_instance
-					as
-					$system::Config
-				>::PalletInfo as $crate::traits::PalletInfo>::name::<Self>().unwrap_or("<unknown pallet name>");
-
-				$crate::log::info!(
-					target: $crate::LOG_TARGET,
-					"⚠️ {} declares internal migrations (which *might* execute). \
-					 On-chain `{:?}` vs current storage version `{:?}`",
-					pallet_name,
-					<Self as $crate::traits::GetStorageVersion>::on_chain_storage_version(),
-					<Self as $crate::traits::GetStorageVersion>::current_storage_version(),
-				);
-
-				(|| { $( $impl )* })()
-			}
-
-			#[cfg(feature = "try-runtime")]
-			fn pre_upgrade() -> Result<(), &'static str> {
-				Ok(())
-			}
-
-			#[cfg(feature = "try-runtime")]
-			fn post_upgrade() -> Result<(), &'static str> {
-				Ok(())
-			}
-		}
-	};
-
+	// Implement OnRuntimeUpgrade trait with no-op
 	(@impl_on_runtime_upgrade
 		{ $system:ident }
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
@@ -1571,19 +1469,6 @@ macro_rules! decl_module {
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 			fn on_runtime_upgrade() -> $crate::dispatch::Weight {
-				$crate::sp_tracing::enter_span!($crate::sp_tracing::trace_span!("on_runtime_upgrade"));
-				let pallet_name = <<
-					$trait_instance
-					as
-					$system::Config
-				>::PalletInfo as $crate::traits::PalletInfo>::name::<Self>().unwrap_or("<unknown pallet name>");
-
-				$crate::log::info!(
-					target: $crate::LOG_TARGET,
-					"✅ no migration for {}",
-					pallet_name,
-				);
-
 				0
 			}
 
@@ -1955,7 +1840,6 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		{ $( $deposit_event:tt )* }
 		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
 		{ $( $on_idle:tt )* }
 		{ $( $on_finalize:tt )* }
 		{ $( $offchain:tt )* }
@@ -1993,7 +1877,6 @@ macro_rules! decl_module {
 			{ $system }
 			$mod_type<$trait_instance: $trait_name $(<I>, $instance: $instantiable)?>;
 			{ $( $other_where_bounds )* }
-			$( $on_runtime_upgrade )*
 		}
 
 		$crate::decl_module! {

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -2416,8 +2416,7 @@ pub mod pallet_prelude {
 /// 	* `ValidateUnsigned` is moved inside the macro under `#[pallet::validate_unsigned)]` if it
 ///    exists
 /// 	* `ProvideInherent` is moved inside macro under `#[pallet::inherent)]` if it exists
-/// 	* `on_initialize`/`on_finalize`/`offchain_worker` are moved to
-///    `Hooks`
+/// 	* `on_initialize`/`on_finalize`/`offchain_worker` are moved to `Hooks`
 /// 	* `on_runtime_upgrade` removal is documented and acknowledged.
 ///
 /// 		implementation

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -1520,14 +1520,11 @@ pub mod pallet_prelude {
 ///
 /// ### Macro expansion:
 ///
-/// The macro implements the traits `OnInitialize`, `OnIdle`, `OnFinalize`, `OnRuntimeUpgrade`,
-/// `OffchainWorker`, `IntegrityTest` using `Hooks` implementation.
-///
-/// NOTE: OnRuntimeUpgrade is implemented with `Hooks::on_runtime_upgrade` and some additional
-/// logic. E.g. logic to write pallet version into storage.
+/// The macro implements the traits `OnInitialize`, `OnIdle`, `OnFinalize`, `OffchainWorker`,
+/// `IntegrityTest` using `Hooks` implementation.
 ///
 /// NOTE: The macro also adds some tracing logic when implementing the above traits. The
-/// following  hooks emit traces: `on_initialize`, `on_finalize` and `on_runtime_upgrade`.
+/// following  hooks emit traces: `on_initialize` and `on_finalize`.
 ///
 /// # Call: `#[pallet::call]` optional
 ///
@@ -1990,7 +1987,7 @@ pub mod pallet_prelude {
 /// 			unimplemented!();
 /// 		}
 ///
-/// 		// can implement also: on_finalize, on_runtime_upgrade, offchain_worker, ...
+/// 		// can implement also: on_finalize, offchain_worker, ...
 /// 		// see `Hooks` trait
 /// 	}
 ///
@@ -2321,7 +2318,9 @@ pub mod pallet_prelude {
 /// 	}
 /// 	```
 /// 	and write inside
-/// 	`on_initialize`, `on_finalize`, `on_runtime_upgrade`, `offchain_worker`, `integrity_test`.
+/// 	`on_initialize`, `on_finalize`, `offchain_worker`, `integrity_test`.
+/// 	`on_runtime_upgrade` can't be declared at the pallet level anymore. Make sure to notify
+/// 	pallet's users.
 ///
 /// 	then write:
 /// 	```ignore
@@ -2417,8 +2416,10 @@ pub mod pallet_prelude {
 /// 	* `ValidateUnsigned` is moved inside the macro under `#[pallet::validate_unsigned)]` if it
 ///    exists
 /// 	* `ProvideInherent` is moved inside macro under `#[pallet::inherent)]` if it exists
-/// 	* `on_initialize`/`on_finalize`/`on_runtime_upgrade`/`offchain_worker` are moved to
+/// 	* `on_initialize`/`on_finalize`/`offchain_worker` are moved to
 ///    `Hooks`
+/// 	* `on_runtime_upgrade` removal is documented and acknowledged.
+///
 /// 		implementation
 /// 	* storages with `config(..)` are converted to `GenesisConfig` field, and their default is
 /// 		`= $expr;` if the storage have default value

--- a/frame/support/src/traits/hooks.rs
+++ b/frame/support/src/traits/hooks.rs
@@ -234,40 +234,6 @@ pub trait Hooks<BlockNumber> {
 		0
 	}
 
-	/// Perform a module upgrade.
-	///
-	/// NOTE: this doesn't include all pallet logic triggered on runtime upgrade. For instance it
-	/// doesn't include the write of the pallet version in storage. The final complete logic
-	/// triggered on runtime upgrade is given by implementation of `OnRuntimeUpgrade` trait by
-	/// `Pallet`.
-	///
-	/// # Warning
-	///
-	/// This function will be called before we initialized any runtime state, aka `on_initialize`
-	/// wasn't called yet. So, information like the block number and any other
-	/// block local data are not accessible.
-	///
-	/// Return the non-negotiable weight consumed for runtime upgrade.
-	fn on_runtime_upgrade() -> crate::weights::Weight {
-		0
-	}
-
-	/// Execute some pre-checks prior to a runtime upgrade.
-	///
-	/// This hook is never meant to be executed on-chain but is meant to be used by testing tools.
-	#[cfg(feature = "try-runtime")]
-	fn pre_upgrade() -> Result<(), &'static str> {
-		Ok(())
-	}
-
-	/// Execute some post-checks after a runtime upgrade.
-	///
-	/// This hook is never meant to be executed on-chain but is meant to be used by testing tools.
-	#[cfg(feature = "try-runtime")]
-	fn post_upgrade() -> Result<(), &'static str> {
-		Ok(())
-	}
-
 	/// Implementing this function on a module allows you to perform long-running tasks
 	/// that make (by default) validators generate transactions that feed results
 	/// of those long-running computations back on chain.

--- a/frame/support/test/tests/decl_module_ui/on_runtime_upgrade.rs
+++ b/frame/support/test/tests/decl_module_ui/on_runtime_upgrade.rs
@@ -1,0 +1,7 @@
+frame_support::decl_module! {
+	pub struct Module<T: Config> for enum Call where origin: T::Origin, system=self {
+		fn on_runtime_upgrade() -> Weight { 0 }
+	}
+}
+
+fn main() {}

--- a/frame/support/test/tests/decl_module_ui/on_runtime_upgrade.stderr
+++ b/frame/support/test/tests/decl_module_ui/on_runtime_upgrade.stderr
@@ -1,0 +1,11 @@
+error: `on_runtime_upgrade` can't be implemented anymore. The runtime upgrade must be defined at the runtime level.
+ --> tests/decl_module_ui/on_runtime_upgrade.rs:1:1
+  |
+1 | / frame_support::decl_module! {
+2 | |     pub struct Module<T: Config> for enum Call where origin: T::Origin, system=self {
+3 | |         fn on_runtime_upgrade() -> Weight { 0 }
+4 | |     }
+5 | | }
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::decl_module` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -176,12 +176,6 @@ pub mod pallet {
 			let _ = T::AccountId::from(SomeType2); // Test for where clause
 			Self::deposit_event(Event::Something(20));
 		}
-		fn on_runtime_upgrade() -> Weight {
-			let _ = T::AccountId::from(SomeType1); // Test for where clause
-			let _ = T::AccountId::from(SomeType2); // Test for where clause
-			Self::deposit_event(Event::Something(30));
-			30
-		}
 		fn integrity_test() {
 			let _ = T::AccountId::from(SomeType1); // Test for where clause
 			let _ = T::AccountId::from(SomeType2); // Test for where clause
@@ -463,10 +457,6 @@ pub mod pallet2 {
 		}
 		fn on_finalize(_: BlockNumberFor<T>) {
 			Self::deposit_event(Event::Something(21));
-		}
-		fn on_runtime_upgrade() -> Weight {
-			Self::deposit_event(Event::Something(31));
-			0
 		}
 	}
 
@@ -979,7 +969,7 @@ fn pallet_hooks_expand() {
 		assert_eq!(AllPalletsWithoutSystem::on_initialize(1), 10);
 		AllPalletsWithoutSystem::on_finalize(1);
 
-		assert_eq!(AllPalletsWithoutSystem::on_runtime_upgrade(), 30);
+		assert_eq!(AllPalletsWithoutSystem::on_runtime_upgrade(), 0);
 
 		assert_eq!(
 			frame_system::Pallet::<Runtime>::events()[0].event,
@@ -1018,7 +1008,7 @@ fn all_pallets_type_reversed_order_is_correct() {
 			assert_eq!(AllPalletsWithoutSystemReversed::on_initialize(1), 10);
 			AllPalletsWithoutSystemReversed::on_finalize(1);
 
-			assert_eq!(AllPalletsWithoutSystemReversed::on_runtime_upgrade(), 30);
+			assert_eq!(AllPalletsWithoutSystemReversed::on_runtime_upgrade(), 0);
 		}
 
 		assert_eq!(

--- a/frame/support/test/tests/pallet_instance.rs
+++ b/frame/support/test/tests/pallet_instance.rs
@@ -65,15 +65,6 @@ pub mod pallet {
 				Self::deposit_event(Event::Something(21));
 			}
 		}
-		fn on_runtime_upgrade() -> Weight {
-			if TypeId::of::<I>() == TypeId::of::<()>() {
-				Self::deposit_event(Event::Something(30));
-				30
-			} else {
-				Self::deposit_event(Event::Something(31));
-				31
-			}
-		}
 		fn integrity_test() {}
 	}
 
@@ -554,7 +545,7 @@ fn pallet_hooks_expand() {
 		assert_eq!(AllPalletsWithoutSystem::on_initialize(1), 21);
 		AllPalletsWithoutSystem::on_finalize(1);
 
-		assert_eq!(AllPalletsWithoutSystem::on_runtime_upgrade(), 61);
+		assert_eq!(AllPalletsWithoutSystem::on_runtime_upgrade(), 0);
 
 		assert_eq!(
 			frame_system::Pallet::<Runtime>::events()[0].event,

--- a/frame/support/test/tests/pallet_ui/hooks_invalid_on_runtime_upgrade.rs
+++ b/frame/support/test/tests/pallet_ui/hooks_invalid_on_runtime_upgrade.rs
@@ -1,0 +1,22 @@
+#[frame_support::pallet]
+mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_runtime_upgrade() -> Weight { 0 }
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
+}
+
+fn main() {
+}

--- a/frame/support/test/tests/pallet_ui/hooks_invalid_on_runtime_upgrade.stderr
+++ b/frame/support/test/tests/pallet_ui/hooks_invalid_on_runtime_upgrade.stderr
@@ -1,0 +1,5 @@
+error[E0407]: method `on_runtime_upgrade` is not a member of trait `Hooks`
+  --> tests/pallet_ui/hooks_invalid_on_runtime_upgrade.rs:14:3
+   |
+14 |         fn on_runtime_upgrade() -> Weight { 0 }
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `Hooks`

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -314,15 +314,6 @@ pub mod pallet {
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		fn on_runtime_upgrade() -> frame_support::weights::Weight {
-			if !UpgradedToTripleRefCount::<T>::get() {
-				UpgradedToTripleRefCount::<T>::put(true);
-				migrations::migrate_to_triple_ref_count::<T>()
-			} else {
-				0
-			}
-		}
-
 		fn integrity_test() {
 			T::BlockWeights::get().validate().expect("The weights are invalid.");
 		}

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -45,7 +45,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod benchmarking;
-mod migrations;
+pub mod migrations;
 #[cfg(test)]
 mod mock;
 #[cfg(test)]

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -179,29 +179,6 @@ pub mod pallet {
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		#[cfg(feature = "try-runtime")]
-		fn pre_upgrade() -> Result<(), &'static str> {
-			if StorageVersion::<T>::get() == Releases::V0 {
-				migrations::v1::pre_migrate::<T>()
-			} else {
-				Ok(())
-			}
-		}
-
-		fn on_runtime_upgrade() -> Weight {
-			if StorageVersion::<T>::get() == Releases::V0 {
-				StorageVersion::<T>::put(Releases::V1);
-				migrations::v1::migrate::<T>().saturating_add(T::DbWeight::get().reads_writes(1, 1))
-			} else {
-				T::DbWeight::get().reads(1)
-			}
-		}
-
-		#[cfg(feature = "try-runtime")]
-		fn post_upgrade() -> Result<(), &'static str> {
-			migrations::v1::post_migrate::<T>()
-		}
-
 		fn integrity_test() {
 			assert!(T::MAX_VESTING_SCHEDULES > 0, "`MaxVestingSchedules` must ge greater than 0");
 		}

--- a/frame/vesting/src/migrations.rs
+++ b/frame/vesting/src/migrations.rs
@@ -19,12 +19,12 @@
 
 use super::*;
 
-// Migration from single schedule to multiple schedules.
-pub(crate) mod v1 {
+/// Migration from single schedule to multiple schedules.
+pub mod v1 {
 	use super::*;
 
 	#[cfg(feature = "try-runtime")]
-	pub(crate) fn pre_migrate<T: Config>() -> Result<(), &'static str> {
+	pub fn pre_migrate<T: Config>() -> Result<(), &'static str> {
 		assert!(StorageVersion::<T>::get() == Releases::V0, "Storage version too high.");
 
 		log::debug!(
@@ -37,7 +37,7 @@ pub(crate) mod v1 {
 
 	/// Migrate from single schedule to multi schedule storage.
 	/// WARNING: This migration will delete schedules if `MaxVestingSchedules < 1`.
-	pub(crate) fn migrate<T: Config>() -> Weight {
+	pub fn migrate<T: Config>() -> Weight {
 		let mut reads_writes = 0;
 
 		Vesting::<T>::translate::<VestingInfo<BalanceOf<T>, T::BlockNumber>, _>(
@@ -65,7 +65,7 @@ pub(crate) mod v1 {
 	}
 
 	#[cfg(feature = "try-runtime")]
-	pub(crate) fn post_migrate<T: Config>() -> Result<(), &'static str> {
+	pub fn post_migrate<T: Config>() -> Result<(), &'static str> {
 		assert_eq!(StorageVersion::<T>::get(), Releases::V1);
 
 		for (_key, schedules) in Vesting::<T>::iter() {


### PR DESCRIPTION
# Breaking change:

* pallets can't declare on_runtime_upgrade anymore.
* pallet on_runtime_upgrade is removed from pallets:
  * system
  * contracts
  * offences
  * staking
  * vesting

User of those pallets must be careful that they are up to date or to trigger the runtime upgrade manually in on_runtime_ugprade definition at the runtime level.

# Description

This PR **doesn't** remove the execution of pallet's on_runtime_upgrade, it only remove the ability to implemented from the macros: `pallet` and `decl_module`.
Maybe in the future we can have some implementation inside pallet on_runtime_upgrade like very little one like the version or stuff like this ?
Also we could use the implementation of `post_upgrade` to define some checks.

This PR also remove the ability to remove to implement `pre_upgrade` / `post_upgrade` in the macros. Maybe we can keep them though.

# TODO:
* polkadot doesn't need to manually call the removed on runtime upgrade.
  * [ ] system
  * [ ] contracts
  * [ ] offences
  * [ ] staking
  * [ ] vesting