### PR TITLE
[Don't merge] Determine contract weights after upgrade to wasmer 2.1

### DIFF
--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -31,7 +31,7 @@ wasmer-compiler-singlepass = { version = "2.1", optional = true }
 wasmer-engine-universal = { version = "2.1", optional = true }
 
 [features]
-default = []
+default = ["wasmer-sandbox"]
 wasmer-sandbox = [
 	"wasmer",
 	"wasmer-compiler-singlepass",

--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -26,12 +26,14 @@ sp-serializer = { version = "4.0.0-dev", path = "../../../primitives/serializer"
 thiserror = "1.0.30"
 environmental = "1.1.3"
 
-wasmer = { version = "1.0", optional = true }
-wasmer-compiler-singlepass = { version = "1.0", optional = true }
+wasmer = { version = "2.1", optional = true }
+wasmer-compiler-singlepass = { version = "2.1", optional = true }
+wasmer-engine-universal = { version = "2.1", optional = true }
 
 [features]
 default = []
 wasmer-sandbox = [
 	"wasmer",
 	"wasmer-compiler-singlepass",
+	"wasmer-engine-universal",
 ]

--- a/primitives/sandbox/src/lib.rs
+++ b/primitives/sandbox/src/lib.rs
@@ -52,10 +52,10 @@ pub mod embedded_executor;
 #[cfg(not(feature = "std"))]
 pub mod host_executor;
 
-#[cfg(all(feature = "wasmer-sandbox", not(feature = "std")))]
+#[cfg(not(feature = "std"))]
 pub use host_executor as default_executor;
 
-#[cfg(not(all(feature = "wasmer-sandbox", not(feature = "std"))))]
+#[cfg(feature = "std")]
 pub use embedded_executor as default_executor;
 
 /// Error that can occur while using this crate.


### PR DESCRIPTION
Not for merging; just need to run the contracts benchmark suite with wasmer.

Results can be viewed by inspecting the weight.rs file in this PRs diff.

The code is modified so that wasmer-sandbox is used by default because we cannot make the bot supply custom features.

