### PR TITLE
Customizable ink address

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -957,6 +957,7 @@ impl pallet_contracts::Config for Runtime {
 	type DeletionQueueDepth = DeletionQueueDepth;
 	type DeletionWeightLimit = DeletionWeightLimit;
 	type Schedule = Schedule;
+	type AddressGenerator = pallet_contracts::DefaultAddressGenerator;
 }
 
 impl pallet_sudo::Config for Runtime {

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -24,7 +24,8 @@ use crate::{
 	storage::Storage,
 	wasm::{PrefabWasmModule, ReturnCode as RuntimeReturnCode},
 	weights::WeightInfo,
-	BalanceOf, Code, CodeStorage, Config, ContractInfoOf, Error, Pallet, Schedule,
+	BalanceOf, Code, CodeStorage, Config, ContractInfoOf, DefaultAddressGenerator, Error, Pallet,
+	Schedule,
 };
 use assert_matches::assert_matches;
 use codec::Encode;
@@ -285,6 +286,7 @@ impl Config for Test {
 	type Schedule = MySchedule;
 	type DepositPerByte = DepositPerByte;
 	type DepositPerItem = DepositPerItem;
+	type AddressGenerator = DefaultAddressGenerator;
 }
 
 pub const ALICE: AccountId32 = AccountId32::new([1u8; 32]);


### PR DESCRIPTION
# Background
We are using the pallet-contracts to implement phala's smart contract. We constructed a minimal substrate runtime which include only pallet-contracts and it's dependencies. The runtime then can runs on multiple seperate storage instance. The problem is that contracts instantiated in different storage instance can have the same address, and we want the address to be unique in global.

# Summary
To solve the problem, this PR adds a type parameter to generate ink addresses. The DefaultAddressGenerator keeps the original formula. And users can customize the address generation formula by implement a custom AddressGenerator.
