### PR TITLE
Fix reentrancy of FrozenBalance::died hook

### DIFF
--- a/frame/assets/src/functions.rs
+++ b/frame/assets/src/functions.rs
@@ -79,7 +79,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	}
 
 	pub(super) fn dead_account(
-		what: T::AssetId,
 		who: &T::AccountId,
 		d: &mut AssetDetails<T::Balance, T::AccountId, DepositBalanceOf<T, I>>,
 		reason: &ExistenceReason<DepositBalanceOf<T, I>>,
@@ -97,7 +96,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			ExistenceReason::DepositHeld(_) => result = Keep,
 		}
 		d.accounts = d.accounts.saturating_sub(1);
-		T::Freezer::died(what, who);
 		result
 	}
 
@@ -318,12 +316,14 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 		T::Currency::unreserve(&who, deposit);
 
-		if let Remove = Self::dead_account(id, &who, &mut details, &account.reason, false) {
+		if let Remove = Self::dead_account(&who, &mut details, &account.reason, false) {
 			Account::<T, I>::remove(id, &who);
 		} else {
 			debug_assert!(false, "refund did not result in dead account?!");
 		}
 		Asset::<T, I>::insert(&id, details);
+		// Executing a hook here is safe, since it is not in a `mutate`.
+		T::Freezer::died(id, &who);
 		Ok(())
 	}
 
@@ -456,6 +456,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		}
 
 		let actual = Self::prep_debit(id, target, amount, f)?;
+		let mut target_died: DeadConsequence = Keep;
 
 		Asset::<T, I>::try_mutate(id, |maybe_details| -> DispatchResult {
 			let mut details = maybe_details.as_mut().ok_or(Error::<T, I>::Unknown)?;
@@ -470,8 +471,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				account.balance = account.balance.saturating_sub(actual);
 				if account.balance < details.min_balance {
 					debug_assert!(account.balance.is_zero(), "checked in prep; qed");
-					if let Remove =
-						Self::dead_account(id, target, &mut details, &account.reason, false)
+					target_died = Remove;
+					if let Remove = Self::dead_account(target, &mut details, &account.reason, false)
 					{
 						return Ok(())
 					}
@@ -483,6 +484,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			Ok(())
 		})?;
 
+		// Execute hook outside of `mutate`.
+		if let Remove = target_died {
+			T::Freezer::died(id, target);
+		}
 		Ok(actual)
 	}
 
