### PR TITLE
Use `exists` host function for child tries

### DIFF
--- a/frame/support/src/storage/child.rs
+++ b/frame/support/src/storage/child.rs
@@ -112,8 +112,7 @@ pub fn take_or_else<T: Codec + Sized, F: FnOnce() -> T>(
 pub fn exists(child_info: &ChildInfo, key: &[u8]) -> bool {
 	match child_info.child_type() {
 		ChildType::ParentKeyId =>
-			sp_io::default_child_storage::read(child_info.storage_key(), key, &mut [0; 0][..], 0)
-				.is_some(),
+			sp_io::default_child_storage::exists(child_info.storage_key(), key),
 	}
 }
 


### PR DESCRIPTION
`frame_support::storage::child::exists` was using the `read` host function when the `exists` host function is the better fit.

Please note that this should not yield any substantial performance benefit because the substrate client does read the complete contents of the stored value from storage in both cases.