### PR TITLE
[DO NOT MERGE] Test drive pipeline-scripts#19

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,6 @@ variables:                         &default-vars
   VAULT_SERVER_URL:                "https://vault.parity-mgmt-vault.parity.io"
   VAULT_AUTH_PATH:                 "gitlab-parity-io-jwt"
   VAULT_AUTH_ROLE:                 "cicd_gitlab_parity_${CI_PROJECT_NAME}"
-  PIPELINE_SCRIPTS_TAG:            "v0.4"
 
 default:
   cache:                           {}
@@ -580,8 +579,8 @@ cargo-check-macos:
   script:
     - git clone
         --depth=1
-        "--branch=$PIPELINE_SCRIPTS_TAG"
-        https://github.com/paritytech/pipeline-scripts
+        --branch=dependents-dependents
+        https://github.com/joao-paulo-parity/pipeline-scripts
     - ./pipeline-scripts/check_dependent_project.sh
         paritytech
         substrate

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -129,7 +129,7 @@ fn new_test_ext() -> sp_io::TestExternalities {
 
 mod benchmarks {
 	use super::{new_test_ext, pallet_test::Value, Test};
-	use crate::{account, BenchmarkError, BenchmarkParameter, BenchmarkResult, BenchmarkingSetup};
+	use crate::{account, BenchmarkErrorFoo, BenchmarkParameter, BenchmarkResult, BenchmarkingSetup};
 	use frame_support::{assert_err, assert_ok, ensure, traits::Get};
 	use frame_system::RawOrigin;
 	use sp_std::prelude::*;
@@ -213,7 +213,7 @@ mod benchmarks {
 			let b in 1 .. 1000;
 			let caller = account::<T::AccountId>("caller", 0, 0);
 		}: {
-			Err(BenchmarkError::Override(
+			Err(BenchmarkErrorFoo::Override(
 				BenchmarkResult {
 					extrinsic_time: 1_234_567_890,
 					reads: 1337,
@@ -224,7 +224,7 @@ mod benchmarks {
 		}
 
 		skip_benchmark {
-			let value = T::MaybeItem::get().ok_or(BenchmarkError::Skip)?;
+			let value = T::MaybeItem::get().ok_or(BenchmarkErrorFoo::Skip)?;
 		}: {
 			// This should never be reached.
 			assert!(value > 100);
@@ -331,7 +331,7 @@ mod benchmarks {
 
 		new_test_ext().execute_with(|| {
 			let result = closure();
-			assert!(matches!(result, Err(BenchmarkError::Override(_))));
+			assert!(matches!(result, Err(BenchmarkErrorFoo::Override(_))));
 		});
 	}
 
@@ -347,9 +347,9 @@ mod benchmarks {
 			assert_ok!(Pallet::<Test>::test_benchmark_variable_components());
 			assert!(matches!(
 				Pallet::<Test>::test_benchmark_override_benchmark(),
-				Err(BenchmarkError::Override(_)),
+				Err(BenchmarkErrorFoo::Override(_)),
 			));
-			assert_eq!(Pallet::<Test>::test_benchmark_skip_benchmark(), Err(BenchmarkError::Skip),);
+			assert_eq!(Pallet::<Test>::test_benchmark_skip_benchmark(), Err(BenchmarkErrorFoo::Skip),);
 		});
 	}
 }

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -120,7 +120,7 @@ impl BenchmarkResult {
 
 /// Possible errors returned from the benchmarking pipeline.
 #[derive(Clone, PartialEq, Debug)]
-pub enum BenchmarkError {
+pub enum BenchmarkErrorFoo {
 	/// The benchmarking pipeline should stop and return the inner string.
 	Stop(&'static str),
 	/// The benchmarking pipeline is allowed to fail here, and we should use the
@@ -131,29 +131,29 @@ pub enum BenchmarkError {
 	Skip,
 }
 
-impl From<BenchmarkError> for &'static str {
-	fn from(e: BenchmarkError) -> Self {
+impl From<BenchmarkErrorFoo> for &'static str {
+	fn from(e: BenchmarkErrorFoo) -> Self {
 		match e {
-			BenchmarkError::Stop(s) => s,
-			BenchmarkError::Override(_) => "benchmark override",
-			BenchmarkError::Skip => "benchmark skip",
+			BenchmarkErrorFoo::Stop(s) => s,
+			BenchmarkErrorFoo::Override(_) => "benchmark override",
+			BenchmarkErrorFoo::Skip => "benchmark skip",
 		}
 	}
 }
 
-impl From<&'static str> for BenchmarkError {
+impl From<&'static str> for BenchmarkErrorFoo {
 	fn from(s: &'static str) -> Self {
 		Self::Stop(s)
 	}
 }
 
-impl From<DispatchErrorWithPostInfo> for BenchmarkError {
+impl From<DispatchErrorWithPostInfo> for BenchmarkErrorFoo {
 	fn from(e: DispatchErrorWithPostInfo) -> Self {
 		Self::Stop(e.into())
 	}
 }
 
-impl From<DispatchError> for BenchmarkError {
+impl From<DispatchError> for BenchmarkErrorFoo {
 	fn from(e: DispatchError) -> Self {
 		Self::Stop(e.into())
 	}
@@ -302,7 +302,7 @@ pub trait Benchmarking {
 		whitelist: &[TrackedStorageKey],
 		verify: bool,
 		internal_repeats: u32,
-	) -> Result<Vec<BenchmarkResult>, BenchmarkError>;
+	) -> Result<Vec<BenchmarkResult>, BenchmarkErrorFoo>;
 }
 
 /// The required setup for creating a benchmark.
@@ -318,7 +318,7 @@ pub trait BenchmarkingSetup<T, I = ()> {
 		&self,
 		components: &[(BenchmarkParameter, u32)],
 		verify: bool,
-	) -> Result<Box<dyn FnOnce() -> Result<(), BenchmarkError>>, BenchmarkError>;
+	) -> Result<Box<dyn FnOnce() -> Result<(), BenchmarkErrorFoo>>, BenchmarkErrorFoo>;
 }
 
 /// Grab an account, seeded by a name and index.

--- a/frame/elections-phragmen/src/benchmarking.rs
+++ b/frame/elections-phragmen/src/benchmarking.rs
@@ -21,7 +21,7 @@
 
 use super::*;
 
-use frame_benchmarking::{account, benchmarks, whitelist, BenchmarkError, BenchmarkResult};
+use frame_benchmarking::{account, benchmarks, whitelist, BenchmarkErrorFoo, BenchmarkResult};
 use frame_support::{
 	dispatch::{DispatchResultWithPostInfo, UnfilteredDispatchable},
 	traits::OnInitialize,
@@ -337,7 +337,7 @@ benchmarks! {
 
 	// We use the max block weight for this extrinsic for now. See below.
 	remove_member_without_replacement {}: {
-		Err(BenchmarkError::Override(
+		Err(BenchmarkErrorFoo::Override(
 			BenchmarkResult::from_weight(T::BlockWeights::get().max_block)
 		))?;
 	}


### PR DESCRIPTION
Setup for this scenario:

1. xcm-executor is a dependency of Cumulus and comes from Polkadot
2. xcm-executor uses `BenchmarkError`
3. Change `BenchmarkError` to `BenchmarkErrorFoo` which causes a downstream breakage on Polkadot
4. Cumulus does not use BenchmarkError directly but is affected transitively since Polkadot no longer would compile normally

In the situation above, the script should patch the Polkadot companion into Cumulus as suggested by https://github.com/paritytech/pipeline-scripts/issues/3#issuecomment-986844759

polkadot companion: https://github.com/paritytech/polkadot/pull/4531