### PR TITLE
Remove offchain workers ownership.

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -27,10 +27,6 @@
 /primitives/sr-sandbox/ @pepyakin
 /primitives/core/src/sandbox.rs @pepyakin
 
-# Offchain
-/client/offchain/ @tomusdrw
-/primitives/offchain/ @tomusdrw
-
 # GRANDPA, BABE, consensus stuff
 /frame/babe/ @andresilva
 /frame/grandpa/ @andresilva


### PR DESCRIPTION
I haven't been maintaining offchain workers for a while, hence removing myself as a codeowner. CC @gnunicorn @dvdplm 