### PR TITLE
[WIP do not merge] Extract sc-network-sync crate

### DIFF
--- a/client/beefy/src/lib.rs
+++ b/client/beefy/src/lib.rs
@@ -69,11 +69,9 @@ pub(crate) mod beefy_protocol_name {
 pub fn beefy_peers_set_config(
 	protocol_name: std::borrow::Cow<'static, str>,
 ) -> sc_network::config::NonDefaultSetConfig {
-	let mut cfg = sc_network::config::NonDefaultSetConfig::new(protocol_name, 1024 * 1024);
-
-	cfg.allow_non_reserved(25, 25);
-	cfg.add_fallback_names(beefy_protocol_name::LEGACY_NAMES.iter().map(|&n| n.into()).collect());
-	cfg
+	sc_network::config::NonDefaultSetConfig::new(protocol_name, 1024 * 1024)
+		.allow_non_reserved(25, 25)
+		.add_fallback_names(beefy_protocol_name::LEGACY_NAMES.iter().map(|&n| n.into()).collect())
 }
 
 /// A convenience BEEFY client trait that defines all the type bounds a BEEFY client

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -722,18 +722,9 @@ pub fn grandpa_peers_set_config(
 	protocol_name: std::borrow::Cow<'static, str>,
 ) -> sc_network::config::NonDefaultSetConfig {
 	use communication::grandpa_protocol_name;
-	sc_network::config::NonDefaultSetConfig {
-		notifications_protocol: protocol_name,
-		fallback_names: grandpa_protocol_name::LEGACY_NAMES.iter().map(|&n| n.into()).collect(),
-		// Notifications reach ~256kiB in size at the time of writing on Kusama and Polkadot.
-		max_notification_size: 1024 * 1024,
-		set_config: sc_network::config::SetConfig {
-			in_peers: 0,
-			out_peers: 0,
-			reserved_nodes: Vec::new(),
-			non_reserved_mode: sc_network::config::NonReservedPeerMode::Deny,
-		},
-	}
+	// Notifications reach ~256kiB in size at the time of writing on Kusama and Polkadot.
+	sc_network::config::NonDefaultSetConfig::new(protocol_name, 1024 * 1024)
+		.add_fallback_names(grandpa_protocol_name::LEGACY_NAMES.iter().map(|&n| n.into()).collect())
 }
 
 /// Run a GRANDPA voter as a task. Provide configuration and a link to a

--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -550,11 +550,12 @@ impl Default for SetConfig {
 	}
 }
 
-/// Extension to [`SetConfig`] for sets that aren't the default set.
-///
-/// > **Note**: As new fields might be added in the future, please consider using the `new` method
-/// >			and modifiers instead of creating this struct manually.
 #[derive(Clone, Debug)]
+struct Trap;
+
+/// Extension to [`SetConfig`] for sets that aren't the default set.
+#[derive(Clone, Debug)]
+#[must_use = "Why would you build a config if you do not use it afterwards?"]
 pub struct NonDefaultSetConfig {
 	/// Name of the notifications protocols of this set. A substream on this set will be
 	/// considered established once this protocol is open.
@@ -573,6 +574,9 @@ pub struct NonDefaultSetConfig {
 	pub max_notification_size: u64,
 	/// Base configuration.
 	pub set_config: SetConfig,
+
+	/// You must use [`NonDefaultSetConfig::new`] to create this structure.
+	_use_new_to_create: Trap,
 }
 
 impl NonDefaultSetConfig {
@@ -588,26 +592,36 @@ impl NonDefaultSetConfig {
 				reserved_nodes: Vec::new(),
 				non_reserved_mode: NonReservedPeerMode::Deny,
 			},
+			_use_new_to_create: Trap,
 		}
 	}
 
 	/// Modifies the configuration to allow non-reserved nodes.
