### PR TITLE
Expose Uniques helper functions and DestroyWitness fields

### DIFF
--- a/frame/uniques/src/functions.rs
+++ b/frame/uniques/src/functions.rs
@@ -22,7 +22,7 @@ use frame_support::{ensure, traits::Get};
 use sp_runtime::{DispatchError, DispatchResult};
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
-	pub(crate) fn do_transfer(
+	pub fn do_transfer(
 		class: T::ClassId,
 		instance: T::InstanceId,
 		dest: T::AccountId,
@@ -53,7 +53,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Ok(())
 	}
 
-	pub(super) fn do_create_class(
+	pub fn do_create_class(
 		class: T::ClassId,
 		owner: T::AccountId,
 		admin: T::AccountId,
@@ -86,7 +86,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Ok(())
 	}
 
-	pub(super) fn do_destroy_class(
+	pub fn do_destroy_class(
 		class: T::ClassId,
 		witness: DestroyWitness,
 		maybe_check_owner: Option<T::AccountId>,
@@ -122,7 +122,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		})
 	}
 
-	pub(super) fn do_mint(
+	pub fn do_mint(
 		class: T::ClassId,
 		instance: T::InstanceId,
 		owner: T::AccountId,
@@ -157,7 +157,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Ok(())
 	}
 
-	pub(super) fn do_burn(
+	pub fn do_burn(
 		class: T::ClassId,
 		instance: T::InstanceId,
 		with_details: impl FnOnce(&ClassDetailsFor<T, I>, &InstanceDetailsFor<T, I>) -> DispatchResult,

--- a/frame/uniques/src/types.rs
+++ b/frame/uniques/src/types.rs
@@ -58,13 +58,13 @@ pub struct ClassDetails<AccountId, DepositBalance> {
 pub struct DestroyWitness {
 	/// The total number of outstanding instances of this asset class.
 	#[codec(compact)]
-	pub(super) instances: u32,
+	pub instances: u32,
 	/// The total number of outstanding instance metadata of this asset class.
 	#[codec(compact)]
-	pub(super) instance_metadatas: u32,
+	pub instance_metadatas: u32,
 	#[codec(compact)]
 	/// The total number of attributes for this asset class.
-	pub(super) attributes: u32,
+	pub attributes: u32,
 }
 
 impl<AccountId, DepositBalance> ClassDetails<AccountId, DepositBalance> {


### PR DESCRIPTION
We@Basilisk are planning to use our custom pallet-nft which is basically wrapped pallet-uniques with some customizations and extended permission functionality.

In order to use pallet-uniques' helper methods do\__method_ we need to make them pub. Also need to make DestroyWitness fields pub to use them - e.g. need to prevent destroying classes which contain instances.