### PR TITLE
grandpa: allow authority set hard forks to be forced

### DIFF
--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -541,6 +541,22 @@ where
 	)
 }
 
+/// A descriptor for an authority set hard fork. These are authority set changes
+/// that are not signalled by the runtime and instead are defined off-chain
+/// (hence the hard fork).
+pub struct AuthoritySetHardFork<Block: BlockT> {
+	/// The new authority set id.
+	set_id: SetId,
+	/// The block hash and number at which the hard fork should be applied.
+	block: (Block::Hash, NumberFor<Block>),
+	/// The authorities in the new set.
+	authorities: AuthorityList,
+	/// The last finalized block number by the network. If defined, then the
+	/// authority set change will be forced, i.e. the node won't wait for the
+	/// block above to be finalized before enacting it.
+	last_finalized: Option<NumberFor<Block>>,
+}
+
 /// Make block importer and link half necessary to tie the background voter to
 /// it. A vector of authority set hard forks can be passed, any authority set
 /// change signaled at the given block (either already signalled or in a further
@@ -550,7 +566,7 @@ pub fn block_import_with_authority_set_hard_forks<BE, Block: BlockT, Client, SC>
 	client: Arc<Client>,
 	genesis_authorities_provider: &dyn GenesisAuthoritySetProvider<Block>,
 	select_chain: SC,
-	authority_set_hard_forks: Vec<(SetId, (Block::Hash, NumberFor<Block>), AuthorityList)>,
+	authority_set_hard_forks: Vec<AuthoritySetHardFork<Block>>,
 	telemetry: Option<TelemetryHandle>,
 ) -> Result<(GrandpaBlockImport<BE, Block, Client, SC>, LinkHalf<Block, Client, SC>), ClientError>
 where
@@ -580,19 +596,24 @@ where
 
 	let (justification_sender, justification_stream) = GrandpaJustificationStream::channel();
 
-	// create pending change objects with 0 delay and enacted on finality
-	// (i.e. standard changes) for each authority set hard fork.
+	// create pending change objects with 0 delay for each authority set hard fork.
 	let authority_set_hard_forks = authority_set_hard_forks
 		.into_iter()
-		.map(|(set_id, (hash, number), authorities)| {
+		.map(|fork| {
+			let delay_kind = if let Some(last_finalized) = fork.last_finalized {
+				authorities::DelayKind::Best { median_last_finalized: last_finalized }
+			} else {
+				authorities::DelayKind::Finalized
+			};
+
 			(
-				set_id,
+				fork.set_id,
 				authorities::PendingChange {
-					next_authorities: authorities,
+					next_authorities: fork.authorities,
 					delay: Zero::zero(),
-					canon_hash: hash,
-					canon_height: number,
-					delay_kind: authorities::DelayKind::Finalized,
+					canon_hash: fork.block.0,
+					canon_height: fork.block.1,
+					delay_kind,
 				},
 			)
 		})

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -551,9 +551,11 @@ pub struct AuthoritySetHardFork<Block: BlockT> {
 	pub block: (Block::Hash, NumberFor<Block>),
 	/// The authorities in the new set.
 	pub authorities: AuthorityList,
-	/// The last finalized block number by the network. If defined, then the
-	/// authority set change will be forced, i.e. the node won't wait for the
-	/// block above to be finalized before enacting it.
+	/// The latest block number that was finalized before this authority set
+	/// hard fork. When defined, the authority set change will be forced, i.e.
+	/// the node won't wait for the block above to be finalized before enacting
+	/// the change, and the given finalized number will be used as a base for
+	/// voting.
 	pub last_finalized: Option<NumberFor<Block>>,
 }
 

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -546,15 +546,15 @@ where
 /// (hence the hard fork).
 pub struct AuthoritySetHardFork<Block: BlockT> {
 	/// The new authority set id.
-	set_id: SetId,
+	pub set_id: SetId,
 	/// The block hash and number at which the hard fork should be applied.
-	block: (Block::Hash, NumberFor<Block>),
+	pub block: (Block::Hash, NumberFor<Block>),
 	/// The authorities in the new set.
-	authorities: AuthorityList,
+	pub authorities: AuthorityList,
 	/// The last finalized block number by the network. If defined, then the
 	/// authority set change will be forced, i.e. the node won't wait for the
 	/// block above to be finalized before enacting it.
-	last_finalized: Option<NumberFor<Block>>,
+	pub last_finalized: Option<NumberFor<Block>>,
 }
 
 /// Make block importer and link half necessary to tie the background voter to

--- a/client/finality-grandpa/src/warp_proof.rs
+++ b/client/finality-grandpa/src/warp_proof.rs
@@ -19,8 +19,8 @@
 use sp_runtime::codec::{self, Decode, Encode};
 
 use crate::{
-	best_justification, find_scheduled_change, AuthoritySetChanges, BlockNumberOps,
-	GrandpaJustification, SharedAuthoritySet,
+	best_justification, find_scheduled_change, AuthoritySetChanges, AuthoritySetHardFork,
+	BlockNumberOps, GrandpaJustification, SharedAuthoritySet,
 };
 use sc_client_api::Backend as ClientBackend;
 use sc_network::warp_request_handler::{EncodedProof, VerificationResult, WarpSyncProvider};
@@ -255,12 +255,15 @@ where
 	pub fn new(
 		backend: Arc<Backend>,
 		authority_set: SharedAuthoritySet<Block::Hash, NumberFor<Block>>,
-		hard_forks: Vec<(SetId, (Block::Hash, NumberFor<Block>), AuthorityList)>,
+		hard_forks: Vec<AuthoritySetHardFork<Block>>,
 	) -> Self {
 		NetworkProvider {
 			backend,
 			authority_set,
-			hard_forks: hard_forks.into_iter().map(|(s, hn, list)| (hn, (s, list))).collect(),
+			hard_forks: hard_forks
+				.into_iter()
+				.map(|fork| (fork.block, (fork.set_id, fork.authorities)))
+				.collect(),
 		}
 	}
 }


### PR DESCRIPTION
This PR extends the GRANDPA authority set hard fork functionality to allow defining the changes as forced, i.e. enacted instantly instead of waiting for finality.

polkadot companion: https://github.com/paritytech/polkadot/pull/4486