### PR TITLE
Release sp-core 4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9391,7 +9391,7 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "4.0.0-dev"
+version = "4.0.0"
 dependencies = [
  "base58",
  "bitflags",
@@ -9443,7 +9443,7 @@ dependencies = [
 
 [[package]]
 name = "sp-core-hashing"
-version = "4.0.0-dev"
+version = "4.0.0"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -9473,7 +9473,7 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "4.0.0-dev"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9482,7 +9482,7 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.10.0-dev"
+version = "0.10.0"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9680,7 +9680,7 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "4.0.0-dev"
+version = "4.0.0"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9702,7 +9702,7 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "4.0.0-dev"
+version = "4.0.0"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.1.0",
@@ -9822,11 +9822,11 @@ dependencies = [
 
 [[package]]
 name = "sp-std"
-version = "4.0.0-dev"
+version = "4.0.0"
 
 [[package]]
 name = "sp-storage"
-version = "4.0.0-dev"
+version = "4.0.0"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9878,7 +9878,7 @@ dependencies = [
 
 [[package]]
 name = "sp-tracing"
-version = "4.0.0-dev"
+version = "4.0.0"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -9957,7 +9957,7 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "4.0.0-dev"
+version = "4.0.0"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -20,7 +20,7 @@ name = "node-template"
 structopt = "0.3.25"
 
 sc-cli = { version = "0.10.0-dev", path = "../../../client/cli", features = ["wasmtime"] }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sc-executor = { version = "0.10.0-dev", path = "../../../client/executor", features = ["wasmtime"] }
 sc-service = { version = "0.10.0-dev", path = "../../../client/service", features = ["wasmtime"] }
 sc-telemetry = { version = "4.0.0-dev", path = "../../../client/telemetry" }

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -20,7 +20,7 @@ name = "node-template"
 structopt = "0.3.25"
 
 sc-cli = { version = "0.10.0-dev", path = "../../../client/cli", features = ["wasmtime"] }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sc-executor = { version = "0.10.0-dev", path = "../../../client/executor", features = ["wasmtime"] }
 sc-service = { version = "0.10.0-dev", path = "../../../client/service", features = ["wasmtime"] }
 sc-telemetry = { version = "4.0.0-dev", path = "../../../client/telemetry" }

--- a/bin/node-template/pallets/template/Cargo.toml
+++ b/bin/node-template/pallets/template/Cargo.toml
@@ -22,7 +22,7 @@ frame-system = { default-features = false, version = "4.0.0-dev", path = "../../
 frame-benchmarking = { default-features = false, version = "4.0.0-dev", path = "../../../../frame/benchmarking", optional = true }
 
 [dev-dependencies]
-sp-core = { default-features = false, version = "4.0.0-dev", path = "../../../../primitives/core" }
+sp-core =  { default-features = false, version = "4.0.0", path = "../../../../primitives/core" }
 sp-io = { default-features = false, version = "4.0.0-dev", path = "../../../../primitives/io" }
 sp-runtime = { default-features = false, version = "4.0.0-dev", path = "../../../../primitives/runtime" }
 

--- a/bin/node-template/pallets/template/Cargo.toml
+++ b/bin/node-template/pallets/template/Cargo.toml
@@ -22,7 +22,7 @@ frame-system = { default-features = false, version = "4.0.0-dev", path = "../../
 frame-benchmarking = { default-features = false, version = "4.0.0-dev", path = "../../../../frame/benchmarking", optional = true }
 
 [dev-dependencies]
-sp-core =  { default-features = false, version = "4.0.0", path = "../../../../primitives/core" }
+sp-core = { default-features = false, version = "4.0.0", path = "../../../../primitives/core" }
 sp-io = { default-features = false, version = "4.0.0-dev", path = "../../../../primitives/io" }
 sp-runtime = { default-features = false, version = "4.0.0-dev", path = "../../../../primitives/runtime" }
 

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -29,12 +29,12 @@ frame-executive = { version = "4.0.0-dev", default-features = false, path = "../
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/api" }
 sp-block-builder = { path = "../../../primitives/block-builder", default-features = false, version = "4.0.0-dev"}
 sp-consensus-aura = { version = "0.10.0-dev", default-features = false, path = "../../../primitives/consensus/aura" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
 sp-inherents = { path = "../../../primitives/inherents", default-features = false, version = "4.0.0-dev"}
 sp-offchain = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/offchain" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 sp-session = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/session" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-transaction-pool = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/transaction-pool" }
 sp-version = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/version" }
 

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -29,12 +29,12 @@ frame-executive = { version = "4.0.0-dev", default-features = false, path = "../
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/api" }
 sp-block-builder = { path = "../../../primitives/block-builder", default-features = false, version = "4.0.0-dev"}
 sp-consensus-aura = { version = "0.10.0-dev", default-features = false, path = "../../../primitives/consensus/aura" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
 sp-inherents = { path = "../../../primitives/inherents", default-features = false, version = "4.0.0-dev"}
 sp-offchain = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/offchain" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 sp-session = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/session" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-transaction-pool = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/transaction-pool" }
 sp-version = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/version" }
 

--- a/bin/node/bench/Cargo.toml
+++ b/bin/node/bench/Cargo.toml
@@ -23,12 +23,12 @@ derive_more = "0.99.16"
 kvdb = "0.10.0"
 kvdb-rocksdb = "0.14.0"
 sp-trie = { version = "4.0.0-dev", path = "../../../primitives/trie" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-consensus = { version = "0.10.0-dev", path = "../../../primitives/consensus/common" }
 sc-basic-authorship = { version = "0.10.0-dev", path = "../../../client/basic-authorship" }
 sp-inherents = { version = "4.0.0-dev", path = "../../../primitives/inherents" }
 sp-timestamp = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/timestamp" }
-sp-tracing =  { version = "4.0.0", path = "../../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../../primitives/tracing" }
 hash-db = "0.15.2"
 tempfile = "3.1.0"
 fs_extra = "1"

--- a/bin/node/bench/Cargo.toml
+++ b/bin/node/bench/Cargo.toml
@@ -23,12 +23,12 @@ derive_more = "0.99.16"
 kvdb = "0.10.0"
 kvdb-rocksdb = "0.14.0"
 sp-trie = { version = "4.0.0-dev", path = "../../../primitives/trie" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-consensus = { version = "0.10.0-dev", path = "../../../primitives/consensus/common" }
 sc-basic-authorship = { version = "0.10.0-dev", path = "../../../client/basic-authorship" }
 sp-inherents = { version = "4.0.0-dev", path = "../../../primitives/inherents" }
 sp-timestamp = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/timestamp" }
-sp-tracing = { version = "4.0.0-dev", path = "../../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../../primitives/tracing" }
 hash-db = "0.15.2"
 tempfile = "3.1.0"
 fs_extra = "1"

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -47,7 +47,7 @@ sp-authority-discovery = { version = "4.0.0-dev", path = "../../../primitives/au
 sp-consensus-babe = { version = "0.10.0-dev", path = "../../../primitives/consensus/babe" }
 grandpa-primitives = { version = "4.0.0-dev", package = "sp-finality-grandpa", path = "../../../primitives/finality-grandpa" }
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 sp-timestamp = { version = "4.0.0-dev", path = "../../../primitives/timestamp" }
 sp-authorship = { version = "4.0.0-dev", path = "../../../primitives/authorship" }
@@ -118,7 +118,7 @@ sc-consensus-babe = { version = "0.10.0-dev", path = "../../../client/consensus/
 sc-consensus-epochs = { version = "0.10.0-dev", path = "../../../client/consensus/epochs" }
 sc-service-test = { version = "2.0.0", path = "../../../client/service/test" }
 sc-block-builder = { version = "0.10.0-dev", path = "../../../client/block-builder" }
-sp-tracing = { version = "4.0.0-dev", path = "../../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../../primitives/tracing" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
 futures = "0.3.16"
 tempfile = "3.1.0"

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -47,7 +47,7 @@ sp-authority-discovery = { version = "4.0.0-dev", path = "../../../primitives/au
 sp-consensus-babe = { version = "0.10.0-dev", path = "../../../primitives/consensus/babe" }
 grandpa-primitives = { version = "4.0.0-dev", package = "sp-finality-grandpa", path = "../../../primitives/finality-grandpa" }
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 sp-timestamp = { version = "4.0.0-dev", path = "../../../primitives/timestamp" }
 sp-authorship = { version = "4.0.0-dev", path = "../../../primitives/authorship" }
@@ -118,7 +118,7 @@ sc-consensus-babe = { version = "0.10.0-dev", path = "../../../client/consensus/
 sc-consensus-epochs = { version = "0.10.0-dev", path = "../../../client/consensus/epochs" }
 sc-service-test = { version = "2.0.0", path = "../../../client/service/test" }
 sc-block-builder = { version = "0.10.0-dev", path = "../../../client/block-builder" }
-sp-tracing =  { version = "4.0.0", path = "../../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../../primitives/tracing" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
 futures = "0.3.16"
 tempfile = "3.1.0"

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -17,10 +17,10 @@ scale-info = { version = "1.0", features = ["derive"] }
 node-primitives = { version = "2.0.0", path = "../primitives" }
 node-runtime = { version = "3.0.0-dev", path = "../runtime" }
 sc-executor = { version = "0.10.0-dev", path = "../../../client/executor" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../../primitives/keystore" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../../primitives/state-machine" }
-sp-tracing = { version = "4.0.0-dev", path = "../../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../../primitives/tracing" }
 sp-trie = { version = "4.0.0-dev", path = "../../../primitives/trie" }
 frame-benchmarking = { version = "4.0.0-dev", path = "../../../frame/benchmarking" }
 
@@ -37,7 +37,7 @@ pallet-treasury = { version = "4.0.0-dev", path = "../../../frame/treasury" }
 sp-application-crypto = { version = "4.0.0-dev", path = "../../../primitives/application-crypto" }
 sp-consensus-babe = { version = "0.10.0-dev", path = "../../../primitives/consensus/babe" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
-sp-externalities = { version = "0.10.0-dev", path = "../../../primitives/externalities" }
+sp-externalities =  { version = "0.10.0", path = "../../../primitives/externalities" }
 wat = "1.0"
 futures = "0.3.9"
 

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -17,10 +17,10 @@ scale-info = { version = "1.0", features = ["derive"] }
 node-primitives = { version = "2.0.0", path = "../primitives" }
 node-runtime = { version = "3.0.0-dev", path = "../runtime" }
 sc-executor = { version = "0.10.0-dev", path = "../../../client/executor" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../../primitives/keystore" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../../primitives/state-machine" }
-sp-tracing =  { version = "4.0.0", path = "../../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../../primitives/tracing" }
 sp-trie = { version = "4.0.0-dev", path = "../../../primitives/trie" }
 frame-benchmarking = { version = "4.0.0-dev", path = "../../../frame/benchmarking" }
 
@@ -37,7 +37,7 @@ pallet-treasury = { version = "4.0.0-dev", path = "../../../frame/treasury" }
 sp-application-crypto = { version = "4.0.0-dev", path = "../../../primitives/application-crypto" }
 sp-consensus-babe = { version = "0.10.0-dev", path = "../../../primitives/consensus/babe" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
-sp-externalities =  { version = "0.10.0", path = "../../../primitives/externalities" }
+sp-externalities = { version = "0.10.0", path = "../../../primitives/externalities" }
 wat = "1.0"
 futures = "0.3.9"
 

--- a/bin/node/inspect/Cargo.toml
+++ b/bin/node/inspect/Cargo.toml
@@ -18,6 +18,6 @@ sc-client-api = { version = "4.0.0-dev", path = "../../../client/api" }
 sc-executor = { version = "0.10.0-dev", path = "../../../client/executor" }
 sc-service = { version = "0.10.0-dev", default-features = false, path = "../../../client/service" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 structopt = "0.3.8"

--- a/bin/node/inspect/Cargo.toml
+++ b/bin/node/inspect/Cargo.toml
@@ -18,6 +18,6 @@ sc-client-api = { version = "4.0.0-dev", path = "../../../client/api" }
 sc-executor = { version = "0.10.0-dev", path = "../../../client/executor" }
 sc-service = { version = "0.10.0-dev", default-features = false, path = "../../../client/service" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 structopt = "0.3.8"

--- a/bin/node/primitives/Cargo.toml
+++ b/bin/node/primitives/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../../frame/system" }
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/application-crypto" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 
 [features]

--- a/bin/node/primitives/Cargo.toml
+++ b/bin/node/primitives/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../../frame/system" }
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/application-crypto" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 
 [features]

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -30,8 +30,8 @@ sp-block-builder = { path = "../../../primitives/block-builder", default-feature
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/inherents" }
 node-primitives = { version = "2.0.0", default-features = false, path = "../primitives" }
 sp-offchain = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/offchain" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/api" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/staking" }

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -30,8 +30,8 @@ sp-block-builder = { path = "../../../primitives/block-builder", default-feature
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/inherents" }
 node-primitives = { version = "2.0.0", default-features = false, path = "../primitives" }
 sp-offchain = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/offchain" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/core" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/api" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/staking" }

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -28,7 +28,7 @@ sp-keyring = { version = "4.0.0-dev", path = "../../../primitives/keyring" }
 node-executor = { version = "3.0.0-dev", path = "../executor" }
 node-primitives = { version = "2.0.0", path = "../primitives" }
 node-runtime = { version = "3.0.0-dev", path = "../runtime" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 sc-executor = { version = "0.10.0-dev", path = "../../../client/executor", features = [

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -28,7 +28,7 @@ sp-keyring = { version = "4.0.0-dev", path = "../../../primitives/keyring" }
 node-executor = { version = "3.0.0-dev", path = "../executor" }
 node-primitives = { version = "2.0.0", path = "../primitives" }
 node-runtime = { version = "3.0.0-dev", path = "../runtime" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 sc-executor = { version = "0.10.0-dev", path = "../../../client/executor", features = [

--- a/bin/utils/chain-spec-builder/Cargo.toml
+++ b/bin/utils/chain-spec-builder/Cargo.toml
@@ -18,7 +18,7 @@ ansi_term = "0.12.1"
 sc-keystore = { version = "4.0.0-dev", path = "../../../client/keystore" }
 sc-chain-spec = { version = "4.0.0-dev", path = "../../../client/chain-spec" }
 node-cli = { version = "3.0.0-dev", path = "../../node/cli" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../../primitives/keystore" }
 rand = "0.7.2"
 structopt = "0.3.25"

--- a/bin/utils/chain-spec-builder/Cargo.toml
+++ b/bin/utils/chain-spec-builder/Cargo.toml
@@ -18,7 +18,7 @@ ansi_term = "0.12.1"
 sc-keystore = { version = "4.0.0-dev", path = "../../../client/keystore" }
 sc-chain-spec = { version = "4.0.0-dev", path = "../../../client/chain-spec" }
 node-cli = { version = "3.0.0-dev", path = "../../node/cli" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../../primitives/keystore" }
 rand = "0.7.2"
 structopt = "0.3.25"

--- a/client/allocator/Cargo.toml
+++ b/client/allocator/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
-sp-wasm-interface = { version = "4.0.0-dev", path = "../../primitives/wasm-interface" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-wasm-interface =  { version = "4.0.0", path = "../../primitives/wasm-interface" }
 log = "0.4.11"
 thiserror = "1.0.30"

--- a/client/allocator/Cargo.toml
+++ b/client/allocator/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
-sp-wasm-interface =  { version = "4.0.0", path = "../../primitives/wasm-interface" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
+sp-wasm-interface = { version = "4.0.0", path = "../../primitives/wasm-interface" }
 log = "0.4.11"
 thiserror = "1.0.30"

--- a/client/api/Cargo.toml
+++ b/client/api/Cargo.toml
@@ -19,7 +19,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 ] }
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }
 sc-executor = { version = "0.10.0-dev", path = "../executor" }
-sp-externalities =  { version = "0.10.0", path = "../../primitives/externalities" }
+sp-externalities = { version = "0.10.0", path = "../../primitives/externalities" }
 fnv = "1.0.6"
 futures = "0.3.1"
 hash-db = { version = "0.15.2", default-features = false }
@@ -27,14 +27,14 @@ sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 log = "0.4.8"
 parking_lot = "0.11.1"
 sp-database = { version = "4.0.0-dev", path = "../../primitives/database" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", default-features = false, path = "../../primitives/keystore" }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
 sc-utils = { version = "4.0.0-dev", path = "../utils" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../primitives/state-machine" }
 sp-trie = { version = "4.0.0-dev", path = "../../primitives/trie" }
-sp-storage =  { version = "4.0.0", path = "../../primitives/storage" }
+sp-storage = { version = "4.0.0", path = "../../primitives/storage" }
 sc-transaction-pool-api = { version = "4.0.0-dev", path = "../transaction-pool/api" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", path = "../../utils/prometheus" }
 

--- a/client/api/Cargo.toml
+++ b/client/api/Cargo.toml
@@ -19,7 +19,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 ] }
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }
 sc-executor = { version = "0.10.0-dev", path = "../executor" }
-sp-externalities = { version = "0.10.0-dev", path = "../../primitives/externalities" }
+sp-externalities =  { version = "0.10.0", path = "../../primitives/externalities" }
 fnv = "1.0.6"
 futures = "0.3.1"
 hash-db = { version = "0.15.2", default-features = false }
@@ -27,14 +27,14 @@ sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 log = "0.4.8"
 parking_lot = "0.11.1"
 sp-database = { version = "4.0.0-dev", path = "../../primitives/database" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", default-features = false, path = "../../primitives/keystore" }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
 sc-utils = { version = "4.0.0-dev", path = "../utils" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../primitives/state-machine" }
 sp-trie = { version = "4.0.0-dev", path = "../../primitives/trie" }
-sp-storage = { version = "4.0.0-dev", path = "../../primitives/storage" }
+sp-storage =  { version = "4.0.0", path = "../../primitives/storage" }
 sc-transaction-pool-api = { version = "4.0.0-dev", path = "../transaction-pool/api" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", path = "../../utils/prometheus" }
 

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -32,12 +32,12 @@ sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sc-network = { version = "0.10.0-dev", path = "../network" }
 sp-authority-discovery = { version = "4.0.0-dev", path = "../../primitives/authority-discovery" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../primitives/keystore" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
 
 [dev-dependencies]
 quickcheck = "1.0.3"
-sp-tracing = { version = "4.0.0-dev", path = "../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -32,12 +32,12 @@ sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sc-network = { version = "0.10.0-dev", path = "../network" }
 sp-authority-discovery = { version = "4.0.0-dev", path = "../../primitives/authority-discovery" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../primitives/keystore" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
 
 [dev-dependencies]
 quickcheck = "1.0.3"
-sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../primitives/tracing" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }

--- a/client/basic-authorship/Cargo.toml
+++ b/client/basic-authorship/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4.8"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.10.0-dev"}
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }

--- a/client/basic-authorship/Cargo.toml
+++ b/client/basic-authorship/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4.8"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.10.0-dev"}
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }

--- a/client/beefy/Cargo.toml
+++ b/client/beefy/Cargo.toml
@@ -22,7 +22,7 @@ sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
 sp-application-crypto = { version = "4.0.0-dev", path = "../../primitives/application-crypto" }
 sp-arithmetic = { version = "4.0.0-dev", path = "../../primitives/arithmetic" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../primitives/keystore" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 
@@ -35,7 +35,7 @@ sc-network-gossip = { version = "0.10.0-dev", path = "../network-gossip" }
 beefy-primitives = { version = "4.0.0-dev", path = "../../primitives/beefy" }
 
 [dev-dependencies]
-sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../primitives/tracing" }
 sc-network-test = { version = "0.8.0", path = "../network/test" }
 
 strum = { version = "0.22", features = ["derive"] }

--- a/client/beefy/Cargo.toml
+++ b/client/beefy/Cargo.toml
@@ -22,7 +22,7 @@ sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
 sp-application-crypto = { version = "4.0.0-dev", path = "../../primitives/application-crypto" }
 sp-arithmetic = { version = "4.0.0-dev", path = "../../primitives/arithmetic" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../primitives/keystore" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 
@@ -35,7 +35,7 @@ sc-network-gossip = { version = "0.10.0-dev", path = "../network-gossip" }
 beefy-primitives = { version = "4.0.0-dev", path = "../../primitives/beefy" }
 
 [dev-dependencies]
-sp-tracing = { version = "4.0.0-dev", path = "../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
 sc-network-test = { version = "0.8.0", path = "../network/test" }
 
 strum = { version = "0.22", features = ["derive"] }

--- a/client/beefy/rpc/Cargo.toml
+++ b/client/beefy/rpc/Cargo.toml
@@ -21,7 +21,7 @@ codec = { version = "2.2.0", package = "parity-scale-codec", features = ["derive
 
 sc-rpc = { version = "4.0.0-dev", path = "../../rpc" }
 
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 
 beefy-gadget = { version = "4.0.0-dev", path = "../." }

--- a/client/beefy/rpc/Cargo.toml
+++ b/client/beefy/rpc/Cargo.toml
@@ -21,7 +21,7 @@ codec = { version = "2.2.0", package = "parity-scale-codec", features = ["derive
 
 sc-rpc = { version = "4.0.0-dev", path = "../../rpc" }
 
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 
 beefy-gadget = { version = "4.0.0-dev", path = "../." }

--- a/client/block-builder/Cargo.toml
+++ b/client/block-builder/Cargo.toml
@@ -18,7 +18,7 @@ sp-state-machine = { version = "0.10.0-dev", path = "../../primitives/state-mach
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-block-builder = { version = "4.0.0-dev", path = "../../primitives/block-builder" }
 sp-inherents = { version = "4.0.0-dev", path = "../../primitives/inherents" }
 sc-client-api = { version = "4.0.0-dev", path = "../api" }

--- a/client/block-builder/Cargo.toml
+++ b/client/block-builder/Cargo.toml
@@ -18,7 +18,7 @@ sp-state-machine = { version = "0.10.0-dev", path = "../../primitives/state-mach
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-block-builder = { version = "4.0.0-dev", path = "../../primitives/block-builder" }
 sp-inherents = { version = "4.0.0-dev", path = "../../primitives/inherents" }
 sc-client-api = { version = "4.0.0-dev", path = "../api" }

--- a/client/chain-spec/Cargo.toml
+++ b/client/chain-spec/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 sc-chain-spec-derive = { version = "4.0.0-dev", path = "./derive" }
 impl-trait-for-tuples = "0.2.1"
 sc-network = { version = "0.10.0-dev", path = "../network" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.71"
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }

--- a/client/chain-spec/Cargo.toml
+++ b/client/chain-spec/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 sc-chain-spec-derive = { version = "4.0.0-dev", path = "./derive" }
 impl-trait-for-tuples = "0.2.1"
 sc-network = { version = "0.10.0-dev", path = "../network" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.71"
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -32,7 +32,7 @@ sc-network = { version = "0.10.0-dev", path = "../network" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sc-utils = { version = "4.0.0-dev", path = "../utils" }
 sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../primitives/keystore" }
 sc-service = { version = "0.10.0-dev", default-features = false, path = "../service" }
 sc-telemetry = { version = "4.0.0-dev", path = "../telemetry" }

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -32,7 +32,7 @@ sc-network = { version = "0.10.0-dev", path = "../network" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sc-utils = { version = "4.0.0-dev", path = "../utils" }
 sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../primitives/keystore" }
 sc-service = { version = "0.10.0-dev", default-features = false, path = "../service" }
 sc-telemetry = { version = "4.0.0-dev", path = "../telemetry" }

--- a/client/consensus/aura/Cargo.toml
+++ b/client/consensus/aura/Cargo.toml
@@ -26,7 +26,7 @@ derive_more = "0.99.16"
 futures = "0.3.9"
 sp-inherents = { version = "4.0.0-dev", path = "../../../primitives/inherents" }
 log = "0.4.8"
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
 sc-consensus-slots = { version = "0.10.0-dev", path = "../slots" }
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
@@ -42,7 +42,7 @@ getrandom = { version = "0.2", features = ["js"], optional = true }
 [dev-dependencies]
 sp-timestamp = { version = "4.0.0-dev", path = "../../../primitives/timestamp" }
 sp-keyring = { version = "4.0.0-dev", path = "../../../primitives/keyring" }
-sp-tracing = { version = "4.0.0-dev", path = "../../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../../primitives/tracing" }
 sc-keystore = { version = "4.0.0-dev", path = "../../keystore" }
 sc-network = { version = "0.10.0-dev", path = "../../network" }
 sc-network-test = { version = "0.8.0", path = "../../network/test" }

--- a/client/consensus/aura/Cargo.toml
+++ b/client/consensus/aura/Cargo.toml
@@ -26,7 +26,7 @@ derive_more = "0.99.16"
 futures = "0.3.9"
 sp-inherents = { version = "4.0.0-dev", path = "../../../primitives/inherents" }
 log = "0.4.8"
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
 sc-consensus-slots = { version = "0.10.0-dev", path = "../slots" }
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
@@ -42,7 +42,7 @@ getrandom = { version = "0.2", features = ["js"], optional = true }
 [dev-dependencies]
 sp-timestamp = { version = "4.0.0-dev", path = "../../../primitives/timestamp" }
 sp-keyring = { version = "4.0.0-dev", path = "../../../primitives/keyring" }
-sp-tracing =  { version = "4.0.0", path = "../../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../../primitives/tracing" }
 sc-keystore = { version = "4.0.0-dev", path = "../../keystore" }
 sc-network = { version = "0.10.0-dev", path = "../../network" }
 sc-network-test = { version = "0.8.0", path = "../../network/test" }

--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -19,7 +19,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", features = [
 ] }
 sp-consensus-babe = { version = "0.10.0-dev", path = "../../../primitives/consensus/babe" }
 sc-consensus = { version = "0.10.0-dev", path = "../../../client/consensus/common" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-application-crypto = { version = "4.0.0-dev", path = "../../../primitives/application-crypto" }
 sp-keystore = { version = "0.10.0-dev", path = "../../../primitives/keystore" }
 num-bigint = "0.2.3"
@@ -55,7 +55,7 @@ async-trait = "0.1.50"
 
 [dev-dependencies]
 sp-timestamp = { version = "4.0.0-dev", path = "../../../primitives/timestamp" }
-sp-tracing = { version = "4.0.0-dev", path = "../../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../../primitives/tracing" }
 sc-network = { version = "0.10.0-dev", path = "../../network" }
 sc-network-test = { version = "0.8.0", path = "../../network/test" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }

--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -19,7 +19,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", features = [
 ] }
 sp-consensus-babe = { version = "0.10.0-dev", path = "../../../primitives/consensus/babe" }
 sc-consensus = { version = "0.10.0-dev", path = "../../../client/consensus/common" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-application-crypto = { version = "4.0.0-dev", path = "../../../primitives/application-crypto" }
 sp-keystore = { version = "0.10.0-dev", path = "../../../primitives/keystore" }
 num-bigint = "0.2.3"
@@ -55,7 +55,7 @@ async-trait = "0.1.50"
 
 [dev-dependencies]
 sp-timestamp = { version = "4.0.0-dev", path = "../../../primitives/timestamp" }
-sp-tracing =  { version = "4.0.0", path = "../../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../../primitives/tracing" }
 sc-network = { version = "0.10.0-dev", path = "../../network" }
 sc-network-test = { version = "0.8.0", path = "../../network/test" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }

--- a/client/consensus/babe/rpc/Cargo.toml
+++ b/client/consensus/babe/rpc/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.3.16"
 derive_more = "0.99.16"
 sp-api = { version = "4.0.0-dev", path = "../../../../primitives/api" }
 sp-consensus = { version = "0.10.0-dev", path = "../../../../primitives/consensus/common" }
-sp-core = { version = "4.0.0-dev", path = "../../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../../primitives/core" }
 sp-application-crypto = { version = "4.0.0-dev", path = "../../../../primitives/application-crypto" }
 sp-keystore = { version = "0.10.0-dev", path = "../../../../primitives/keystore" }
 

--- a/client/consensus/babe/rpc/Cargo.toml
+++ b/client/consensus/babe/rpc/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.3.16"
 derive_more = "0.99.16"
 sp-api = { version = "4.0.0-dev", path = "../../../../primitives/api" }
 sp-consensus = { version = "0.10.0-dev", path = "../../../../primitives/consensus/common" }
-sp-core =  { version = "4.0.0", path = "../../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../../primitives/core" }
 sp-application-crypto = { version = "4.0.0-dev", path = "../../../../primitives/application-crypto" }
 sp-keystore = { version = "0.10.0-dev", path = "../../../../primitives/keystore" }
 

--- a/client/consensus/common/Cargo.toml
+++ b/client/consensus/common/Cargo.toml
@@ -20,7 +20,7 @@ futures = { version = "0.3.1", features = ["thread-pool"] }
 futures-timer = "3.0.1"
 sc-client-api = { version = "4.0.0-dev", path = "../../api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
-sp-core = { path = "../../../primitives/core", version = "4.0.0-dev" }
+sp-core =  { path = "../../../primitives/core", version = "4.0.0" }
 sp-consensus = { path = "../../../primitives/consensus/common", version = "0.10.0-dev" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../../primitives/state-machine" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }

--- a/client/consensus/common/Cargo.toml
+++ b/client/consensus/common/Cargo.toml
@@ -20,7 +20,7 @@ futures = { version = "0.3.1", features = ["thread-pool"] }
 futures-timer = "3.0.1"
 sc-client-api = { version = "4.0.0-dev", path = "../../api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
-sp-core =  { path = "../../../primitives/core", version = "4.0.0" }
+sp-core = { path = "../../../primitives/core", version = "4.0.0" }
 sp-consensus = { path = "../../../primitives/consensus/common", version = "0.10.0-dev" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../../primitives/state-machine" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }

--- a/client/consensus/manual-seal/Cargo.toml
+++ b/client/consensus/manual-seal/Cargo.toml
@@ -36,7 +36,7 @@ sp-consensus = { path = "../../../primitives/consensus/common", version = "0.10.
 sp-consensus-slots = { path = "../../../primitives/consensus/slots", version = "0.10.0-dev" }
 sp-inherents = { path = "../../../primitives/inherents", version = "4.0.0-dev" }
 sp-runtime = { path = "../../../primitives/runtime", version = "4.0.0-dev" }
-sp-core =  { path = "../../../primitives/core", version = "4.0.0" }
+sp-core = { path = "../../../primitives/core", version = "4.0.0" }
 sp-keystore = { path = "../../../primitives/keystore", version = "0.10.0-dev" }
 sp-api = { path = "../../../primitives/api", version = "4.0.0-dev" }
 sc-transaction-pool-api = { path = "../../../client/transaction-pool/api", version = "4.0.0-dev" }

--- a/client/consensus/manual-seal/Cargo.toml
+++ b/client/consensus/manual-seal/Cargo.toml
@@ -36,7 +36,7 @@ sp-consensus = { path = "../../../primitives/consensus/common", version = "0.10.
 sp-consensus-slots = { path = "../../../primitives/consensus/slots", version = "0.10.0-dev" }
 sp-inherents = { path = "../../../primitives/inherents", version = "4.0.0-dev" }
 sp-runtime = { path = "../../../primitives/runtime", version = "4.0.0-dev" }
-sp-core = { path = "../../../primitives/core", version = "4.0.0-dev" }
+sp-core =  { path = "../../../primitives/core", version = "4.0.0" }
 sp-keystore = { path = "../../../primitives/keystore", version = "0.10.0-dev" }
 sp-api = { path = "../../../primitives/api", version = "4.0.0-dev" }
 sc-transaction-pool-api = { path = "../../../client/transaction-pool/api", version = "4.0.0-dev" }

--- a/client/consensus/pow/Cargo.toml
+++ b/client/consensus/pow/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }

--- a/client/consensus/pow/Cargo.toml
+++ b/client/consensus/pow/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }

--- a/client/consensus/slots/Cargo.toml
+++ b/client/consensus/slots/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 sc-client-api = { version = "4.0.0-dev", path = "../../api" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-arithmetic = { version = "4.0.0-dev", path = "../../../primitives/arithmetic" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
 sc-consensus = { version = "0.10.0-dev", path = "../../../client/consensus/common" }

--- a/client/consensus/slots/Cargo.toml
+++ b/client/consensus/slots/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 sc-client-api = { version = "4.0.0-dev", path = "../../api" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-arithmetic = { version = "4.0.0-dev", path = "../../../primitives/arithmetic" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
 sc-consensus = { version = "0.10.0-dev", path = "../../../client/consensus/common" }

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -26,7 +26,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", features = [
 
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sp-arithmetic = { version = "4.0.0-dev", path = "../../primitives/arithmetic" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../primitives/state-machine" }
 sc-state-db = { version = "0.10.0-dev", path = "../state-db" }
@@ -36,7 +36,7 @@ sp-database = { version = "4.0.0-dev", path = "../../primitives/database" }
 parity-db = { version = "0.3.4", optional = true }
 
 [dev-dependencies]
-sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../primitives/tracing" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }
 quickcheck = "1.0.3"
 kvdb-rocksdb = "0.14.0"

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -26,7 +26,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", features = [
 
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sp-arithmetic = { version = "4.0.0-dev", path = "../../primitives/arithmetic" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../primitives/state-machine" }
 sc-state-db = { version = "0.10.0-dev", path = "../state-db" }
@@ -36,7 +36,7 @@ sp-database = { version = "4.0.0-dev", path = "../../primitives/database" }
 parity-db = { version = "0.3.4", optional = true }
 
 [dev-dependencies]
-sp-tracing = { version = "4.0.0-dev", path = "../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }
 quickcheck = "1.0.3"
 kvdb-rocksdb = "0.14.0"

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-tasks = { version = "4.0.0-dev", path = "../../primitives/tasks" }
 sp-trie = { version = "4.0.0-dev", path = "../../primitives/trie" }
 sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
@@ -24,9 +24,9 @@ sp-panic-handler = { version = "4.0.0-dev", path = "../../primitives/panic-handl
 wasmi = "0.9.1"
 lazy_static = "1.4.0"
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
-sp-wasm-interface = { version = "4.0.0-dev", path = "../../primitives/wasm-interface" }
-sp-runtime-interface = { version = "4.0.0-dev", path = "../../primitives/runtime-interface" }
-sp-externalities = { version = "0.10.0-dev", path = "../../primitives/externalities" }
+sp-wasm-interface =  { version = "4.0.0", path = "../../primitives/wasm-interface" }
+sp-runtime-interface =  { version = "4.0.0", path = "../../primitives/runtime-interface" }
+sp-externalities =  { version = "0.10.0", path = "../../primitives/externalities" }
 sc-executor-common = { version = "0.10.0-dev", path = "common" }
 sc-executor-wasmi = { version = "0.10.0-dev", path = "wasmi" }
 sc-executor-wasmtime = { version = "0.10.0-dev", path = "wasmtime", optional = true }

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-tasks = { version = "4.0.0-dev", path = "../../primitives/tasks" }
 sp-trie = { version = "4.0.0-dev", path = "../../primitives/trie" }
 sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
@@ -24,9 +24,9 @@ sp-panic-handler = { version = "4.0.0-dev", path = "../../primitives/panic-handl
 wasmi = "0.9.1"
 lazy_static = "1.4.0"
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
-sp-wasm-interface =  { version = "4.0.0", path = "../../primitives/wasm-interface" }
-sp-runtime-interface =  { version = "4.0.0", path = "../../primitives/runtime-interface" }
-sp-externalities =  { version = "0.10.0", path = "../../primitives/externalities" }
+sp-wasm-interface = { version = "4.0.0", path = "../../primitives/wasm-interface" }
+sp-runtime-interface = { version = "4.0.0", path = "../../primitives/runtime-interface" }
+sp-externalities = { version = "0.10.0", path = "../../primitives/externalities" }
 sc-executor-common = { version = "0.10.0-dev", path = "common" }
 sc-executor-wasmi = { version = "0.10.0-dev", path = "wasmi" }
 sc-executor-wasmtime = { version = "0.10.0-dev", path = "wasmtime", optional = true }

--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -18,9 +18,9 @@ derive_more = "0.99.16"
 pwasm-utils = "0.18.2"
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 wasmi = "0.9.1"
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }
-sp-wasm-interface = { version = "4.0.0-dev", path = "../../../primitives/wasm-interface" }
+sp-wasm-interface =  { version = "4.0.0", path = "../../../primitives/wasm-interface" }
 sp-maybe-compressed-blob = { version = "4.1.0-dev", path = "../../../primitives/maybe-compressed-blob" }
 sp-serializer = { version = "4.0.0-dev", path = "../../../primitives/serializer" }
 thiserror = "1.0.30"

--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -18,9 +18,9 @@ derive_more = "0.99.16"
 pwasm-utils = "0.18.2"
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 wasmi = "0.9.1"
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }
-sp-wasm-interface =  { version = "4.0.0", path = "../../../primitives/wasm-interface" }
+sp-wasm-interface = { version = "4.0.0", path = "../../../primitives/wasm-interface" }
 sp-maybe-compressed-blob = { version = "4.1.0-dev", path = "../../../primitives/maybe-compressed-blob" }
 sp-serializer = { version = "4.0.0-dev", path = "../../../primitives/serializer" }
 thiserror = "1.0.30"

--- a/client/executor/runtime-test/Cargo.toml
+++ b/client/executor/runtime-test/Cargo.toml
@@ -13,11 +13,11 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 sp-sandbox = { version = "0.10.0-dev", default-features = false, path = "../../../primitives/sandbox" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-tasks = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/tasks" }
 paste = "1.0.6"
 

--- a/client/executor/runtime-test/Cargo.toml
+++ b/client/executor/runtime-test/Cargo.toml
@@ -13,11 +13,11 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 sp-sandbox = { version = "0.10.0-dev", default-features = false, path = "../../../primitives/sandbox" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-tasks = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/tasks" }
 paste = "1.0.6"
 

--- a/client/executor/wasmi/Cargo.toml
+++ b/client/executor/wasmi/Cargo.toml
@@ -19,7 +19,7 @@ wasmi = "0.9.1"
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 sc-executor-common = { version = "0.10.0-dev", path = "../common" }
 sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }
-sp-wasm-interface =  { version = "4.0.0", path = "../../../primitives/wasm-interface" }
-sp-runtime-interface =  { version = "4.0.0", path = "../../../primitives/runtime-interface" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-wasm-interface = { version = "4.0.0", path = "../../../primitives/wasm-interface" }
+sp-runtime-interface = { version = "4.0.0", path = "../../../primitives/runtime-interface" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 scoped-tls = "1.0"

--- a/client/executor/wasmi/Cargo.toml
+++ b/client/executor/wasmi/Cargo.toml
@@ -19,7 +19,7 @@ wasmi = "0.9.1"
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 sc-executor-common = { version = "0.10.0-dev", path = "../common" }
 sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }
-sp-wasm-interface = { version = "4.0.0-dev", path = "../../../primitives/wasm-interface" }
-sp-runtime-interface = { version = "4.0.0-dev", path = "../../../primitives/runtime-interface" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-wasm-interface =  { version = "4.0.0", path = "../../../primitives/wasm-interface" }
+sp-runtime-interface =  { version = "4.0.0", path = "../../../primitives/runtime-interface" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 scoped-tls = "1.0"

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -19,9 +19,9 @@ log = "0.4.8"
 parity-wasm = "0.42.0"
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 sc-executor-common = { version = "0.10.0-dev", path = "../common" }
-sp-wasm-interface =  { version = "4.0.0", path = "../../../primitives/wasm-interface" }
-sp-runtime-interface =  { version = "4.0.0", path = "../../../primitives/runtime-interface" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-wasm-interface = { version = "4.0.0", path = "../../../primitives/wasm-interface" }
+sp-runtime-interface = { version = "4.0.0", path = "../../../primitives/runtime-interface" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }
 wasmtime = { version = "0.31.0", default-features = false, features = [
     "cache",

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -19,9 +19,9 @@ log = "0.4.8"
 parity-wasm = "0.42.0"
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 sc-executor-common = { version = "0.10.0-dev", path = "../common" }
-sp-wasm-interface = { version = "4.0.0-dev", path = "../../../primitives/wasm-interface" }
-sp-runtime-interface = { version = "4.0.0-dev", path = "../../../primitives/runtime-interface" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-wasm-interface =  { version = "4.0.0", path = "../../../primitives/wasm-interface" }
+sp-runtime-interface =  { version = "4.0.0", path = "../../../primitives/runtime-interface" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }
 wasmtime = { version = "0.31.0", default-features = false, features = [
     "cache",

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -30,7 +30,7 @@ sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sc-utils = { version = "4.0.0-dev", path = "../utils" }
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }
 sc-consensus = { version = "0.10.0-dev", path = "../consensus/common" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../primitives/keystore" }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
 sc-telemetry = { version = "4.0.0-dev", path = "../telemetry" }
@@ -56,6 +56,6 @@ sc-network = { version = "0.10.0-dev", path = "../network" }
 sc-network-test = { version = "0.8.0", path = "../network/test" }
 sp-keyring = { version = "4.0.0-dev", path = "../../primitives/keyring" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }
-sp-tracing = { version = "4.0.0-dev", path = "../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
 tokio = "1.13"
 tempfile = "3.1.0"

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -30,7 +30,7 @@ sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sc-utils = { version = "4.0.0-dev", path = "../utils" }
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }
 sc-consensus = { version = "0.10.0-dev", path = "../consensus/common" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../primitives/keystore" }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
 sc-telemetry = { version = "4.0.0-dev", path = "../telemetry" }
@@ -56,6 +56,6 @@ sc-network = { version = "0.10.0-dev", path = "../network" }
 sc-network-test = { version = "0.8.0", path = "../network/test" }
 sp-keyring = { version = "4.0.0-dev", path = "../../primitives/keyring" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }
-sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../primitives/tracing" }
 tokio = "1.13"
 tempfile = "3.1.0"

--- a/client/finality-grandpa/rpc/Cargo.toml
+++ b/client/finality-grandpa/rpc/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 sc-finality-grandpa = { version = "0.10.0-dev", path = "../" }
 sc-rpc = { version = "4.0.0-dev", path = "../../rpc" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 finality-grandpa = { version = "0.14.4", features = ["derive-codec"] }
 jsonrpc-core = "18.0.0"
@@ -32,7 +32,7 @@ sc-block-builder = { version = "0.10.0-dev", path = "../../block-builder" }
 sc-rpc = { version = "4.0.0-dev", path = "../../rpc", features = [
     "test-helpers",
 ] }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-finality-grandpa = { version = "4.0.0-dev", path = "../../../primitives/finality-grandpa" }
 sp-keyring = { version = "4.0.0-dev", path = "../../../primitives/keyring" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }

--- a/client/finality-grandpa/rpc/Cargo.toml
+++ b/client/finality-grandpa/rpc/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 sc-finality-grandpa = { version = "0.10.0-dev", path = "../" }
 sc-rpc = { version = "4.0.0-dev", path = "../../rpc" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 finality-grandpa = { version = "0.14.4", features = ["derive-codec"] }
 jsonrpc-core = "18.0.0"
@@ -32,7 +32,7 @@ sc-block-builder = { version = "0.10.0-dev", path = "../../block-builder" }
 sc-rpc = { version = "4.0.0-dev", path = "../../rpc", features = [
     "test-helpers",
 ] }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-finality-grandpa = { version = "4.0.0-dev", path = "../../../primitives/finality-grandpa" }
 sp-keyring = { version = "4.0.0-dev", path = "../../../primitives/keyring" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }

--- a/client/keystore/Cargo.toml
+++ b/client/keystore/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 async-trait = "0.1.50"
 derive_more = "0.99.16"
 sp-application-crypto = { version = "4.0.0-dev", path = "../../primitives/application-crypto" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../primitives/keystore" }
 hex = "0.4.0"
 parking_lot = "0.11.1"

--- a/client/keystore/Cargo.toml
+++ b/client/keystore/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 async-trait = "0.1.50"
 derive_more = "0.99.16"
 sp-application-crypto = { version = "4.0.0-dev", path = "../../primitives/application-crypto" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../primitives/keystore" }
 hex = "0.4.0"
 parking_lot = "0.11.1"

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -53,7 +53,7 @@ sp-arithmetic = { version = "4.0.0-dev", path = "../../primitives/arithmetic" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }
 sc-consensus = { version = "0.10.0-dev", path = "../consensus/common" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sc-utils = { version = "4.0.0-dev", path = "../utils" }
 sp-finality-grandpa = { version = "4.0.0-dev", path = "../../primitives/finality-grandpa" }
@@ -72,7 +72,7 @@ libp2p = { version = "0.40.0", default-features = false }
 quickcheck = "1.0.3"
 rand = "0.7.2"
 sp-test-primitives = { version = "2.0.0", path = "../../primitives/test-primitives" }
-sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../primitives/tracing" }
 substrate-test-runtime = { version = "2.0.0", path = "../../test-utils/runtime" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }
 tempfile = "3.1.0"

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -53,7 +53,7 @@ sp-arithmetic = { version = "4.0.0-dev", path = "../../primitives/arithmetic" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }
 sc-consensus = { version = "0.10.0-dev", path = "../consensus/common" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sc-utils = { version = "4.0.0-dev", path = "../utils" }
 sp-finality-grandpa = { version = "4.0.0-dev", path = "../../primitives/finality-grandpa" }
@@ -72,7 +72,7 @@ libp2p = { version = "0.40.0", default-features = false }
 quickcheck = "1.0.3"
 rand = "0.7.2"
 sp-test-primitives = { version = "2.0.0", path = "../../primitives/test-primitives" }
-sp-tracing = { version = "4.0.0-dev", path = "../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
 substrate-test-runtime = { version = "2.0.0", path = "../../test-utils/runtime" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }
 tempfile = "3.1.0"

--- a/client/network/test/Cargo.toml
+++ b/client/network/test/Cargo.toml
@@ -26,11 +26,11 @@ sc-consensus = { version = "0.10.0-dev", path = "../../consensus/common" }
 sc-client-api = { version = "4.0.0-dev", path = "../../api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sc-block-builder = { version = "0.10.0-dev", path = "../../block-builder" }
 sp-consensus-babe = { version = "0.10.0-dev", path = "../../../primitives/consensus/babe" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }
 substrate-test-runtime = { version = "2.0.0", path = "../../../test-utils/runtime" }
-sp-tracing =  { version = "4.0.0", path = "../../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../../primitives/tracing" }
 sc-service = { version = "0.10.0-dev", default-features = false, features = ["test-helpers"],  path = "../../service" }
 async-trait = "0.1.50"

--- a/client/network/test/Cargo.toml
+++ b/client/network/test/Cargo.toml
@@ -26,11 +26,11 @@ sc-consensus = { version = "0.10.0-dev", path = "../../consensus/common" }
 sc-client-api = { version = "4.0.0-dev", path = "../../api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sc-block-builder = { version = "0.10.0-dev", path = "../../block-builder" }
 sp-consensus-babe = { version = "0.10.0-dev", path = "../../../primitives/consensus/babe" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }
 substrate-test-runtime = { version = "2.0.0", path = "../../../test-utils/runtime" }
-sp-tracing = { version = "4.0.0-dev", path = "../../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../../primitives/tracing" }
 sc-service = { version = "0.10.0-dev", default-features = false, features = ["test-helpers"],  path = "../../service" }
 async-trait = "0.1.50"

--- a/client/offchain/Cargo.toml
+++ b/client/offchain/Cargo.toml
@@ -25,7 +25,7 @@ rand = "0.7.2"
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sc-network = { version = "0.10.0-dev", path = "../network" }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-offchain = { version = "4.0.0-dev", path = "../../primitives/offchain" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sc-utils = { version = "4.0.0-dev", path = "../utils" }
@@ -40,7 +40,7 @@ sc-client-db = { version = "0.10.0-dev", default-features = true, path = "../db"
 sc-block-builder = { version = "0.10.0-dev", path = "../block-builder" }
 sc-transaction-pool = { version = "4.0.0-dev", path = "../transaction-pool" }
 sc-transaction-pool-api = { version = "4.0.0-dev", path = "../transaction-pool/api" }
-sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../primitives/tracing" }
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }
 tokio = "1.13"

--- a/client/offchain/Cargo.toml
+++ b/client/offchain/Cargo.toml
@@ -25,7 +25,7 @@ rand = "0.7.2"
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sc-network = { version = "0.10.0-dev", path = "../network" }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-offchain = { version = "4.0.0-dev", path = "../../primitives/offchain" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sc-utils = { version = "4.0.0-dev", path = "../utils" }
@@ -40,7 +40,7 @@ sc-client-db = { version = "0.10.0-dev", default-features = true, path = "../db"
 sc-block-builder = { version = "0.10.0-dev", path = "../block-builder" }
 sc-transaction-pool = { version = "4.0.0-dev", path = "../transaction-pool" }
 sc-transaction-pool-api = { version = "4.0.0-dev", path = "../transaction-pool/api" }
-sp-tracing = { version = "4.0.0-dev", path = "../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }
 tokio = "1.13"

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4.8"
 parking_lot = "0.11.1"
 thiserror = "1.0"
 
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
 sp-runtime = { path = "../../primitives/runtime", version = "4.0.0-dev" }
 sc-chain-spec = { path = "../chain-spec", version = "4.0.0-dev" }
@@ -31,4 +31,4 @@ serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.71"
 sc-transaction-pool-api = { version = "4.0.0-dev", path = "../transaction-pool/api" }
 sp-rpc = { version = "4.0.0-dev", path = "../../primitives/rpc" }
-sp-tracing = { version = "4.0.0-dev", path = "../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4.8"
 parking_lot = "0.11.1"
 thiserror = "1.0"
 
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
 sp-runtime = { path = "../../primitives/runtime", version = "4.0.0-dev" }
 sc-chain-spec = { path = "../chain-spec", version = "4.0.0-dev" }
@@ -31,4 +31,4 @@ serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.71"
 sc-transaction-pool-api = { version = "4.0.0-dev", path = "../transaction-pool/api" }
 sp-rpc = { version = "4.0.0-dev", path = "../../primitives/rpc" }
-sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../primitives/tracing" }

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0" }
 futures = "0.3.16"
 jsonrpc-pubsub = "18.0.0"
 log = "0.4.8"
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 rpc = { package = "jsonrpc-core", version = "18.0.0" }
 sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
 serde_json = "1.0.71"

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0" }
 futures = "0.3.16"
 jsonrpc-pubsub = "18.0.0"
 log = "0.4.8"
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 rpc = { package = "jsonrpc-core", version = "18.0.0" }
 sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
 serde_json = "1.0.71"

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -38,11 +38,11 @@ serde_json = "1.0.71"
 sc-keystore = { version = "4.0.0-dev", path = "../keystore" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sp-trie = { version = "4.0.0-dev", path = "../../primitives/trie" }
-sp-externalities =  { version = "0.10.0", path = "../../primitives/externalities" }
+sp-externalities = { version = "0.10.0", path = "../../primitives/externalities" }
 sc-utils = { version = "4.0.0-dev", path = "../utils" }
 sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../primitives/keystore" }
 sp-session = { version = "4.0.0-dev", path = "../../primitives/session" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../primitives/state-machine" }
@@ -50,7 +50,7 @@ sp-application-crypto = { version = "4.0.0-dev", path = "../../primitives/applic
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }
 sc-consensus = { version = "0.10.0-dev", path = "../../client/consensus/common" }
 sp-inherents = { version = "4.0.0-dev", path = "../../primitives/inherents" }
-sp-storage =  { version = "4.0.0", path = "../../primitives/storage" }
+sp-storage = { version = "4.0.0", path = "../../primitives/storage" }
 sc-network = { version = "0.10.0-dev", path = "../network" }
 sc-chain-spec = { version = "4.0.0-dev", path = "../chain-spec" }
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
@@ -71,7 +71,7 @@ sc-telemetry = { version = "4.0.0-dev", path = "../telemetry" }
 sc-offchain = { version = "4.0.0-dev", path = "../offchain" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.10.0-dev" }
 sc-tracing = { version = "4.0.0-dev", path = "../tracing" }
-sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../primitives/tracing" }
 tracing = "0.1.29"
 tracing-futures = { version = "0.2.4" }
 parity-util-mem = { version = "0.10.2", default-features = false, features = [

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -38,11 +38,11 @@ serde_json = "1.0.71"
 sc-keystore = { version = "4.0.0-dev", path = "../keystore" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sp-trie = { version = "4.0.0-dev", path = "../../primitives/trie" }
-sp-externalities = { version = "0.10.0-dev", path = "../../primitives/externalities" }
+sp-externalities =  { version = "0.10.0", path = "../../primitives/externalities" }
 sc-utils = { version = "4.0.0-dev", path = "../utils" }
 sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../primitives/keystore" }
 sp-session = { version = "4.0.0-dev", path = "../../primitives/session" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../primitives/state-machine" }
@@ -50,7 +50,7 @@ sp-application-crypto = { version = "4.0.0-dev", path = "../../primitives/applic
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }
 sc-consensus = { version = "0.10.0-dev", path = "../../client/consensus/common" }
 sp-inherents = { version = "4.0.0-dev", path = "../../primitives/inherents" }
-sp-storage = { version = "4.0.0-dev", path = "../../primitives/storage" }
+sp-storage =  { version = "4.0.0", path = "../../primitives/storage" }
 sc-network = { version = "0.10.0-dev", path = "../network" }
 sc-chain-spec = { version = "4.0.0-dev", path = "../chain-spec" }
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
@@ -71,7 +71,7 @@ sc-telemetry = { version = "4.0.0-dev", path = "../telemetry" }
 sc-offchain = { version = "4.0.0-dev", path = "../offchain" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.10.0-dev" }
 sc-tracing = { version = "4.0.0-dev", path = "../tracing" }
-sp-tracing = { version = "4.0.0-dev", path = "../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
 tracing = "0.1.29"
 tracing-futures = { version = "0.2.4" }
 parity-util-mem = { version = "0.10.2", default-features = false, features = [

--- a/client/service/test/Cargo.toml
+++ b/client/service/test/Cargo.toml
@@ -22,9 +22,9 @@ parking_lot = "0.11.1"
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../../primitives/state-machine" }
-sp-externalities = { version = "0.10.0-dev", path = "../../../primitives/externalities" }
+sp-externalities =  { version = "0.10.0", path = "../../../primitives/externalities" }
 sp-trie = { version = "4.0.0-dev", path = "../../../primitives/trie" }
-sp-storage = { version = "4.0.0-dev", path = "../../../primitives/storage" }
+sp-storage =  { version = "4.0.0", path = "../../../primitives/storage" }
 sc-client-db = { version = "0.10.0-dev", default-features = false, path = "../../db" }
 futures = "0.3.16"
 sc-service = { version = "0.10.0-dev", features = ["test-helpers"], path = "../../service" }
@@ -32,7 +32,7 @@ sc-network = { version = "0.10.0-dev", path = "../../network" }
 sp-consensus = { version = "0.10.0-dev", path = "../../../primitives/consensus/common" }
 sc-consensus = { version = "0.10.0-dev", path = "../../../client/consensus/common" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sc-transaction-pool-api = { version = "4.0.0-dev", path = "../../../client/transaction-pool/api" }
 substrate-test-runtime = { version = "2.0.0", path = "../../../test-utils/runtime" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }
@@ -41,4 +41,4 @@ sc-block-builder = { version = "0.10.0-dev", path = "../../block-builder" }
 sc-executor = { version = "0.10.0-dev", path = "../../executor" }
 sp-panic-handler = { version = "4.0.0-dev", path = "../../../primitives/panic-handler" }
 parity-scale-codec = "2.3.1"
-sp-tracing = { version = "4.0.0-dev", path = "../../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../../primitives/tracing" }

--- a/client/service/test/Cargo.toml
+++ b/client/service/test/Cargo.toml
@@ -22,9 +22,9 @@ parking_lot = "0.11.1"
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../../primitives/state-machine" }
-sp-externalities =  { version = "0.10.0", path = "../../../primitives/externalities" }
+sp-externalities = { version = "0.10.0", path = "../../../primitives/externalities" }
 sp-trie = { version = "4.0.0-dev", path = "../../../primitives/trie" }
-sp-storage =  { version = "4.0.0", path = "../../../primitives/storage" }
+sp-storage = { version = "4.0.0", path = "../../../primitives/storage" }
 sc-client-db = { version = "0.10.0-dev", default-features = false, path = "../../db" }
 futures = "0.3.16"
 sc-service = { version = "0.10.0-dev", features = ["test-helpers"], path = "../../service" }
@@ -32,7 +32,7 @@ sc-network = { version = "0.10.0-dev", path = "../../network" }
 sp-consensus = { version = "0.10.0-dev", path = "../../../primitives/consensus/common" }
 sc-consensus = { version = "0.10.0-dev", path = "../../../client/consensus/common" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sc-transaction-pool-api = { version = "4.0.0-dev", path = "../../../client/transaction-pool/api" }
 substrate-test-runtime = { version = "2.0.0", path = "../../../test-utils/runtime" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }
@@ -41,4 +41,4 @@ sc-block-builder = { version = "0.10.0-dev", path = "../../block-builder" }
 sc-executor = { version = "0.10.0-dev", path = "../../executor" }
 sp-panic-handler = { version = "4.0.0-dev", path = "../../../primitives/panic-handler" }
 parity-scale-codec = "2.3.1"
-sp-tracing =  { version = "4.0.0", path = "../../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../../primitives/tracing" }

--- a/client/state-db/Cargo.toml
+++ b/client/state-db/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 parking_lot = "0.11.1"
 log = "0.4.11"
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
 parity-util-mem = { version = "0.10.2", default-features = false, features = ["primitive-types"] }
 parity-util-mem-derive = "0.1.0"

--- a/client/state-db/Cargo.toml
+++ b/client/state-db/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 parking_lot = "0.11.1"
 log = "0.4.11"
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
 parity-util-mem = { version = "0.10.2", default-features = false, features = ["primitive-types"] }
 parity-util-mem-derive = "0.1.0"

--- a/client/tracing/Cargo.toml
+++ b/client/tracing/Cargo.toml
@@ -28,12 +28,12 @@ thiserror = "1.0.30"
 tracing = "0.1.29"
 tracing-log = "0.1.2"
 tracing-subscriber = { version = "0.2.25", features = ["parking_lot"] }
-sp-tracing = { version = "4.0.0-dev", path = "../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
 sp-rpc = { version = "4.0.0-dev", path = "../../primitives/rpc" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sc-tracing-proc-macro = { version = "4.0.0-dev", path = "./proc-macro" }
 sc-rpc-server = { version = "4.0.0-dev", path = "../rpc-servers" }

--- a/client/tracing/Cargo.toml
+++ b/client/tracing/Cargo.toml
@@ -28,12 +28,12 @@ thiserror = "1.0.30"
 tracing = "0.1.29"
 tracing-log = "0.1.2"
 tracing-subscriber = { version = "0.2.25", features = ["parking_lot"] }
-sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../primitives/tracing" }
 sp-rpc = { version = "4.0.0-dev", path = "../../primitives/rpc" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sc-tracing-proc-macro = { version = "4.0.0-dev", path = "./proc-macro" }
 sc-rpc-server = { version = "4.0.0-dev", path = "../rpc-servers" }

--- a/client/transaction-pool/Cargo.toml
+++ b/client/transaction-pool/Cargo.toml
@@ -23,9 +23,9 @@ parking_lot = "0.11.1"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.10.0-dev"}
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
-sp-tracing = { version = "4.0.0-dev", path = "../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
 sp-transaction-pool = { version = "4.0.0-dev", path = "../../primitives/transaction-pool" }
 sc-transaction-pool-api = { version = "4.0.0-dev", path = "./api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }

--- a/client/transaction-pool/Cargo.toml
+++ b/client/transaction-pool/Cargo.toml
@@ -23,9 +23,9 @@ parking_lot = "0.11.1"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.10.0-dev"}
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
-sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../primitives/tracing" }
 sp-transaction-pool = { version = "4.0.0-dev", path = "../../primitives/transaction-pool" }
 sc-transaction-pool-api = { version = "4.0.0-dev", path = "./api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }

--- a/frame/assets/Cargo.toml
+++ b/frame/assets/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 # Needed for various traits. In our case, `OnFinalize`.
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 # Needed for type-safe access to storage DB.
@@ -25,8 +25,8 @@ frame-system = { version = "4.0.0-dev", default-features = false, path = "../sys
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
-sp-std =  { version = "4.0.0", path = "../../primitives/std" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
+sp-std = { version = "4.0.0", path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 

--- a/frame/assets/Cargo.toml
+++ b/frame/assets/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 # Needed for various traits. In our case, `OnFinalize`.
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 # Needed for type-safe access to storage DB.
@@ -25,8 +25,8 @@ frame-system = { version = "4.0.0-dev", default-features = false, path = "../sys
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
-sp-std = { version = "4.0.0-dev", path = "../../primitives/std" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-std =  { version = "4.0.0", path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 

--- a/frame/atomic-swap/Cargo.toml
+++ b/frame/atomic-swap/Cargo.toml
@@ -18,9 +18,9 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 
 [dev-dependencies]
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }

--- a/frame/atomic-swap/Cargo.toml
+++ b/frame/atomic-swap/Cargo.toml
@@ -18,9 +18,9 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 
 [dev-dependencies]
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }

--- a/frame/aura/Cargo.toml
+++ b/frame/aura/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../../primitives/application-crypto" }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 sp-consensus-aura = { version = "0.10.0-dev", path = "../../primitives/consensus/aura", default-features = false }
@@ -24,7 +24,7 @@ frame-system = { version = "4.0.0-dev", default-features = false, path = "../sys
 pallet-timestamp = { version = "4.0.0-dev", default-features = false, path = "../timestamp" }
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 
 [features]

--- a/frame/aura/Cargo.toml
+++ b/frame/aura/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../../primitives/application-crypto" }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 sp-consensus-aura = { version = "0.10.0-dev", path = "../../primitives/consensus/aura", default-features = false }
@@ -24,7 +24,7 @@ frame-system = { version = "4.0.0-dev", default-features = false, path = "../sys
 pallet-timestamp = { version = "4.0.0-dev", default-features = false, path = "../timestamp" }
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 
 [features]

--- a/frame/authority-discovery/Cargo.toml
+++ b/frame/authority-discovery/Cargo.toml
@@ -19,7 +19,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 	"derive",
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 pallet-session = { version = "4.0.0-dev", features = [
 	"historical",
 ], path = "../session", default-features = false }
@@ -28,7 +28,7 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../su
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 
 [features]

--- a/frame/authority-discovery/Cargo.toml
+++ b/frame/authority-discovery/Cargo.toml
@@ -19,7 +19,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 	"derive",
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 pallet-session = { version = "4.0.0-dev", features = [
 	"historical",
 ], path = "../session", default-features = false }
@@ -28,7 +28,7 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../su
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 
 [features]

--- a/frame/authorship/Cargo.toml
+++ b/frame/authorship/Cargo.toml
@@ -18,14 +18,14 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-authorship = { version = "4.0.0-dev", default-features = false, path = "../../primitives/authorship" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 impl-trait-for-tuples = "0.2.1"
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 
 [features]

--- a/frame/authorship/Cargo.toml
+++ b/frame/authorship/Cargo.toml
@@ -18,14 +18,14 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-authorship = { version = "4.0.0-dev", default-features = false, path = "../../primitives/authorship" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 impl-trait-for-tuples = "0.2.1"
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 
 [features]

--- a/frame/babe/Cargo.toml
+++ b/frame/babe/Cargo.toml
@@ -28,7 +28,7 @@ sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primiti
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-session = { version = "4.0.0-dev", default-features = false, path = "../../primitives/session" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../primitives/staking" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 log = { version = "0.4.14", default-features = false }
 
 [dev-dependencies]
@@ -36,7 +36,7 @@ pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 pallet-offences = { version = "4.0.0-dev", path = "../offences" }
 pallet-staking = { version = "4.0.0-dev", path = "../staking" }
 pallet-staking-reward-curve = { version = "4.0.0-dev", path = "../staking/reward-curve" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 frame-election-provider-support = { version = "4.0.0-dev", path = "../election-provider-support" }
 
 [features]

--- a/frame/babe/Cargo.toml
+++ b/frame/babe/Cargo.toml
@@ -28,7 +28,7 @@ sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primiti
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-session = { version = "4.0.0-dev", default-features = false, path = "../../primitives/session" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../primitives/staking" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 log = { version = "0.4.14", default-features = false }
 
 [dev-dependencies]
@@ -36,7 +36,7 @@ pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 pallet-offences = { version = "4.0.0-dev", path = "../offences" }
 pallet-staking = { version = "4.0.0-dev", path = "../staking" }
 pallet-staking-reward-curve = { version = "4.0.0-dev", path = "../staking/reward-curve" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 frame-election-provider-support = { version = "4.0.0-dev", path = "../election-provider-support" }
 
 [features]

--- a/frame/bags-list/Cargo.toml
+++ b/frame/bags-list/Cargo.toml
@@ -19,7 +19,7 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 
 # primitives
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 # FRAME
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
@@ -32,14 +32,14 @@ log = { version = "0.4.14", default-features = false }
 # Optional imports for benchmarking
 frame-benchmarking = { version = "4.0.0-dev", path = "../benchmarking", optional = true, default-features = false }
 pallet-balances = { version = "4.0.0-dev", path = "../balances", optional = true, default-features = false }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core", optional = true, default-features = false }
+sp-core =  { version = "4.0.0", path = "../../primitives/core", optional = true, default-features = false }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io", optional = true, default-features = false }
-sp-tracing = { version = "4.0.0-dev", path = "../../primitives/tracing", optional = true, default-features = false }
+sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing", optional = true, default-features = false }
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core"}
+sp-core =  { version = "4.0.0", path = "../../primitives/core"}
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io"}
-sp-tracing = { version = "4.0.0-dev", path = "../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 frame-election-provider-support = { version = "4.0.0-dev", path = "../election-provider-support", features = ["runtime-benchmarks"] }
 frame-benchmarking = { version = "4.0.0-dev", path = "../benchmarking" }
@@ -70,4 +70,3 @@ fuzz = [
 	"sp-tracing",
 ]
 try-runtime = [ "frame-support/try-runtime" ]
-

--- a/frame/bags-list/Cargo.toml
+++ b/frame/bags-list/Cargo.toml
@@ -19,7 +19,7 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 
 # primitives
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 # FRAME
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
@@ -32,14 +32,14 @@ log = { version = "0.4.14", default-features = false }
 # Optional imports for benchmarking
 frame-benchmarking = { version = "4.0.0-dev", path = "../benchmarking", optional = true, default-features = false }
 pallet-balances = { version = "4.0.0-dev", path = "../balances", optional = true, default-features = false }
-sp-core =  { version = "4.0.0", path = "../../primitives/core", optional = true, default-features = false }
+sp-core = { version = "4.0.0", path = "../../primitives/core", optional = true, default-features = false }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io", optional = true, default-features = false }
-sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing", optional = true, default-features = false }
+sp-tracing = { version = "4.0.0", path = "../../primitives/tracing", optional = true, default-features = false }
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", path = "../../primitives/core"}
+sp-core = { version = "4.0.0", path = "../../primitives/core"}
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io"}
-sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../primitives/tracing" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 frame-election-provider-support = { version = "4.0.0-dev", path = "../election-provider-support", features = ["runtime-benchmarks"] }
 frame-benchmarking = { version = "4.0.0-dev", path = "../benchmarking" }

--- a/frame/bags-list/remote-tests/Cargo.toml
+++ b/frame/bags-list/remote-tests/Cargo.toml
@@ -21,11 +21,11 @@ frame-system = { path = "../../system", version = "4.0.0-dev" }
 frame-support = { path = "../../support", version = "4.0.0-dev" }
 
 # core
-sp-storage = { path = "../../../primitives/storage", version = "4.0.0-dev" }
-sp-core = { path = "../../../primitives/core", version = "4.0.0-dev" }
-sp-tracing = { path = "../../../primitives/tracing", version = "4.0.0-dev" }
+sp-storage =  { path = "../../../primitives/storage", version = "4.0.0" }
+sp-core =  { path = "../../../primitives/core", version = "4.0.0" }
+sp-tracing =  { path = "../../../primitives/tracing", version = "4.0.0" }
 sp-runtime = { path = "../../../primitives/runtime", version = "4.0.0-dev" }
-sp-std = { path = "../../../primitives/std", version = "4.0.0-dev" }
+sp-std =  { path = "../../../primitives/std", version = "4.0.0" }
 
 # utils
 remote-externalities = { path = "../../../utils/frame/remote-externalities", version = "0.10.0-dev" }

--- a/frame/bags-list/remote-tests/Cargo.toml
+++ b/frame/bags-list/remote-tests/Cargo.toml
@@ -21,11 +21,11 @@ frame-system = { path = "../../system", version = "4.0.0-dev" }
 frame-support = { path = "../../support", version = "4.0.0-dev" }
 
 # core
-sp-storage =  { path = "../../../primitives/storage", version = "4.0.0" }
-sp-core =  { path = "../../../primitives/core", version = "4.0.0" }
-sp-tracing =  { path = "../../../primitives/tracing", version = "4.0.0" }
+sp-storage = { path = "../../../primitives/storage", version = "4.0.0" }
+sp-core = { path = "../../../primitives/core", version = "4.0.0" }
+sp-tracing = { path = "../../../primitives/tracing", version = "4.0.0" }
 sp-runtime = { path = "../../../primitives/runtime", version = "4.0.0-dev" }
-sp-std =  { path = "../../../primitives/std", version = "4.0.0" }
+sp-std = { path = "../../../primitives/std", version = "4.0.0" }
 
 # utils
 remote-externalities = { path = "../../../utils/frame/remote-externalities", version = "0.10.0-dev" }

--- a/frame/balances/Cargo.toml
+++ b/frame/balances/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
@@ -24,7 +24,7 @@ log = { version = "0.4.14", default-features = false }
 
 [dev-dependencies]
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 pallet-transaction-payment = { version = "4.0.0-dev", path = "../transaction-payment" }
 
 [features]

--- a/frame/balances/Cargo.toml
+++ b/frame/balances/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
@@ -24,7 +24,7 @@ log = { version = "0.4.14", default-features = false }
 
 [dev-dependencies]
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 pallet-transaction-payment = { version = "4.0.0-dev", path = "../transaction-payment" }
 
 [features]

--- a/frame/beefy-mmr/Cargo.toml
+++ b/frame/beefy-mmr/Cargo.toml
@@ -21,10 +21,10 @@ pallet-mmr = { version = "4.0.0-dev", path = "../merkle-mountain-range", default
 pallet-mmr-primitives = { version = "4.0.0-dev", path = "../merkle-mountain-range/primitives", default-features = false }
 pallet-session = { version = "4.0.0-dev", path = "../session", default-features = false }
 
-sp-core =  { version = "4.0.0", path = "../../primitives/core", default-features = false }
+sp-core = { version = "4.0.0", path = "../../primitives/core", default-features = false }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io", default-features = false }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime", default-features = false }
-sp-std =  { version = "4.0.0", path = "../../primitives/std", default-features = false }
+sp-std = { version = "4.0.0", path = "../../primitives/std", default-features = false }
 
 beefy-merkle-tree = { version = "4.0.0-dev", path = "./primitives", default-features = false }
 beefy-primitives = { version = "4.0.0-dev", path = "../../primitives/beefy", default-features = false }

--- a/frame/beefy-mmr/Cargo.toml
+++ b/frame/beefy-mmr/Cargo.toml
@@ -21,10 +21,10 @@ pallet-mmr = { version = "4.0.0-dev", path = "../merkle-mountain-range", default
 pallet-mmr-primitives = { version = "4.0.0-dev", path = "../merkle-mountain-range/primitives", default-features = false }
 pallet-session = { version = "4.0.0-dev", path = "../session", default-features = false }
 
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core", default-features = false }
+sp-core =  { version = "4.0.0", path = "../../primitives/core", default-features = false }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io", default-features = false }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime", default-features = false }
-sp-std = { version = "4.0.0-dev", path = "../../primitives/std", default-features = false }
+sp-std =  { version = "4.0.0", path = "../../primitives/std", default-features = false }
 
 beefy-merkle-tree = { version = "4.0.0-dev", path = "./primitives", default-features = false }
 beefy-primitives = { version = "4.0.0-dev", path = "../../primitives/beefy", default-features = false }

--- a/frame/beefy/Cargo.toml
+++ b/frame/beefy/Cargo.toml
@@ -16,14 +16,14 @@ frame-support = { version = "4.0.0-dev", path = "../support", default-features =
 frame-system = { version = "4.0.0-dev", path = "../system", default-features = false }
 
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime", default-features = false }
-sp-std =  { version = "4.0.0", path = "../../primitives/std", default-features = false }
+sp-std = { version = "4.0.0", path = "../../primitives/std", default-features = false }
 
 pallet-session = { version = "4.0.0-dev", path = "../session", default-features = false }
 
 beefy-primitives = { version = "4.0.0-dev", path = "../../primitives/beefy", default-features = false }
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 sp-staking = { version = "4.0.0-dev", path = "../../primitives/staking" }
 

--- a/frame/beefy/Cargo.toml
+++ b/frame/beefy/Cargo.toml
@@ -16,14 +16,14 @@ frame-support = { version = "4.0.0-dev", path = "../support", default-features =
 frame-system = { version = "4.0.0-dev", path = "../system", default-features = false }
 
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime", default-features = false }
-sp-std = { version = "4.0.0-dev", path = "../../primitives/std", default-features = false }
+sp-std =  { version = "4.0.0", path = "../../primitives/std", default-features = false }
 
 pallet-session = { version = "4.0.0-dev", path = "../session", default-features = false }
 
 beefy-primitives = { version = "4.0.0-dev", path = "../../primitives/beefy", default-features = false }
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 sp-staking = { version = "4.0.0-dev", path = "../../primitives/staking" }
 

--- a/frame/benchmarking/Cargo.toml
+++ b/frame/benchmarking/Cargo.toml
@@ -18,12 +18,12 @@ paste = "1.0"
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api", default-features = false }
-sp-runtime-interface = { version = "4.0.0-dev", path = "../../primitives/runtime-interface", default-features = false }
+sp-runtime-interface =  { version = "4.0.0", path = "../../primitives/runtime-interface", default-features = false }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime", default-features = false }
-sp-std = { version = "4.0.0-dev", path = "../../primitives/std", default-features = false }
+sp-std =  { version = "4.0.0", path = "../../primitives/std", default-features = false }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io", default-features = false }
 sp-application-crypto = { version = "4.0.0-dev", path = "../../primitives/application-crypto", default-features = false }
-sp-storage = { version = "4.0.0-dev", path = "../../primitives/storage", default-features = false }
+sp-storage =  { version = "4.0.0", path = "../../primitives/storage", default-features = false }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 log = { version = "0.4.14", default-features = false }

--- a/frame/benchmarking/Cargo.toml
+++ b/frame/benchmarking/Cargo.toml
@@ -18,12 +18,12 @@ paste = "1.0"
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api", default-features = false }
-sp-runtime-interface =  { version = "4.0.0", path = "../../primitives/runtime-interface", default-features = false }
+sp-runtime-interface = { version = "4.0.0", path = "../../primitives/runtime-interface", default-features = false }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime", default-features = false }
-sp-std =  { version = "4.0.0", path = "../../primitives/std", default-features = false }
+sp-std = { version = "4.0.0", path = "../../primitives/std", default-features = false }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io", default-features = false }
 sp-application-crypto = { version = "4.0.0-dev", path = "../../primitives/application-crypto", default-features = false }
-sp-storage =  { version = "4.0.0", path = "../../primitives/storage", default-features = false }
+sp-storage = { version = "4.0.0", path = "../../primitives/storage", default-features = false }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 log = { version = "0.4.14", default-features = false }

--- a/frame/bounties/Cargo.toml
+++ b/frame/bounties/Cargo.toml
@@ -17,13 +17,13 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 	"derive",
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 pallet-treasury = { version = "4.0.0-dev", default-features = false, path = "../treasury" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io", default-features = false }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core", default-features = false }
+sp-core =  { version = "4.0.0", path = "../../primitives/core", default-features = false }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 log = { version = "0.4.14", default-features = false }
 

--- a/frame/bounties/Cargo.toml
+++ b/frame/bounties/Cargo.toml
@@ -17,13 +17,13 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 	"derive",
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 pallet-treasury = { version = "4.0.0-dev", default-features = false, path = "../treasury" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io", default-features = false }
-sp-core =  { version = "4.0.0", path = "../../primitives/core", default-features = false }
+sp-core = { version = "4.0.0", path = "../../primitives/core", default-features = false }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 log = { version = "0.4.14", default-features = false }
 

--- a/frame/child-bounties/Cargo.toml
+++ b/frame/child-bounties/Cargo.toml
@@ -17,14 +17,14 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 	"derive",
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 pallet-treasury = { version = "4.0.0-dev", default-features = false, path = "../treasury" }
 pallet-bounties = { version = "4.0.0-dev", default-features = false, path = "../bounties" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io", default-features = false }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core", default-features = false }
+sp-core =  { version = "4.0.0", path = "../../primitives/core", default-features = false }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 log = { version = "0.4.14", default-features = false }
 

--- a/frame/child-bounties/Cargo.toml
+++ b/frame/child-bounties/Cargo.toml
@@ -17,14 +17,14 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 	"derive",
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 pallet-treasury = { version = "4.0.0-dev", default-features = false, path = "../treasury" }
 pallet-bounties = { version = "4.0.0-dev", default-features = false, path = "../bounties" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io", default-features = false }
-sp-core =  { version = "4.0.0", path = "../../primitives/core", default-features = false }
+sp-core = { version = "4.0.0", path = "../../primitives/core", default-features = false }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 log = { version = "0.4.14", default-features = false }
 

--- a/frame/collective/Cargo.toml
+++ b/frame/collective/Cargo.toml
@@ -17,10 +17,10 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 log = { version = "0.4.14", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }

--- a/frame/collective/Cargo.toml
+++ b/frame/collective/Cargo.toml
@@ -17,10 +17,10 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 log = { version = "0.4.14", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -38,11 +38,11 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../su
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 pallet-contracts-primitives = { version = "4.0.0-dev", default-features = false, path = "common" }
 pallet-contracts-proc-macro = { version = "4.0.0-dev", path = "proc-macro" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-sandbox = { version = "0.10.0-dev", default-features = false, path = "../../primitives/sandbox" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 [dev-dependencies]
 assert_matches = "1"

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -38,11 +38,11 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../su
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 pallet-contracts-primitives = { version = "4.0.0-dev", default-features = false, path = "common" }
 pallet-contracts-proc-macro = { version = "4.0.0-dev", path = "proc-macro" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-sandbox = { version = "0.10.0-dev", default-features = false, path = "../../primitives/sandbox" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 [dev-dependencies]
 assert_matches = "1"

--- a/frame/contracts/common/Cargo.toml
+++ b/frame/contracts/common/Cargo.toml
@@ -19,8 +19,8 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 serde = { version = "1", features = ["derive"], optional = true }
 
 # Substrate Dependencies (This crate should not rely on frame)
-sp-core =  { version = "4.0.0", path = "../../../primitives/core", default-features = false }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core", default-features = false }
+sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-rpc = { version = "4.0.0-dev", path = "../../../primitives/rpc", optional = true }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 

--- a/frame/contracts/common/Cargo.toml
+++ b/frame/contracts/common/Cargo.toml
@@ -19,8 +19,8 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 serde = { version = "1", features = ["derive"], optional = true }
 
 # Substrate Dependencies (This crate should not rely on frame)
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core", default-features = false }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core", default-features = false }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-rpc = { version = "4.0.0-dev", path = "../../../primitives/rpc", optional = true }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 

--- a/frame/contracts/rpc/Cargo.toml
+++ b/frame/contracts/rpc/Cargo.toml
@@ -24,7 +24,7 @@ pallet-contracts-primitives = { version = "4.0.0-dev", path = "../common" }
 pallet-contracts-rpc-runtime-api = { version = "4.0.0-dev", path = "./runtime-api" }
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-rpc = { version = "4.0.0-dev", path = "../../../primitives/rpc" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 

--- a/frame/contracts/rpc/Cargo.toml
+++ b/frame/contracts/rpc/Cargo.toml
@@ -24,7 +24,7 @@ pallet-contracts-primitives = { version = "4.0.0-dev", path = "../common" }
 pallet-contracts-rpc-runtime-api = { version = "4.0.0-dev", path = "./runtime-api" }
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-rpc = { version = "4.0.0-dev", path = "../../../primitives/rpc" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 

--- a/frame/contracts/rpc/runtime-api/Cargo.toml
+++ b/frame/contracts/rpc/runtime-api/Cargo.toml
@@ -20,7 +20,7 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 pallet-contracts-primitives = { version = "4.0.0-dev", default-features = false, path = "../../common" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../../../primitives/api" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../../../primitives/std" }
 
 [features]
 default = ["std"]

--- a/frame/contracts/rpc/runtime-api/Cargo.toml
+++ b/frame/contracts/rpc/runtime-api/Cargo.toml
@@ -20,7 +20,7 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 pallet-contracts-primitives = { version = "4.0.0-dev", default-features = false, path = "../../common" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../../../primitives/api" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../../../primitives/std" }
 
 [features]
 default = ["std"]

--- a/frame/democracy/Cargo.toml
+++ b/frame/democracy/Cargo.toml
@@ -18,7 +18,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 	"derive",
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
@@ -26,7 +26,7 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../su
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 pallet-scheduler = { version = "4.0.0-dev", path = "../scheduler" }
 

--- a/frame/democracy/Cargo.toml
+++ b/frame/democracy/Cargo.toml
@@ -18,7 +18,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 	"derive",
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
@@ -26,7 +26,7 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../su
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 pallet-scheduler = { version = "4.0.0-dev", path = "../scheduler" }
 

--- a/frame/election-provider-multi-phase/Cargo.toml
+++ b/frame/election-provider-multi-phase/Cargo.toml
@@ -24,8 +24,8 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../su
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-npos-elections = { version = "4.0.0-dev", default-features = false, path = "../../primitives/npos-elections" }
 sp-arithmetic = { version = "4.0.0-dev", default-features = false, path = "../../primitives/arithmetic" }
@@ -43,10 +43,10 @@ strum_macros = { optional = true, version = "0.22.0" }
 [dev-dependencies]
 parking_lot = "0.11.0"
 rand = { version = "0.7.3" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 sp-npos-elections = { version = "4.0.0-dev", default-features = false, path = "../../primitives/npos-elections" }
-sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../primitives/tracing" }
 frame-election-provider-support = { version = "4.0.0-dev", features = [
 ], path = "../election-provider-support" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }

--- a/frame/election-provider-multi-phase/Cargo.toml
+++ b/frame/election-provider-multi-phase/Cargo.toml
@@ -24,8 +24,8 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../su
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-npos-elections = { version = "4.0.0-dev", default-features = false, path = "../../primitives/npos-elections" }
 sp-arithmetic = { version = "4.0.0-dev", default-features = false, path = "../../primitives/arithmetic" }
@@ -43,10 +43,10 @@ strum_macros = { optional = true, version = "0.22.0" }
 [dev-dependencies]
 parking_lot = "0.11.0"
 rand = { version = "0.7.3" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 sp-npos-elections = { version = "4.0.0-dev", default-features = false, path = "../../primitives/npos-elections" }
-sp-tracing = { version = "4.0.0-dev", path = "../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
 frame-election-provider-support = { version = "4.0.0-dev", features = [
 ], path = "../election-provider-support" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }

--- a/frame/election-provider-support/Cargo.toml
+++ b/frame/election-provider-support/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-arithmetic = { version = "4.0.0-dev", default-features = false, path = "../../primitives/arithmetic" }
 sp-npos-elections = { version = "4.0.0-dev", default-features = false, path = "../../primitives/npos-elections" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
@@ -24,7 +24,7 @@ frame-system = { version = "4.0.0-dev", default-features = false, path = "../sys
 [dev-dependencies]
 sp-npos-elections = { version = "4.0.0-dev", path = "../../primitives/npos-elections" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 
 [features]

--- a/frame/election-provider-support/Cargo.toml
+++ b/frame/election-provider-support/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-arithmetic = { version = "4.0.0-dev", default-features = false, path = "../../primitives/arithmetic" }
 sp-npos-elections = { version = "4.0.0-dev", default-features = false, path = "../../primitives/npos-elections" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
@@ -24,7 +24,7 @@ frame-system = { version = "4.0.0-dev", default-features = false, path = "../sys
 [dev-dependencies]
 sp-npos-elections = { version = "4.0.0-dev", path = "../../primitives/npos-elections" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 
 [features]

--- a/frame/elections-phragmen/Cargo.toml
+++ b/frame/elections-phragmen/Cargo.toml
@@ -22,14 +22,14 @@ sp-npos-elections = { version = "4.0.0-dev", default-features = false, path = ".
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 log = { version = "0.4.14", default-features = false }
 
 [dev-dependencies]
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 substrate-test-utils = { version = "4.0.0-dev", path = "../../test-utils" }
 
 [features]

--- a/frame/elections-phragmen/Cargo.toml
+++ b/frame/elections-phragmen/Cargo.toml
@@ -22,14 +22,14 @@ sp-npos-elections = { version = "4.0.0-dev", default-features = false, path = ".
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 log = { version = "0.4.14", default-features = false }
 
 [dev-dependencies]
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 substrate-test-utils = { version = "4.0.0-dev", path = "../../test-utils" }
 
 [features]

--- a/frame/elections/Cargo.toml
+++ b/frame/elections/Cargo.toml
@@ -17,8 +17,8 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 	"derive",
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }

--- a/frame/elections/Cargo.toml
+++ b/frame/elections/Cargo.toml
@@ -17,8 +17,8 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 	"derive",
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }

--- a/frame/examples/basic/Cargo.toml
+++ b/frame/examples/basic/Cargo.toml
@@ -23,10 +23,10 @@ frame-system = { version = "4.0.0-dev", default-features = false, path = "../../
 pallet-balances = { version = "4.0.0-dev", default-features = false, path = "../../balances" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core", default-features = false }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/examples/basic/Cargo.toml
+++ b/frame/examples/basic/Cargo.toml
@@ -23,10 +23,10 @@ frame-system = { version = "4.0.0-dev", default-features = false, path = "../../
 pallet-balances = { version = "4.0.0-dev", default-features = false, path = "../../balances" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", path = "../../../primitives/core", default-features = false }
+sp-core = { version = "4.0.0", path = "../../../primitives/core", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/examples/offchain-worker/Cargo.toml
+++ b/frame/examples/offchain-worker/Cargo.toml
@@ -20,11 +20,11 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/io" }
 sp-keystore = { version = "0.10.0-dev", path = "../../../primitives/keystore", optional = true }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 
 [features]
 default = ["std"]

--- a/frame/examples/offchain-worker/Cargo.toml
+++ b/frame/examples/offchain-worker/Cargo.toml
@@ -20,11 +20,11 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/io" }
 sp-keystore = { version = "0.10.0-dev", path = "../../../primitives/keystore", optional = true }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 
 [features]
 default = ["std"]

--- a/frame/examples/parallel/Cargo.toml
+++ b/frame/examples/parallel/Cargo.toml
@@ -17,10 +17,10 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-tasks = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/tasks" }
 
 [features]

--- a/frame/examples/parallel/Cargo.toml
+++ b/frame/examples/parallel/Cargo.toml
@@ -17,10 +17,10 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-tasks = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/tasks" }
 
 [features]

--- a/frame/executive/Cargo.toml
+++ b/frame/executive/Cargo.toml
@@ -20,14 +20,14 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-tracing = { version = "4.0.0-dev", default-features = false, path = "../../primitives/tracing" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-tracing =  { version = "4.0.0", default-features = false, path = "../../primitives/tracing" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 
 [dev-dependencies]
 hex-literal = "0.3.4"
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 pallet-transaction-payment = { version = "4.0.0-dev", path = "../transaction-payment" }

--- a/frame/executive/Cargo.toml
+++ b/frame/executive/Cargo.toml
@@ -20,14 +20,14 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-tracing =  { version = "4.0.0", default-features = false, path = "../../primitives/tracing" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-tracing = { version = "4.0.0", default-features = false, path = "../../primitives/tracing" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 
 [dev-dependencies]
 hex-literal = "0.3.4"
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 pallet-transaction-payment = { version = "4.0.0-dev", path = "../transaction-payment" }

--- a/frame/gilt/Cargo.toml
+++ b/frame/gilt/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-arithmetic = { version = "4.0.0-dev", default-features = false, path = "../../primitives/arithmetic" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
@@ -24,7 +24,7 @@ frame-system = { version = "4.0.0-dev", default-features = false, path = "../sys
 
 [dev-dependencies]
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 
 [features]

--- a/frame/gilt/Cargo.toml
+++ b/frame/gilt/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-arithmetic = { version = "4.0.0-dev", default-features = false, path = "../../primitives/arithmetic" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
@@ -24,7 +24,7 @@ frame-system = { version = "4.0.0-dev", default-features = false, path = "../sys
 
 [dev-dependencies]
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 
 [features]

--- a/frame/grandpa/Cargo.toml
+++ b/frame/grandpa/Cargo.toml
@@ -16,11 +16,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../../primitives/application-crypto" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-finality-grandpa = { version = "4.0.0-dev", default-features = false, path = "../../primitives/finality-grandpa" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-session = { version = "4.0.0-dev", default-features = false, path = "../../primitives/session" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../primitives/staking" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }

--- a/frame/grandpa/Cargo.toml
+++ b/frame/grandpa/Cargo.toml
@@ -16,11 +16,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../../primitives/application-crypto" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-finality-grandpa = { version = "4.0.0-dev", default-features = false, path = "../../primitives/finality-grandpa" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-session = { version = "4.0.0-dev", default-features = false, path = "../../primitives/session" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../primitives/staking" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }

--- a/frame/identity/Cargo.toml
+++ b/frame/identity/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 enumflags2 = { version = "0.6.2" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
@@ -24,7 +24,7 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../su
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 
 [features]

--- a/frame/identity/Cargo.toml
+++ b/frame/identity/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 enumflags2 = { version = "0.6.2" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
@@ -24,7 +24,7 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../su
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 
 [features]

--- a/frame/im-online/Cargo.toml
+++ b/frame/im-online/Cargo.toml
@@ -17,8 +17,8 @@ sp-application-crypto = { version = "4.0.0-dev", default-features = false, path 
 pallet-authorship = { version = "4.0.0-dev", default-features = false, path = "../authorship" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../primitives/staking" }

--- a/frame/im-online/Cargo.toml
+++ b/frame/im-online/Cargo.toml
@@ -17,8 +17,8 @@ sp-application-crypto = { version = "4.0.0-dev", default-features = false, path 
 pallet-authorship = { version = "4.0.0-dev", default-features = false, path = "../authorship" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../primitives/staking" }

--- a/frame/indices/Cargo.toml
+++ b/frame/indices/Cargo.toml
@@ -16,10 +16,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-keyring = { version = "4.0.0-dev", optional = true, path = "../../primitives/keyring" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 

--- a/frame/indices/Cargo.toml
+++ b/frame/indices/Cargo.toml
@@ -16,10 +16,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-keyring = { version = "4.0.0-dev", optional = true, path = "../../primitives/keyring" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 

--- a/frame/lottery/Cargo.toml
+++ b/frame/lottery/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 	"derive",
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
@@ -27,7 +27,7 @@ frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "
 [dev-dependencies]
 frame-support-test = { version = "3.0.0", path = "../support/test" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 
 [features]

--- a/frame/lottery/Cargo.toml
+++ b/frame/lottery/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 	"derive",
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
@@ -27,7 +27,7 @@ frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "
 [dev-dependencies]
 frame-support-test = { version = "3.0.0", path = "../support/test" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 
 [features]

--- a/frame/membership/Cargo.toml
+++ b/frame/membership/Cargo.toml
@@ -17,10 +17,10 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.0", default-features = false }
 
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }

--- a/frame/membership/Cargo.toml
+++ b/frame/membership/Cargo.toml
@@ -17,10 +17,10 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.0", default-features = false }
 
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }

--- a/frame/merkle-mountain-range/Cargo.toml
+++ b/frame/merkle-mountain-range/Cargo.toml
@@ -16,10 +16,10 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 mmr-lib = { package = "ckb-merkle-mountain-range", default-features = false, version = "0.3.2" }
 
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }

--- a/frame/merkle-mountain-range/Cargo.toml
+++ b/frame/merkle-mountain-range/Cargo.toml
@@ -16,10 +16,10 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 mmr-lib = { package = "ckb-merkle-mountain-range", default-features = false, version = "0.3.2" }
 
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }

--- a/frame/merkle-mountain-range/primitives/Cargo.toml
+++ b/frame/merkle-mountain-range/primitives/Cargo.toml
@@ -17,9 +17,9 @@ log = { version = "0.4.14", default-features = false }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/api" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system" }

--- a/frame/merkle-mountain-range/primitives/Cargo.toml
+++ b/frame/merkle-mountain-range/primitives/Cargo.toml
@@ -17,9 +17,9 @@ log = { version = "0.4.14", default-features = false }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/api" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system" }

--- a/frame/merkle-mountain-range/rpc/Cargo.toml
+++ b/frame/merkle-mountain-range/rpc/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.126", features = ["derive"] }
 
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 
 pallet-mmr-primitives = { version = "4.0.0-dev", path = "../primitives" }

--- a/frame/merkle-mountain-range/rpc/Cargo.toml
+++ b/frame/merkle-mountain-range/rpc/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.126", features = ["derive"] }
 
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 
 pallet-mmr-primitives = { version = "4.0.0-dev", path = "../primitives" }

--- a/frame/multisig/Cargo.toml
+++ b/frame/multisig/Cargo.toml
@@ -18,13 +18,13 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 
 [features]

--- a/frame/multisig/Cargo.toml
+++ b/frame/multisig/Cargo.toml
@@ -18,13 +18,13 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 
 [features]

--- a/frame/nicks/Cargo.toml
+++ b/frame/nicks/Cargo.toml
@@ -15,14 +15,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 
 [features]

--- a/frame/nicks/Cargo.toml
+++ b/frame/nicks/Cargo.toml
@@ -15,14 +15,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 
 [features]

--- a/frame/node-authorization/Cargo.toml
+++ b/frame/node-authorization/Cargo.toml
@@ -16,10 +16,10 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 log = { version = "0.4.14", default-features = false }
 
 [features]

--- a/frame/node-authorization/Cargo.toml
+++ b/frame/node-authorization/Cargo.toml
@@ -16,10 +16,10 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 log = { version = "0.4.14", default-features = false }
 
 [features]

--- a/frame/offences/Cargo.toml
+++ b/frame/offences/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 pallet-balances = { version = "4.0.0-dev", default-features = false, path = "../balances" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 serde = { version = "1.0.126", optional = true }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../primitives/staking" }
@@ -26,7 +26,7 @@ log = { version = "0.4.14", default-features = false }
 
 [dev-dependencies]
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/offences/Cargo.toml
+++ b/frame/offences/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 pallet-balances = { version = "4.0.0-dev", default-features = false, path = "../balances" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 serde = { version = "1.0.126", optional = true }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../primitives/staking" }
@@ -26,7 +26,7 @@ log = { version = "0.4.14", default-features = false }
 
 [dev-dependencies]
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/offences/benchmarking/Cargo.toml
+++ b/frame/offences/benchmarking/Cargo.toml
@@ -31,13 +31,13 @@ pallet-staking = { version = "4.0.0-dev", default-features = false, features = [
 ], path = "../../staking" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/staking" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 frame-election-provider-support = { version = "4.0.0-dev", default-features = false, path = "../../election-provider-support" }
 
 [dev-dependencies]
 pallet-staking-reward-curve = { version = "4.0.0-dev", path = "../../staking/reward-curve" }
 pallet-timestamp = { version = "4.0.0-dev", path = "../../timestamp" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../../primitives/io" }
 
 [features]

--- a/frame/offences/benchmarking/Cargo.toml
+++ b/frame/offences/benchmarking/Cargo.toml
@@ -31,13 +31,13 @@ pallet-staking = { version = "4.0.0-dev", default-features = false, features = [
 ], path = "../../staking" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/staking" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 frame-election-provider-support = { version = "4.0.0-dev", default-features = false, path = "../../election-provider-support" }
 
 [dev-dependencies]
 pallet-staking-reward-curve = { version = "4.0.0-dev", path = "../../staking/reward-curve" }
 pallet-timestamp = { version = "4.0.0-dev", path = "../../timestamp" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../../primitives/io" }
 
 [features]

--- a/frame/proxy/Cargo.toml
+++ b/frame/proxy/Cargo.toml
@@ -19,12 +19,12 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../su
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 pallet-utility = { version = "4.0.0-dev", path = "../utility" }
 

--- a/frame/proxy/Cargo.toml
+++ b/frame/proxy/Cargo.toml
@@ -19,12 +19,12 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../su
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 pallet-utility = { version = "4.0.0-dev", path = "../utility" }
 

--- a/frame/randomness-collective-flip/Cargo.toml
+++ b/frame/randomness-collective-flip/Cargo.toml
@@ -17,13 +17,13 @@ safe-mix = { version = "1.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 
 [features]

--- a/frame/randomness-collective-flip/Cargo.toml
+++ b/frame/randomness-collective-flip/Cargo.toml
@@ -17,13 +17,13 @@ safe-mix = { version = "1.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 
 [features]

--- a/frame/recovery/Cargo.toml
+++ b/frame/recovery/Cargo.toml
@@ -15,14 +15,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 
 [features]

--- a/frame/recovery/Cargo.toml
+++ b/frame/recovery/Cargo.toml
@@ -15,14 +15,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 
 [features]

--- a/frame/scheduler/Cargo.toml
+++ b/frame/scheduler/Cargo.toml
@@ -15,14 +15,14 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 log = { version = "0.4.14", default-features = false }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core", default-features = false }
+sp-core =  { version = "4.0.0", path = "../../primitives/core", default-features = false }
 substrate-test-utils = { version = "4.0.0-dev", path = "../../test-utils" }
 
 [features]

--- a/frame/scheduler/Cargo.toml
+++ b/frame/scheduler/Cargo.toml
@@ -15,14 +15,14 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 log = { version = "0.4.14", default-features = false }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", path = "../../primitives/core", default-features = false }
+sp-core = { version = "4.0.0", path = "../../primitives/core", default-features = false }
 substrate-test-utils = { version = "4.0.0-dev", path = "../../test-utils" }
 
 [features]

--- a/frame/scored-pool/Cargo.toml
+++ b/frame/scored-pool/Cargo.toml
@@ -17,13 +17,13 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/scored-pool/Cargo.toml
+++ b/frame/scored-pool/Cargo.toml
@@ -17,13 +17,13 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/session/Cargo.toml
+++ b/frame/session/Cargo.toml
@@ -19,8 +19,8 @@ impl-trait-for-tuples = "0.2.1"
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-session = { version = "4.0.0-dev", default-features = false, path = "../../primitives/session" }

--- a/frame/session/Cargo.toml
+++ b/frame/session/Cargo.toml
@@ -19,8 +19,8 @@ impl-trait-for-tuples = "0.2.1"
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-session = { version = "4.0.0-dev", default-features = false, path = "../../primitives/session" }

--- a/frame/session/benchmarking/Cargo.toml
+++ b/frame/session/benchmarking/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 rand = { version = "0.7.2", default-features = false }
 
-sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 sp-session = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/session" }
 
@@ -28,7 +28,7 @@ pallet-staking = { version = "4.0.0-dev", default-features = false, features = [
 [dev-dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
 scale-info = "1.0"
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../../primitives/io" }
 pallet-balances = { version = "4.0.0-dev", path = "../../balances" }
 pallet-timestamp = { version = "4.0.0-dev", path = "../../timestamp" }

--- a/frame/session/benchmarking/Cargo.toml
+++ b/frame/session/benchmarking/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 rand = { version = "0.7.2", default-features = false }
 
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 sp-session = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/session" }
 
@@ -28,7 +28,7 @@ pallet-staking = { version = "4.0.0-dev", default-features = false, features = [
 [dev-dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
 scale-info = "1.0"
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../../primitives/io" }
 pallet-balances = { version = "4.0.0-dev", path = "../../balances" }
 pallet-timestamp = { version = "4.0.0-dev", path = "../../timestamp" }

--- a/frame/society/Cargo.toml
+++ b/frame/society/Cargo.toml
@@ -16,13 +16,13 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 rand_chacha = { version = "0.2", default-features = false }
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-io ={ version = "4.0.0-dev", path = "../../primitives/io" }
 frame-support-test = { version = "3.0.0", path = "../support/test" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }

--- a/frame/society/Cargo.toml
+++ b/frame/society/Cargo.toml
@@ -16,13 +16,13 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 rand_chacha = { version = "0.2", default-features = false }
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-io ={ version = "4.0.0-dev", path = "../../primitives/io" }
 frame-support-test = { version = "3.0.0", path = "../support/test" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }

--- a/frame/staking/Cargo.toml
+++ b/frame/staking/Cargo.toml
@@ -18,7 +18,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 	"derive",
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../primitives/staking" }
@@ -37,8 +37,8 @@ frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "
 rand_chacha = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
-sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-tracing = { version = "4.0.0", path = "../../primitives/tracing" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-npos-elections = { version = "4.0.0-dev", path = "../../primitives/npos-elections" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 pallet-timestamp = { version = "4.0.0-dev", path = "../timestamp" }

--- a/frame/staking/Cargo.toml
+++ b/frame/staking/Cargo.toml
@@ -18,7 +18,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 	"derive",
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../primitives/staking" }
@@ -37,8 +37,8 @@ frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "
 rand_chacha = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
-sp-tracing = { version = "4.0.0-dev", path = "../../primitives/tracing" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-npos-elections = { version = "4.0.0-dev", path = "../../primitives/npos-elections" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 pallet-timestamp = { version = "4.0.0-dev", path = "../timestamp" }

--- a/frame/sudo/Cargo.toml
+++ b/frame/sudo/Cargo.toml
@@ -15,14 +15,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/sudo/Cargo.toml
+++ b/frame/sudo/Cargo.toml
@@ -15,14 +15,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -17,11 +17,11 @@ serde = { version = "1.0.126", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 frame-metadata = { version = "14.0.0", default-features = false, features = ["v14"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-tracing = { version = "4.0.0-dev", default-features = false, path = "../../primitives/tracing" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-tracing =  { version = "4.0.0", default-features = false, path = "../../primitives/tracing" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-arithmetic = { version = "4.0.0-dev", default-features = false, path = "../../primitives/arithmetic" }
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../../primitives/inherents" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../primitives/staking" }

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -17,11 +17,11 @@ serde = { version = "1.0.126", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 frame-metadata = { version = "14.0.0", default-features = false, features = ["v14"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-tracing =  { version = "4.0.0", default-features = false, path = "../../primitives/tracing" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-tracing = { version = "4.0.0", default-features = false, path = "../../primitives/tracing" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-arithmetic = { version = "4.0.0-dev", default-features = false, path = "../../primitives/arithmetic" }
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../../primitives/inherents" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../primitives/staking" }

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -20,8 +20,8 @@ sp-io = { version = "4.0.0-dev", path = "../../../primitives/io", default-featur
 sp-state-machine = { version = "0.10.0-dev", optional = true, path = "../../../primitives/state-machine" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-version = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/version" }
 trybuild = "1.0.52"
 pretty_assertions = "1.0.0"

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -20,8 +20,8 @@ sp-io = { version = "4.0.0-dev", path = "../../../primitives/io", default-featur
 sp-state-machine = { version = "0.10.0-dev", optional = true, path = "../../../primitives/state-machine" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/core" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-version = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/version" }
 trybuild = "1.0.52"
 pretty_assertions = "1.0.0"

--- a/frame/support/test/compile_pass/Cargo.toml
+++ b/frame/support/test/compile_pass/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../../primitives/runtime" }
 sp-version = { version = "4.0.0-dev", default-features = false, path = "../../../../primitives/version" }
 support = { package = "frame-support", version = "4.0.0-dev", default-features = false, path = "../../" }

--- a/frame/support/test/compile_pass/Cargo.toml
+++ b/frame/support/test/compile_pass/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../../primitives/runtime" }
 sp-version = { version = "4.0.0-dev", default-features = false, path = "../../../../primitives/version" }
 support = { package = "frame-support", version = "4.0.0-dev", default-features = false, path = "../../" }

--- a/frame/system/Cargo.toml
+++ b/frame/system/Cargo.toml
@@ -16,8 +16,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io", default-features = false }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-version = { version = "4.0.0-dev", default-features = false, path = "../../primitives/version" }
@@ -26,7 +26,7 @@ log = { version = "0.4.14", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.3"
-sp-externalities = { version = "0.10.0-dev", path = "../../primitives/externalities" }
+sp-externalities =  { version = "0.10.0", path = "../../primitives/externalities" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }
 
 [features]

--- a/frame/system/Cargo.toml
+++ b/frame/system/Cargo.toml
@@ -16,8 +16,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io", default-features = false }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-version = { version = "4.0.0-dev", default-features = false, path = "../../primitives/version" }
@@ -26,7 +26,7 @@ log = { version = "0.4.14", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.3"
-sp-externalities =  { version = "0.10.0", path = "../../primitives/externalities" }
+sp-externalities = { version = "0.10.0", path = "../../primitives/externalities" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }
 
 [features]

--- a/frame/system/benchmarking/Cargo.toml
+++ b/frame/system/benchmarking/Cargo.toml
@@ -15,12 +15,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../../benchmarking" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../../support" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
 
 [dev-dependencies]
 sp-io = { version = "4.0.0-dev", path = "../../../primitives/io" }

--- a/frame/system/benchmarking/Cargo.toml
+++ b/frame/system/benchmarking/Cargo.toml
@@ -15,12 +15,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../../benchmarking" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../../support" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
 
 [dev-dependencies]
 sp-io = { version = "4.0.0-dev", path = "../../../primitives/io" }

--- a/frame/timestamp/Cargo.toml
+++ b/frame/timestamp/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io", optional = true }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../../primitives/inherents" }
@@ -29,7 +29,7 @@ log = { version = "0.4.14", default-features = false }
 
 [dev-dependencies]
 sp-io ={ version = "4.0.0-dev", path = "../../primitives/io" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/timestamp/Cargo.toml
+++ b/frame/timestamp/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io", optional = true }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../../primitives/inherents" }
@@ -29,7 +29,7 @@ log = { version = "0.4.14", default-features = false }
 
 [dev-dependencies]
 sp-io ={ version = "4.0.0-dev", path = "../../primitives/io" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/tips/Cargo.toml
+++ b/frame/tips/Cargo.toml
@@ -18,10 +18,10 @@ log = { version = "0.4.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.126", features = ["derive"], optional = true }
 
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
@@ -30,7 +30,7 @@ pallet-treasury = { version = "4.0.0-dev", default-features = false, path = "../
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-storage =  { version = "4.0.0", path = "../../primitives/storage" }
+sp-storage = { version = "4.0.0", path = "../../primitives/storage" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 
 [features]

--- a/frame/tips/Cargo.toml
+++ b/frame/tips/Cargo.toml
@@ -18,10 +18,10 @@ log = { version = "0.4.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.126", features = ["derive"], optional = true }
 
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
@@ -30,7 +30,7 @@ pallet-treasury = { version = "4.0.0-dev", default-features = false, path = "../
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-storage = { version = "4.0.0-dev", path = "../../primitives/storage" }
+sp-storage =  { version = "4.0.0", path = "../../primitives/storage" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 
 [features]

--- a/frame/transaction-payment/Cargo.toml
+++ b/frame/transaction-payment/Cargo.toml
@@ -20,10 +20,10 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 serde = { version = "1.0.126", optional = true }
 smallvec = "1.7.0"
 
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core", default-features = false }
+sp-core =  { version = "4.0.0", path = "../../primitives/core", default-features = false }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io", default-features = false }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }

--- a/frame/transaction-payment/Cargo.toml
+++ b/frame/transaction-payment/Cargo.toml
@@ -20,10 +20,10 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 serde = { version = "1.0.126", optional = true }
 smallvec = "1.7.0"
 
-sp-core =  { version = "4.0.0", path = "../../primitives/core", default-features = false }
+sp-core = { version = "4.0.0", path = "../../primitives/core", default-features = false }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io", default-features = false }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }

--- a/frame/transaction-payment/asset-tx-payment/Cargo.toml
+++ b/frame/transaction-payment/asset-tx-payment/Cargo.toml
@@ -14,10 +14,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # Substrate dependencies
-sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system" }
@@ -32,7 +32,7 @@ serde = { version = "1.0.126", optional = true }
 smallvec = "1.7.0"
 serde_json = "1.0.71"
 
-sp-storage =  { version = "4.0.0", default-features = false, path = "../../../primitives/storage" }
+sp-storage = { version = "4.0.0", default-features = false, path = "../../../primitives/storage" }
 
 pallet-assets = { version = "4.0.0-dev", path = "../../assets" }
 pallet-authorship = { version = "4.0.0-dev", path = "../../authorship" }

--- a/frame/transaction-payment/asset-tx-payment/Cargo.toml
+++ b/frame/transaction-payment/asset-tx-payment/Cargo.toml
@@ -14,10 +14,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # Substrate dependencies
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../../primitives/core" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/io" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system" }
@@ -32,7 +32,7 @@ serde = { version = "1.0.126", optional = true }
 smallvec = "1.7.0"
 serde_json = "1.0.71"
 
-sp-storage = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/storage" }
+sp-storage =  { version = "4.0.0", default-features = false, path = "../../../primitives/storage" }
 
 pallet-assets = { version = "4.0.0-dev", path = "../../assets" }
 pallet-authorship = { version = "4.0.0-dev", path = "../../authorship" }

--- a/frame/transaction-payment/rpc/Cargo.toml
+++ b/frame/transaction-payment/rpc/Cargo.toml
@@ -20,7 +20,7 @@ jsonrpc-derive = "18.0.0"
 
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-rpc = { version = "4.0.0-dev", path = "../../../primitives/rpc" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", path = "./runtime-api" }

--- a/frame/transaction-payment/rpc/Cargo.toml
+++ b/frame/transaction-payment/rpc/Cargo.toml
@@ -20,7 +20,7 @@ jsonrpc-derive = "18.0.0"
 
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-rpc = { version = "4.0.0-dev", path = "../../../primitives/rpc" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", path = "./runtime-api" }

--- a/frame/transaction-storage/Cargo.toml
+++ b/frame/transaction-storage/Cargo.toml
@@ -21,7 +21,7 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../su
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 pallet-balances = { version = "4.0.0-dev", default-features = false, path = "../balances" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../../primitives/inherents" }
 sp-transaction-storage-proof = { version = "4.0.0-dev", default-features = false, path = "../../primitives/transaction-storage-proof" }
@@ -29,7 +29,7 @@ frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "
 
 [dev-dependencies]
 sp-transaction-storage-proof = { version = "4.0.0-dev", default-features = true, path = "../../primitives/transaction-storage-proof" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core", default-features = false }
+sp-core = { version = "4.0.0", path = "../../primitives/core", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/transaction-storage/Cargo.toml
+++ b/frame/transaction-storage/Cargo.toml
@@ -21,7 +21,7 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../su
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 pallet-balances = { version = "4.0.0-dev", default-features = false, path = "../balances" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../../primitives/inherents" }
 sp-transaction-storage-proof = { version = "4.0.0-dev", default-features = false, path = "../../primitives/transaction-storage-proof" }
@@ -29,7 +29,7 @@ frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "
 
 [dev-dependencies]
 sp-transaction-storage-proof = { version = "4.0.0-dev", default-features = true, path = "../../primitives/transaction-storage-proof" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core", default-features = false }
+sp-core =  { version = "4.0.0", path = "../../primitives/core", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/treasury/Cargo.toml
+++ b/frame/treasury/Cargo.toml
@@ -21,7 +21,7 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 serde = { version = "1.0.126", features = ["derive"], optional = true }
 impl-trait-for-tuples = "0.2.1"
 
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
@@ -32,7 +32,7 @@ pallet-balances = { version = "4.0.0-dev", default-features = false, path = "../
 
 [dev-dependencies]
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/treasury/Cargo.toml
+++ b/frame/treasury/Cargo.toml
@@ -21,7 +21,7 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 serde = { version = "1.0.126", features = ["derive"], optional = true }
 impl-trait-for-tuples = "0.2.1"
 
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
@@ -32,7 +32,7 @@ pallet-balances = { version = "4.0.0-dev", default-features = false, path = "../
 
 [dev-dependencies]
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/try-runtime/Cargo.toml
+++ b/frame/try-runtime/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api", default-features = false }
-sp-std = { version = "4.0.0-dev", path = "../../primitives/std" , default-features = false }
+sp-std =  { version = "4.0.0", path = "../../primitives/std" , default-features = false }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" , default-features = false }
 
 frame-support = { version = "4.0.0-dev", path = "../support", default-features = false }

--- a/frame/try-runtime/Cargo.toml
+++ b/frame/try-runtime/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api", default-features = false }
-sp-std =  { version = "4.0.0", path = "../../primitives/std" , default-features = false }
+sp-std = { version = "4.0.0", path = "../../primitives/std" , default-features = false }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" , default-features = false }
 
 frame-support = { version = "4.0.0-dev", path = "../support", default-features = false }

--- a/frame/uniques/Cargo.toml
+++ b/frame/uniques/Cargo.toml
@@ -15,15 +15,15 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-std = { version = "4.0.0-dev", path = "../../primitives/std" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-std =  { version = "4.0.0", path = "../../primitives/std" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 

--- a/frame/uniques/Cargo.toml
+++ b/frame/uniques/Cargo.toml
@@ -15,15 +15,15 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-std =  { version = "4.0.0", path = "../../primitives/std" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-std = { version = "4.0.0", path = "../../primitives/std" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../primitives/io" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 

--- a/frame/utility/Cargo.toml
+++ b/frame/utility/Cargo.toml
@@ -17,15 +17,15 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 
 [features]

--- a/frame/utility/Cargo.toml
+++ b/frame/utility/Cargo.toml
@@ -17,15 +17,15 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 
 [features]

--- a/frame/vesting/Cargo.toml
+++ b/frame/vesting/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 	"derive",
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
@@ -26,7 +26,7 @@ log = { version = "0.4.0", default-features = false  }
 
 [dev-dependencies]
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 
 [features]

--- a/frame/vesting/Cargo.toml
+++ b/frame/vesting/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 	"derive",
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
@@ -26,7 +26,7 @@ log = { version = "0.4.0", default-features = false  }
 
 [dev-dependencies]
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 
 [features]

--- a/primitives/api/Cargo.toml
+++ b/primitives/api/Cargo.toml
@@ -15,8 +15,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-api-proc-macro = { version = "4.0.0-dev", path = "proc-macro" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-core = { version = "4.0.0", default-features = false, path = "../core" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
 sp-version = { version = "4.0.0-dev", default-features = false, path = "../version" }
 sp-state-machine = { version = "0.10.0-dev", optional = true, path = "../state-machine" }

--- a/primitives/api/Cargo.toml
+++ b/primitives/api/Cargo.toml
@@ -15,8 +15,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-api-proc-macro = { version = "4.0.0-dev", path = "proc-macro" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
 sp-version = { version = "4.0.0-dev", default-features = false, path = "../version" }
 sp-state-machine = { version = "0.10.0-dev", optional = true, path = "../state-machine" }

--- a/primitives/api/test/Cargo.toml
+++ b/primitives/api/test/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 sp-api = { version = "4.0.0-dev", path = "../" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }
 sp-version = { version = "4.0.0-dev", path = "../../version" }
-sp-tracing = { version = "4.0.0-dev", path = "../../tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../tracing" }
 sp-runtime = { version = "4.0.0-dev", path = "../../runtime" }
 sp-consensus = { version = "0.10.0-dev", path = "../../consensus/common" }
 sc-block-builder = { version = "0.10.0-dev", path = "../../../client/block-builder" }
@@ -28,7 +28,7 @@ rustversion = "1.0.5"
 criterion = "0.3.0"
 futures = "0.3.9"
 log = "0.4.14"
-sp-core = { version = "4.0.0-dev", path = "../../core" }
+sp-core =  { version = "4.0.0", path = "../../core" }
 
 [[bench]]
 name = "bench"

--- a/primitives/api/test/Cargo.toml
+++ b/primitives/api/test/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 sp-api = { version = "4.0.0-dev", path = "../" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }
 sp-version = { version = "4.0.0-dev", path = "../../version" }
-sp-tracing =  { version = "4.0.0", path = "../../tracing" }
+sp-tracing = { version = "4.0.0", path = "../../tracing" }
 sp-runtime = { version = "4.0.0-dev", path = "../../runtime" }
 sp-consensus = { version = "0.10.0-dev", path = "../../consensus/common" }
 sc-block-builder = { version = "0.10.0-dev", path = "../../../client/block-builder" }
@@ -28,7 +28,7 @@ rustversion = "1.0.5"
 criterion = "0.3.0"
 futures = "0.3.9"
 log = "0.4.14"
-sp-core =  { version = "4.0.0", path = "../../core" }
+sp-core = { version = "4.0.0", path = "../../core" }
 
 [[bench]]
 name = "bench"

--- a/primitives/application-crypto/Cargo.toml
+++ b/primitives/application-crypto/Cargo.toml
@@ -15,11 +15,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 
 [dependencies]
-sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../core" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../io" }
 
 [features]

--- a/primitives/application-crypto/Cargo.toml
+++ b/primitives/application-crypto/Cargo.toml
@@ -15,11 +15,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 
 [dependencies]
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../io" }
 
 [features]

--- a/primitives/application-crypto/test/Cargo.toml
+++ b/primitives/application-crypto/test/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../keystore", default-features = false }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }
 sp-runtime = { version = "4.0.0-dev", path = "../../runtime" }

--- a/primitives/application-crypto/test/Cargo.toml
+++ b/primitives/application-crypto/test/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-core =  { version = "4.0.0", default-features = false, path = "../../core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../keystore", default-features = false }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }
 sp-runtime = { version = "4.0.0-dev", path = "../../runtime" }

--- a/primitives/arithmetic/Cargo.toml
+++ b/primitives/arithmetic/Cargo.toml
@@ -22,9 +22,9 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 integer-sqrt = "0.1.2"
 static_assertions = "1.1.0"
 num-traits = { version = "0.2.8", default-features = false }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
-sp-debug-derive =  { version = "4.0.0", default-features = false, path = "../debug-derive" }
+sp-debug-derive = { version = "4.0.0", default-features = false, path = "../debug-derive" }
 
 [dev-dependencies]
 rand = "0.7.2"

--- a/primitives/arithmetic/Cargo.toml
+++ b/primitives/arithmetic/Cargo.toml
@@ -22,9 +22,9 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 integer-sqrt = "0.1.2"
 static_assertions = "1.1.0"
 num-traits = { version = "0.2.8", default-features = false }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
-sp-debug-derive = { version = "4.0.0-dev", default-features = false, path = "../debug-derive" }
+sp-debug-derive =  { version = "4.0.0", default-features = false, path = "../debug-derive" }
 
 [dev-dependencies]
 rand = "0.7.2"

--- a/primitives/authority-discovery/Cargo.toml
+++ b/primitives/authority-discovery/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../application-crypto" }
 codec = { package = "parity-scale-codec", default-features = false, version = "2.0.0" }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
 

--- a/primitives/authority-discovery/Cargo.toml
+++ b/primitives/authority-discovery/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../application-crypto" }
 codec = { package = "parity-scale-codec", default-features = false, version = "2.0.0" }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
 

--- a/primitives/authorship/Cargo.toml
+++ b/primitives/authorship/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../inherents" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 async-trait = { version = "0.1.50", optional = true }
 

--- a/primitives/authorship/Cargo.toml
+++ b/primitives/authorship/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../inherents" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 async-trait = { version = "0.1.50", optional = true }
 

--- a/primitives/beefy/Cargo.toml
+++ b/primitives/beefy/Cargo.toml
@@ -13,9 +13,9 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 
 sp-api = { version = "4.0.0-dev", path = "../api", default-features = false }
 sp-application-crypto = { version = "4.0.0-dev", path = "../application-crypto", default-features = false }
-sp-core = { version = "4.0.0-dev", path = "../core", default-features = false }
+sp-core =  { version = "4.0.0", path = "../core", default-features = false }
 sp-runtime = { version = "4.0.0-dev", path = "../runtime", default-features = false }
-sp-std = { version = "4.0.0-dev", path = "../std", default-features = false }
+sp-std =  { version = "4.0.0", path = "../std", default-features = false }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/primitives/beefy/Cargo.toml
+++ b/primitives/beefy/Cargo.toml
@@ -13,9 +13,9 @@ scale-info = { version = "1.0", default-features = false, features = ["derive"] 
 
 sp-api = { version = "4.0.0-dev", path = "../api", default-features = false }
 sp-application-crypto = { version = "4.0.0-dev", path = "../application-crypto", default-features = false }
-sp-core =  { version = "4.0.0", path = "../core", default-features = false }
+sp-core = { version = "4.0.0", path = "../core", default-features = false }
 sp-runtime = { version = "4.0.0-dev", path = "../runtime", default-features = false }
-sp-std =  { version = "4.0.0", path = "../std", default-features = false }
+sp-std = { version = "4.0.0", path = "../std", default-features = false }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/primitives/block-builder/Cargo.toml
+++ b/primitives/block-builder/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../inherents" }
 

--- a/primitives/block-builder/Cargo.toml
+++ b/primitives/block-builder/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../inherents" }
 

--- a/primitives/consensus/aura/Cargo.toml
+++ b/primitives/consensus/aura/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../../application-crypto" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../std" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../api" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../runtime" }
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../../inherents" }

--- a/primitives/consensus/aura/Cargo.toml
+++ b/primitives/consensus/aura/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../../application-crypto" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../std" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../api" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../runtime" }
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../../inherents" }

--- a/primitives/consensus/babe/Cargo.toml
+++ b/primitives/consensus/babe/Cargo.toml
@@ -17,12 +17,12 @@ sp-application-crypto = { version = "4.0.0-dev", default-features = false, path 
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 merlin = { version = "2.0", default-features = false }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../std" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../api" }
 sp-consensus = { version = "0.10.0-dev", optional = true, path = "../common" }
 sp-consensus-slots = { version = "0.10.0-dev", default-features = false, path = "../slots" }
 sp-consensus-vrf = { version = "0.10.0-dev", path = "../vrf", default-features = false }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../core" }
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../../inherents" }
 sp-keystore = { version = "0.10.0-dev", default-features = false, path = "../../keystore", optional = true }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../runtime" }

--- a/primitives/consensus/babe/Cargo.toml
+++ b/primitives/consensus/babe/Cargo.toml
@@ -17,12 +17,12 @@ sp-application-crypto = { version = "4.0.0-dev", default-features = false, path 
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 merlin = { version = "2.0", default-features = false }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../std" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../api" }
 sp-consensus = { version = "0.10.0-dev", optional = true, path = "../common" }
 sp-consensus-slots = { version = "0.10.0-dev", default-features = false, path = "../slots" }
 sp-consensus-vrf = { version = "0.10.0-dev", path = "../vrf", default-features = false }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../core" }
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../../inherents" }
 sp-keystore = { version = "0.10.0-dev", default-features = false, path = "../../keystore", optional = true }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../runtime" }

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -20,11 +20,11 @@ codec = { package = "parity-scale-codec", version = "2.0.0", features = [
 ] }
 futures = { version = "0.3.1", features = ["thread-pool"] }
 log = "0.4.8"
-sp-core = { path = "../../core", version = "4.0.0-dev" }
+sp-core =  { path = "../../core", version = "4.0.0" }
 sp-inherents = { version = "4.0.0-dev", path = "../../inherents" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../state-machine" }
 futures-timer = "3.0.1"
-sp-std = { version = "4.0.0-dev", path = "../../std" }
+sp-std =  { version = "4.0.0", path = "../../std" }
 sp-version = { version = "4.0.0-dev", path = "../../version" }
 sp-runtime = { version = "4.0.0-dev", path = "../../runtime" }
 thiserror = "1.0.30"

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -24,7 +24,7 @@ sp-core =  { path = "../../core", version = "4.0.0" }
 sp-inherents = { version = "4.0.0-dev", path = "../../inherents" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../state-machine" }
 futures-timer = "3.0.1"
-sp-std =  { version = "4.0.0", path = "../../std" }
+sp-std = { version = "4.0.0", path = "../../std" }
 sp-version = { version = "4.0.0-dev", path = "../../version" }
 sp-runtime = { version = "4.0.0-dev", path = "../../runtime" }
 thiserror = "1.0.30"

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", features = [
 ] }
 futures = { version = "0.3.1", features = ["thread-pool"] }
 log = "0.4.8"
-sp-core =  { path = "../../core", version = "4.0.0" }
+sp-core = { path = "../../core", version = "4.0.0" }
 sp-inherents = { version = "4.0.0-dev", path = "../../inherents" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../state-machine" }
 futures-timer = "3.0.1"

--- a/primitives/consensus/pow/Cargo.toml
+++ b/primitives/consensus/pow/Cargo.toml
@@ -14,9 +14,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../api" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../runtime" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../core" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 
 [features]

--- a/primitives/consensus/pow/Cargo.toml
+++ b/primitives/consensus/pow/Cargo.toml
@@ -14,9 +14,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../api" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../runtime" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../core" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 
 [features]

--- a/primitives/consensus/vrf/Cargo.toml
+++ b/primitives/consensus/vrf/Cargo.toml
@@ -15,8 +15,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
 schnorrkel = { version = "0.9.1", features = ["preaudit_deprecated", "u64_backend"], default-features = false }
-sp-std =  { version = "4.0.0", path = "../../std", default-features = false }
-sp-core =  { version = "4.0.0", path = "../../core", default-features = false }
+sp-std = { version = "4.0.0", path = "../../std", default-features = false }
+sp-core = { version = "4.0.0", path = "../../core", default-features = false }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../runtime" }
 
 [features]

--- a/primitives/consensus/vrf/Cargo.toml
+++ b/primitives/consensus/vrf/Cargo.toml
@@ -15,8 +15,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false }
 schnorrkel = { version = "0.9.1", features = ["preaudit_deprecated", "u64_backend"], default-features = false }
-sp-std = { version = "4.0.0-dev", path = "../../std", default-features = false }
-sp-core = { version = "4.0.0-dev", path = "../../core", default-features = false }
+sp-std =  { version = "4.0.0", path = "../../std", default-features = false }
+sp-core =  { version = "4.0.0", path = "../../core", default-features = false }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../runtime" }
 
 [features]

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-core"
-version = "4.0.0-dev"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -13,7 +13,6 @@ documentation = "https://docs.rs/sp-core"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = [
 	"derive",
 	"max-encoded-len",
@@ -40,9 +39,10 @@ zeroize = { version = "1.4.2", default-features = false }
 secrecy = { version = "0.8.0", default-features = false }
 lazy_static = { version = "1.4.0", default-features = false, optional = true }
 parking_lot = { version = "0.11.1", optional = true }
-sp-debug-derive = { version = "4.0.0-dev", default-features = false, path = "../debug-derive" }
-sp-externalities = { version = "0.10.0-dev", optional = true, path = "../externalities" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
+sp-debug-derive = { version = "4.0.0", default-features = false, path = "../debug-derive" }
 sp-storage = { version = "4.0.0-dev", default-features = false, path = "../storage" }
+sp-externalities = { version = "0.10.0-dev", optional = true, path = "../externalities" }
 parity-util-mem = { version = "0.10.2", default-features = false, features = [
 	"primitive-types",
 ] }
@@ -66,9 +66,9 @@ sha2 = { version = "0.9.8", default-features = false, optional = true }
 hex = { version = "0.4", default-features = false, optional = true }
 twox-hash = { version = "1.6.1", default-features = false, optional = true }
 libsecp256k1 = { version = "0.7", default-features = false, features = ["hmac", "static-context"], optional = true }
-sp-core-hashing = { version = "4.0.0-dev", path = "./hashing", default-features = false, optional = true }
 merlin = { version = "2.0", default-features = false, optional = true }
 ss58-registry = { version = "1.5.0", default-features = false }
+sp-core-hashing = { version = "4.0.0-dev", path = "./hashing", default-features = false, optional = true }
 sp-runtime-interface = { version = "4.0.0-dev", default-features = false, path = "../runtime-interface" }
 
 [dev-dependencies]

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -41,8 +41,8 @@ lazy_static = { version = "1.4.0", default-features = false, optional = true }
 parking_lot = { version = "0.11.1", optional = true }
 sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 sp-debug-derive = { version = "4.0.0", default-features = false, path = "../debug-derive" }
-sp-storage = { version = "4.0.0-dev", default-features = false, path = "../storage" }
-sp-externalities = { version = "0.10.0-dev", optional = true, path = "../externalities" }
+sp-storage =  { version = "4.0.0", default-features = false, path = "../storage" }
+sp-externalities =  { version = "0.10.0", optional = true, path = "../externalities" }
 parity-util-mem = { version = "0.10.2", default-features = false, features = [
 	"primitive-types",
 ] }
@@ -68,8 +68,8 @@ twox-hash = { version = "1.6.1", default-features = false, optional = true }
 libsecp256k1 = { version = "0.7", default-features = false, features = ["hmac", "static-context"], optional = true }
 merlin = { version = "2.0", default-features = false, optional = true }
 ss58-registry = { version = "1.5.0", default-features = false }
-sp-core-hashing = { version = "4.0.0-dev", path = "./hashing", default-features = false, optional = true }
-sp-runtime-interface = { version = "4.0.0-dev", default-features = false, path = "../runtime-interface" }
+sp-core-hashing =  { version = "4.0.0", path = "./hashing", default-features = false, optional = true }
+sp-runtime-interface =  { version = "4.0.0", default-features = false, path = "../runtime-interface" }
 
 [dev-dependencies]
 sp-serializer = { version = "4.0.0-dev", path = "../serializer" }

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -41,8 +41,8 @@ lazy_static = { version = "1.4.0", default-features = false, optional = true }
 parking_lot = { version = "0.11.1", optional = true }
 sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 sp-debug-derive = { version = "4.0.0", default-features = false, path = "../debug-derive" }
-sp-storage =  { version = "4.0.0", default-features = false, path = "../storage" }
-sp-externalities =  { version = "0.10.0", optional = true, path = "../externalities" }
+sp-storage = { version = "4.0.0", default-features = false, path = "../storage" }
+sp-externalities = { version = "0.10.0", optional = true, path = "../externalities" }
 parity-util-mem = { version = "0.10.2", default-features = false, features = [
 	"primitive-types",
 ] }
@@ -68,8 +68,8 @@ twox-hash = { version = "1.6.1", default-features = false, optional = true }
 libsecp256k1 = { version = "0.7", default-features = false, features = ["hmac", "static-context"], optional = true }
 merlin = { version = "2.0", default-features = false, optional = true }
 ss58-registry = { version = "1.5.0", default-features = false }
-sp-core-hashing =  { version = "4.0.0", path = "./hashing", default-features = false, optional = true }
-sp-runtime-interface =  { version = "4.0.0", default-features = false, path = "../runtime-interface" }
+sp-core-hashing = { version = "4.0.0", path = "./hashing", default-features = false, optional = true }
+sp-runtime-interface = { version = "4.0.0", default-features = false, path = "../runtime-interface" }
 
 [dev-dependencies]
 sp-serializer = { version = "4.0.0-dev", path = "../serializer" }

--- a/primitives/core/hashing/Cargo.toml
+++ b/primitives/core/hashing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-core-hashing"
-version = "4.0.0-dev"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/sp-core-hashing"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../std" }
 byteorder = { version = "1.3.2", default-features = false }
 
 blake2-rfc = { version = "0.2.18", default-features = false }

--- a/primitives/core/hashing/proc-macro/Cargo.toml
+++ b/primitives/core/hashing/proc-macro/Cargo.toml
@@ -19,4 +19,4 @@ proc-macro = true
 syn = { version = "1.0.81", features = ["full", "parsing"] }
 quote = "1.0.6"
 proc-macro2 = "1.0.29"
-sp-core-hashing = { version = "4.0.0-dev", path = "../", default-features = false }
+sp-core-hashing =  { version = "4.0.0", path = "../", default-features = false }

--- a/primitives/core/hashing/proc-macro/Cargo.toml
+++ b/primitives/core/hashing/proc-macro/Cargo.toml
@@ -19,4 +19,4 @@ proc-macro = true
 syn = { version = "1.0.81", features = ["full", "parsing"] }
 quote = "1.0.6"
 proc-macro2 = "1.0.29"
-sp-core-hashing =  { version = "4.0.0", path = "../", default-features = false }
+sp-core-hashing = { version = "4.0.0", path = "../", default-features = false }

--- a/primitives/debug-derive/Cargo.toml
+++ b/primitives/debug-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-debug-derive"
-version = "4.0.0-dev"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/primitives/externalities/Cargo.toml
+++ b/primitives/externalities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-externalities"
-version = "0.10.0-dev"
+version = "0.10.0"
 license = "Apache-2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
@@ -14,8 +14,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-storage = { version = "4.0.0-dev", path = "../storage", default-features = false }
-sp-std = { version = "4.0.0-dev", path = "../std", default-features = false }
+sp-storage = { version = "4.0.0", path = "../storage", default-features = false }
+sp-std = { version = "4.0.0", path = "../std", default-features = false }
 environmental = { version = "1.1.3", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 

--- a/primitives/finality-grandpa/Cargo.toml
+++ b/primitives/finality-grandpa/Cargo.toml
@@ -22,10 +22,10 @@ log = { version = "0.4.8", optional = true }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../application-crypto" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
 sp-keystore = { version = "0.10.0-dev", default-features = false, path = "../keystore", optional = true }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 
 [features]
 default = ["std"]

--- a/primitives/finality-grandpa/Cargo.toml
+++ b/primitives/finality-grandpa/Cargo.toml
@@ -22,10 +22,10 @@ log = { version = "0.4.8", optional = true }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../application-crypto" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../core" }
 sp-keystore = { version = "0.10.0-dev", default-features = false, path = "../keystore", optional = true }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 
 [features]
 default = ["std"]

--- a/primitives/inherents/Cargo.toml
+++ b/primitives/inherents/Cargo.toml
@@ -15,8 +15,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 
 [dependencies]
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
+sp-core = { version = "4.0.0", default-features = false, path = "../core" }
 sp-runtime = { version = "4.0.0-dev", path = "../runtime", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.30", optional = true }

--- a/primitives/inherents/Cargo.toml
+++ b/primitives/inherents/Cargo.toml
@@ -15,8 +15,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 
 [dependencies]
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
 sp-runtime = { version = "4.0.0-dev", path = "../runtime", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.30", optional = true }

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -17,16 +17,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 hash-db = { version = "0.15.2", default-features = false }
-sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../core" }
 sp-keystore = { version = "0.10.0-dev", default-features = false, optional = true, path = "../keystore" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 libsecp256k1 = { version = "0.7", optional = true }
 sp-state-machine = { version = "0.10.0-dev", optional = true, path = "../state-machine" }
-sp-wasm-interface =  { version = "4.0.0", path = "../wasm-interface", default-features = false }
-sp-runtime-interface =  { version = "4.0.0", default-features = false, path = "../runtime-interface" }
+sp-wasm-interface = { version = "4.0.0", path = "../wasm-interface", default-features = false }
+sp-runtime-interface = { version = "4.0.0", default-features = false, path = "../runtime-interface" }
 sp-trie = { version = "4.0.0-dev", optional = true, path = "../trie" }
-sp-externalities =  { version = "0.10.0", optional = true, path = "../externalities" }
-sp-tracing =  { version = "4.0.0", default-features = false, path = "../tracing" }
+sp-externalities = { version = "0.10.0", optional = true, path = "../externalities" }
+sp-tracing = { version = "4.0.0", default-features = false, path = "../tracing" }
 log = { version = "0.4.8", optional = true }
 futures = { version = "0.3.1", features = ["thread-pool"], optional = true }
 parking_lot = { version = "0.11.1", optional = true }

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -17,16 +17,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 hash-db = { version = "0.15.2", default-features = false }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
 sp-keystore = { version = "0.10.0-dev", default-features = false, optional = true, path = "../keystore" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 libsecp256k1 = { version = "0.7", optional = true }
 sp-state-machine = { version = "0.10.0-dev", optional = true, path = "../state-machine" }
-sp-wasm-interface = { version = "4.0.0-dev", path = "../wasm-interface", default-features = false }
-sp-runtime-interface = { version = "4.0.0-dev", default-features = false, path = "../runtime-interface" }
+sp-wasm-interface =  { version = "4.0.0", path = "../wasm-interface", default-features = false }
+sp-runtime-interface =  { version = "4.0.0", default-features = false, path = "../runtime-interface" }
 sp-trie = { version = "4.0.0-dev", optional = true, path = "../trie" }
-sp-externalities = { version = "0.10.0-dev", optional = true, path = "../externalities" }
-sp-tracing = { version = "4.0.0-dev", default-features = false, path = "../tracing" }
+sp-externalities =  { version = "0.10.0", optional = true, path = "../externalities" }
+sp-tracing =  { version = "4.0.0", default-features = false, path = "../tracing" }
 log = { version = "0.4.8", optional = true }
 futures = { version = "0.3.1", features = ["thread-pool"], optional = true }
 parking_lot = { version = "0.11.1", optional = true }

--- a/primitives/keyring/Cargo.toml
+++ b/primitives/keyring/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 
 [dependencies]
-sp-core =  { version = "4.0.0", path = "../core" }
+sp-core = { version = "4.0.0", path = "../core" }
 sp-runtime = { version = "4.0.0-dev", path = "../runtime" }
 lazy_static = "1.4.0"
 strum = { version = "0.22.0", features = ["derive"] }

--- a/primitives/keyring/Cargo.toml
+++ b/primitives/keyring/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 
 [dependencies]
-sp-core = { version = "4.0.0-dev", path = "../core" }
+sp-core =  { version = "4.0.0", path = "../core" }
 sp-runtime = { version = "4.0.0-dev", path = "../runtime" }
 lazy_static = "1.4.0"
 strum = { version = "0.22.0", features = ["derive"] }

--- a/primitives/keystore/Cargo.toml
+++ b/primitives/keystore/Cargo.toml
@@ -21,8 +21,8 @@ schnorrkel = { version = "0.9.1", features = ["preaudit_deprecated", "u64_backen
 merlin = { version = "2.0", default-features = false }
 parking_lot = { version = "0.11.1", default-features = false }
 serde = { version = "1.0", optional = true}
-sp-core =  { version = "4.0.0", path = "../core" }
-sp-externalities =  { version = "0.10.0", path = "../externalities", default-features = false }
+sp-core = { version = "4.0.0", path = "../core" }
+sp-externalities = { version = "0.10.0", path = "../externalities", default-features = false }
 
 [dev-dependencies]
 rand = "0.7.2"

--- a/primitives/keystore/Cargo.toml
+++ b/primitives/keystore/Cargo.toml
@@ -21,8 +21,8 @@ schnorrkel = { version = "0.9.1", features = ["preaudit_deprecated", "u64_backen
 merlin = { version = "2.0", default-features = false }
 parking_lot = { version = "0.11.1", default-features = false }
 serde = { version = "1.0", optional = true}
-sp-core = { version = "4.0.0-dev", path = "../core" }
-sp-externalities = { version = "0.10.0-dev", path = "../externalities", default-features = false }
+sp-core =  { version = "4.0.0", path = "../core" }
+sp-externalities =  { version = "0.10.0", path = "../externalities", default-features = false }
 
 [dev-dependencies]
 rand = "0.7.2"

--- a/primitives/npos-elections/Cargo.toml
+++ b/primitives/npos-elections/Cargo.toml
@@ -16,10 +16,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 sp-npos-elections-solution-type = { version = "4.0.0-dev", path = "./solution-type" }
 sp-arithmetic = { version = "4.0.0-dev", default-features = false, path = "../arithmetic" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../core" }
 sp-runtime = { version = "4.0.0-dev", path = "../runtime", default-features = false }
 
 [dev-dependencies]

--- a/primitives/npos-elections/Cargo.toml
+++ b/primitives/npos-elections/Cargo.toml
@@ -16,10 +16,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 sp-npos-elections-solution-type = { version = "4.0.0-dev", path = "./solution-type" }
 sp-arithmetic = { version = "4.0.0-dev", default-features = false, path = "../arithmetic" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
 sp-runtime = { version = "4.0.0-dev", path = "../runtime", default-features = false }
 
 [dev-dependencies]

--- a/primitives/offchain/Cargo.toml
+++ b/primitives/offchain/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
 

--- a/primitives/offchain/Cargo.toml
+++ b/primitives/offchain/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../core" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
 

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 serde = { version = "1.0.126", features = ["derive"] }
-sp-core = { version = "4.0.0-dev", path = "../core" }
+sp-core =  { version = "4.0.0", path = "../core" }
 rustc-hash = "1.1.0"
 
 [dev-dependencies]

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 serde = { version = "1.0.126", features = ["derive"] }
-sp-core =  { version = "4.0.0", path = "../core" }
+sp-core = { version = "4.0.0", path = "../core" }
 rustc-hash = "1.1.0"
 
 [dev-dependencies]

--- a/primitives/runtime-interface/Cargo.toml
+++ b/primitives/runtime-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-runtime-interface"
-version = "4.0.0-dev"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -14,21 +14,21 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-wasm-interface = { version = "4.0.0-dev", path = "../wasm-interface", default-features = false }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
-sp-tracing = { version = "4.0.0-dev", default-features = false, path = "../tracing" }
-sp-runtime-interface-proc-macro = { version = "4.0.0-dev", path = "proc-macro" }
-sp-externalities = { version = "0.10.0-dev", optional = true, path = "../externalities" }
+sp-wasm-interface = { version = "4.0.0", path = "../wasm-interface", default-features = false }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
+sp-tracing = { version = "4.0.0", default-features = false, path = "../tracing" }
+sp-runtime-interface-proc-macro = { version = "4.0.0", path = "proc-macro" }
+sp-externalities = { version = "0.10.0", optional = true, path = "../externalities" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 static_assertions = "1.0.0"
 primitive-types = { version = "0.10.1", default-features = false }
-sp-storage = { version = "4.0.0-dev", default-features = false, path = "../storage" }
+sp-storage = { version = "4.0.0", default-features = false, path = "../storage" }
 impl-trait-for-tuples = "0.2.1"
 
 [dev-dependencies]
 sp-runtime-interface-test-wasm = { version = "2.0.0", path = "test-wasm" }
 sp-state-machine = { version = "0.10.0-dev", path = "../state-machine" }
-sp-core = { version = "4.0.0-dev", path = "../core" }
+sp-core = { version = "4.0.0", path = "../core" }
 sp-io = { version = "4.0.0-dev", path = "../io" }
 rustversion = "1.0.5"
 trybuild = "1.0.52"

--- a/primitives/runtime-interface/proc-macro/Cargo.toml
+++ b/primitives/runtime-interface/proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-runtime-interface-proc-macro"
-version = "4.0.0-dev"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/primitives/runtime-interface/test-wasm-deprecated/Cargo.toml
+++ b/primitives/runtime-interface/test-wasm-deprecated/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-runtime-interface =  { version = "4.0.0", default-features = false, path = "../" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../std" }
+sp-runtime-interface = { version = "4.0.0", default-features = false, path = "../" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../io" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../core" }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", path = "../../../utils/wasm-builder" }

--- a/primitives/runtime-interface/test-wasm-deprecated/Cargo.toml
+++ b/primitives/runtime-interface/test-wasm-deprecated/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-runtime-interface = { version = "4.0.0-dev", default-features = false, path = "../" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../std" }
+sp-runtime-interface =  { version = "4.0.0", default-features = false, path = "../" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../io" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../core" }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", path = "../../../utils/wasm-builder" }

--- a/primitives/runtime-interface/test-wasm/Cargo.toml
+++ b/primitives/runtime-interface/test-wasm/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-runtime-interface =  { version = "4.0.0", default-features = false, path = "../" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../std" }
+sp-runtime-interface = { version = "4.0.0", default-features = false, path = "../" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../io" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../core" }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", path = "../../../utils/wasm-builder" }

--- a/primitives/runtime-interface/test-wasm/Cargo.toml
+++ b/primitives/runtime-interface/test-wasm/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-runtime-interface = { version = "4.0.0-dev", default-features = false, path = "../" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../std" }
+sp-runtime-interface =  { version = "4.0.0", default-features = false, path = "../" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../io" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../core" }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", path = "../../../utils/wasm-builder" }

--- a/primitives/runtime-interface/test/Cargo.toml
+++ b/primitives/runtime-interface/test/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-runtime-interface =  { version = "4.0.0", path = "../" }
+sp-runtime-interface = { version = "4.0.0", path = "../" }
 sc-executor = { version = "0.10.0-dev", path = "../../../client/executor" }
 sc-executor-common = { version = "0.10.0-dev", path = "../../../client/executor/common" }
 sp-runtime-interface-test-wasm = { version = "2.0.0", path = "../test-wasm" }

--- a/primitives/runtime-interface/test/Cargo.toml
+++ b/primitives/runtime-interface/test/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-runtime-interface = { version = "4.0.0-dev", path = "../" }
+sp-runtime-interface =  { version = "4.0.0", path = "../" }
 sc-executor = { version = "0.10.0-dev", path = "../../../client/executor" }
 sc-executor-common = { version = "0.10.0-dev", path = "../../../client/executor/common" }
 sp-runtime-interface-test-wasm = { version = "2.0.0", path = "../test-wasm" }

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -18,10 +18,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../application-crypto" }
 sp-arithmetic = { version = "4.0.0-dev", default-features = false, path = "../arithmetic" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../io" }
 log = { version = "0.4.14", default-features = false }
 paste = "1.0"
@@ -37,7 +37,7 @@ rand = "0.7.2"
 sp-state-machine = { version = "0.10.0-dev", path = "../state-machine" }
 sp-api = { version = "4.0.0-dev", path = "../api" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }
-sp-tracing = { version = "4.0.0-dev", path = "../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
 zstd = "0.9"
 
 [features]

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -18,10 +18,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../core" }
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../application-crypto" }
 sp-arithmetic = { version = "4.0.0-dev", default-features = false, path = "../arithmetic" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../io" }
 log = { version = "0.4.14", default-features = false }
 paste = "1.0"
@@ -37,7 +37,7 @@ rand = "0.7.2"
 sp-state-machine = { version = "0.10.0-dev", path = "../state-machine" }
 sp-api = { version = "4.0.0-dev", path = "../api" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }
-sp-tracing =  { version = "4.0.0", path = "../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../primitives/tracing" }
 zstd = "0.9"
 
 [features]

--- a/primitives/sandbox/Cargo.toml
+++ b/primitives/sandbox/Cargo.toml
@@ -20,10 +20,10 @@ wasmi = "0.9.0"
 
 [dependencies]
 wasmi = { version = "0.9.0", optional = true }
-sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-core = { version = "4.0.0", default-features = false, path = "../core" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../io" }
-sp-wasm-interface =  { version = "4.0.0", default-features = false, path = "../wasm-interface" }
+sp-wasm-interface = { version = "4.0.0", default-features = false, path = "../wasm-interface" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 log = { version = "0.4", default-features = false }
 

--- a/primitives/sandbox/Cargo.toml
+++ b/primitives/sandbox/Cargo.toml
@@ -20,10 +20,10 @@ wasmi = "0.9.0"
 
 [dependencies]
 wasmi = { version = "0.9.0", optional = true }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../io" }
-sp-wasm-interface = { version = "4.0.0-dev", default-features = false, path = "../wasm-interface" }
+sp-wasm-interface =  { version = "4.0.0", default-features = false, path = "../wasm-interface" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 log = { version = "0.4", default-features = false }
 

--- a/primitives/session/Cargo.toml
+++ b/primitives/session/Cargo.toml
@@ -16,8 +16,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-core = { version = "4.0.0", default-features = false, path = "../core" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../staking" }
 sp-runtime = { version = "4.0.0-dev", optional = true, path = "../runtime" }
 

--- a/primitives/session/Cargo.toml
+++ b/primitives/session/Cargo.toml
@@ -16,8 +16,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../staking" }
 sp-runtime = { version = "4.0.0-dev", optional = true, path = "../runtime" }
 

--- a/primitives/staking/Cargo.toml
+++ b/primitives/staking/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 
 [features]
 default = ["std"]

--- a/primitives/staking/Cargo.toml
+++ b/primitives/staking/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 
 [features]
 default = ["std"]

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -21,14 +21,14 @@ hash-db = { version = "0.15.2", default-features = false }
 trie-db = { version = "0.22.6", default-features = false }
 trie-root = { version = "0.16.0", default-features = false }
 sp-trie = { version = "4.0.0-dev", path = "../trie", default-features = false }
-sp-core = { version = "4.0.0-dev", path = "../core", default-features = false }
+sp-core =  { version = "4.0.0", path = "../core", default-features = false }
 sp-panic-handler = { version = "4.0.0-dev", path = "../panic-handler", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 num-traits = { version = "0.2.8", default-features = false }
 rand = { version = "0.7.2", optional = true }
-sp-externalities = { version = "0.10.0-dev", path = "../externalities", default-features = false }
+sp-externalities =  { version = "0.10.0", path = "../externalities", default-features = false }
 smallvec = "1.7.0"
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 tracing = { version = "0.1.29", optional = true }
 
 [dev-dependencies]

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -21,14 +21,14 @@ hash-db = { version = "0.15.2", default-features = false }
 trie-db = { version = "0.22.6", default-features = false }
 trie-root = { version = "0.16.0", default-features = false }
 sp-trie = { version = "4.0.0-dev", path = "../trie", default-features = false }
-sp-core =  { version = "4.0.0", path = "../core", default-features = false }
+sp-core = { version = "4.0.0", path = "../core", default-features = false }
 sp-panic-handler = { version = "4.0.0-dev", path = "../panic-handler", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 num-traits = { version = "0.2.8", default-features = false }
 rand = { version = "0.7.2", optional = true }
-sp-externalities =  { version = "0.10.0", path = "../externalities", default-features = false }
+sp-externalities = { version = "0.10.0", path = "../externalities", default-features = false }
 smallvec = "1.7.0"
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 tracing = { version = "0.1.29", optional = true }
 
 [dev-dependencies]

--- a/primitives/std/Cargo.toml
+++ b/primitives/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-std"
-version = "4.0.0-dev"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/primitives/storage/Cargo.toml
+++ b/primitives/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-storage"
-version = "4.0.0-dev"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 description = "Storage related primitives"
@@ -14,11 +14,11 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 impl-serde = { version = "0.3.1", optional = true }
 ref-cast = "1.0.0"
-sp-debug-derive = { version = "4.0.0-dev", default-features = false, path = "../debug-derive" }
+sp-debug-derive = { version = "4.0.0", default-features = false, path = "../debug-derive" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 
 [features]

--- a/primitives/tasks/Cargo.toml
+++ b/primitives/tasks/Cargo.toml
@@ -15,11 +15,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 log = { version = "0.4.8", optional = true }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }
-sp-externalities = { version = "0.10.0-dev", optional = true, path = "../externalities" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
+sp-externalities =  { version = "0.10.0", optional = true, path = "../externalities" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../io" }
-sp-runtime-interface = { version = "4.0.0-dev", default-features = false, path = "../runtime-interface" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-runtime-interface =  { version = "4.0.0", default-features = false, path = "../runtime-interface" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 
 [dev-dependencies]
 codec = { package = "parity-scale-codec", default-features = false, version = "2.0.0" }

--- a/primitives/tasks/Cargo.toml
+++ b/primitives/tasks/Cargo.toml
@@ -15,11 +15,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 log = { version = "0.4.8", optional = true }
-sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
-sp-externalities =  { version = "0.10.0", optional = true, path = "../externalities" }
+sp-core = { version = "4.0.0", default-features = false, path = "../core" }
+sp-externalities = { version = "0.10.0", optional = true, path = "../externalities" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../io" }
-sp-runtime-interface =  { version = "4.0.0", default-features = false, path = "../runtime-interface" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-runtime-interface = { version = "4.0.0", default-features = false, path = "../runtime-interface" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 
 [dev-dependencies]
 codec = { package = "parity-scale-codec", default-features = false, version = "2.0.0" }

--- a/primitives/test-primitives/Cargo.toml
+++ b/primitives/test-primitives/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../application-crypto" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
 parity-util-mem = { version = "0.10.2", default-features = false, features = ["primitive-types"] }

--- a/primitives/test-primitives/Cargo.toml
+++ b/primitives/test-primitives/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, path = "../application-crypto" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../core" }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
 parity-util-mem = { version = "0.10.2", default-features = false, features = ["primitive-types"] }

--- a/primitives/timestamp/Cargo.toml
+++ b/primitives/timestamp/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../inherents" }

--- a/primitives/timestamp/Cargo.toml
+++ b/primitives/timestamp/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../inherents" }

--- a/primitives/tracing/Cargo.toml
+++ b/primitives/tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-tracing"
-version = "4.0.0-dev"
+version = "4.0.0"
 license = "Apache-2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
@@ -18,7 +18,7 @@ features = ["with-tracing"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-sp-std = { version = "4.0.0-dev", path = "../std", default-features = false }
+sp-std = { version = "4.0.0", path = "../std", default-features = false }
 codec = { version = "2.0.0", package = "parity-scale-codec", default-features = false, features = [
 	"derive",
 ] }

--- a/primitives/transaction-storage-proof/Cargo.toml
+++ b/primitives/transaction-storage-proof/Cargo.toml
@@ -15,9 +15,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../inherents" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 sp-trie = { version = "4.0.0-dev", optional = true, path = "../trie" }
-sp-core = { version = "4.0.0-dev", path = "../core", optional = true }
+sp-core =  { version = "4.0.0", path = "../core", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.8", optional = true }

--- a/primitives/transaction-storage-proof/Cargo.toml
+++ b/primitives/transaction-storage-proof/Cargo.toml
@@ -15,9 +15,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../inherents" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 sp-trie = { version = "4.0.0-dev", optional = true, path = "../trie" }
-sp-core =  { version = "4.0.0", path = "../core", optional = true }
+sp-core = { version = "4.0.0", path = "../core", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.8", optional = true }

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -20,12 +20,12 @@ harness = false
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 hash-db = { version = "0.15.2", default-features = false }
 trie-db = { version = "0.22.6", default-features = false }
 trie-root = { version = "0.16.0", default-features = false }
 memory-db = { version = "0.27.0", default-features = false }
-sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
+sp-core = { version = "4.0.0", default-features = false, path = "../core" }
 
 [dev-dependencies]
 trie-bench = "0.28.0"

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -20,12 +20,12 @@ harness = false
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 hash-db = { version = "0.15.2", default-features = false }
 trie-db = { version = "0.22.6", default-features = false }
 trie-root = { version = "0.16.0", default-features = false }
 memory-db = { version = "0.27.0", default-features = false }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../core" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../core" }
 
 [dev-dependencies]
 trie-bench = "0.28.0"

--- a/primitives/version/Cargo.toml
+++ b/primitives/version/Cargo.toml
@@ -19,7 +19,7 @@ impl-serde = { version = "0.3.1", optional = true }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../std" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
 sp-version-proc-macro = { version = "4.0.0-dev", default-features = false, path = "proc-macro" }
 parity-wasm = { version = "0.42.2", optional = true }

--- a/primitives/version/Cargo.toml
+++ b/primitives/version/Cargo.toml
@@ -19,7 +19,7 @@ impl-serde = { version = "0.3.1", optional = true }
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std =  { version = "4.0.0", default-features = false, path = "../std" }
+sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../runtime" }
 sp-version-proc-macro = { version = "4.0.0-dev", default-features = false, path = "proc-macro" }
 parity-wasm = { version = "0.42.2", optional = true }

--- a/primitives/wasm-interface/Cargo.toml
+++ b/primitives/wasm-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-wasm-interface"
-version = "4.0.0-dev"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 wasmi = { version = "0.9.1", optional = true }
 impl-trait-for-tuples = "0.2.1"
-sp-std = { version = "4.0.0-dev", path = "../std", default-features = false }
+sp-std = { version = "4.0.0", path = "../std", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 
 [features]

--- a/test-utils/client/Cargo.toml
+++ b/test-utils/client/Cargo.toml
@@ -29,7 +29,7 @@ sc-service = { version = "0.10.0-dev", default-features = false, features = [
 ], path = "../../client/service" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }
-sp-core =  { version = "4.0.0", path = "../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../primitives/keystore" }
 sp-keyring = { version = "4.0.0-dev", path = "../../primitives/keyring" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }

--- a/test-utils/client/Cargo.toml
+++ b/test-utils/client/Cargo.toml
@@ -29,7 +29,7 @@ sc-service = { version = "0.10.0-dev", default-features = false, features = [
 ], path = "../../client/service" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }
-sp-core = { version = "4.0.0-dev", path = "../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0-dev", path = "../../primitives/keystore" }
 sp-keyring = { version = "4.0.0-dev", path = "../../primitives/keyring" }
 sp-runtime = { version = "4.0.0-dev", path = "../../primitives/runtime" }

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -23,9 +23,9 @@ sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../../
 sp-keyring = { version = "4.0.0-dev", optional = true, path = "../../primitives/keyring" }
 memory-db = { version = "0.27.0", default-features = false }
 sp-offchain = { version = "4.0.0-dev", default-features = false, path = "../../primitives/offchain" }
-sp-core = { version = "4.0.0-dev", default-features = false, path = "../../primitives/core" }
-sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
-sp-runtime-interface = { version = "4.0.0-dev", default-features = false, path = "../../primitives/runtime-interface" }
+sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-runtime-interface =  { version = "4.0.0", default-features = false, path = "../../primitives/runtime-interface" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../../frame/support" }
 sp-version = { version = "4.0.0-dev", default-features = false, path = "../../primitives/version" }
@@ -43,7 +43,7 @@ trie-db = { version = "0.22.6", default-features = false }
 parity-util-mem = { version = "0.10.2", default-features = false, features = ["primitive-types"] }
 sc-service = { version = "0.10.0-dev", default-features = false, optional = true, features = ["test-helpers"], path = "../../client/service" }
 sp-state-machine = { version = "0.10.0-dev", default-features = false, path = "../../primitives/state-machine" }
-sp-externalities = { version = "0.10.0-dev", default-features = false, path = "../../primitives/externalities" }
+sp-externalities =  { version = "0.10.0", default-features = false, path = "../../primitives/externalities" }
 
 # 3rd party
 cfg-if = "1.0"

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -23,9 +23,9 @@ sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../../
 sp-keyring = { version = "4.0.0-dev", optional = true, path = "../../primitives/keyring" }
 memory-db = { version = "0.27.0", default-features = false }
 sp-offchain = { version = "4.0.0-dev", default-features = false, path = "../../primitives/offchain" }
-sp-core =  { version = "4.0.0", default-features = false, path = "../../primitives/core" }
-sp-std =  { version = "4.0.0", default-features = false, path = "../../primitives/std" }
-sp-runtime-interface =  { version = "4.0.0", default-features = false, path = "../../primitives/runtime-interface" }
+sp-core = { version = "4.0.0", default-features = false, path = "../../primitives/core" }
+sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+sp-runtime-interface = { version = "4.0.0", default-features = false, path = "../../primitives/runtime-interface" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../../frame/support" }
 sp-version = { version = "4.0.0-dev", default-features = false, path = "../../primitives/version" }
@@ -43,7 +43,7 @@ trie-db = { version = "0.22.6", default-features = false }
 parity-util-mem = { version = "0.10.2", default-features = false, features = ["primitive-types"] }
 sc-service = { version = "0.10.0-dev", default-features = false, optional = true, features = ["test-helpers"], path = "../../client/service" }
 sp-state-machine = { version = "0.10.0-dev", default-features = false, path = "../../primitives/state-machine" }
-sp-externalities =  { version = "0.10.0", default-features = false, path = "../../primitives/externalities" }
+sp-externalities = { version = "0.10.0", default-features = false, path = "../../primitives/externalities" }
 
 # 3rd party
 cfg-if = "1.0"

--- a/test-utils/runtime/client/Cargo.toml
+++ b/test-utils/runtime/client/Cargo.toml
@@ -16,7 +16,7 @@ sp-consensus = { version = "0.10.0-dev", path = "../../../primitives/consensus/c
 sc-consensus = { version = "0.10.0-dev", path = "../../../client/consensus/common" }
 sc-block-builder = { version = "0.10.0-dev", path = "../../../client/block-builder" }
 substrate-test-client = { version = "2.0.0", path = "../../client" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 substrate-test-runtime = { version = "2.0.0", path = "../../runtime" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }

--- a/test-utils/runtime/client/Cargo.toml
+++ b/test-utils/runtime/client/Cargo.toml
@@ -16,7 +16,7 @@ sp-consensus = { version = "0.10.0-dev", path = "../../../primitives/consensus/c
 sc-consensus = { version = "0.10.0-dev", path = "../../../client/consensus/common" }
 sc-block-builder = { version = "0.10.0-dev", path = "../../../client/block-builder" }
 substrate-test-client = { version = "2.0.0", path = "../../client" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 substrate-test-runtime = { version = "2.0.0", path = "../../runtime" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }

--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -15,12 +15,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 frame-benchmarking = { version = "4.0.0-dev", path = "../../../frame/benchmarking" }
 frame-support = { version = "4.0.0-dev", path = "../../../frame/support" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sc-service = { version = "0.10.0-dev", default-features = false, path = "../../../client/service" }
 sc-cli = { version = "0.10.0-dev", path = "../../../client/cli" }
 sc-client-db = { version = "0.10.0-dev", path = "../../../client/db" }
 sc-executor = { version = "0.10.0-dev", path = "../../../client/executor" }
-sp-externalities = { version = "0.10.0-dev", path = "../../../primitives/externalities" }
+sp-externalities =  { version = "0.10.0", path = "../../../primitives/externalities" }
 sp-keystore = { version = "0.10.0-dev", path = "../../../primitives/keystore" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../../primitives/state-machine" }

--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -15,12 +15,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 frame-benchmarking = { version = "4.0.0-dev", path = "../../../frame/benchmarking" }
 frame-support = { version = "4.0.0-dev", path = "../../../frame/support" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sc-service = { version = "0.10.0-dev", default-features = false, path = "../../../client/service" }
 sc-cli = { version = "0.10.0-dev", path = "../../../client/cli" }
 sc-client-db = { version = "0.10.0-dev", path = "../../../client/db" }
 sc-executor = { version = "0.10.0-dev", path = "../../../client/executor" }
-sp-externalities =  { version = "0.10.0", path = "../../../primitives/externalities" }
+sp-externalities = { version = "0.10.0", path = "../../../primitives/externalities" }
 sp-keystore = { version = "0.10.0-dev", path = "../../../primitives/keystore" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../../primitives/state-machine" }

--- a/utils/frame/frame-utilities-cli/Cargo.toml
+++ b/utils/frame/frame-utilities-cli/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/substrate-frame-cli"
 readme = "README.md"
 
 [dependencies]
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sc-cli = { version = "0.10.0-dev", path = "../../../client/cli" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 structopt = "0.3.25"

--- a/utils/frame/frame-utilities-cli/Cargo.toml
+++ b/utils/frame/frame-utilities-cli/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/substrate-frame-cli"
 readme = "README.md"
 
 [dependencies]
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sc-cli = { version = "0.10.0-dev", path = "../../../client/cli" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 structopt = "0.3.25"

--- a/utils/frame/remote-externalities/Cargo.toml
+++ b/utils/frame/remote-externalities/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1.0"
 serde = "1.0.126"
 
 sp-io = { version = "4.0.0-dev", path = "../../../primitives/io" }
-sp-core = { version = "4.0.0-dev", path = "../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 sp-version = { version = "4.0.0-dev", path = "../../../primitives/version" }
 

--- a/utils/frame/remote-externalities/Cargo.toml
+++ b/utils/frame/remote-externalities/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1.0"
 serde = "1.0.126"
 
 sp-io = { version = "4.0.0-dev", path = "../../../primitives/io" }
-sp-core =  { version = "4.0.0", path = "../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../primitives/runtime" }
 sp-version = { version = "4.0.0-dev", path = "../../../primitives/version" }
 

--- a/utils/frame/rpc/support/Cargo.toml
+++ b/utils/frame/rpc/support/Cargo.toml
@@ -20,7 +20,7 @@ jsonrpc-client-transports = { version = "18.0.0", features = ["http"] }
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 serde = "1"
 frame-support = { version = "4.0.0-dev", path = "../../../../frame/support" }
-sp-storage = { version = "4.0.0-dev", path = "../../../../primitives/storage" }
+sp-storage =  { version = "4.0.0", path = "../../../../primitives/storage" }
 sc-rpc-api = { version = "0.10.0-dev", path = "../../../../client/rpc-api" }
 
 [dev-dependencies]

--- a/utils/frame/rpc/support/Cargo.toml
+++ b/utils/frame/rpc/support/Cargo.toml
@@ -20,7 +20,7 @@ jsonrpc-client-transports = { version = "18.0.0", features = ["http"] }
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 serde = "1"
 frame-support = { version = "4.0.0-dev", path = "../../../../frame/support" }
-sp-storage =  { version = "4.0.0", path = "../../../../primitives/storage" }
+sp-storage = { version = "4.0.0", path = "../../../../primitives/storage" }
 sc-rpc-api = { version = "0.10.0-dev", path = "../../../../client/rpc-api" }
 
 [dev-dependencies]

--- a/utils/frame/rpc/system/Cargo.toml
+++ b/utils/frame/rpc/system/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4.8"
 sp-runtime = { version = "4.0.0-dev", path = "../../../../primitives/runtime" }
 sp-api = { version = "4.0.0-dev", path = "../../../../primitives/api" }
 frame-system-rpc-runtime-api = { version = "4.0.0-dev", path = "../../../../frame/system/rpc/runtime-api" }
-sp-core = { version = "4.0.0-dev", path = "../../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../../primitives/core" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../../primitives/blockchain" }
 sc-transaction-pool-api = { version = "4.0.0-dev", path = "../../../../client/transaction-pool/api" }
 sp-block-builder = { version = "4.0.0-dev", path = "../../../../primitives/block-builder" }
@@ -31,5 +31,5 @@ sc-rpc-api = { version = "0.10.0-dev", path = "../../../../client/rpc-api" }
 
 [dev-dependencies]
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../../test-utils/runtime/client" }
-sp-tracing = { version = "4.0.0-dev", path = "../../../../primitives/tracing" }
+sp-tracing =  { version = "4.0.0", path = "../../../../primitives/tracing" }
 sc-transaction-pool = { version = "4.0.0-dev", path = "../../../../client/transaction-pool" }

--- a/utils/frame/rpc/system/Cargo.toml
+++ b/utils/frame/rpc/system/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4.8"
 sp-runtime = { version = "4.0.0-dev", path = "../../../../primitives/runtime" }
 sp-api = { version = "4.0.0-dev", path = "../../../../primitives/api" }
 frame-system-rpc-runtime-api = { version = "4.0.0-dev", path = "../../../../frame/system/rpc/runtime-api" }
-sp-core =  { version = "4.0.0", path = "../../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../../primitives/core" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../../primitives/blockchain" }
 sc-transaction-pool-api = { version = "4.0.0-dev", path = "../../../../client/transaction-pool/api" }
 sp-block-builder = { version = "4.0.0-dev", path = "../../../../primitives/block-builder" }
@@ -31,5 +31,5 @@ sc-rpc-api = { version = "0.10.0-dev", path = "../../../../client/rpc-api" }
 
 [dev-dependencies]
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../../test-utils/runtime/client" }
-sp-tracing =  { version = "4.0.0", path = "../../../../primitives/tracing" }
+sp-tracing = { version = "4.0.0", path = "../../../../primitives/tracing" }
 sc-transaction-pool = { version = "4.0.0-dev", path = "../../../../client/transaction-pool" }

--- a/utils/frame/try-runtime/cli/Cargo.toml
+++ b/utils/frame/try-runtime/cli/Cargo.toml
@@ -24,10 +24,10 @@ sc-executor = { version = "0.10.0-dev", path = "../../../../client/executor" }
 sc-chain-spec = { version = "4.0.0-dev", path = "../../../../client/chain-spec" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../../../primitives/state-machine" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../../primitives/runtime" }
-sp-core = { version = "4.0.0-dev", path = "../../../../primitives/core" }
+sp-core =  { version = "4.0.0", path = "../../../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../../../primitives/io" }
 sp-keystore = { version = "0.10.0-dev", path = "../../../../primitives/keystore" }
-sp-externalities = { version = "0.10.0-dev", path = "../../../../primitives/externalities" }
+sp-externalities =  { version = "0.10.0", path = "../../../../primitives/externalities" }
 sp-version = { version = "4.0.0-dev", path = "../../../../primitives/version" }
 
 remote-externalities = { version = "0.10.0-dev", path = "../../remote-externalities" }

--- a/utils/frame/try-runtime/cli/Cargo.toml
+++ b/utils/frame/try-runtime/cli/Cargo.toml
@@ -24,10 +24,10 @@ sc-executor = { version = "0.10.0-dev", path = "../../../../client/executor" }
 sc-chain-spec = { version = "4.0.0-dev", path = "../../../../client/chain-spec" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../../../primitives/state-machine" }
 sp-runtime = { version = "4.0.0-dev", path = "../../../../primitives/runtime" }
-sp-core =  { version = "4.0.0", path = "../../../../primitives/core" }
+sp-core = { version = "4.0.0", path = "../../../../primitives/core" }
 sp-io = { version = "4.0.0-dev", path = "../../../../primitives/io" }
 sp-keystore = { version = "0.10.0-dev", path = "../../../../primitives/keystore" }
-sp-externalities =  { version = "0.10.0", path = "../../../../primitives/externalities" }
+sp-externalities = { version = "0.10.0", path = "../../../../primitives/externalities" }
 sp-version = { version = "4.0.0-dev", path = "../../../../primitives/version" }
 
 remote-externalities = { version = "0.10.0-dev", path = "../../remote-externalities" }


### PR DESCRIPTION
Release `sp-core` and its dependencies as v4.0.0 (and 0.10.0 for `sp-externalities`).

**NOTE**: the v4.0 version number does not mean very much other than "incompatible with v3.0" and most users/builders should continue to track substrate master.

<img width="528" alt="Screenshot 2021-12-08 at 16 23 27" src="https://user-images.githubusercontent.com/18515/145234657-857cdc94-de02-4c7c-af1a-a00e930e9377.png">