-	pub fn allow_non_reserved(&mut self, in_peers: u32, out_peers: u32) {
+	pub fn allow_non_reserved(mut self, in_peers: u32, out_peers: u32) -> Self {
 		self.set_config.in_peers = in_peers;
 		self.set_config.out_peers = out_peers;
 		self.set_config.non_reserved_mode = NonReservedPeerMode::Accept;
+		self
 	}
 
 	/// Add a node to the list of reserved nodes.
-	pub fn add_reserved(&mut self, peer: MultiaddrWithPeerId) {
+	pub fn add_reserved(mut self, peer: MultiaddrWithPeerId) -> Self {
 		self.set_config.reserved_nodes.push(peer);
+		self
 	}
 
 	/// Add a list of protocol names used for backward compatibility.
 	///
 	/// See the explanations in [`NonDefaultSetConfig::fallback_names`].
-	pub fn add_fallback_names(&mut self, fallback_names: Vec<Cow<'static, str>>) {
+	pub fn add_fallback_names(mut self, fallback_names: Vec<Cow<'static, str>>) -> Self {
 		self.fallback_names.extend(fallback_names);
+		self
+	}
+
+	/// Replace the peer set configuration
+	pub fn with_config(mut self, config: SetConfig) -> Self {
+		self.set_config = config;
+		self
 	}
 }
 

--- a/client/network/src/service/tests.rs
+++ b/client/network/src/service/tests.rs
@@ -154,30 +154,23 @@ fn build_nodes_one_proto() -> (
 	let listen_addr = config::build_multiaddr![Memory(rand::random::<u64>())];
 
 	let (node1, events_stream1) = build_test_full_node(config::NetworkConfiguration {
-		extra_sets: vec![config::NonDefaultSetConfig {
-			notifications_protocol: PROTOCOL_NAME,
-			fallback_names: Vec::new(),
-			max_notification_size: 1024 * 1024,
-			set_config: Default::default(),
-		}],
+		extra_sets: vec![config::NonDefaultSetConfig::new(PROTOCOL_NAME, 1024 * 1024)
+			.with_config(Default::default())],
 		listen_addresses: vec![listen_addr.clone()],
 		transport: config::TransportConfig::MemoryOnly,
 		..config::NetworkConfiguration::new_local()
 	});
 
 	let (node2, events_stream2) = build_test_full_node(config::NetworkConfiguration {
-		extra_sets: vec![config::NonDefaultSetConfig {
-			notifications_protocol: PROTOCOL_NAME,
-			fallback_names: Vec::new(),
-			max_notification_size: 1024 * 1024,
-			set_config: config::SetConfig {
+		extra_sets: vec![config::NonDefaultSetConfig::new(PROTOCOL_NAME, 1024 * 1024).with_config(
+			config::SetConfig {
 				reserved_nodes: vec![config::MultiaddrWithPeerId {
 					multiaddr: listen_addr,
 					peer_id: node1.local_peer_id().clone(),
 				}],
 				..Default::default()
 			},
-		}],
+		)],
 		listen_addresses: vec![],
 		transport: config::TransportConfig::MemoryOnly,
 		..config::NetworkConfiguration::new_local()
@@ -345,12 +338,8 @@ fn lots_of_incoming_peers_works() {
 
 	let (main_node, _) = build_test_full_node(config::NetworkConfiguration {
 		listen_addresses: vec![listen_addr.clone()],
-		extra_sets: vec![config::NonDefaultSetConfig {
-			notifications_protocol: PROTOCOL_NAME,
-			fallback_names: Vec::new(),
-			max_notification_size: 1024 * 1024,
-			set_config: config::SetConfig { in_peers: u32::MAX, ..Default::default() },
-		}],
+		extra_sets: vec![config::NonDefaultSetConfig::new(PROTOCOL_NAME, 1024 * 1024)
+			.with_config(config::SetConfig { in_peers: u32::MAX, ..Default::default() })],
 		transport: config::TransportConfig::MemoryOnly,
 		..config::NetworkConfiguration::new_local()
 	});
@@ -364,18 +353,14 @@ fn lots_of_incoming_peers_works() {
 	for _ in 0..32 {
 		let (_dialing_node, event_stream) = build_test_full_node(config::NetworkConfiguration {
 			listen_addresses: vec![],
-			extra_sets: vec![config::NonDefaultSetConfig {
-				notifications_protocol: PROTOCOL_NAME,
-				fallback_names: Vec::new(),
-				max_notification_size: 1024 * 1024,
-				set_config: config::SetConfig {
+			extra_sets: vec![config::NonDefaultSetConfig::new(PROTOCOL_NAME, 1024 * 1024)
+				.with_config(config::SetConfig {
 					reserved_nodes: vec![config::MultiaddrWithPeerId {
 						multiaddr: listen_addr.clone(),
 						peer_id: main_node_peer_id,
 					}],
 					..Default::default()
-				},
-			}],
+				})],
 			transport: config::TransportConfig::MemoryOnly,
 			..config::NetworkConfiguration::new_local()
 		});
@@ -477,30 +462,24 @@ fn fallback_name_working() {
 	let listen_addr = config::build_multiaddr![Memory(rand::random::<u64>())];
 
 	let (node1, mut events_stream1) = build_test_full_node(config::NetworkConfiguration {
-		extra_sets: vec![config::NonDefaultSetConfig {
-			notifications_protocol: NEW_PROTOCOL_NAME.clone(),
-			fallback_names: vec![PROTOCOL_NAME],
-			max_notification_size: 1024 * 1024,
-			set_config: Default::default(),
-		}],
+		extra_sets: vec![config::NonDefaultSetConfig::new(NEW_PROTOCOL_NAME.clone(), 1024 * 1024)
+			.add_fallback_names(vec![PROTOCOL_NAME])
+			.with_config(Default::default())],
 		listen_addresses: vec![listen_addr.clone()],
 		transport: config::TransportConfig::MemoryOnly,
 		..config::NetworkConfiguration::new_local()
 	});
 
 	let (_, mut events_stream2) = build_test_full_node(config::NetworkConfiguration {
-		extra_sets: vec![config::NonDefaultSetConfig {
-			notifications_protocol: PROTOCOL_NAME,
-			fallback_names: Vec::new(),
-			max_notification_size: 1024 * 1024,
-			set_config: config::SetConfig {
+		extra_sets: vec![config::NonDefaultSetConfig::new(PROTOCOL_NAME, 1024 * 1024).with_config(
+			config::SetConfig {
 				reserved_nodes: vec![config::MultiaddrWithPeerId {
 					multiaddr: listen_addr,
 					peer_id: node1.local_peer_id().clone(),
 				}],
 				..Default::default()
 			},
-		}],
+		)],
 		listen_addresses: vec![],
 		transport: config::TransportConfig::MemoryOnly,
 		..config::NetworkConfiguration::new_local()

--- a/client/network/src/transactions.rs
+++ b/client/network/src/transactions.rs
@@ -146,17 +146,7 @@ impl TransactionsHandlerPrototype {
 
 	/// Returns the configuration of the set to put in the network configuration.
 	pub fn set_config(&self) -> config::NonDefaultSetConfig {
-		config::NonDefaultSetConfig {
-			notifications_protocol: self.protocol_name.clone(),
-			fallback_names: Vec::new(),
-			max_notification_size: MAX_TRANSACTIONS_SIZE,
-			set_config: config::SetConfig {
-				in_peers: 0,
-				out_peers: 0,
-				reserved_nodes: Vec::new(),
-				non_reserved_mode: config::NonReservedPeerMode::Deny,
-			},
-		}
+		config::NonDefaultSetConfig::new(self.protocol_name.clone(), MAX_TRANSACTIONS_SIZE)
 	}
 
 	/// Turns the prototype into the actual handler. Returns a controller that allows controlling

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -766,12 +766,7 @@ where
 		network_config.extra_sets = config
 			.notifications_protocols
 			.into_iter()
-			.map(|p| NonDefaultSetConfig {
-				notifications_protocol: p,
-				fallback_names: Vec::new(),
-				max_notification_size: 1024 * 1024,
-				set_config: Default::default(),
-			})
+			.map(|p| NonDefaultSetConfig::new(p, 1024 * 1024).with_config(Default::default()))
 			.collect();
 		if let Some(connect_to) = config.connect_to_peers {
 			let addrs = connect_to


### PR DESCRIPTION
Extract synchronization related code into its own crate. This is the last protocol that was handled in a special way in the network crate.

closes: #8686
polkadot companion: paritytech/polkadot#4701