### PR TITLE
Prepare code for rust 1.57

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ variables:                         &default-vars
   CARGO_INCREMENTAL:               0
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  CI_IMAGE:                        "paritytech/ci-linux:staging"
+  CI_IMAGE:                        "paritytech/ci-linux:production"
   # FIXME set to release
   CARGO_UNLEASH_INSTALL_PARAMS:    "--version 1.0.0-alpha.13"
   CARGO_UNLEASH_PKG_DEF:           "--skip node node-* pallet-template pallet-example-* subkey chain-spec-builder"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ variables:                         &default-vars
   CARGO_INCREMENTAL:               0
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  CI_IMAGE:                        "paritytech/ci-linux:production"
+  CI_IMAGE:                        "paritytech/ci-linux:staging"
   # FIXME set to release
   CARGO_UNLEASH_INSTALL_PARAMS:    "--version 1.0.0-alpha.13"
   CARGO_UNLEASH_PKG_DEF:           "--skip node node-* pallet-template pallet-example-* subkey chain-spec-builder"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10957,9 +10957,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "150e726dc059e6fbd4fce3288f5bb3cf70128cf63b0dde23b938a3cad810fb23"
+checksum = "9d664de8ea7e531ad4c0f5a834f20b8cb2b8e6dfe88d05796ee7887518ed67b9"
 dependencies = [
  "dissimilar",
  "glob",

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -23,7 +23,7 @@ sp-runtime = { version = "4.0.0-dev", default-features = false, path = "../../..
 sp-core = { version = "4.1.0-dev", default-features = false, path = "../../../primitives/core" }
 sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-version = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/version" }
-trybuild = "1.0.52"
+trybuild = "1.0.53"
 pretty_assertions = "1.0.0"
 rustversion = "1.0.5"
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system" }

--- a/frame/support/test/tests/derive_no_bound_ui/clone.stderr
+++ b/frame/support/test/tests/derive_no_bound_ui/clone.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `<T as Config>::C: Clone` is not satisfied
-   --> $DIR/clone.rs:7:2
+   --> tests/derive_no_bound_ui/clone.rs:7:2
     |
 7   |     c: T::C,
     |     ^ the trait `Clone` is not implemented for `<T as Config>::C`
     |
 note: required by `clone`
-   --> $DIR/clone.rs:121:5
+   --> $RUST/core/src/clone.rs
     |
-121 |     fn clone(&self) -> Self;
+    |     fn clone(&self) -> Self;
     |     ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/frame/support/test/tests/derive_no_bound_ui/eq.stderr
+++ b/frame/support/test/tests/derive_no_bound_ui/eq.stderr
@@ -1,12 +1,12 @@
 error[E0277]: can't compare `Foo<T>` with `Foo<T>`
-   --> $DIR/eq.rs:6:8
+   --> tests/derive_no_bound_ui/eq.rs:6:8
     |
 6   | struct Foo<T: Config> {
     |        ^^^ no implementation for `Foo<T> == Foo<T>`
     |
     = help: the trait `PartialEq` is not implemented for `Foo<T>`
 note: required by a bound in `std::cmp::Eq`
-   --> $DIR/cmp.rs:272:15
+   --> $RUST/core/src/cmp.rs
     |
-272 | pub trait Eq: PartialEq<Self> {
+    | pub trait Eq: PartialEq<Self> {
     |               ^^^^^^^^^^^^^^^ required by this bound in `std::cmp::Eq`

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
-  --> $DIR/call_argument_invalid_bound.rs:20:36
+  --> tests/pallet_ui/call_argument_invalid_bound.rs:20:36
    |
 20 |         pub fn foo(origin: OriginFor<T>, bar: T::Bar) -> DispatchResultWithPostInfo {
    |                                          ^^^ `<T as pallet::Config>::Bar` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
@@ -9,19 +9,19 @@ error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
    = note: required for the cast to the object type `dyn std::fmt::Debug`
 
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: Clone` is not satisfied
-   --> $DIR/call_argument_invalid_bound.rs:20:36
+   --> tests/pallet_ui/call_argument_invalid_bound.rs:20:36
     |
 20  |         pub fn foo(origin: OriginFor<T>, bar: T::Bar) -> DispatchResultWithPostInfo {
     |                                          ^^^ the trait `Clone` is not implemented for `<T as pallet::Config>::Bar`
     |
 note: required by `clone`
-   --> $DIR/clone.rs:121:5
+   --> $RUST/core/src/clone.rs
     |
-121 |     fn clone(&self) -> Self;
+    |     fn clone(&self) -> Self;
     |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0369]: binary operation `==` cannot be applied to type `&<T as pallet::Config>::Bar`
-  --> $DIR/call_argument_invalid_bound.rs:20:36
+  --> tests/pallet_ui/call_argument_invalid_bound.rs:20:36
    |
 20 |         pub fn foo(origin: OriginFor<T>, bar: T::Bar) -> DispatchResultWithPostInfo {
    |                                          ^^^

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
-  --> $DIR/call_argument_invalid_bound_2.rs:20:36
+  --> tests/pallet_ui/call_argument_invalid_bound_2.rs:20:36
    |
 20 |         pub fn foo(origin: OriginFor<T>, bar: T::Bar) -> DispatchResultWithPostInfo {
    |                                          ^^^ `<T as pallet::Config>::Bar` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
@@ -9,19 +9,19 @@ error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
    = note: required for the cast to the object type `dyn std::fmt::Debug`
 
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: Clone` is not satisfied
-   --> $DIR/call_argument_invalid_bound_2.rs:20:36
+   --> tests/pallet_ui/call_argument_invalid_bound_2.rs:20:36
     |
 20  |         pub fn foo(origin: OriginFor<T>, bar: T::Bar) -> DispatchResultWithPostInfo {
     |                                          ^^^ the trait `Clone` is not implemented for `<T as pallet::Config>::Bar`
     |
 note: required by `clone`
-   --> $DIR/clone.rs:121:5
+   --> $RUST/core/src/clone.rs
     |
-121 |     fn clone(&self) -> Self;
+    |     fn clone(&self) -> Self;
     |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0369]: binary operation `==` cannot be applied to type `&<T as pallet::Config>::Bar`
-  --> $DIR/call_argument_invalid_bound_2.rs:20:36
+  --> tests/pallet_ui/call_argument_invalid_bound_2.rs:20:36
    |
 20 |         pub fn foo(origin: OriginFor<T>, bar: T::Bar) -> DispatchResultWithPostInfo {
    |                                          ^^^
@@ -32,7 +32,7 @@ help: consider further restricting this bound
    |                    +++++++++++++++++++++
 
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeEncode` is not satisfied
-   --> $DIR/call_argument_invalid_bound_2.rs:1:1
+   --> tests/pallet_ui/call_argument_invalid_bound_2.rs:1:1
     |
 1   |   #[frame_support::pallet]
     |   ^-----------------------
@@ -49,21 +49,21 @@ error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeEncode` is
     |
     = note: required because of the requirements on the impl of `Encode` for `<T as pallet::Config>::Bar`
 note: required by a bound in `encode_to`
-   --> $DIR/codec.rs:223:18
+   --> $CARGO/parity-scale-codec-2.3.1/src/codec.rs
     |
-223 |     fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+    |     fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
     |                     ^^^^^^ required by this bound in `encode_to`
     = note: this error originates in the derive macro `frame_support::codec::Encode` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeDecode` is not satisfied
-   --> $DIR/call_argument_invalid_bound_2.rs:20:36
+   --> tests/pallet_ui/call_argument_invalid_bound_2.rs:20:36
     |
 20  |         pub fn foo(origin: OriginFor<T>, bar: T::Bar) -> DispatchResultWithPostInfo {
     |                                          ^^^ the trait `WrapperTypeDecode` is not implemented for `<T as pallet::Config>::Bar`
     |
     = note: required because of the requirements on the impl of `Decode` for `<T as pallet::Config>::Bar`
 note: required by a bound in `parity_scale_codec::Decode::decode`
-   --> $DIR/codec.rs:284:15
+   --> $CARGO/parity-scale-codec-2.3.1/src/codec.rs
     |
-284 |     fn decode<I: Input>(input: &mut I) -> Result<Self, Error>;
+    |     fn decode<I: Input>(input: &mut I) -> Result<Self, Error>;
     |                  ^^^^^ required by this bound in `parity_scale_codec::Decode::decode`

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `Bar` doesn't implement `std::fmt::Debug`
-  --> $DIR/call_argument_invalid_bound_3.rs:22:36
+  --> tests/pallet_ui/call_argument_invalid_bound_3.rs:22:36
    |
 22 |         pub fn foo(origin: OriginFor<T>, bar: Bar) -> DispatchResultWithPostInfo {
    |                                          ^^^ `Bar` cannot be formatted using `{:?}`
@@ -10,21 +10,19 @@ error[E0277]: `Bar` doesn't implement `std::fmt::Debug`
    = note: required for the cast to the object type `dyn std::fmt::Debug`
 
 error[E0277]: the trait bound `Bar: Clone` is not satisfied
-   --> $DIR/call_argument_invalid_bound_3.rs:22:36
+   --> tests/pallet_ui/call_argument_invalid_bound_3.rs:22:36
     |
 22  |         pub fn foo(origin: OriginFor<T>, bar: Bar) -> DispatchResultWithPostInfo {
     |                                          ^^^ the trait `Clone` is not implemented for `Bar`
     |
 note: required by `clone`
-   --> $DIR/clone.rs:121:5
+   --> $RUST/core/src/clone.rs
     |
-121 |     fn clone(&self) -> Self;
+    |     fn clone(&self) -> Self;
     |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0369]: binary operation `==` cannot be applied to type `&Bar`
-  --> $DIR/call_argument_invalid_bound_3.rs:22:36
+  --> tests/pallet_ui/call_argument_invalid_bound_3.rs:22:36
    |
 22 |         pub fn foo(origin: OriginFor<T>, bar: Bar) -> DispatchResultWithPostInfo {
    |                                          ^^^
-   |
-   = note: an implementation of `std::cmp::PartialEq` might be missing for `&Bar`

--- a/frame/support/test/tests/pallet_ui/event_field_not_member.stderr
+++ b/frame/support/test/tests/pallet_ui/event_field_not_member.stderr
@@ -1,17 +1,17 @@
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: Clone` is not satisfied
-   --> $DIR/event_field_not_member.rs:23:7
+   --> tests/pallet_ui/event_field_not_member.rs:23:7
     |
 23  |         B { b: T::Bar },
     |             ^ the trait `Clone` is not implemented for `<T as pallet::Config>::Bar`
     |
 note: required by `clone`
-   --> $DIR/clone.rs:121:5
+   --> $RUST/core/src/clone.rs
     |
-121 |     fn clone(&self) -> Self;
+    |     fn clone(&self) -> Self;
     |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0369]: binary operation `==` cannot be applied to type `&<T as pallet::Config>::Bar`
-  --> $DIR/event_field_not_member.rs:23:7
+  --> tests/pallet_ui/event_field_not_member.rs:23:7
    |
 23 |         B { b: T::Bar },
    |             ^
@@ -22,7 +22,7 @@ help: consider further restricting this bound
    |                              +++++++++++++++++++++
 
 error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
-  --> $DIR/event_field_not_member.rs:23:7
+  --> tests/pallet_ui/event_field_not_member.rs:23:7
    |
 23 |         B { b: T::Bar },
    |             ^ `<T as pallet::Config>::Bar` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`

--- a/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.stderr
+++ b/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.stderr
@@ -1,13 +1,13 @@
 error[E0277]: the trait bound `Bar: MaxEncodedLen` is not satisfied
-  --> $DIR/storage_info_unsatisfied_nmap.rs:10:12
+  --> tests/pallet_ui/storage_info_unsatisfied_nmap.rs:10:12
    |
 10 |     #[pallet::generate_storage_info]
    |               ^^^^^^^^^^^^^^^^^^^^^ the trait `MaxEncodedLen` is not implemented for `Bar`
    |
-   = note: required because of the requirements on the impl of `KeyGeneratorMaxEncodedLen` for `NMapKey<frame_support::Twox64Concat, Bar>`
-   = note: required because of the requirements on the impl of `StorageInfoTrait` for `frame_support::pallet_prelude::StorageNMap<_GeneratedPrefixForStorageFoo<T>, NMapKey<frame_support::Twox64Concat, Bar>, u32>`
+   = note: required because of the requirements on the impl of `KeyGeneratorMaxEncodedLen` for `Key<frame_support::Twox64Concat, Bar>`
+   = note: required because of the requirements on the impl of `StorageInfoTrait` for `frame_support::pallet_prelude::StorageNMap<_GeneratedPrefixForStorageFoo<T>, Key<frame_support::Twox64Concat, Bar>, u32>`
 note: required by `storage_info`
-  --> $DIR/storage.rs:71:2
+  --> $WORKSPACE/frame/support/src/traits/storage.rs
    |
-71 |     fn storage_info() -> Vec<StorageInfo>;
+   |     fn storage_info() -> Vec<StorageInfo>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/frame/support/test/tests/reserved_keyword/on_initialize.stderr
+++ b/frame/support/test/tests/reserved_keyword/on_initialize.stderr
@@ -1,39 +1,39 @@
 error: Invalid call fn name: `on_finalize`, name is reserved and doesn't match expected signature, please refer to `decl_module!` documentation to see the appropriate usage, or rename it to an unreserved keyword.
-  --> $DIR/on_initialize.rs:28:1
+  --> tests/reserved_keyword/on_initialize.rs:28:1
    |
 28 | reserved!(on_finalize on_initialize on_runtime_upgrade offchain_worker deposit_event);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `$crate::__check_reserved_fn_name` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Invalid call fn name: `on_initialize`, name is reserved and doesn't match expected signature, please refer to `decl_module!` documentation to see the appropriate usage, or rename it to an unreserved keyword.
-  --> $DIR/on_initialize.rs:28:1
+  --> tests/reserved_keyword/on_initialize.rs:28:1
    |
 28 | reserved!(on_finalize on_initialize on_runtime_upgrade offchain_worker deposit_event);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `$crate::__check_reserved_fn_name` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Invalid call fn name: `on_runtime_upgrade`, name is reserved and doesn't match expected signature, please refer to `decl_module!` documentation to see the appropriate usage, or rename it to an unreserved keyword.
-  --> $DIR/on_initialize.rs:28:1
+  --> tests/reserved_keyword/on_initialize.rs:28:1
    |
 28 | reserved!(on_finalize on_initialize on_runtime_upgrade offchain_worker deposit_event);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `$crate::__check_reserved_fn_name` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Invalid call fn name: `offchain_worker`, name is reserved and doesn't match expected signature, please refer to `decl_module!` documentation to see the appropriate usage, or rename it to an unreserved keyword.
-  --> $DIR/on_initialize.rs:28:1
+  --> tests/reserved_keyword/on_initialize.rs:28:1
    |
 28 | reserved!(on_finalize on_initialize on_runtime_upgrade offchain_worker deposit_event);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `$crate::__check_reserved_fn_name` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Invalid call fn name: `deposit_event`, name is reserved and doesn't match expected signature, please refer to `decl_module!` documentation to see the appropriate usage, or rename it to an unreserved keyword.
-  --> $DIR/on_initialize.rs:28:1
+  --> tests/reserved_keyword/on_initialize.rs:28:1
    |
 28 | reserved!(on_finalize on_initialize on_runtime_upgrade offchain_worker deposit_event);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `$crate::__check_reserved_fn_name` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/primitives/api/test/Cargo.toml
+++ b/primitives/api/test/Cargo.toml
@@ -21,7 +21,7 @@ sp-consensus = { version = "0.10.0-dev", path = "../../consensus/common" }
 sc-block-builder = { version = "0.10.0-dev", path = "../../../client/block-builder" }
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 sp-state-machine = { version = "0.10.0-dev", path = "../../state-machine" }
-trybuild = "1.0.52"
+trybuild = "1.0.53"
 rustversion = "1.0.5"
 
 [dev-dependencies]

--- a/primitives/npos-elections/solution-type/Cargo.toml
+++ b/primitives/npos-elections/solution-type/Cargo.toml
@@ -26,4 +26,4 @@ scale-info = "1.0"
 sp-arithmetic = { path = "../../arithmetic", version = "4.0.0-dev" }
 # used by generate_solution_type:
 sp-npos-elections = { path = "..", version = "4.0.0-dev" }
-trybuild = "1.0.52"
+trybuild = "1.0.53"

--- a/primitives/runtime-interface/Cargo.toml
+++ b/primitives/runtime-interface/Cargo.toml
@@ -31,7 +31,7 @@ sp-state-machine = { version = "0.10.0-dev", path = "../state-machine" }
 sp-core = { version = "4.1.0-dev", path = "../core" }
 sp-io = { version = "4.0.0-dev", path = "../io" }
 rustversion = "1.0.5"
-trybuild = "1.0.52"
+trybuild = "1.0.53"
 
 [features]
 default = [ "std" ]

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -18,4 +18,4 @@ tokio = { version = "1.10", features = ["macros", "time"] }
 
 [dev-dependencies]
 sc-service = { version = "0.10.0-dev", path = "../client/service" }
-trybuild = { version = "1.0.52", features = [ "diff" ] }
+trybuild = { version = "1.0.53", features = [ "diff" ] }


### PR DESCRIPTION
Closes: https://github.com/paritytech/substrate/issues/10411

@TriplEight @alvicsam we need a new image with rust 1.57 and then we need to test that with this branch.