### PR TITLE
contracts: serialize `CodeUploadReturnValue` deposit as hex

### DIFF
--- a/frame/contracts/common/src/lib.rs
+++ b/frame/contracts/common/src/lib.rs
@@ -151,11 +151,19 @@ pub struct InstantiateReturnValue<AccountId> {
 /// The result of succesfully uploading a contract.
 #[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+#[cfg_attr(
+	feature = "std",
+	serde(
+		rename_all = "camelCase",
+		bound(serialize = "CodeHash: Serialize, Balance: Copy + Into<NumberOrHex>"),
+		bound(deserialize = "CodeHash: Deserialize<'de>, Balance: TryFrom<NumberOrHex>")
+	)
+)]
 pub struct CodeUploadReturnValue<CodeHash, Balance> {
 	/// The key under which the new code is stored.
 	pub code_hash: CodeHash,
 	/// The deposit that was reserved at the caller. Is zero when the code already existed.
+	#[cfg_attr(feature = "std", serde(with = "as_hex"))]
 	pub deposit: Balance,
 }
 


### PR DESCRIPTION
As per other `Balance` fields in RPC return types, for correctly serializing `u128`.