### PR TITLE
rework `fn account` in frame-benchmarking

### DIFF
--- a/bin/node-template/pallets/template/src/benchmarking.rs
+++ b/bin/node-template/pallets/template/src/benchmarking.rs
@@ -10,7 +10,7 @@ use frame_system::RawOrigin;
 benchmarks! {
 	do_something {
 		let s in 0 .. 100;
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 	}: _(RawOrigin::Signed(caller), s)
 	verify {
 		assert_eq!(Something::<T>::get(), Some(s));

--- a/frame/assets/src/benchmarking.rs
+++ b/frame/assets/src/benchmarking.rs
@@ -38,7 +38,7 @@ const SEED: u32 = 0;
 fn create_default_asset<T: Config<I>, I: 'static>(
 	is_sufficient: bool,
 ) -> (T::AccountId, <T::Lookup as StaticLookup>::Source) {
-	let caller: T::AccountId = whitelisted_caller();
+	let caller: T::AccountId = whitelisted_caller::<T>();
 	let caller_lookup = T::Lookup::unlookup(caller.clone());
 	let root = SystemOrigin::Root.into();
 	assert!(Assets::<T, I>::force_create(
@@ -83,7 +83,7 @@ fn add_consumers<T: Config<I>, I: 'static>(minter: T::AccountId, n: u32) {
 	let mut s = false;
 	swap_is_sufficient::<T, I>(&mut s);
 	for i in 0..n {
-		let target = account("consumer", i, SEED);
+		let target = account::<T>("consumer", i, SEED);
 		T::Currency::make_free_balance_be(&target, T::Currency::minimum_balance());
 		let target_lookup = T::Lookup::unlookup(target);
 		assert!(Assets::<T, I>::mint(
@@ -102,7 +102,7 @@ fn add_sufficients<T: Config<I>, I: 'static>(minter: T::AccountId, n: u32) {
 	let mut s = true;
 	swap_is_sufficient::<T, I>(&mut s);
 	for i in 0..n {
-		let target = account("sufficient", i, SEED);
+		let target = account::<T>("sufficient", i, SEED);
 		let target_lookup = T::Lookup::unlookup(target);
 		assert!(Assets::<T, I>::mint(
 			origin.clone().into(),
@@ -127,7 +127,7 @@ fn add_approvals<T: Config<I>, I: 'static>(minter: T::AccountId, n: u32) {
 	)
 	.unwrap();
 	for i in 0..n {
-		let target = account("approval", i, SEED);
+		let target = account::<T>("approval", i, SEED);
 		T::Currency::make_free_balance_be(&target, T::Currency::minimum_balance());
 		let target_lookup = T::Lookup::unlookup(target);
 		Assets::<T, I>::approve_transfer(
@@ -150,7 +150,7 @@ fn assert_event<T: Config<I>, I: 'static>(generic_event: <T as Config<I>>::Event
 
 benchmarks_instance_pallet! {
 	create {
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		let caller_lookup = T::Lookup::unlookup(caller.clone());
 		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
 	}: _(SystemOrigin::Signed(caller.clone()), Default::default(), caller_lookup, 1u32.into())
@@ -159,7 +159,7 @@ benchmarks_instance_pallet! {
 	}
 
 	force_create {
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		let caller_lookup = T::Lookup::unlookup(caller.clone());
 	}: _(SystemOrigin::Root, Default::default(), caller_lookup, true, 1u32.into())
 	verify {
@@ -199,7 +199,7 @@ benchmarks_instance_pallet! {
 	transfer {
 		let amount = T::Balance::from(100u32);
 		let (caller, caller_lookup) = create_default_minted_asset::<T, I>(true, amount);
-		let target: T::AccountId = account("target", 0, SEED);
+		let target: T::AccountId = account::<T>("target", 0, SEED);
 		let target_lookup = T::Lookup::unlookup(target.clone());
 	}: _(SystemOrigin::Signed(caller.clone()), Default::default(), target_lookup, amount)
 	verify {
@@ -210,7 +210,7 @@ benchmarks_instance_pallet! {
 		let mint_amount = T::Balance::from(200u32);
 		let amount = T::Balance::from(100u32);
 		let (caller, caller_lookup) = create_default_minted_asset::<T, I>(true, mint_amount);
-		let target: T::AccountId = account("target", 0, SEED);
+		let target: T::AccountId = account::<T>("target", 0, SEED);
 		let target_lookup = T::Lookup::unlookup(target.clone());
 	}: _(SystemOrigin::Signed(caller.clone()), Default::default(), target_lookup, amount)
 	verify {
@@ -221,7 +221,7 @@ benchmarks_instance_pallet! {
 	force_transfer {
 		let amount = T::Balance::from(100u32);
 		let (caller, caller_lookup) = create_default_minted_asset::<T, I>(true, amount);
-		let target: T::AccountId = account("target", 0, SEED);
+		let target: T::AccountId = account::<T>("target", 0, SEED);
 		let target_lookup = T::Lookup::unlookup(target.clone());
 	}: _(SystemOrigin::Signed(caller.clone()), Default::default(), caller_lookup, target_lookup, amount)
 	verify {
@@ -269,7 +269,7 @@ benchmarks_instance_pallet! {
 
 	transfer_ownership {
 		let (caller, _) = create_default_asset::<T, I>(true);
-		let target: T::AccountId = account("target", 0, SEED);
+		let target: T::AccountId = account::<T>("target", 0, SEED);
 		let target_lookup = T::Lookup::unlookup(target.clone());
 	}: _(SystemOrigin::Signed(caller), Default::default(), target_lookup)
 	verify {
@@ -278,16 +278,16 @@ benchmarks_instance_pallet! {
 
 	set_team {
 		let (caller, _) = create_default_asset::<T, I>(true);
-		let target0 = T::Lookup::unlookup(account("target", 0, SEED));
-		let target1 = T::Lookup::unlookup(account("target", 1, SEED));
-		let target2 = T::Lookup::unlookup(account("target", 2, SEED));
+		let target0 = T::Lookup::unlookup(account::<T>("target", 0, SEED));
+		let target1 = T::Lookup::unlookup(account::<T>("target", 1, SEED));
+		let target2 = T::Lookup::unlookup(account::<T>("target", 2, SEED));
 	}: _(SystemOrigin::Signed(caller), Default::default(), target0.clone(), target1.clone(), target2.clone())
 	verify {
 		assert_last_event::<T, I>(Event::TeamChanged {
 			asset_id: Default::default(),
-			issuer: account("target", 0, SEED),
-			admin: account("target", 1, SEED),
-			freezer: account("target", 2, SEED),
+			issuer: account::<T>("target", 0, SEED),
+			admin: account::<T>("target", 1, SEED),
+			freezer: account::<T>("target", 2, SEED),
 		}.into());
 	}
 
@@ -380,7 +380,7 @@ benchmarks_instance_pallet! {
 		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
 
 		let id = Default::default();
-		let delegate: T::AccountId = account("delegate", 0, SEED);
+		let delegate: T::AccountId = account::<T>("delegate", 0, SEED);
 		let delegate_lookup = T::Lookup::unlookup(delegate.clone());
 		let amount = 100u32.into();
 	}: _(SystemOrigin::Signed(caller.clone()), id, delegate_lookup, amount)
@@ -393,14 +393,14 @@ benchmarks_instance_pallet! {
 		T::Currency::make_free_balance_be(&owner, DepositBalanceOf::<T, I>::max_value());
 
 		let id = Default::default();
-		let delegate: T::AccountId = account("delegate", 0, SEED);
+		let delegate: T::AccountId = account::<T>("delegate", 0, SEED);
 		whitelist_account!(delegate);
 		let delegate_lookup = T::Lookup::unlookup(delegate.clone());
 		let amount = 100u32.into();
 		let origin = SystemOrigin::Signed(owner.clone()).into();
 		Assets::<T, I>::approve_transfer(origin, id, delegate_lookup.clone(), amount)?;
 
-		let dest: T::AccountId = account("dest", 0, SEED);
+		let dest: T::AccountId = account::<T>("dest", 0, SEED);
 		let dest_lookup = T::Lookup::unlookup(dest.clone());
 	}: _(SystemOrigin::Signed(delegate.clone()), id, owner_lookup, dest_lookup, amount)
 	verify {
@@ -413,7 +413,7 @@ benchmarks_instance_pallet! {
 		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
 
 		let id = Default::default();
-		let delegate: T::AccountId = account("delegate", 0, SEED);
+		let delegate: T::AccountId = account::<T>("delegate", 0, SEED);
 		let delegate_lookup = T::Lookup::unlookup(delegate.clone());
 		let amount = 100u32.into();
 		let origin = SystemOrigin::Signed(caller.clone()).into();
@@ -428,7 +428,7 @@ benchmarks_instance_pallet! {
 		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
 
 		let id = Default::default();
-		let delegate: T::AccountId = account("delegate", 0, SEED);
+		let delegate: T::AccountId = account::<T>("delegate", 0, SEED);
 		let delegate_lookup = T::Lookup::unlookup(delegate.clone());
 		let amount = 100u32.into();
 		let origin = SystemOrigin::Signed(caller.clone()).into();

--- a/frame/bags-list/src/benchmarks.rs
+++ b/frame/bags-list/src/benchmarks.rs
@@ -43,17 +43,17 @@ frame_benchmarking::benchmarks! {
 		let dest_bag_thresh = T::BagThresholds::get()[1];
 
 		// seed items in the origin bag.
-		let origin_head: T::AccountId = account("origin_head", 0, 0);
+		let origin_head: T::AccountId = account::<T>("origin_head", 0, 0);
 		assert_ok!(List::<T>::insert(origin_head.clone(), origin_bag_thresh));
 
-		let origin_middle: T::AccountId = account("origin_middle", 0, 0); // the node we rebag (_R_)
+		let origin_middle: T::AccountId = account::<T>("origin_middle", 0, 0); // the node we rebag (_R_)
 		assert_ok!(List::<T>::insert(origin_middle.clone(), origin_bag_thresh));
 
-		let origin_tail: T::AccountId  = account("origin_tail", 0, 0);
+		let origin_tail: T::AccountId  = account::<T>("origin_tail", 0, 0);
 		assert_ok!(List::<T>::insert(origin_tail.clone(), origin_bag_thresh));
 
 		// seed items in the destination bag.
-		let dest_head: T::AccountId  = account("dest_head", 0, 0);
+		let dest_head: T::AccountId  = account::<T>("dest_head", 0, 0);
 		assert_ok!(List::<T>::insert(dest_head.clone(), dest_bag_thresh));
 
 		// the bags are in the expected state after initial setup.
@@ -65,7 +65,7 @@ frame_benchmarking::benchmarks! {
 			]
 		);
 
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 		// update the weight of `origin_middle` to guarantee it will be rebagged into the destination.
 		T::VoteWeightProvider::set_vote_weight_of(&origin_middle, dest_bag_thresh);
 	}: rebag(SystemOrigin::Signed(caller), origin_middle.clone())
@@ -103,14 +103,14 @@ frame_benchmarking::benchmarks! {
 		let dest_bag_thresh = T::BagThresholds::get()[1];
 
 		// seed items in the origin bag.
-		let origin_head: T::AccountId = account("origin_head", 0, 0);
+		let origin_head: T::AccountId = account::<T>("origin_head", 0, 0);
 		assert_ok!(List::<T>::insert(origin_head.clone(), origin_bag_thresh));
 
-		let origin_tail: T::AccountId  = account("origin_tail", 0, 0); // the node we rebag (_R_)
+		let origin_tail: T::AccountId  = account::<T>("origin_tail", 0, 0); // the node we rebag (_R_)
 		assert_ok!(List::<T>::insert(origin_tail.clone(), origin_bag_thresh));
 
 		// seed items in the destination bag.
-		let dest_head: T::AccountId  = account("dest_head", 0, 0);
+		let dest_head: T::AccountId  = account::<T>("dest_head", 0, 0);
 		assert_ok!(List::<T>::insert(dest_head.clone(), dest_bag_thresh));
 
 		// the bags are in the expected state after initial setup.
@@ -122,7 +122,7 @@ frame_benchmarking::benchmarks! {
 			]
 		);
 
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 		// update the weight of `origin_tail` to guarantee it will be rebagged into the destination.
 		T::VoteWeightProvider::set_vote_weight_of(&origin_tail, dest_bag_thresh);
 	}: rebag(SystemOrigin::Signed(caller), origin_tail.clone())
@@ -146,16 +146,16 @@ frame_benchmarking::benchmarks! {
 		let bag_thresh = T::BagThresholds::get()[0];
 
 		// insert the nodes in order
-		let lighter: T::AccountId = account("lighter", 0, 0);
+		let lighter: T::AccountId = account::<T>("lighter", 0, 0);
 		assert_ok!(List::<T>::insert(lighter.clone(), bag_thresh));
 
-		let heavier_prev: T::AccountId = account("heavier_prev", 0, 0);
+		let heavier_prev: T::AccountId = account::<T>("heavier_prev", 0, 0);
 		assert_ok!(List::<T>::insert(heavier_prev.clone(), bag_thresh));
 
-		let heavier: T::AccountId = account("heavier", 0, 0);
+		let heavier: T::AccountId = account::<T>("heavier", 0, 0);
 		assert_ok!(List::<T>::insert(heavier.clone(), bag_thresh));
 
-		let heavier_next: T::AccountId = account("heavier_next", 0, 0);
+		let heavier_next: T::AccountId = account::<T>("heavier_next", 0, 0);
 		assert_ok!(List::<T>::insert(heavier_next.clone(), bag_thresh));
 
 		T::VoteWeightProvider::set_vote_weight_of(&lighter, bag_thresh - 1);

--- a/frame/balances/src/benchmarking.rs
+++ b/frame/balances/src/benchmarking.rs
@@ -37,7 +37,7 @@ benchmarks_instance_pallet! {
 	// * Transfer will create the recipient account.
 	transfer {
 		let existential_deposit = T::ExistentialDeposit::get();
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 
 		// Give some multiple of the existential deposit
 		let balance = existential_deposit.saturating_mul(ED_MULTIPLIER.into());
@@ -45,7 +45,7 @@ benchmarks_instance_pallet! {
 
 		// Transfer `e - 1` existential deposits + 1 unit, which guarantees to create one account,
 		// and reap this user.
-		let recipient: T::AccountId = account("recipient", 0, SEED);
+		let recipient: T::AccountId = account::<T>("recipient", 0, SEED);
 		let recipient_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(recipient.clone());
 		let transfer_amount = existential_deposit.saturating_mul((ED_MULTIPLIER - 1).into()) + 1u32.into();
 	}: transfer(RawOrigin::Signed(caller.clone()), recipient_lookup, transfer_amount)
@@ -58,8 +58,8 @@ benchmarks_instance_pallet! {
 	// * Both accounts exist and will continue to exist.
 	#[extra]
 	transfer_best_case {
-		let caller = whitelisted_caller();
-		let recipient: T::AccountId = account("recipient", 0, SEED);
+		let caller = whitelisted_caller::<T>();
+		let recipient: T::AccountId = account::<T>("recipient", 0, SEED);
 		let recipient_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(recipient.clone());
 
 		// Give the sender account max funds for transfer (their account will never reasonably be killed).
@@ -78,8 +78,8 @@ benchmarks_instance_pallet! {
 	// Benchmark `transfer_keep_alive` with the worst possible condition:
 	// * The recipient account is created.
 	transfer_keep_alive {
-		let caller = whitelisted_caller();
-		let recipient: T::AccountId = account("recipient", 0, SEED);
+		let caller = whitelisted_caller::<T>();
+		let recipient: T::AccountId = account::<T>("recipient", 0, SEED);
 		let recipient_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(recipient.clone());
 
 		// Give the sender account max funds, thus a transfer will not kill account.
@@ -94,7 +94,7 @@ benchmarks_instance_pallet! {
 
 	// Benchmark `set_balance` coming from ROOT account. This always creates an account.
 	set_balance_creating {
-		let user: T::AccountId = account("user", 0, SEED);
+		let user: T::AccountId = account::<T>("user", 0, SEED);
 		let user_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(user.clone());
 
 		// Give the user some initial balance.
@@ -109,7 +109,7 @@ benchmarks_instance_pallet! {
 
 	// Benchmark `set_balance` coming from ROOT account. This always kills an account.
 	set_balance_killing {
-		let user: T::AccountId = account("user", 0, SEED);
+		let user: T::AccountId = account::<T>("user", 0, SEED);
 		let user_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(user.clone());
 
 		// Give the user some initial balance.
@@ -126,7 +126,7 @@ benchmarks_instance_pallet! {
 	// * Transfer will create the recipient account.
 	force_transfer {
 		let existential_deposit = T::ExistentialDeposit::get();
-		let source: T::AccountId = account("source", 0, SEED);
+		let source: T::AccountId = account::<T>("source", 0, SEED);
 		let source_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(source.clone());
 
 		// Give some multiple of the existential deposit
@@ -134,7 +134,7 @@ benchmarks_instance_pallet! {
 		let _ = <Balances<T, I> as Currency<_>>::make_free_balance_be(&source, balance);
 
 		// Transfer `e - 1` existential deposits + 1 unit, which guarantees to create one account, and reap this user.
-		let recipient: T::AccountId = account("recipient", 0, SEED);
+		let recipient: T::AccountId = account::<T>("recipient", 0, SEED);
 		let recipient_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(recipient.clone());
 		let transfer_amount = existential_deposit.saturating_mul((ED_MULTIPLIER - 1).into()) + 1u32.into();
 	}: force_transfer(RawOrigin::Root, source_lookup, recipient_lookup, transfer_amount)
@@ -151,7 +151,7 @@ benchmarks_instance_pallet! {
 		// 1_000 is not very much, but this upper bound can be controlled by the CLI.
 		let u in 0 .. 1_000;
 		let existential_deposit = T::ExistentialDeposit::get();
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 
 		// Give some multiple of the existential deposit
 		let balance = existential_deposit.saturating_mul(ED_MULTIPLIER.into());
@@ -159,7 +159,7 @@ benchmarks_instance_pallet! {
 
 		// Transfer `e - 1` existential deposits + 1 unit, which guarantees to create one account,
 		// and reap this user.
-		let recipient: T::AccountId = account("recipient", 0, SEED);
+		let recipient: T::AccountId = account::<T>("recipient", 0, SEED);
 		let recipient_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(recipient.clone());
 		let transfer_amount = existential_deposit.saturating_mul((ED_MULTIPLIER - 1).into()) + 1u32.into();
 
@@ -167,7 +167,7 @@ benchmarks_instance_pallet! {
 		for i in 0 .. u {
 			// The `account` function uses `blake2_256` to generate unique accounts, so these
 			// should be quite random and evenly distributed in the trie.
-			let new_user: T::AccountId = account("new_user", i, SEED);
+			let new_user: T::AccountId = account::<T>("new_user", i, SEED);
 			let _ = <Balances<T, I> as Currency<_>>::make_free_balance_be(&new_user, balance);
 		}
 	}: transfer(RawOrigin::Signed(caller.clone()), recipient_lookup, transfer_amount)
@@ -180,8 +180,8 @@ benchmarks_instance_pallet! {
 	// * The recipient account is created
 	// * The sender is killed
 	transfer_all {
-		let caller = whitelisted_caller();
-		let recipient: T::AccountId = account("recipient", 0, SEED);
+		let caller = whitelisted_caller::<T>();
+		let recipient: T::AccountId = account::<T>("recipient", 0, SEED);
 		let recipient_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(recipient.clone());
 
 		// Give some multiple of the existential deposit
@@ -195,7 +195,7 @@ benchmarks_instance_pallet! {
 	}
 
 	force_unreserve {
-		let user: T::AccountId = account("user", 0, SEED);
+		let user: T::AccountId = account::<T>("user", 0, SEED);
 		let user_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(user.clone());
 
 		// Give some multiple of the existential deposit

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -907,7 +907,7 @@ macro_rules! impl_bench_name_tests {
 // Every variant must implement [`BenchmarkingSetup`].
 //
 // ```nocompile
-// 
+//
 // struct Transfer;
 // impl BenchmarkingSetup for Transfer { ... }
 //
@@ -1017,7 +1017,7 @@ macro_rules! impl_benchmark {
 				let mut whitelist = whitelist.to_vec();
 				let whitelisted_caller_key =
 					<frame_system::Account::<T> as $crate::frame_support::storage::StorageMap<_,_>>::hashed_key_for(
-						$crate::whitelisted_caller::<T::AccountId>()
+						$crate::whitelisted_caller::<T>()
 					);
 				whitelist.push(whitelisted_caller_key.into());
 				$crate::benchmarking::set_whitelist(whitelist);

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -145,7 +145,7 @@ mod benchmarks {
 
 		set_value {
 			let b in 1 .. 1000;
-			let caller = account::<T::AccountId>("caller", 0, 0);
+			let caller = account::<T>("caller", 0, 0);
 		}: _ (RawOrigin::Signed(caller), b.into())
 		verify {
 			assert_eq!(Value::<T>::get(), Some(b));
@@ -169,7 +169,7 @@ mod benchmarks {
 
 		bad_origin {
 			let b in 1 .. 1000;
-			let caller = account::<T::AccountId>("caller", 0, 0);
+			let caller = account::<T>("caller", 0, 0);
 		}: dummy (RawOrigin::Signed(caller), b.into())
 
 		bad_verify {
@@ -184,7 +184,7 @@ mod benchmarks {
 		}
 
 		no_components {
-			let caller = account::<T::AccountId>("caller", 0, 0);
+			let caller = account::<T>("caller", 0, 0);
 		}: set_value(RawOrigin::Signed(caller), 0)
 
 		variable_components {
@@ -194,7 +194,7 @@ mod benchmarks {
 		#[extra]
 		extra_benchmark {
 			let b in 1 .. 1000;
-			let caller = account::<T::AccountId>("caller", 0, 0);
+			let caller = account::<T>("caller", 0, 0);
 		}: set_value(RawOrigin::Signed(caller), b.into())
 		verify {
 			assert_eq!(Value::<T>::get(), Some(b));
@@ -203,7 +203,7 @@ mod benchmarks {
 		#[skip_meta]
 		skip_meta_benchmark {
 			let b in 1 .. 1000;
-			let caller = account::<T::AccountId>("caller", 0, 0);
+			let caller = account::<T>("caller", 0, 0);
 		}: set_value(RawOrigin::Signed(caller), b.into())
 		verify {
 			assert_eq!(Value::<T>::get(), Some(b));
@@ -211,7 +211,7 @@ mod benchmarks {
 
 		override_benchmark {
 			let b in 1 .. 1000;
-			let caller = account::<T::AccountId>("caller", 0, 0);
+			let caller = account::<T>("caller", 0, 0);
 		}: {
 			Err(BenchmarkError::Override(
 				BenchmarkResult {

--- a/frame/benchmarking/src/tests_instance.rs
+++ b/frame/benchmarking/src/tests_instance.rs
@@ -153,7 +153,7 @@ mod benchmarks {
 
 		set_value {
 			let b in 1 .. 1000;
-			let caller = account::<T::AccountId>("caller", 0, 0);
+			let caller = account::<T>("caller", 0, 0);
 		}: _ (RawOrigin::Signed(caller), b.into())
 		verify {
 			assert_eq!(Value::<pallet_test::DefaultInstance>::get(), Some(b));

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -321,18 +321,14 @@ pub trait BenchmarkingSetup<T, I = ()> {
 }
 
 /// Grab an account, seeded by a name and index.
-pub fn account<AccountId: Decode + Default>(
-	name: &'static str,
-	index: u32,
-	seed: u32,
-) -> AccountId {
+pub fn account<T: frame_system::Config>(name: &'static str, index: u32, seed: u32) -> T::AccountId {
 	let entropy = (name, index, seed).using_encoded(blake2_256);
-	AccountId::decode(&mut &entropy[..]).unwrap_or_default()
+	T::AccountId::decode(&mut &entropy[..]).unwrap_or_default()
 }
 
 /// This caller account is automatically whitelisted for DB reads/writes by the benchmarking macro.
-pub fn whitelisted_caller<AccountId: Decode + Default>() -> AccountId {
-	account::<AccountId>("whitelisted_caller", 0, 0)
+pub fn whitelisted_caller<T: frame_system::Config>() -> T::AccountId {
+	account::<T>("whitelisted_caller", 0, 0)
 }
 
 #[macro_export]

--- a/frame/bounties/src/benchmarking.rs
+++ b/frame/bounties/src/benchmarking.rs
@@ -48,13 +48,13 @@ fn setup_bounty<T: Config>(
 	u: u32,
 	d: u32,
 ) -> (T::AccountId, T::AccountId, BalanceOf<T>, BalanceOf<T>, Vec<u8>) {
-	let caller = account("caller", u, SEED);
+	let caller = account::<T>("caller", u, SEED);
 	let value: BalanceOf<T> = T::BountyValueMinimum::get().saturating_mul(100u32.into());
 	let fee = value / 2u32.into();
 	let deposit = T::BountyDepositBase::get() +
 		T::DataDepositPerByte::get() * T::MaximumReasonLength::get().into();
 	let _ = T::Currency::make_free_balance_be(&caller, deposit);
-	let curator = account("curator", u, SEED);
+	let curator = account::<T>("curator", u, SEED);
 	let _ = T::Currency::make_free_balance_be(&curator, fee / 2u32.into());
 	let reason = vec![0; d as usize];
 	(caller, curator, fee, value, reason)
@@ -113,7 +113,7 @@ benchmarks! {
 		Bounties::<T>::on_initialize(T::BlockNumber::zero());
 		let bounty_id = BountyCount::<T>::get() - 1;
 		frame_system::Pallet::<T>::set_block_number(T::BountyUpdatePeriod::get() + 1u32.into());
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 	}: _(RawOrigin::Signed(caller), bounty_id)
 
 	accept_curator {
@@ -135,7 +135,7 @@ benchmarks! {
 		let bounty_id = BountyCount::<T>::get() - 1;
 		let curator = T::Lookup::lookup(curator_lookup).map_err(<&str>::from)?;
 
-		let beneficiary = T::Lookup::unlookup(account("beneficiary", 0, SEED));
+		let beneficiary = T::Lookup::unlookup(account::<T>("beneficiary", 0, SEED));
 	}: _(RawOrigin::Signed(curator), bounty_id, beneficiary)
 
 	claim_bounty {
@@ -146,7 +146,7 @@ benchmarks! {
 		let bounty_id = BountyCount::<T>::get() - 1;
 		let curator = T::Lookup::lookup(curator_lookup).map_err(<&str>::from)?;
 
-		let beneficiary_account: T::AccountId = account("beneficiary", 0, SEED);
+		let beneficiary_account: T::AccountId = account::<T>("beneficiary", 0, SEED);
 		let beneficiary = T::Lookup::unlookup(beneficiary_account.clone());
 		Bounties::<T>::award_bounty(RawOrigin::Signed(curator.clone()).into(), bounty_id, beneficiary)?;
 

--- a/frame/child-bounties/src/benchmarking.rs
+++ b/frame/child-bounties/src/benchmarking.rs
@@ -58,13 +58,13 @@ fn setup_bounty<T: Config>(
 	user: u32,
 	description: u32,
 ) -> (T::AccountId, T::AccountId, BalanceOf<T>, BalanceOf<T>, Vec<u8>) {
-	let caller = account("caller", user, SEED);
+	let caller = account::<T>("caller", user, SEED);
 	let value: BalanceOf<T> = T::BountyValueMinimum::get().saturating_mul(100u32.into());
 	let fee = value / 2u32.into();
 	let deposit = T::BountyDepositBase::get() +
 		T::DataDepositPerByte::get() * T::MaximumReasonLength::get().into();
 	let _ = T::Currency::make_free_balance_be(&caller, deposit);
-	let curator = account("curator", user, SEED);
+	let curator = account::<T>("curator", user, SEED);
 	let _ = T::Currency::make_free_balance_be(&curator, fee / 2u32.into());
 	let reason = vec![0; description as usize];
 	(caller, curator, fee, value, reason)
@@ -72,7 +72,7 @@ fn setup_bounty<T: Config>(
 
 fn setup_child_bounty<T: Config>(user: u32, description: u32) -> BenchmarkChildBounty<T> {
 	let (caller, curator, fee, value, reason) = setup_bounty::<T>(user, description);
-	let child_curator = account("child-curator", user, SEED);
+	let child_curator = account::<T>("child-curator", user, SEED);
 	let _ = T::Currency::make_free_balance_be(&child_curator, fee / 2u32.into());
 	let child_bounty_value = (value - fee) / 4u32.into();
 	let child_bounty_fee = child_bounty_value / 2u32.into();
@@ -223,14 +223,14 @@ benchmarks! {
 		let bounty_setup = activate_child_bounty::<T>(0, T::MaximumReasonLength::get())?;
 		Bounties::<T>::on_initialize(T::BlockNumber::zero());
 		frame_system::Pallet::<T>::set_block_number(T::BountyUpdatePeriod::get() + 1u32.into());
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 	}: _(RawOrigin::Signed(caller), bounty_setup.bounty_id,
 			bounty_setup.child_bounty_id)
 
 	award_child_bounty {
 		setup_pot_account::<T>();
 		let bounty_setup = activate_child_bounty::<T>(0, T::MaximumReasonLength::get())?;
-		let beneficiary_account: T::AccountId = account("beneficiary", 0, SEED);
+		let beneficiary_account: T::AccountId = account::<T>("beneficiary", 0, SEED);
 		let beneficiary = T::Lookup::unlookup(beneficiary_account.clone());
 	}: _(RawOrigin::Signed(bounty_setup.child_curator), bounty_setup.bounty_id,
 			bounty_setup.child_bounty_id, beneficiary)
@@ -245,7 +245,7 @@ benchmarks! {
 	claim_child_bounty {
 		setup_pot_account::<T>();
 		let bounty_setup = activate_child_bounty::<T>(0, T::MaximumReasonLength::get())?;
-		let beneficiary_account: T::AccountId = account("beneficiary", 0, SEED);
+		let beneficiary_account: T::AccountId = account::<T>("beneficiary", 0, SEED);
 		let beneficiary = T::Lookup::unlookup(beneficiary_account.clone());
 
 		ChildBounties::<T>::award_child_bounty(
@@ -255,7 +255,7 @@ benchmarks! {
 			beneficiary
 		)?;
 
-		let beneficiary_account: T::AccountId = account("beneficiary", 0, SEED);
+		let beneficiary_account: T::AccountId = account::<T>("beneficiary", 0, SEED);
 		let beneficiary = T::Lookup::unlookup(beneficiary_account.clone());
 
 		frame_system::Pallet::<T>::set_block_number(T::BountyDepositPayoutDelay::get());

--- a/frame/collective/src/benchmarking.rs
+++ b/frame/collective/src/benchmarking.rs
@@ -45,7 +45,7 @@ benchmarks_instance_pallet! {
 		let mut old_members = vec![];
 		let mut last_old_member = T::AccountId::default();
 		for i in 0 .. m {
-			last_old_member = account("old member", i, SEED);
+			last_old_member = account::<T>("old member", i, SEED);
 			old_members.push(last_old_member.clone());
 		}
 		let old_members_count = old_members.len() as u32;
@@ -93,7 +93,7 @@ benchmarks_instance_pallet! {
 		let mut new_members = vec![];
 		let mut last_member = T::AccountId::default();
 		for i in 0 .. n {
-			last_member = account("member", i, SEED);
+			last_member = account::<T>("member", i, SEED);
 			new_members.push(last_member.clone());
 		}
 
@@ -112,11 +112,11 @@ benchmarks_instance_pallet! {
 		// Construct `members`.
 		let mut members = vec![];
 		for i in 0 .. m - 1 {
-			let member = account("member", i, SEED);
+			let member = account::<T>("member", i, SEED);
 			members.push(member);
 		}
 
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		members.push(caller.clone());
 
 		Collective::<T, I>::set_members(SystemOrigin::Root.into(), members, None, T::MaxMembers::get())?;
@@ -142,11 +142,11 @@ benchmarks_instance_pallet! {
 		// Construct `members`.
 		let mut members = vec![];
 		for i in 0 .. m - 1 {
-			let member = account("member", i, SEED);
+			let member = account::<T>("member", i, SEED);
 			members.push(member);
 		}
 
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		members.push(caller.clone());
 
 		Collective::<T, I>::set_members(SystemOrigin::Root.into(), members, None, T::MaxMembers::get())?;
@@ -174,10 +174,10 @@ benchmarks_instance_pallet! {
 		// Construct `members`.
 		let mut members = vec![];
 		for i in 0 .. m - 1 {
-			let member = account("member", i, SEED);
+			let member = account::<T>("member", i, SEED);
 			members.push(member);
 		}
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		members.push(caller.clone());
 		Collective::<T, I>::set_members(SystemOrigin::Root.into(), members, None, T::MaxMembers::get())?;
 
@@ -216,13 +216,13 @@ benchmarks_instance_pallet! {
 
 		// Construct `members`.
 		let mut members = vec![];
-		let proposer: T::AccountId = account("proposer", 0, SEED);
+		let proposer: T::AccountId = account::<T>("proposer", 0, SEED);
 		members.push(proposer.clone());
 		for i in 1 .. m - 1 {
-			let member = account("member", i, SEED);
+			let member = account::<T>("member", i, SEED);
 			members.push(member);
 		}
-		let voter: T::AccountId = account("voter", 0, SEED);
+		let voter: T::AccountId = account::<T>("voter", 0, SEED);
 		members.push(voter.clone());
 		Collective::<T, I>::set_members(SystemOrigin::Root.into(), members.clone(), None, T::MaxMembers::get())?;
 
@@ -291,13 +291,13 @@ benchmarks_instance_pallet! {
 
 		// Construct `members`.
 		let mut members = vec![];
-		let proposer: T::AccountId = account("proposer", 0, SEED);
+		let proposer: T::AccountId = account::<T>("proposer", 0, SEED);
 		members.push(proposer.clone());
 		for i in 1 .. m - 1 {
-			let member = account("member", i, SEED);
+			let member = account::<T>("member", i, SEED);
 			members.push(member);
 		}
-		let voter: T::AccountId = account("voter", 0, SEED);
+		let voter: T::AccountId = account::<T>("voter", 0, SEED);
 		members.push(voter.clone());
 		Collective::<T, I>::set_members(SystemOrigin::Root.into(), members.clone(), None, T::MaxMembers::get())?;
 
@@ -373,10 +373,10 @@ benchmarks_instance_pallet! {
 		// Construct `members`.
 		let mut members = vec![];
 		for i in 0 .. m - 1 {
-			let member = account("member", i, SEED);
+			let member = account::<T>("member", i, SEED);
 			members.push(member);
 		}
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		members.push(caller.clone());
 		Collective::<T, I>::set_members(SystemOrigin::Root.into(), members.clone(), None, T::MaxMembers::get())?;
 
@@ -454,10 +454,10 @@ benchmarks_instance_pallet! {
 		// Construct `members`.
 		let mut members = vec![];
 		for i in 0 .. m - 1 {
-			let member = account("member", i, SEED);
+			let member = account::<T>("member", i, SEED);
 			members.push(member);
 		}
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		members.push(caller.clone());
 		Collective::<T, I>::set_members(
 			SystemOrigin::Root.into(),
@@ -528,10 +528,10 @@ benchmarks_instance_pallet! {
 		// Construct `members`.
 		let mut members = vec![];
 		for i in 0 .. m - 1 {
-			let member = account("member", i, SEED);
+			let member = account::<T>("member", i, SEED);
 			members.push(member);
 		}
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		members.push(caller.clone());
 		Collective::<T, I>::set_members(
 			SystemOrigin::Root.into(),
@@ -599,10 +599,10 @@ benchmarks_instance_pallet! {
 		// Construct `members`.
 		let mut members = vec![];
 		for i in 0 .. m - 1 {
-			let member = account("member", i, SEED);
+			let member = account::<T>("member", i, SEED);
 			members.push(member);
 		}
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = account::<T>("caller", 0, SEED);
 		members.push(caller.clone());
 		Collective::<T, I>::set_members(
 			SystemOrigin::Root.into(),

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -77,7 +77,7 @@ where
 		module: WasmModule<T>,
 		data: Vec<u8>,
 	) -> Result<Contract<T>, &'static str> {
-		Self::with_caller(account("instantiator", index, 0), module, data)
+		Self::with_caller(account::<T>("instantiator", index, 0), module, data)
 	}
 
 	/// Create new contract and use the supplied `caller` as instantiator.
@@ -232,7 +232,7 @@ benchmarks! {
 	instrument {
 		let c in 0 .. T::Schedule::get().limits.code_len / 1024;
 		let WasmModule { code, hash, .. } = WasmModule::<T>::sized(c * 1024);
-		Contracts::<T>::store_code_raw(code, whitelisted_caller())?;
+		Contracts::<T>::store_code_raw(code, whitelisted_caller::<T>())?;
 		let schedule = T::Schedule::get();
 		let mut gas_meter = GasMeter::new(Weight::MAX);
 		let mut module = PrefabWasmModule::from_storage(hash, &schedule, &mut gas_meter)?;
@@ -244,7 +244,7 @@ benchmarks! {
 	code_load {
 		let c in 0 .. T::Schedule::get().limits.code_len / 1024;
 		let WasmModule { code, hash, .. } = WasmModule::<T>::dummy_with_bytes(c * 1024);
-		Contracts::<T>::store_code_raw(code, whitelisted_caller())?;
+		Contracts::<T>::store_code_raw(code, whitelisted_caller::<T>())?;
 		let schedule = T::Schedule::get();
 		let mut gas_meter = GasMeter::new(Weight::MAX);
 	}: {
@@ -267,7 +267,7 @@ benchmarks! {
 		let s in 0 .. code::max_pages::<T>() * 64;
 		let salt = vec![42u8; (s * 1024) as usize];
 		let value = T::Currency::minimum_balance();
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, caller_funding::<T>());
 		let WasmModule { code, hash, .. } = WasmModule::<T>::sized(c * 1024);
 		let origin = RawOrigin::Signed(caller.clone());
@@ -294,7 +294,7 @@ benchmarks! {
 		let s in 0 .. code::max_pages::<T>() * 64;
 		let salt = vec![42u8; (s * 1024) as usize];
 		let value = T::Currency::minimum_balance();
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, caller_funding::<T>());
 		let WasmModule { code, hash, .. } = WasmModule::<T>::dummy();
 		let origin = RawOrigin::Signed(caller.clone());
@@ -320,7 +320,7 @@ benchmarks! {
 	call {
 		let data = vec![42u8; 1024];
 		let instance = Contract::<T>::with_caller(
-			whitelisted_caller(), WasmModule::dummy(), vec![],
+			whitelisted_caller::<T>(), WasmModule::dummy(), vec![],
 		)?;
 		let value = T::Currency::minimum_balance();
 		let origin = RawOrigin::Signed(instance.caller.clone());
@@ -351,7 +351,7 @@ benchmarks! {
 	// to be larger than the maximum size **after instrumentation**.
 	upload_code {
 		let c in 0 .. Perbill::from_percent(50).mul_ceil(T::Schedule::get().limits.code_len / 1024);
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, caller_funding::<T>());
 		let WasmModule { code, hash, .. } = WasmModule::<T>::sized(c * 1024);
 		let origin = RawOrigin::Signed(caller.clone());
@@ -366,7 +366,7 @@ benchmarks! {
 	// needed to verify the removal claim (refcount, owner) is stored in a separate storage
 	// item (`OwnerInfoOf`).
 	remove_code {
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, caller_funding::<T>());
 		let WasmModule { code, hash, .. } = WasmModule::<T>::dummy();
 		let origin = RawOrigin::Signed(caller.clone());
@@ -600,7 +600,7 @@ benchmarks! {
 	// The same argument as for `seal_return` is true here.
 	seal_terminate {
 		let r in 0 .. 1;
-		let beneficiary = account::<T::AccountId>("beneficiary", 0, 0);
+		let beneficiary = account::<T>("beneficiary", 0, 0);
 		let beneficiary_bytes = beneficiary.encode();
 		let beneficiary_len = beneficiary_bytes.len();
 		let code = WasmModule::<T>::from(ModuleDefinition {
@@ -971,7 +971,7 @@ benchmarks! {
 	seal_transfer {
 		let r in 0 .. API_BENCHMARK_BATCHES;
 		let accounts = (0..r * API_BENCHMARK_BATCH_SIZE)
-			.map(|i| account::<T::AccountId>("receiver", i, 0))
+			.map(|i| account::<T>("receiver", i, 0))
 			.collect::<Vec<_>>();
 		let account_len = accounts.get(0).map(|i| i.encode().len()).unwrap_or(0);
 		let account_bytes = accounts.iter().flat_map(|x| x.encode()).collect();
@@ -1180,7 +1180,7 @@ benchmarks! {
 					])),
 					.. Default::default()
 				});
-				Contracts::<T>::store_code_raw(code.code, whitelisted_caller())?;
+				Contracts::<T>::store_code_raw(code.code, whitelisted_caller::<T>())?;
 				Ok(code.hash)
 			})
 			.collect::<Result<Vec<_>, &'static str>>()?;
@@ -1306,7 +1306,7 @@ benchmarks! {
 		let hash = callee_code.hash.clone();
 		let hash_bytes = callee_code.hash.encode();
 		let hash_len = hash_bytes.len();
-		Contracts::<T>::store_code_raw(callee_code.code, whitelisted_caller())?;
+		Contracts::<T>::store_code_raw(callee_code.code, whitelisted_caller::<T>())?;
 		let inputs = (0..API_BENCHMARK_BATCH_SIZE).map(|x| x.encode()).collect::<Vec<_>>();
 		let input_len = inputs.get(0).map(|x| x.len()).unwrap_or(0);
 		let input_bytes = inputs.iter().cloned().flatten().collect::<Vec<_>>();
@@ -2318,7 +2318,7 @@ benchmarks! {
 		let data = {
 			let transfer: ([u8; 4], AccountIdOf<T>, BalanceOf<T>) = (
 				[0x84, 0xa1, 0x5d, 0xa1],
-				account::<T::AccountId>("receiver", 0, 0),
+				account::<T>("receiver", 0, 0),
 				1u32.into(),
 			);
 			transfer.encode()
@@ -2345,7 +2345,7 @@ benchmarks! {
 		let g in 0 .. 1;
 		let gas_metering = if g == 0 { false } else { true };
 		let code = include_bytes!("../../benchmarks/solang_erc20.wasm");
-		let caller = account::<T::AccountId>("instantiator", 0, 0);
+		let caller = account::<T>("instantiator", 0, 0);
 		let mut balance = [0u8; 32];
 		balance[0] = 100;
 		let data = {
@@ -2365,7 +2365,7 @@ benchmarks! {
 		let data = {
 			let transfer: ([u8; 4], AccountIdOf<T>, [u8; 32]) = (
 				[0x6a, 0x46, 0x73, 0x94],
-				account::<T::AccountId>("receiver", 0, 0),
+				account::<T>("receiver", 0, 0),
 				balance,
 			);
 			transfer.encode()

--- a/frame/democracy/src/benchmarking.rs
+++ b/frame/democracy/src/benchmarking.rs
@@ -42,7 +42,7 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
 }
 
 fn funded_account<T: Config>(name: &'static str, index: u32) -> T::AccountId {
-	let caller: T::AccountId = account(name, index, SEED);
+	let caller: T::AccountId = account::<T>(name, index, SEED);
 	T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 	caller
 }
@@ -292,7 +292,7 @@ benchmarks! {
 
 		let mut vetoers: Vec<T::AccountId> = Vec::new();
 		for i in 0 .. v {
-			vetoers.push(account("vetoer", i, SEED));
+			vetoers.push(account::<T>("vetoer", i, SEED));
 		}
 		vetoers.sort();
 		Blacklist::<T>::insert(proposal_hash, (T::BlockNumber::zero(), vetoers));

--- a/frame/election-provider-multi-phase/src/benchmarking.rs
+++ b/frame/election-provider-multi-phase/src/benchmarking.rs
@@ -53,7 +53,7 @@ fn solution_with_size<T: Config>(
 
 	// first generates random targets.
 	let targets: Vec<T::AccountId> = (0..size.targets)
-		.map(|i| frame_benchmarking::account("Targets", i, SEED))
+		.map(|i| frame_benchmarking::account::<T>("Targets", i, SEED))
 		.collect();
 
 	let mut rng = SmallRng::seed_from_u64(SEED.into());
@@ -74,7 +74,7 @@ fn solution_with_size<T: Config>(
 				.choose_multiple(&mut rng, <SolutionOf<T>>::LIMIT)
 				.cloned()
 				.collect::<Vec<_>>();
-			let voter = frame_benchmarking::account::<T::AccountId>("Voter", i, SEED);
+			let voter = frame_benchmarking::account::<T>("Voter", i, SEED);
 			(voter, stake, winner_votes)
 		})
 		.collect::<Vec<_>>();
@@ -91,7 +91,7 @@ fn solution_with_size<T: Config>(
 				.choose_multiple(&mut rng, <SolutionOf<T>>::LIMIT)
 				.cloned()
 				.collect::<Vec<T::AccountId>>();
-			let voter = frame_benchmarking::account::<T::AccountId>("Voter", i, SEED);
+			let voter = frame_benchmarking::account::<T>("Voter", i, SEED);
 			(voter, stake, votes)
 		})
 		.collect::<Vec<_>>();
@@ -159,7 +159,7 @@ fn set_up_data_provider<T: Config>(v: u32, t: u32) {
 	// fill targets.
 	let mut targets = (0..t)
 		.map(|i| {
-			let target = frame_benchmarking::account::<T::AccountId>("Target", i, SEED);
+			let target = frame_benchmarking::account::<T>("Target", i, SEED);
 			T::DataProvider::add_target(target.clone());
 			target
 		})
@@ -170,7 +170,7 @@ fn set_up_data_provider<T: Config>(v: u32, t: u32) {
 
 	// fill voters.
 	(0..v).for_each(|i| {
-		let voter = frame_benchmarking::account::<T::AccountId>("Voter", i, SEED);
+		let voter = frame_benchmarking::account::<T>("Voter", i, SEED);
 		let weight = T::Currency::minimum_balance().saturated_into::<u64>() * 1000;
 		T::DataProvider::add_voter(voter, weight, targets.clone());
 	});
@@ -206,7 +206,7 @@ frame_benchmarking::benchmarks! {
 	}
 
 	finalize_signed_phase_accept_solution {
-		let receiver = account("receiver", 0, SEED);
+		let receiver = account::<T>("receiver", 0, SEED);
 		let initial_balance = T::Currency::minimum_balance() * 10u32.into();
 		T::Currency::make_free_balance_be(&receiver, initial_balance);
 		let ready: ReadySolution<T::AccountId> = Default::default();
@@ -223,7 +223,7 @@ frame_benchmarking::benchmarks! {
 	}
 
 	finalize_signed_phase_reject_solution {
-		let receiver = account("receiver", 0, SEED);
+		let receiver = account::<T>("receiver", 0, SEED);
 		let initial_balance = T::Currency::minimum_balance().max(One::one()) * 10u32.into();
 		let deposit: BalanceOf<T> = 10u32.into();
 		T::Currency::make_free_balance_be(&receiver, initial_balance);
@@ -319,7 +319,7 @@ frame_benchmarking::benchmarks! {
 		}
 		signed_submissions.put();
 
-		let caller = frame_benchmarking::whitelisted_caller();
+		let caller = frame_benchmarking::whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller,  T::Currency::minimum_balance() * 10u32.into());
 
 	}: _(RawOrigin::Signed(caller), Box::new(solution), c)

--- a/frame/elections-phragmen/src/benchmarking.rs
+++ b/frame/elections-phragmen/src/benchmarking.rs
@@ -38,7 +38,7 @@ type Lookup<T> = <<T as frame_system::Config>::Lookup as StaticLookup>::Source;
 
 /// grab new account with infinite balance.
 fn endowed_account<T: Config>(name: &'static str, index: u32) -> T::AccountId {
-	let account: T::AccountId = account(name, index, 0);
+	let account: T::AccountId = account::<T>(name, index, 0);
 	let amount = default_stake::<T>(BALANCE_FACTOR);
 	let _ = T::Currency::make_free_balance_be(&account, amount);
 	// important to increase the total issuance since T::CurrencyToVote will need it to be sane for

--- a/frame/examples/basic/src/benchmarking.rs
+++ b/frame/examples/basic/src/benchmarking.rs
@@ -51,7 +51,7 @@ benchmarks! {
 	accumulate_dummy {
 		let b in 1 .. 1000;
 		// The caller account is whitelisted for DB reads/write by the benchmarking macro.
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 	}: _(RawOrigin::Signed(caller), b.into())
 
 	// This will measure the execution time of sorting a vector.

--- a/frame/gilt/src/benchmarking.rs
+++ b/frame/gilt/src/benchmarking.rs
@@ -38,7 +38,7 @@ type BalanceOf<T> =
 benchmarks! {
 	place_bid {
 		let l in 0..(T::MaxQueueLen::get() - 1);
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		for i in 0..l {
 			Gilt::<T>::place_bid(RawOrigin::Signed(caller.clone()).into(), T::MinFreeze::get(), 1)?;
@@ -49,7 +49,7 @@ benchmarks! {
 	}
 
 	place_bid_max {
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		let origin = RawOrigin::Signed(caller.clone());
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		for i in 0..T::MaxQueueLen::get() {
@@ -65,7 +65,7 @@ benchmarks! {
 
 	retract_bid {
 		let l in 1..T::MaxQueueLen::get();
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		for i in 0..l {
 			Gilt::<T>::place_bid(RawOrigin::Signed(caller.clone()).into(), T::MinFreeze::get(), 1)?;
@@ -81,7 +81,7 @@ benchmarks! {
 	verify {}
 
 	thaw {
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, T::MinFreeze::get() * BalanceOf::<T>::from(3u32));
 		Gilt::<T>::place_bid(RawOrigin::Signed(caller.clone()).into(), T::MinFreeze::get(), 1)?;
 		Gilt::<T>::place_bid(RawOrigin::Signed(caller.clone()).into(), T::MinFreeze::get(), 1)?;
@@ -99,7 +99,7 @@ benchmarks! {
 		// bids taken
 		let b in 1..T::MaxQueueLen::get();
 
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, T::MinFreeze::get() * BalanceOf::<T>::from(b + 1));
 
 		for _ in 0..b {
@@ -115,7 +115,7 @@ benchmarks! {
 		// total queues hit
 		let q in 1..T::QueueCount::get();
 
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, T::MinFreeze::get() * BalanceOf::<T>::from(q + 1));
 
 		for i in 0..q {

--- a/frame/indices/src/benchmarking.rs
+++ b/frame/indices/src/benchmarking.rs
@@ -31,7 +31,7 @@ const SEED: u32 = 0;
 benchmarks! {
 	claim {
 		let account_index = T::AccountIndex::from(SEED);
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 	}: _(RawOrigin::Signed(caller.clone()), account_index)
 	verify {
@@ -41,9 +41,9 @@ benchmarks! {
 	transfer {
 		let account_index = T::AccountIndex::from(SEED);
 		// Setup accounts
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
-		let recipient: T::AccountId = account("recipient", 0, SEED);
+		let recipient: T::AccountId = account::<T>("recipient", 0, SEED);
 		T::Currency::make_free_balance_be(&recipient, BalanceOf::<T>::max_value());
 		// Claim the index
 		Indices::<T>::claim(RawOrigin::Signed(caller.clone()).into(), account_index)?;
@@ -55,7 +55,7 @@ benchmarks! {
 	free {
 		let account_index = T::AccountIndex::from(SEED);
 		// Setup accounts
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		// Claim the index
 		Indices::<T>::claim(RawOrigin::Signed(caller.clone()).into(), account_index)?;
@@ -67,9 +67,9 @@ benchmarks! {
 	force_transfer {
 		let account_index = T::AccountIndex::from(SEED);
 		// Setup accounts
-		let original: T::AccountId = account("original", 0, SEED);
+		let original: T::AccountId = account::<T>("original", 0, SEED);
 		T::Currency::make_free_balance_be(&original, BalanceOf::<T>::max_value());
-		let recipient: T::AccountId = account("recipient", 0, SEED);
+		let recipient: T::AccountId = account::<T>("recipient", 0, SEED);
 		T::Currency::make_free_balance_be(&recipient, BalanceOf::<T>::max_value());
 		// Claim the index
 		Indices::<T>::claim(RawOrigin::Signed(original).into(), account_index)?;
@@ -81,7 +81,7 @@ benchmarks! {
 	freeze {
 		let account_index = T::AccountIndex::from(SEED);
 		// Setup accounts
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		// Claim the index
 		Indices::<T>::claim(RawOrigin::Signed(caller.clone()).into(), account_index)?;

--- a/frame/lottery/src/benchmarking.rs
+++ b/frame/lottery/src/benchmarking.rs
@@ -48,7 +48,7 @@ fn setup_lottery<T: Config>(repeat: bool) -> Result<(), &'static str> {
 
 benchmarks! {
 	buy_ticket {
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		setup_lottery::<T>(false)?;
 		// force user to have a long vec of calls participating
@@ -103,7 +103,7 @@ benchmarks! {
 
 	on_initialize_end {
 		setup_lottery::<T>(false)?;
-		let winner = account("winner", 0, 0);
+		let winner = account::<T>("winner", 0, 0);
 		// User needs more than min balance to get ticket
 		T::Currency::make_free_balance_be(&winner, T::Currency::minimum_balance() * 10u32.into());
 		// Make sure lottery account has at least min balance too
@@ -134,7 +134,7 @@ benchmarks! {
 
 	on_initialize_repeat {
 		setup_lottery::<T>(true)?;
-		let winner = account("winner", 0, 0);
+		let winner = account::<T>("winner", 0, 0);
 		// User needs more than min balance to get ticket
 		T::Currency::make_free_balance_be(&winner, T::Currency::minimum_balance() * 10u32.into());
 		// Make sure lottery account has at least min balance too

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -379,9 +379,9 @@ mod benchmark {
 		add_member {
 			let m in 1 .. T::MaxMembers::get();
 
-			let members = (0..m).map(|i| account("member", i, SEED)).collect::<Vec<T::AccountId>>();
+			let members = (0..m).map(|i| account::<T>("member", i, SEED)).collect::<Vec<T::AccountId>>();
 			set_members::<T, I>(members.clone(), None);
-			let new_member = account::<T::AccountId>("add", m, SEED);
+			let new_member = account::<T>("add", m, SEED);
 		}: {
 			assert_ok!(<Membership<T, I>>::add_member(T::AddOrigin::successful_origin(), new_member.clone()));
 		}
@@ -395,7 +395,7 @@ mod benchmark {
 		remove_member {
 			let m in 2 .. T::MaxMembers::get();
 
-			let members = (0..m).map(|i| account("member", i, SEED)).collect::<Vec<T::AccountId>>();
+			let members = (0..m).map(|i| account::<T>("member", i, SEED)).collect::<Vec<T::AccountId>>();
 			set_members::<T, I>(members.clone(), Some(members.len() - 1));
 
 			let to_remove = members.first().cloned().unwrap();
@@ -412,9 +412,9 @@ mod benchmark {
 		swap_member {
 			let m in 2 .. T::MaxMembers::get();
 
-			let members = (0..m).map(|i| account("member", i, SEED)).collect::<Vec<T::AccountId>>();
+			let members = (0..m).map(|i| account::<T>("member", i, SEED)).collect::<Vec<T::AccountId>>();
 			set_members::<T, I>(members.clone(), Some(members.len() - 1));
-			let add = account::<T::AccountId>("member", m, SEED);
+			let add = account::<T>("member", m, SEED);
 			let remove = members.first().cloned().unwrap();
 		}: {
 			assert_ok!(<Membership<T, I>>::swap_member(
@@ -434,9 +434,9 @@ mod benchmark {
 		reset_member {
 			let m in 1 .. T::MaxMembers::get();
 
-			let members = (1..m+1).map(|i| account("member", i, SEED)).collect::<Vec<T::AccountId>>();
+			let members = (1..m+1).map(|i| account::<T>("member", i, SEED)).collect::<Vec<T::AccountId>>();
 			set_members::<T, I>(members.clone(), Some(members.len() - 1));
-			let mut new_members = (m..2*m).map(|i| account("member", i, SEED)).collect::<Vec<T::AccountId>>();
+			let mut new_members = (m..2*m).map(|i| account::<T>("member", i, SEED)).collect::<Vec<T::AccountId>>();
 		}: {
 			assert_ok!(<Membership<T, I>>::reset_members(T::ResetOrigin::successful_origin(), new_members.clone()));
 		} verify {
@@ -451,11 +451,11 @@ mod benchmark {
 			let m in 1 .. T::MaxMembers::get();
 
 			// worse case would be to change the prime
-			let members = (0..m).map(|i| account("member", i, SEED)).collect::<Vec<T::AccountId>>();
+			let members = (0..m).map(|i| account::<T>("member", i, SEED)).collect::<Vec<T::AccountId>>();
 			let prime = members.last().cloned().unwrap();
 			set_members::<T, I>(members.clone(), Some(members.len() - 1));
 
-			let add = account::<T::AccountId>("member", m, SEED);
+			let add = account::<T>("member", m, SEED);
 			whitelist!(prime);
 		}: {
 			assert_ok!(<Membership<T, I>>::change_key(RawOrigin::Signed(prime.clone()).into(), add.clone()));
@@ -469,7 +469,7 @@ mod benchmark {
 
 		set_prime {
 			let m in 1 .. T::MaxMembers::get();
-			let members = (0..m).map(|i| account("member", i, SEED)).collect::<Vec<T::AccountId>>();
+			let members = (0..m).map(|i| account::<T>("member", i, SEED)).collect::<Vec<T::AccountId>>();
 			let prime = members.last().cloned().unwrap();
 			set_members::<T, I>(members, None);
 		}: {
@@ -482,7 +482,7 @@ mod benchmark {
 
 		clear_prime {
 			let m in 1 .. T::MaxMembers::get();
-			let members = (0..m).map(|i| account("member", i, SEED)).collect::<Vec<T::AccountId>>();
+			let members = (0..m).map(|i| account::<T>("member", i, SEED)).collect::<Vec<T::AccountId>>();
 			let prime = members.last().cloned().unwrap();
 			set_members::<T, I>(members, None);
 		}: {

--- a/frame/multisig/src/benchmarking.rs
+++ b/frame/multisig/src/benchmarking.rs
@@ -34,7 +34,7 @@ fn setup_multi<T: Config>(
 ) -> Result<(Vec<T::AccountId>, OpaqueCall<T>), &'static str> {
 	let mut signatories: Vec<T::AccountId> = Vec::new();
 	for i in 0..s {
-		let signatory = account("signatory", i, SEED);
+		let signatory = account::<T>("signatory", i, SEED);
 		// Give them some balance for a possible deposit
 		let balance = BalanceOf::<T>::max_value();
 		T::Currency::make_free_balance_be(&signatory, balance);

--- a/frame/offences/benchmarking/src/lib.rs
+++ b/frame/offences/benchmarking/src/lib.rs
@@ -97,8 +97,8 @@ fn bond_amount<T: Config>() -> BalanceOf<T> {
 }
 
 fn create_offender<T: Config>(n: u32, nominators: u32) -> Result<Offender<T>, &'static str> {
-	let stash: T::AccountId = account("stash", n, SEED);
-	let controller: T::AccountId = account("controller", n, SEED);
+	let stash: T::AccountId = account::<T>("stash", n, SEED);
+	let controller: T::AccountId = account::<T>("controller", n, SEED);
 	let controller_lookup: LookupSourceOf<T> = T::Lookup::unlookup(controller.clone());
 	let reward_destination = RewardDestination::Staked;
 	let raw_amount = bond_amount::<T>();
@@ -122,9 +122,9 @@ fn create_offender<T: Config>(n: u32, nominators: u32) -> Result<Offender<T>, &'
 	// Create n nominators
 	for i in 0..nominators {
 		let nominator_stash: T::AccountId =
-			account("nominator stash", n * MAX_NOMINATORS + i, SEED);
+			account::<T>("nominator stash", n * MAX_NOMINATORS + i, SEED);
 		let nominator_controller: T::AccountId =
-			account("nominator controller", n * MAX_NOMINATORS + i, SEED);
+			account::<T>("nominator controller", n * MAX_NOMINATORS + i, SEED);
 		let nominator_controller_lookup: LookupSourceOf<T> =
 			T::Lookup::unlookup(nominator_controller.clone());
 		T::Currency::make_free_balance_be(&nominator_stash, free_amount.into());
@@ -280,7 +280,7 @@ benchmarks! {
 		// Make r reporters
 		let mut reporters = vec![];
 		for i in 0 .. r {
-			let reporter = account("reporter", i, SEED);
+			let reporter = account::<T>("reporter", i, SEED);
 			reporters.push(reporter);
 		}
 
@@ -385,7 +385,7 @@ benchmarks! {
 
 		// for grandpa equivocation reports the number of reporters
 		// and offenders is always 1
-		let reporters = vec![account("reporter", 1, SEED)];
+		let reporters = vec![account::<T>("reporter", 1, SEED)];
 
 		// make sure reporters actually get rewarded
 		Staking::<T>::set_slash_reward_fraction(Perbill::one());
@@ -420,7 +420,7 @@ benchmarks! {
 
 		// for babe equivocation reports the number of reporters
 		// and offenders is always 1
-		let reporters = vec![account("reporter", 1, SEED)];
+		let reporters = vec![account::<T>("reporter", 1, SEED)];
 
 		// make sure reporters actually get rewarded
 		Staking::<T>::set_slash_reward_fraction(Perbill::one());

--- a/frame/proxy/src/benchmarking.rs
+++ b/frame/proxy/src/benchmarking.rs
@@ -32,12 +32,12 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
 }
 
 fn add_proxies<T: Config>(n: u32, maybe_who: Option<T::AccountId>) -> Result<(), &'static str> {
-	let caller = maybe_who.unwrap_or_else(|| whitelisted_caller());
+	let caller = maybe_who.unwrap_or_else(|| whitelisted_caller::<T>());
 	T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 	for i in 0..n {
 		Proxy::<T>::add_proxy(
 			RawOrigin::Signed(caller.clone()).into(),
-			account("target", i, SEED),
+			account::<T>("target", i, SEED),
 			T::ProxyType::default(),
 			T::BlockNumber::zero(),
 		)?;
@@ -50,12 +50,12 @@ fn add_announcements<T: Config>(
 	maybe_who: Option<T::AccountId>,
 	maybe_real: Option<T::AccountId>,
 ) -> Result<(), &'static str> {
-	let caller = maybe_who.unwrap_or_else(|| account("caller", 0, SEED));
+	let caller = maybe_who.unwrap_or_else(|| account::<T>("caller", 0, SEED));
 	T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 	let real = if let Some(real) = maybe_real {
 		real
 	} else {
-		let real = account("real", 0, SEED);
+		let real = account::<T>("real", 0, SEED);
 		T::Currency::make_free_balance_be(&real, BalanceOf::<T>::max_value());
 		Proxy::<T>::add_proxy(
 			RawOrigin::Signed(real.clone()).into(),
@@ -79,10 +79,10 @@ benchmarks! {
 	proxy {
 		let p in 1 .. (T::MaxProxies::get() - 1).into() => add_proxies::<T>(p, None)?;
 		// In this case the caller is the "target" proxy
-		let caller: T::AccountId = account("target", p - 1, SEED);
+		let caller: T::AccountId = account::<T>("target", p - 1, SEED);
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		// ... and "real" is the traditional caller. This is not a typo.
-		let real: T::AccountId = whitelisted_caller();
+		let real: T::AccountId = whitelisted_caller::<T>();
 		let call: <T as Config>::Call = frame_system::Call::<T>::remark { remark: vec![] }.into();
 	}: _(RawOrigin::Signed(caller), real, Some(T::ProxyType::default()), Box::new(call))
 	verify {
@@ -93,11 +93,11 @@ benchmarks! {
 		let a in 0 .. T::MaxPending::get() - 1;
 		let p in 1 .. (T::MaxProxies::get() - 1).into() => add_proxies::<T>(p, None)?;
 		// In this case the caller is the "target" proxy
-		let caller: T::AccountId = account("anonymous", 0, SEED);
-		let delegate: T::AccountId = account("target", p - 1, SEED);
+		let caller: T::AccountId = account::<T>("anonymous", 0, SEED);
+		let delegate: T::AccountId = account::<T>("target", p - 1, SEED);
 		T::Currency::make_free_balance_be(&delegate, BalanceOf::<T>::max_value());
 		// ... and "real" is the traditional caller. This is not a typo.
-		let real: T::AccountId = whitelisted_caller();
+		let real: T::AccountId = whitelisted_caller::<T>();
 		let call: <T as Config>::Call = frame_system::Call::<T>::remark { remark: vec![] }.into();
 		Proxy::<T>::announce(
 			RawOrigin::Signed(delegate.clone()).into(),
@@ -114,10 +114,10 @@ benchmarks! {
 		let a in 0 .. T::MaxPending::get() - 1;
 		let p in 1 .. (T::MaxProxies::get() - 1).into() => add_proxies::<T>(p, None)?;
 		// In this case the caller is the "target" proxy
-		let caller: T::AccountId = account("target", p - 1, SEED);
+		let caller: T::AccountId = account::<T>("target", p - 1, SEED);
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		// ... and "real" is the traditional caller. This is not a typo.
-		let real: T::AccountId = whitelisted_caller();
+		let real: T::AccountId = whitelisted_caller::<T>();
 		let call: <T as Config>::Call = frame_system::Call::<T>::remark { remark: vec![] }.into();
 		Proxy::<T>::announce(
 			RawOrigin::Signed(caller.clone()).into(),
@@ -135,10 +135,10 @@ benchmarks! {
 		let a in 0 .. T::MaxPending::get() - 1;
 		let p in 1 .. (T::MaxProxies::get() - 1).into() => add_proxies::<T>(p, None)?;
 		// In this case the caller is the "target" proxy
-		let caller: T::AccountId = account("target", p - 1, SEED);
+		let caller: T::AccountId = account::<T>("target", p - 1, SEED);
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		// ... and "real" is the traditional caller. This is not a typo.
-		let real: T::AccountId = whitelisted_caller();
+		let real: T::AccountId = whitelisted_caller::<T>();
 		let call: <T as Config>::Call = frame_system::Call::<T>::remark { remark: vec![] }.into();
 		Proxy::<T>::announce(
 			RawOrigin::Signed(caller.clone()).into(),
@@ -156,10 +156,10 @@ benchmarks! {
 		let a in 0 .. T::MaxPending::get() - 1;
 		let p in 1 .. (T::MaxProxies::get() - 1).into() => add_proxies::<T>(p, None)?;
 		// In this case the caller is the "target" proxy
-		let caller: T::AccountId = account("target", p - 1, SEED);
+		let caller: T::AccountId = account::<T>("target", p - 1, SEED);
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		// ... and "real" is the traditional caller. This is not a typo.
-		let real: T::AccountId = whitelisted_caller();
+		let real: T::AccountId = whitelisted_caller::<T>();
 		add_announcements::<T>(a, Some(caller.clone()), None)?;
 		let call: <T as Config>::Call = frame_system::Call::<T>::remark { remark: vec![] }.into();
 		let call_hash = T::CallHasher::hash_of(&call);
@@ -170,10 +170,10 @@ benchmarks! {
 
 	add_proxy {
 		let p in 1 .. (T::MaxProxies::get() - 1).into() => add_proxies::<T>(p, None)?;
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 	}: _(
 		RawOrigin::Signed(caller.clone()),
-		account("target", T::MaxProxies::get().into(), SEED),
+		account::<T>("target", T::MaxProxies::get().into(), SEED),
 		T::ProxyType::default(),
 		T::BlockNumber::zero()
 	)
@@ -184,10 +184,10 @@ benchmarks! {
 
 	remove_proxy {
 		let p in 1 .. (T::MaxProxies::get() - 1).into() => add_proxies::<T>(p, None)?;
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 	}: _(
 		RawOrigin::Signed(caller.clone()),
-		account("target", 0, SEED),
+		account::<T>("target", 0, SEED),
 		T::ProxyType::default(),
 		T::BlockNumber::zero()
 	)
@@ -198,7 +198,7 @@ benchmarks! {
 
 	remove_proxies {
 		let p in 1 .. (T::MaxProxies::get() - 1).into() => add_proxies::<T>(p, None)?;
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 	}: _(RawOrigin::Signed(caller.clone()))
 	verify {
 		let (proxies, _) = Proxies::<T>::get(caller);
@@ -207,7 +207,7 @@ benchmarks! {
 
 	anonymous {
 		let p in 1 .. (T::MaxProxies::get() - 1).into() => add_proxies::<T>(p, None)?;
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 	}: _(
 		RawOrigin::Signed(caller.clone()),
 		T::ProxyType::default(),
@@ -227,10 +227,10 @@ benchmarks! {
 	kill_anonymous {
 		let p in 0 .. (T::MaxProxies::get() - 2).into();
 
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		Pallet::<T>::anonymous(
-			RawOrigin::Signed(whitelisted_caller()).into(),
+			RawOrigin::Signed(whitelisted_caller::<T>()).into(),
 			T::ProxyType::default(),
 			T::BlockNumber::zero(),
 			0

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -173,7 +173,7 @@ impl<T: Config> ListScenario<T> {
 		Staking::<T>::nominate(
 			RawOrigin::Signed(origin_controller1.clone()).into(),
 			// NOTE: these don't really need to be validators.
-			vec![T::Lookup::unlookup(account("random_validator", 0, SEED))],
+			vec![T::Lookup::unlookup(account::<T>("random_validator", 0, SEED))],
 		)?;
 
 		let (_origin_stash2, origin_controller2) = create_stash_controller_with_balance::<T>(
@@ -183,7 +183,7 @@ impl<T: Config> ListScenario<T> {
 		)?;
 		Staking::<T>::nominate(
 			RawOrigin::Signed(origin_controller2.clone()).into(),
-			vec![T::Lookup::unlookup(account("random_validator", 0, SEED))].clone(),
+			vec![T::Lookup::unlookup(account::<T>("random_validator", 0, SEED))].clone(),
 		)?;
 
 		// find a destination weight that will trigger the worst case scenario
@@ -203,7 +203,7 @@ impl<T: Config> ListScenario<T> {
 		)?;
 		Staking::<T>::nominate(
 			RawOrigin::Signed(dest_controller1).into(),
-			vec![T::Lookup::unlookup(account("random_validator", 0, SEED))],
+			vec![T::Lookup::unlookup(account::<T>("random_validator", 0, SEED))],
 		)?;
 
 		Ok(ListScenario { origin_stash1, origin_controller1, dest_weight })
@@ -502,7 +502,7 @@ benchmarks! {
 		let v in 0 .. MaxValidators::<T>::get();
 		let mut invulnerables = Vec::new();
 		for i in 0 .. v {
-			invulnerables.push(account("invulnerable", i, SEED));
+			invulnerables.push(account::<T>("invulnerable", i, SEED));
 		}
 	}: _(RawOrigin::Root, invulnerables)
 	verify {
@@ -559,7 +559,7 @@ benchmarks! {
 		// set the commission for this particular era as well.
 		<ErasValidatorPrefs<T>>::insert(current_era, validator.clone(), <Staking<T>>::validators(&validator));
 
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 		let validator_controller = <Bonded<T>>::get(&validator).unwrap();
 		let balance_before = T::Currency::free_balance(&validator_controller);
 		for (_, controller) in &nominators {
@@ -592,7 +592,7 @@ benchmarks! {
 		// set the commission for this particular era as well.
 		<ErasValidatorPrefs<T>>::insert(current_era, validator.clone(), <Staking<T>>::validators(&validator));
 
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 		let balance_before = T::Currency::free_balance(&validator);
 		let mut nominator_balances_before = Vec::new();
 		for (stash, _) in &nominators {
@@ -763,7 +763,7 @@ benchmarks! {
 		let total_payout = T::Currency::minimum_balance() * 1000u32.into();
 		<ErasValidatorReward<T>>::insert(current_era, total_payout);
 
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		let origin = RawOrigin::Signed(caller);
 		let calls: Vec<_> = payout_calls_arg.iter().map(|arg|
 			Call::<T>::payout_stakers { validator_stash: arg.0.clone(), era: arg.1 }.encode()
@@ -884,7 +884,7 @@ benchmarks! {
 			Zero::zero(),
 		)?;
 
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 	}: _(RawOrigin::Signed(caller), controller.clone())
 	verify {
 		assert!(!T::SortedListProvider::contains(&stash));

--- a/frame/staking/src/testing_utils.rs
+++ b/frame/staking/src/testing_utils.rs
@@ -51,7 +51,7 @@ pub fn create_funded_user<T: Config>(
 	n: u32,
 	balance_factor: u32,
 ) -> T::AccountId {
-	let user = account(string, n, SEED);
+	let user = account::<T>(string, n, SEED);
 	let balance = T::Currency::minimum_balance() * balance_factor.into();
 	let _ = T::Currency::make_free_balance_be(&user, balance);
 	user
@@ -63,7 +63,7 @@ pub fn create_funded_user_with_balance<T: Config>(
 	n: u32,
 	balance: BalanceOf<T>,
 ) -> T::AccountId {
-	let user = account(string, n, SEED);
+	let user = account::<T>(string, n, SEED);
 	let _ = T::Currency::make_free_balance_be(&user, balance);
 	user
 }

--- a/frame/system/benchmarking/src/lib.rs
+++ b/frame/system/benchmarking/src/lib.rs
@@ -36,13 +36,13 @@ benchmarks! {
 	remark {
 		let b in 0 .. *T::BlockLength::get().max.get(DispatchClass::Normal) as u32;
 		let remark_message = vec![1; b as usize];
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 	}: _(RawOrigin::Signed(caller), remark_message)
 
 	remark_with_event {
 		let b in 0 .. *T::BlockLength::get().max.get(DispatchClass::Normal) as u32;
 		let remark_message = vec![1; b as usize];
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 	}: _(RawOrigin::Signed(caller), remark_message)
 
 	set_heap_pages {

--- a/frame/tips/src/benchmarking.rs
+++ b/frame/tips/src/benchmarking.rs
@@ -31,13 +31,13 @@ const SEED: u32 = 0;
 
 // Create the pre-requisite information needed to create a `report_awesome`.
 fn setup_awesome<T: Config>(length: u32) -> (T::AccountId, Vec<u8>, T::AccountId) {
-	let caller = whitelisted_caller();
+	let caller = whitelisted_caller::<T>();
 	let value = T::TipReportDepositBase::get() +
 		T::DataDepositPerByte::get() * length.into() +
 		T::Currency::minimum_balance();
 	let _ = T::Currency::make_free_balance_be(&caller, value);
 	let reason = vec![0; length as usize];
-	let awesome_person = account("awesome", 0, SEED);
+	let awesome_person = account::<T>("awesome", 0, SEED);
 	(caller, reason, awesome_person)
 }
 
@@ -49,15 +49,15 @@ fn setup_tip<T: Config>(
 	let tippers_count = T::Tippers::count();
 
 	for i in 0..t {
-		let member = account("member", i, SEED);
+		let member = account::<T>("member", i, SEED);
 		T::Tippers::add(&member);
 		ensure!(T::Tippers::contains(&member), "failed to add tipper");
 	}
 
 	ensure!(T::Tippers::count() == tippers_count + t as usize, "problem creating tippers");
-	let caller = account("member", t - 1, SEED);
+	let caller = account::<T>("member", t - 1, SEED);
 	let reason = vec![0; r as usize];
-	let beneficiary = account("beneficiary", t, SEED);
+	let beneficiary = account::<T>("beneficiary", t, SEED);
 	let value = T::Currency::minimum_balance().saturating_mul(100u32.into());
 	Ok((caller, reason, beneficiary, value))
 }
@@ -66,7 +66,7 @@ fn setup_tip<T: Config>(
 // This function automatically makes the tip able to close.
 fn create_tips<T: Config>(t: u32, hash: T::Hash, value: BalanceOf<T>) -> Result<(), &'static str> {
 	for i in 0..t {
-		let caller = account("member", i, SEED);
+		let caller = account::<T>("member", i, SEED);
 		ensure!(T::Tippers::contains(&caller), "caller is not a tipper");
 		TipsMod::<T>::tip(RawOrigin::Signed(caller).into(), hash, value)?;
 	}
@@ -132,7 +132,7 @@ benchmarks! {
 		let hash = T::Hashing::hash_of(&(&reason_hash, &beneficiary));
 		ensure!(Tips::<T>::contains_key(hash), "tip does not exist");
 		create_tips::<T>(t - 1, hash.clone(), value)?;
-		let caller = account("member", t - 1, SEED);
+		let caller = account::<T>("member", t - 1, SEED);
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
 		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
@@ -161,7 +161,7 @@ benchmarks! {
 
 		create_tips::<T>(t, hash.clone(), value)?;
 
-		let caller = account("caller", t, SEED);
+		let caller = account::<T>("caller", t, SEED);
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
 		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());

--- a/frame/transaction-storage/src/benchmarking.rs
+++ b/frame/transaction-storage/src/benchmarking.rs
@@ -104,7 +104,7 @@ pub fn run_to_block<T: Config>(n: T::BlockNumber) {
 benchmarks! {
 	store {
 		let l in 1 .. MaxTransactionSize::<T>::get();
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 	}: _(RawOrigin::Signed(caller.clone()), vec![0u8; l as usize])
 	verify {
@@ -113,7 +113,7 @@ benchmarks! {
 	}
 
 	renew {
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		TransactionStorage::<T>::store(
 			RawOrigin::Signed(caller.clone()).into(),
@@ -127,7 +127,7 @@ benchmarks! {
 
 	check_proof_max {
 		run_to_block::<T>(1u32.into());
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		for _ in 0 .. MaxBlockTransactions::<T>::get() {
 			TransactionStorage::<T>::store(

--- a/frame/treasury/src/benchmarking.rs
+++ b/frame/treasury/src/benchmarking.rs
@@ -31,10 +31,10 @@ const SEED: u32 = 0;
 fn setup_proposal<T: Config<I>, I: 'static>(
 	u: u32,
 ) -> (T::AccountId, BalanceOf<T, I>, <T::Lookup as StaticLookup>::Source) {
-	let caller = account("caller", u, SEED);
+	let caller = account::<T>("caller", u, SEED);
 	let value: BalanceOf<T, I> = T::ProposalBondMinimum::get().saturating_mul(100u32.into());
 	let _ = T::Currency::make_free_balance_be(&caller, value);
-	let beneficiary = account("beneficiary", u, SEED);
+	let beneficiary = account::<T>("beneficiary", u, SEED);
 	let beneficiary_lookup = T::Lookup::unlookup(beneficiary);
 	(caller, value, beneficiary_lookup)
 }

--- a/frame/uniques/src/benchmarking.rs
+++ b/frame/uniques/src/benchmarking.rs
@@ -38,7 +38,7 @@ const SEED: u32 = 0;
 
 fn create_class<T: Config<I>, I: 'static>(
 ) -> (T::ClassId, T::AccountId, <T::Lookup as StaticLookup>::Source) {
-	let caller: T::AccountId = whitelisted_caller();
+	let caller: T::AccountId = whitelisted_caller::<T>();
 	let caller_lookup = T::Lookup::unlookup(caller.clone());
 	let class = Default::default();
 	T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
@@ -54,7 +54,7 @@ fn create_class<T: Config<I>, I: 'static>(
 fn add_class_metadata<T: Config<I>, I: 'static>(
 ) -> (T::AccountId, <T::Lookup as StaticLookup>::Source) {
 	let caller = Class::<T, I>::get(T::ClassId::default()).unwrap().owner;
-	if caller != whitelisted_caller() {
+	if caller != whitelisted_caller::<T>() {
 		whitelist_account!(caller);
 	}
 	let caller_lookup = T::Lookup::unlookup(caller.clone());
@@ -72,7 +72,7 @@ fn mint_instance<T: Config<I>, I: 'static>(
 	index: u16,
 ) -> (T::InstanceId, T::AccountId, <T::Lookup as StaticLookup>::Source) {
 	let caller = Class::<T, I>::get(T::ClassId::default()).unwrap().admin;
-	if caller != whitelisted_caller() {
+	if caller != whitelisted_caller::<T>() {
 		whitelist_account!(caller);
 	}
 	let caller_lookup = T::Lookup::unlookup(caller.clone());
@@ -91,7 +91,7 @@ fn add_instance_metadata<T: Config<I>, I: 'static>(
 	instance: T::InstanceId,
 ) -> (T::AccountId, <T::Lookup as StaticLookup>::Source) {
 	let caller = Class::<T, I>::get(T::ClassId::default()).unwrap().owner;
-	if caller != whitelisted_caller() {
+	if caller != whitelisted_caller::<T>() {
 		whitelist_account!(caller);
 	}
 	let caller_lookup = T::Lookup::unlookup(caller.clone());
@@ -110,7 +110,7 @@ fn add_instance_attribute<T: Config<I>, I: 'static>(
 	instance: T::InstanceId,
 ) -> (BoundedVec<u8, T::KeyLimit>, T::AccountId, <T::Lookup as StaticLookup>::Source) {
 	let caller = Class::<T, I>::get(T::ClassId::default()).unwrap().owner;
-	if caller != whitelisted_caller() {
+	if caller != whitelisted_caller::<T>() {
 		whitelist_account!(caller);
 	}
 	let caller_lookup = T::Lookup::unlookup(caller.clone());
@@ -136,7 +136,7 @@ fn assert_last_event<T: Config<I>, I: 'static>(generic_event: <T as Config<I>>::
 
 benchmarks_instance_pallet! {
 	create {
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		let caller_lookup = T::Lookup::unlookup(caller.clone());
 		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
 	}: _(SystemOrigin::Signed(caller.clone()), Default::default(), caller_lookup)
@@ -145,7 +145,7 @@ benchmarks_instance_pallet! {
 	}
 
 	force_create {
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		let caller_lookup = T::Lookup::unlookup(caller.clone());
 	}: _(SystemOrigin::Root, Default::default(), caller_lookup, true)
 	verify {
@@ -194,7 +194,7 @@ benchmarks_instance_pallet! {
 		let (class, caller, caller_lookup) = create_class::<T, I>();
 		let (instance, ..) = mint_instance::<T, I>(Default::default());
 
-		let target: T::AccountId = account("target", 0, SEED);
+		let target: T::AccountId = account::<T>("target", 0, SEED);
 		let target_lookup = T::Lookup::unlookup(target.clone());
 	}: _(SystemOrigin::Signed(caller.clone()), class, instance, target_lookup)
 	verify {
@@ -259,7 +259,7 @@ benchmarks_instance_pallet! {
 
 	transfer_ownership {
 		let (class, caller, _) = create_class::<T, I>();
-		let target: T::AccountId = account("target", 0, SEED);
+		let target: T::AccountId = account::<T>("target", 0, SEED);
 		let target_lookup = T::Lookup::unlookup(target.clone());
 		T::Currency::make_free_balance_be(&target, T::Currency::minimum_balance());
 	}: _(SystemOrigin::Signed(caller), class, target_lookup)
@@ -269,16 +269,16 @@ benchmarks_instance_pallet! {
 
 	set_team {
 		let (class, caller, _) = create_class::<T, I>();
-		let target0 = T::Lookup::unlookup(account("target", 0, SEED));
-		let target1 = T::Lookup::unlookup(account("target", 1, SEED));
-		let target2 = T::Lookup::unlookup(account("target", 2, SEED));
+		let target0 = T::Lookup::unlookup(account::<T>("target", 0, SEED));
+		let target1 = T::Lookup::unlookup(account::<T>("target", 1, SEED));
+		let target2 = T::Lookup::unlookup(account::<T>("target", 2, SEED));
 	}: _(SystemOrigin::Signed(caller), Default::default(), target0.clone(), target1.clone(), target2.clone())
 	verify {
 		assert_last_event::<T, I>(Event::TeamChanged{
 			class,
-			issuer: account("target", 0, SEED),
-			admin: account("target", 1, SEED),
-			freezer: account("target", 2, SEED),
+			issuer: account::<T>("target", 0, SEED),
+			admin: account::<T>("target", 1, SEED),
+			freezer: account::<T>("target", 2, SEED),
 		}.into());
 	}
 
@@ -360,7 +360,7 @@ benchmarks_instance_pallet! {
 	approve_transfer {
 		let (class, caller, _) = create_class::<T, I>();
 		let (instance, ..) = mint_instance::<T, I>(0);
-		let delegate: T::AccountId = account("delegate", 0, SEED);
+		let delegate: T::AccountId = account::<T>("delegate", 0, SEED);
 		let delegate_lookup = T::Lookup::unlookup(delegate.clone());
 	}: _(SystemOrigin::Signed(caller.clone()), class, instance, delegate_lookup)
 	verify {
@@ -370,7 +370,7 @@ benchmarks_instance_pallet! {
 	cancel_approval {
 		let (class, caller, _) = create_class::<T, I>();
 		let (instance, ..) = mint_instance::<T, I>(0);
-		let delegate: T::AccountId = account("delegate", 0, SEED);
+		let delegate: T::AccountId = account::<T>("delegate", 0, SEED);
 		let delegate_lookup = T::Lookup::unlookup(delegate.clone());
 		let origin = SystemOrigin::Signed(caller.clone()).into();
 		Uniques::<T, I>::approve_transfer(origin, class, instance, delegate_lookup.clone())?;

--- a/frame/utility/src/benchmarking.rs
+++ b/frame/utility/src/benchmarking.rs
@@ -38,14 +38,14 @@ benchmarks! {
 			let call = frame_system::Call::remark { remark: vec![] }.into();
 			calls.push(call);
 		}
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 	}: _(RawOrigin::Signed(caller), calls)
 	verify {
 		assert_last_event::<T>(Event::BatchCompleted.into())
 	}
 
 	as_derivative {
-		let caller = account("caller", SEED, SEED);
+		let caller = account::<T>("caller", SEED, SEED);
 		let call = Box::new(frame_system::Call::remark { remark: vec![] }.into());
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
@@ -59,14 +59,14 @@ benchmarks! {
 			let call = frame_system::Call::remark { remark: vec![] }.into();
 			calls.push(call);
 		}
-		let caller = whitelisted_caller();
+		let caller = whitelisted_caller::<T>();
 	}: _(RawOrigin::Signed(caller), calls)
 	verify {
 		assert_last_event::<T>(Event::BatchCompleted.into())
 	}
 
 	dispatch_as {
-		let caller = account("caller", SEED, SEED);
+		let caller = account::<T>("caller", SEED, SEED);
 		let call = Box::new(frame_system::Call::remark { remark: vec![] }.into());
 		let origin: T::Origin = RawOrigin::Signed(caller).into();
 		let pallets_origin: <T::Origin as frame_support::traits::OriginTrait>::PalletsOrigin = origin.caller().clone();

--- a/frame/vesting/src/benchmarking.rs
+++ b/frame/vesting/src/benchmarking.rs
@@ -51,7 +51,7 @@ fn add_vesting_schedules<T: Config>(
 	let per_block = min_transfer;
 	let starting_block = 1u32;
 
-	let source: T::AccountId = account("source", 0, SEED);
+	let source: T::AccountId = account::<T>("source", 0, SEED);
 	let source_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(source.clone());
 	T::Currency::make_free_balance_be(&source, BalanceOf::<T>::max_value());
 
@@ -80,7 +80,7 @@ benchmarks! {
 		let l in 0 .. MaxLocksOf::<T>::get() - 1;
 		let s in 1 .. T::MAX_VESTING_SCHEDULES;
 
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		let caller_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(caller.clone());
 		T::Currency::make_free_balance_be(&caller, T::Currency::minimum_balance());
 
@@ -108,7 +108,7 @@ benchmarks! {
 		let l in 0 .. MaxLocksOf::<T>::get() - 1;
 		let s in 1 .. T::MAX_VESTING_SCHEDULES;
 
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		let caller_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(caller.clone());
 		T::Currency::make_free_balance_be(&caller, T::Currency::minimum_balance());
 
@@ -136,7 +136,7 @@ benchmarks! {
 		let l in 0 .. MaxLocksOf::<T>::get() - 1;
 		let s in 1 .. T::MAX_VESTING_SCHEDULES;
 
-		let other: T::AccountId = account("other", 0, SEED);
+		let other: T::AccountId = account::<T>("other", 0, SEED);
 		let other_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(other.clone());
 
 		add_locks::<T>(&other, l as u8);
@@ -150,7 +150,7 @@ benchmarks! {
 			"Vesting schedule not added",
 		);
 
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 	}: vest_other(RawOrigin::Signed(caller.clone()), other_lookup)
 	verify {
 		// Nothing happened since everything is still vested.
@@ -165,7 +165,7 @@ benchmarks! {
 		let l in 0 .. MaxLocksOf::<T>::get() - 1;
 		let s in 1 .. T::MAX_VESTING_SCHEDULES;
 
-		let other: T::AccountId = account("other", 0, SEED);
+		let other: T::AccountId = account::<T>("other", 0, SEED);
 		let other_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(other.clone());
 
 		add_locks::<T>(&other, l as u8);
@@ -179,7 +179,7 @@ benchmarks! {
 			"Vesting schedule still active",
 		);
 
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 	}: vest_other(RawOrigin::Signed(caller.clone()), other_lookup)
 	verify {
 		// Vesting schedule is removed.
@@ -194,10 +194,10 @@ benchmarks! {
 		let l in 0 .. MaxLocksOf::<T>::get() - 1;
 		let s in 0 .. T::MAX_VESTING_SCHEDULES - 1;
 
-		let caller: T::AccountId = whitelisted_caller();
+		let caller: T::AccountId = whitelisted_caller::<T>();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 
-		let target: T::AccountId = account("target", 0, SEED);
+		let target: T::AccountId = account::<T>("target", 0, SEED);
 		let target_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(target.clone());
 		// Give target existing locks
 		add_locks::<T>(&target, l as u8);
@@ -231,11 +231,11 @@ benchmarks! {
 		let l in 0 .. MaxLocksOf::<T>::get() - 1;
 		let s in 0 .. T::MAX_VESTING_SCHEDULES - 1;
 
-		let source: T::AccountId = account("source", 0, SEED);
+		let source: T::AccountId = account::<T>("source", 0, SEED);
 		let source_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(source.clone());
 		T::Currency::make_free_balance_be(&source, BalanceOf::<T>::max_value());
 
-		let target: T::AccountId = account("target", 0, SEED);
+		let target: T::AccountId = account::<T>("target", 0, SEED);
 		let target_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(target.clone());
 		// Give target existing locks
 		add_locks::<T>(&target, l as u8);
@@ -269,7 +269,7 @@ benchmarks! {
 		let l in 0 .. MaxLocksOf::<T>::get() - 1;
 		let s in 2 .. T::MAX_VESTING_SCHEDULES;
 
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = account::<T>("caller", 0, SEED);
 		let caller_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(caller.clone());
 		// Give target existing locks.
 		add_locks::<T>(&caller, l as u8);
@@ -317,9 +317,9 @@ benchmarks! {
 		let s in 2 .. T::MAX_VESTING_SCHEDULES;
 
 		// Destination used just for currency transfers in asserts.
-		let test_dest: T::AccountId = account("test_dest", 0, SEED);
+		let test_dest: T::AccountId = account::<T>("test_dest", 0, SEED);
 
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = account::<T>("caller", 0, SEED);
 		let caller_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(caller.clone());
 		// Give target other locks.
 		add_locks::<T>(&caller, l as u8);


### PR DESCRIPTION
We encountered mistakes in #10403 where you could easily write code like: 

```
let foo: WringTypeWhichIsAlsoDecode = account(...);
```

and it would mistakenly work, without any compile errors, and lead to wrong benchmarks. 

This PR makes the function be generic over a `T: frame_system::Config`, which should prevent any further mistakes like this. 

I don't believe there is any code that won't work with `T: frame_system::Config`. Downside is that it is a rather huge change and breaks a bunch of downstream code. 

Will only prepare a companion if this is acceptable.