### PR TITLE
Async block import params

### DIFF
--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -382,72 +382,51 @@ where
 		vec![<DigestItem as CompatibleDigestItem<P::Signature>>::aura_pre_digest(slot)]
 	}
 
-	fn block_import_params(
+	async fn block_import_params(
 		&self,
-	) -> Box<
-		dyn Fn(
-				B::Header,
-				B::Hash,
-				Vec<B::Extrinsic>,
-				StorageChanges<<Self::BlockImport as BlockImport<B>>::Transaction, B>,
-				Self::Claim,
-				Self::EpochData,
-			) -> Pin<
-				Box<
-					dyn Future<
-							Output = Result<
-								sc_consensus::BlockImportParams<
-									B,
-									<Self::BlockImport as BlockImport<B>>::Transaction,
-								>,
-								sp_consensus::Error,
-							>,
-						> + Send,
-				>,
-			> + Send
-			+ 'static,
+		header: B::Header,
+		header_hash: &B::Hash,
+		body: Vec<B::Extrinsic>,
+		storage_changes: StorageChanges<<Self::BlockImport as BlockImport<B>>::Transaction, B>,
+		public: Self::Claim,
+		_epoch: Self::EpochData,
+	) -> Result<
+		sc_consensus::BlockImportParams<B, <Self::BlockImport as BlockImport<B>>::Transaction>,
+		sp_consensus::Error,
 	> {
-		let keystore = self.keystore.clone();
-		Box::new(move |header, header_hash, body, storage_changes, public, _epoch| {
-			let keystore = keystore.clone();
+		// sign the pre-sealed hash of the block and then
+		// add it to a digest item.
+		let public_type_pair = public.to_public_crypto_pair();
+		let public = public.to_raw_vec();
+		let signature = SyncCryptoStore::sign_with(
+			&*self.keystore,
+			<AuthorityId<P> as AppKey>::ID,
+			&public_type_pair,
+			header_hash.as_ref(),
+		)
+		.map_err(|e| sp_consensus::Error::CannotSign(public.clone(), e.to_string()))?
+		.ok_or_else(|| {
+			sp_consensus::Error::CannotSign(
+				public.clone(),
+				"Could not find key in keystore.".into(),
+			)
+		})?;
+		let signature = signature
+			.clone()
+			.try_into()
+			.map_err(|_| sp_consensus::Error::InvalidSignature(signature, public))?;
 
-			Box::pin(async move {
-				// sign the pre-sealed hash of the block and then
-				// add it to a digest item.
-				let public_type_pair = public.to_public_crypto_pair();
-				let public = public.to_raw_vec();
-				let signature = SyncCryptoStore::sign_with(
-					&*keystore,
-					<AuthorityId<P> as AppKey>::ID,
-					&public_type_pair,
-					header_hash.as_ref(),
-				)
-				.map_err(|e| sp_consensus::Error::CannotSign(public.clone(), e.to_string()))?
-				.ok_or_else(|| {
-					sp_consensus::Error::CannotSign(
-						public.clone(),
-						"Could not find key in keystore.".into(),
-					)
-				})?;
-				let signature = signature
-					.clone()
-					.try_into()
-					.map_err(|_| sp_consensus::Error::InvalidSignature(signature, public))?;
+		let signature_digest_item =
+			<DigestItem as CompatibleDigestItem<P::Signature>>::aura_seal(signature);
 
-				let signature_digest_item =
-					<DigestItem as CompatibleDigestItem<P::Signature>>::aura_seal(signature);
+		let mut import_block = BlockImportParams::new(BlockOrigin::Own, header);
+		import_block.post_digests.push(signature_digest_item);
+		import_block.body = Some(body);
+		import_block.state_action =
+			StateAction::ApplyChanges(sc_consensus::StorageChanges::Changes(storage_changes));
+		import_block.fork_choice = Some(ForkChoiceStrategy::LongestChain);
 
-				let mut import_block = BlockImportParams::new(BlockOrigin::Own, header);
-				import_block.post_digests.push(signature_digest_item);
-				import_block.body = Some(body);
-				import_block.state_action = StateAction::ApplyChanges(
-					sc_consensus::StorageChanges::Changes(storage_changes),
-				);
-				import_block.fork_choice = Some(ForkChoiceStrategy::LongestChain);
-
-				Ok(import_block)
-			})
-		})
+		Ok(import_block)
 	}
 
 	fn force_authoring(&self) -> bool {

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -772,76 +772,52 @@ where
 		vec![<DigestItem as CompatibleDigestItem>::babe_pre_digest(claim.0.clone())]
 	}
 
