### PR TITLE
Make check-dependent-* jobs only be executed in PRs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -575,7 +575,7 @@ cargo-check-macos:
 .check-dependent-project:          &check-dependent-project
   stage:                           build
   <<:                              *docker-env
-  <<:                              *test-refs-no-trigger
+  <<:                              *test-refs-no-trigger-prs-only
   <<:                              *vault-secrets
   script:
     - git clone


### PR DESCRIPTION
Make `check-dependent-*` jobs only be executed in PRs instead of both PRs and master.

Reason 1: The companion is not merged at the same time as the parent PR ([1](https://github.com/paritytech/parity-processbot/issues/347#issuecomment-994729950)), therefore the pipeline will fail on master since the companion PR is not yet merged in the other repository. This scenario is demonstrated by the pipeline of https://github.com/paritytech/substrate/commit/82cc3746450ae9722a249f4ddf83b8de59ba6e0d.

Reason 2: The job can still fail on master due to a new commit on the companion PR's repository which was merged after `bot merge` happened, as demonstrated by the following scheme:

1. Parent PR is merged
2. Companion PR is updated and set to merge in the future
3. In the meantime a new commit is merged into the companion PR repository's master branch
4. The `check-dependent-*` job runs on master but, due to the new commit, it fails for unrelated reasons

While "Reason 2" can be used as an argument against this PR, in that it would be useful to know if the integration is failing on master, "Reason 1" should be taken care of due to this inherent flaw of the current companion build system design.