### PR TITLE
Bounties - reset curator deposit when curator unassigns themself.

### DIFF
--- a/frame/bounties/src/lib.rs
+++ b/frame/bounties/src/lib.rs
@@ -430,6 +430,7 @@ pub mod pallet {
 									let err_amount =
 										T::Currency::unreserve(&curator, bounty.curator_deposit);
 									debug_assert!(err_amount.is_zero());
+									bounty.curator_deposit = Zero::zero();
 									// Continue to change bounty status below...
 								}
 							},

--- a/frame/bounties/src/tests.rs
+++ b/frame/bounties/src/tests.rs
@@ -1002,3 +1002,42 @@ fn genesis_funding_works() {
 		assert_eq!(Treasury::pot(), initial_funding - Balances::minimum_balance());
 	});
 }
+
+#[test]
+fn unassign_curator_self() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		Balances::make_free_balance_be(&Treasury::account_id(), 101);
+		assert_ok!(Bounties::propose_bounty(Origin::signed(0), 50, b"12345".to_vec()));
+		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
+
+		System::set_block_number(2);
+		<Treasury as OnInitialize<u64>>::on_initialize(2);
+
+		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 1, 10));
+		assert_ok!(Bounties::accept_curator(Origin::signed(1), 0));
+
+		assert_eq!(Balances::free_balance(1), 93);
+		assert_eq!(Balances::reserved_balance(1), 5);
+
+		System::set_block_number(8);
+		<Treasury as OnInitialize<u64>>::on_initialize(8);
+
+		assert_ok!(Bounties::unassign_curator(Origin::signed(1), 0));
+
+		assert_eq!(
+			Bounties::bounties(0).unwrap(),
+			Bounty {
+				proposer: 0,
+				fee: 10,
+				curator_deposit: 0,
+				value: 50,
+				bond: 85,
+				status: BountyStatus::Funded,
+			}
+		);
+
+		assert_eq!(Balances::free_balance(1), 98);
+		assert_eq!(Balances::reserved_balance(1), 0); // not slashed
+	});
+}


### PR DESCRIPTION
Fixes https://github.com/paritytech/substrate/issues/10442

In the bounties pallet, in the unassign_curator extrinsic, under the arm where the sender is the curator themself, the bounty deposit is not reset to zero.
In other arms, this is being done as part of a utility function is used for slashing the deposit. But in this case, because we don't use this function, we should do this explicitly.

skip check-dependent-cumulus