-	fn block_import_params(
+	async fn block_import_params(
 		&self,
-	) -> Box<
-		dyn Fn(
-				B::Header,
-				B::Hash,
-				Vec<B::Extrinsic>,
-				StorageChanges<<Self::BlockImport as BlockImport<B>>::Transaction, B>,
-				Self::Claim,
-				Self::EpochData,
-			) -> Pin<
-				Box<
-					dyn Future<
-							Output = Result<
-								sc_consensus::BlockImportParams<
-									B,
-									<Self::BlockImport as BlockImport<B>>::Transaction,
-								>,
-								sp_consensus::Error,
-							>,
-						> + Send,
-				>,
-			> + Send
-			+ 'static,
+		header: B::Header,
+		header_hash: &B::Hash,
+		body: Vec<B::Extrinsic>,
+		storage_changes: StorageChanges<<Self::BlockImport as BlockImport<B>>::Transaction, B>,
+		(_, public): Self::Claim,
+		epoch_descriptor: Self::EpochData,
+	) -> Result<
+		sc_consensus::BlockImportParams<B, <Self::BlockImport as BlockImport<B>>::Transaction>,
+		sp_consensus::Error,
 	> {
-		let keystore = self.keystore.clone();
-		Box::new(
-			move |header, header_hash, body, storage_changes, (_, public), epoch_descriptor| {
-				let keystore = keystore.clone();
-
-				Box::pin(async move {
-					// sign the pre-sealed hash of the block and then
-					// add it to a digest item.
-					let public_type_pair = public.clone().into();
-					let public = public.to_raw_vec();
-					let signature = SyncCryptoStore::sign_with(
-						&*keystore,
-						<AuthorityId as AppKey>::ID,
-						&public_type_pair,
-						header_hash.as_ref(),
-					)
-					.map_err(|e| sp_consensus::Error::CannotSign(public.clone(), e.to_string()))?
-					.ok_or_else(|| {
-						sp_consensus::Error::CannotSign(
-							public.clone(),
-							"Could not find key in keystore.".into(),
-						)
-					})?;
-					let signature: AuthoritySignature = signature
-						.clone()
-						.try_into()
-						.map_err(|_| sp_consensus::Error::InvalidSignature(signature, public))?;
-					let digest_item =
-						<DigestItem as CompatibleDigestItem>::babe_seal(signature.into());
-
-					let mut import_block = BlockImportParams::new(BlockOrigin::Own, header);
-					import_block.post_digests.push(digest_item);
-					import_block.body = Some(body);
-					import_block.state_action = StateAction::ApplyChanges(
-						sc_consensus::StorageChanges::Changes(storage_changes),
-					);
-					import_block.intermediates.insert(
-						Cow::from(INTERMEDIATE_KEY),
-						Box::new(BabeIntermediate::<B> { epoch_descriptor }) as Box<_>,
-					);
-
-					Ok(import_block)
-				})
-			},
+		// sign the pre-sealed hash of the block and then
+		// add it to a digest item.
+		let public_type_pair = public.clone().into();
+		let public = public.to_raw_vec();
+		let signature = SyncCryptoStore::sign_with(
+			&*self.keystore,
+			<AuthorityId as AppKey>::ID,
+			&public_type_pair,
+			header_hash.as_ref(),
 		)
+		.map_err(|e| sp_consensus::Error::CannotSign(public.clone(), e.to_string()))?
+		.ok_or_else(|| {
+			sp_consensus::Error::CannotSign(
+				public.clone(),
+				"Could not find key in keystore.".into(),
+			)
+		})?;
+		let signature: AuthoritySignature = signature
+			.clone()
+			.try_into()
+			.map_err(|_| sp_consensus::Error::InvalidSignature(signature, public))?;
+		let digest_item = <DigestItem as CompatibleDigestItem>::babe_seal(signature.into());
+
+		let mut import_block = BlockImportParams::new(BlockOrigin::Own, header);
+		import_block.post_digests.push(digest_item);
+		import_block.body = Some(body);
+		import_block.state_action =
+			StateAction::ApplyChanges(sc_consensus::StorageChanges::Changes(storage_changes));
+		import_block.intermediates.insert(
+			Cow::from(INTERMEDIATE_KEY),
+			Box::new(BabeIntermediate::<B> { epoch_descriptor }) as Box<_>,
+		);
+
+		Ok(import_block)
 	}
 
 	fn force_authoring(&self) -> bool {

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -777,53 +777,69 @@ where
 	) -> Box<
 		dyn Fn(
 				B::Header,
-				&B::Hash,
+				B::Hash,
 				Vec<B::Extrinsic>,
-				StorageChanges<I::Transaction, B>,
+				StorageChanges<<Self::BlockImport as BlockImport<B>>::Transaction, B>,
 				Self::Claim,
 				Self::EpochData,
-			) -> Result<sc_consensus::BlockImportParams<B, I::Transaction>, sp_consensus::Error>
-			+ Send
+			) -> Pin<
+				Box<
+					dyn Future<
+							Output = Result<
+								sc_consensus::BlockImportParams<
+									B,
+									<Self::BlockImport as BlockImport<B>>::Transaction,
+								>,
+								sp_consensus::Error,
+							>,
+						> + Send,
+				>,
+			> + Send
 			+ 'static,
 	> {
 		let keystore = self.keystore.clone();
 		Box::new(
 			move |header, header_hash, body, storage_changes, (_, public), epoch_descriptor| {
-				// sign the pre-sealed hash of the block and then
-				// add it to a digest item.
-				let public_type_pair = public.clone().into();
-				let public = public.to_raw_vec();
-				let signature = SyncCryptoStore::sign_with(
-					&*keystore,
-					<AuthorityId as AppKey>::ID,
-					&public_type_pair,
-					header_hash.as_ref(),
-				)
-				.map_err(|e| sp_consensus::Error::CannotSign(public.clone(), e.to_string()))?
-				.ok_or_else(|| {
-					sp_consensus::Error::CannotSign(
-						public.clone(),
-						"Could not find key in keystore.".into(),
+				let keystore = keystore.clone();
+
+				Box::pin(async move {
+					// sign the pre-sealed hash of the block and then
+					// add it to a digest item.
+					let public_type_pair = public.clone().into();
+					let public = public.to_raw_vec();
+					let signature = SyncCryptoStore::sign_with(
+						&*keystore,
+						<AuthorityId as AppKey>::ID,
+						&public_type_pair,
+						header_hash.as_ref(),
 					)
-				})?;
-				let signature: AuthoritySignature = signature
-					.clone()
-					.try_into()
-					.map_err(|_| sp_consensus::Error::InvalidSignature(signature, public))?;
-				let digest_item = <DigestItem as CompatibleDigestItem>::babe_seal(signature.into());
+					.map_err(|e| sp_consensus::Error::CannotSign(public.clone(), e.to_string()))?
+					.ok_or_else(|| {
+						sp_consensus::Error::CannotSign(
+							public.clone(),
+							"Could not find key in keystore.".into(),
+						)
+					})?;
+					let signature: AuthoritySignature = signature
+						.clone()
+						.try_into()
+						.map_err(|_| sp_consensus::Error::InvalidSignature(signature, public))?;
+					let digest_item =
+						<DigestItem as CompatibleDigestItem>::babe_seal(signature.into());
 
-				let mut import_block = BlockImportParams::new(BlockOrigin::Own, header);
-				import_block.post_digests.push(digest_item);
-				import_block.body = Some(body);
-				import_block.state_action = StateAction::ApplyChanges(
-					sc_consensus::StorageChanges::Changes(storage_changes),
-				);
-				import_block.intermediates.insert(
-					Cow::from(INTERMEDIATE_KEY),
-					Box::new(BabeIntermediate::<B> { epoch_descriptor }) as Box<_>,
-				);
+					let mut import_block = BlockImportParams::new(BlockOrigin::Own, header);
+					import_block.post_digests.push(digest_item);
+					import_block.body = Some(body);
+					import_block.state_action = StateAction::ApplyChanges(
+						sc_consensus::StorageChanges::Changes(storage_changes),
+					);
+					import_block.intermediates.insert(
+						Cow::from(INTERMEDIATE_KEY),
+						Box::new(BabeIntermediate::<B> { epoch_descriptor }) as Box<_>,
+					);
 
-				Ok(import_block)
+					Ok(import_block)
+				})
 			},
 		)
 	}


### PR DESCRIPTION
This allows block import params to do some async work.

In our protocol slot challenges are solved by an external app connected over RPC (which is why previously I needed `on_slot` to become async) and when solution is found block header needs to be signed by the same app (only that external app controls keypair and public key is already a part of the solution). In order to not block executor along the way, `block_import_params` needs to also become async.

I'm not happy about the complexity of the return type either :disappointed: 