### PR TITLE
[WIP, do not merge] Use MinIO as `sccache`'s backend

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,6 +43,11 @@ variables:                         &default-vars
   VAULT_AUTH_PATH:                 "gitlab-parity-io-jwt"
   VAULT_AUTH_ROLE:                 "cicd_gitlab_parity_${CI_PROJECT_NAME}"
   PIPELINE_SCRIPTS_TAG:            "v0.4"
+  # Global sccache's MinIO backend settings
+  SCCACHE_ENDPOINT:                $SCCACHE_MINIO_ENDPOINT
+  SCCACHE_BUCKET:                  $SCCACHE_MINIO_BUCKET
+  AWS_ACCESS_KEY_ID:               $SCCACHE_MINIO_USER
+  AWS_SECRET_ACCESS_KEY:           $SCCACHE_MINIO_PASSWORD
 
 default:
   cache:                           {}
@@ -75,6 +80,9 @@ default:
     - kubernetes-parity-build
 
 .rust-info-script:                 &rust-info-script
+  - unset SCCACHE_REDIS
+  - unset SCCACHE_IDLE_TIMEOUT
+  - unset SCCACHE_CACHE_SIZE
   - rustup show
   - cargo --version
   - rustup +nightly show
@@ -204,10 +212,10 @@ default:
     GITHUB_TOKEN:
       vault:                       cicd/gitlab/parity/GITHUB_TOKEN@kv
       file:                        false
-    AWS_ACCESS_KEY_ID:
+    S3_AWS_ACCESS_KEY_ID:
       vault:                       cicd/gitlab/$CI_PROJECT_PATH/AWS_ACCESS_KEY_ID@kv
       file:                        false
-    AWS_SECRET_ACCESS_KEY:
+    S3_AWS_SECRET_ACCESS_KEY:
       vault:                       cicd/gitlab/$CI_PROJECT_PATH/AWS_SECRET_ACCESS_KEY@kv
       file:                        false
     AWX_TOKEN:
@@ -760,6 +768,8 @@ publish-s3-release:
     GIT_STRATEGY:                  none
     BUCKET:                        "releases.parity.io"
     PREFIX:                        "substrate/${ARCH}-${DOCKER_OS}"
+    AWS_ACCESS_KEY_ID:             $S3_AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY:         $S3_AWS_SECRET_ACCESS_KEY
   script:
     - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/$(cat ./artifacts/substrate/VERSION)/
     - echo "update objects in latest path"


### PR DESCRIPTION
_This MR isn't marked as draft because it requires full pipeline runs to check its correctness._

This MR switches `sccache` storage backend setup from using per-host Redis instances to the single unified S3-compatible storage solution.