@@ -502,6 +507,24 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		maybe_need_admin: Option<T::AccountId>,
 		f: TransferFlags,
 	) -> Result<T::Balance, DispatchError> {
+		let (balance, died) =
+			Self::transfer_and_die(id, source, dest, amount, maybe_need_admin, f)?;
+		if let Remove = died {
+			T::Freezer::died(id, source);
+		}
+		Ok(balance)
+	}
+
+	/// Same as `do_transfer` but it does not execute the `FrozenBalance::died` hook and
+	/// instead returns whether the `source` account died in this operation.
+	fn transfer_and_die(
+		id: T::AssetId,
+		source: &T::AccountId,
+		dest: &T::AccountId,
+		amount: T::Balance,
+		maybe_need_admin: Option<T::AccountId>,
+		f: TransferFlags,
+	) -> Result<(T::Balance, DeadConsequence), DispatchError> {
 		// Early exist if no-op.
 		if amount.is_zero() {
 			Self::deposit_event(Event::Transferred {
@@ -510,7 +533,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				to: dest.clone(),
 				amount,
 			});
-			return Ok(amount)
+			return Ok((amount, Keep))
 		}
 
 		// Figure out the debit and credit, together with side-effects.
@@ -519,6 +542,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 		let mut source_account =
 			Account::<T, I>::get(id, &source).ok_or(Error::<T, I>::NoAccount)?;
+		let mut source_died: DeadConsequence = Keep;
 
 		Asset::<T, I>::try_mutate(id, |maybe_details| -> DispatchResult {
 			let details = maybe_details.as_mut().ok_or(Error::<T, I>::Unknown)?;
@@ -571,8 +595,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			// Remove source account if it's now dead.
 			if source_account.balance < details.min_balance {
 				debug_assert!(source_account.balance.is_zero(), "checked in prep; qed");
-				if let Remove =
-					Self::dead_account(id, &source, details, &source_account.reason, false)
+				source_died = Remove;
+				if let Remove = Self::dead_account(&source, details, &source_account.reason, false)
 				{
 					Account::<T, I>::remove(id, &source);
 					return Ok(())
@@ -588,7 +612,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			to: dest.clone(),
 			amount: credit,
 		});
-		Ok(credit)
+		Ok((credit, source_died))
 	}
 
 	/// Create a new asset without taking a deposit.
@@ -641,41 +665,53 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		witness: DestroyWitness,
 		maybe_check_owner: Option<T::AccountId>,
 	) -> Result<DestroyWitness, DispatchError> {
-		Asset::<T, I>::try_mutate_exists(id, |maybe_details| {
-			let mut details = maybe_details.take().ok_or(Error::<T, I>::Unknown)?;
-			if let Some(check_owner) = maybe_check_owner {
-				ensure!(details.owner == check_owner, Error::<T, I>::NoPermission);
-			}
-			ensure!(details.accounts <= witness.accounts, Error::<T, I>::BadWitness);
-			ensure!(details.sufficients <= witness.sufficients, Error::<T, I>::BadWitness);
-			ensure!(details.approvals <= witness.approvals, Error::<T, I>::BadWitness);
+		let mut dead_accounts: Vec<T::AccountId> = vec![];
 
-			for (who, v) in Account::<T, I>::drain_prefix(id) {
-				// We have to force this as it's destroying the entire asset class.
-				// This could mean that some accounts now have irreversibly reserved
-				// funds.
-				let _ = Self::dead_account(id, &who, &mut details, &v.reason, true);
-			}
-			debug_assert_eq!(details.accounts, 0);
-			debug_assert_eq!(details.sufficients, 0);
+		let result_witness: DestroyWitness = Asset::<T, I>::try_mutate_exists(
+			id,
+			|maybe_details| -> Result<DestroyWitness, DispatchError> {
+				let mut details = maybe_details.take().ok_or(Error::<T, I>::Unknown)?;
+				if let Some(check_owner) = maybe_check_owner {
+					ensure!(details.owner == check_owner, Error::<T, I>::NoPermission);
+				}
+				ensure!(details.accounts <= witness.accounts, Error::<T, I>::BadWitness);
+				ensure!(details.sufficients <= witness.sufficients, Error::<T, I>::BadWitness);
+				ensure!(details.approvals <= witness.approvals, Error::<T, I>::BadWitness);
 
-			let metadata = Metadata::<T, I>::take(&id);
-			T::Currency::unreserve(
-				&details.owner,
-				details.deposit.saturating_add(metadata.deposit),
-			);
+				for (who, v) in Account::<T, I>::drain_prefix(id) {
+					// We have to force this as it's destroying the entire asset class.
+					// This could mean that some accounts now have irreversibly reserved
+					// funds.
+					let _ = Self::dead_account(&who, &mut details, &v.reason, true);
+					dead_accounts.push(who);
+				}
+				debug_assert_eq!(details.accounts, 0);
+				debug_assert_eq!(details.sufficients, 0);
 
-			for ((owner, _), approval) in Approvals::<T, I>::drain_prefix((&id,)) {
-				T::Currency::unreserve(&owner, approval.deposit);
-			}
-			Self::deposit_event(Event::Destroyed { asset_id: id });
+				let metadata = Metadata::<T, I>::take(&id);
+				T::Currency::unreserve(
+					&details.owner,
+					details.deposit.saturating_add(metadata.deposit),
+				);
 
-			Ok(DestroyWitness {
-				accounts: details.accounts,
-				sufficients: details.sufficients,
-				approvals: details.approvals,
-			})
-		})
+				for ((owner, _), approval) in Approvals::<T, I>::drain_prefix((&id,)) {
+					T::Currency::unreserve(&owner, approval.deposit);
+				}
+				Self::deposit_event(Event::Destroyed { asset_id: id });
+
+				Ok(DestroyWitness {
+					accounts: details.accounts,
+					sufficients: details.sufficients,
+					approvals: details.approvals,
+				})
+			},
+		)?;
+
+		// Execute hooks outside of `mutate`.
+		for who in dead_accounts {
+			T::Freezer::died(id, &who);
+		}
+		Ok(result_witness)
 	}
 
 	/// Creates an approval from `owner` to spend `amount` of asset `id` tokens by 'delegate'
@@ -737,6 +773,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		destination: &T::AccountId,
 		amount: T::Balance,
 	) -> DispatchResult {
+		let mut owner_died: DeadConsequence = Keep;
+
 		Approvals::<T, I>::try_mutate_exists(
 			(id, &owner, delegate),
 			|maybe_approved| -> DispatchResult {
@@ -745,7 +783,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					approved.amount.checked_sub(&amount).ok_or(Error::<T, I>::Unapproved)?;
 
 				let f = TransferFlags { keep_alive: false, best_effort: false, burn_dust: false };
-				Self::do_transfer(id, &owner, &destination, amount, None, f)?;
+				owner_died = Self::transfer_and_die(id, &owner, &destination, amount, None, f)?.1;
 
 				if remaining.is_zero() {
 					T::Currency::unreserve(&owner, approved.deposit);
@@ -761,6 +799,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				Ok(())
 			},
 		)?;
+
+		// Execute hook outside of `mutate`.
+		if let Remove = owner_died {
+			T::Freezer::died(id, owner);
+		}
 		Ok(())
 	}
 

--- a/frame/assets/src/mock.rs
+++ b/frame/assets/src/mock.rs
@@ -120,17 +120,25 @@ impl FrozenBalance<u32, u64, u64> for TestFreezer {
 
 	fn died(asset: u32, who: &u64) {
 		HOOKS.with(|h| h.borrow_mut().push(Hook::Died(asset, who.clone())));
+		// Sanity check: dead accounts have no balance.
+		assert!(Assets::balance(asset, *who).is_zero());
 	}
 }
 
 pub(crate) fn set_frozen_balance(asset: u32, who: u64, amount: u64) {
 	FROZEN.with(|f| f.borrow_mut().insert((asset, who), amount));
 }
+
 pub(crate) fn clear_frozen_balance(asset: u32, who: u64) {
 	FROZEN.with(|f| f.borrow_mut().remove(&(asset, who)));
 }
+
 pub(crate) fn hooks() -> Vec<Hook> {
 	HOOKS.with(|h| h.borrow().clone())
+}
+
+pub(crate) fn take_hooks() -> Vec<Hook> {
+	HOOKS.with(|h| h.take())
 }
 
 pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
@@ -154,6 +162,8 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 	config.assimilate_storage(&mut storage).unwrap();
 
 	let mut ext: sp_io::TestExternalities = storage.into();
+	// Clear thread local vars for tarpaulin (github.com/xd009642/tarpaulin/issues/892).
+	ext.execute_with(|| take_hooks());
 	ext.execute_with(|| System::set_block_number(1));
 	ext
 }

