### PR TITLE
fix weight-info template for clippy

### DIFF
--- a/utils/frame/benchmarking-cli/src/template.hbs
+++ b/utils/frame/benchmarking-cli/src/template.hbs
@@ -5,14 +5,15 @@
 //! DATE: {{date}}, STEPS: `{{cmd.steps}}`, REPEAT: {{cmd.repeat}}, LOW RANGE: `{{cmd.lowest_range_values}}`, HIGH RANGE: `{{cmd.highest_range_values}}`
 //! EXECUTION: {{cmd.execution}}, WASM-EXECUTION: {{cmd.wasm_execution}}, CHAIN: {{cmd.chain}}, DB CACHE: {{cmd.db_cache}}
 
-// Executed Command:
+/* Executed Command:
 {{#each args as |arg|}}
-// {{arg}}
-{{/each}}
+    {{arg}}
+{{/each}} */
 
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(unused_parens)]
 #![allow(unused_imports)]
+#![allow(clippy::unnecessary_cast)]
 
 use frame_support::{traits::Get, weights::Weight};
 use sp_std::marker::PhantomData;


### PR DESCRIPTION
- added allow `clippy::unnecessary_cast`
- improved comment with command for better copy-pasting