--- a/frame/assets/src/types.rs
+++ b/frame/assets/src/types.rs
@@ -172,13 +172,9 @@ pub trait FrozenBalance<AssetId, AccountId, Balance> {
 	/// If `None` is returned, then nothing special is enforced.
 	fn frozen_balance(asset: AssetId, who: &AccountId) -> Option<Balance>;
 
-	/// Called when an account has been removed.
+	/// Called after an account has been removed.
 	///
-	/// # Warning
-	///
-	/// This function must never access storage of pallet asset. This function is called while some
-	/// change are pending. Calling into the pallet asset in this function can result in unexpected
-	/// state.
+	/// NOTE: It is possible that the asset does no longer exist when this hook is called.
 	fn died(asset: AssetId, who: &AccountId);
 }
 


### PR DESCRIPTION
This MR  
- refactors calls to the `FrozenBalance::died` hook to run without any pending changes in memory
- adds tests for account reaping after
  - `transfer_approved` below `min-balance`
  - `refund`
  - asset `destroy`
- updates the doc of `FrozenBalance::died`

Closes #10432 

**@ reviewers**
[This else case](https://github.com/ggwpez/substrate/blob/5f49f1498a44614e3fb48394c99d4e8a253e910f/frame/assets/src/functions.rs#L479) is not tested in the `assets` pallet (only implicitly through other pallets). If you have a straight forward way to do so, please add a commit or let me know.  
The `do_destroy` function did not change as much as it looks like, its just the indentation.