### PR TITLE
[_WIP, don't merge_] Improve `cargo` and `rustc` caching

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,6 +43,13 @@ variables:                         &default-vars
   VAULT_AUTH_PATH:                 "gitlab-parity-io-jwt"
   VAULT_AUTH_ROLE:                 "cicd_gitlab_parity_${CI_PROJECT_NAME}"
   PIPELINE_SCRIPTS_TAG:            "v0.4"
+  # Global sccache's MinIO backend settings
+  SCCACHE_ENDPOINT:                $SCCACHE_MINIO_ENDPOINT
+  SCCACHE_BUCKET:                  $SCCACHE_MINIO_BUCKET
+  AWS_ACCESS_KEY_ID:               $SCCACHE_MINIO_USER
+  AWS_SECRET_ACCESS_KEY:           $SCCACHE_MINIO_PASSWORD
+  # TODO remove when pr is ready
+  RUSTY_CACHIER_TESTING:           "true"
 
 default:
   cache:                           {}
@@ -74,17 +81,26 @@ default:
   tags:
     - kubernetes-parity-build
 
-.rust-info-script:                 &rust-info-script
+.docker-env-rust-prepare-script:  &docker-env-rust-prepare-script
+  # TODO remove after #<PR> lands to master
+  - unset SCCACHE_REDIS
+  - unset SCCACHE_IDLE_TIMEOUT
+  - unset SCCACHE_CACHE_SIZE
+  #
   - rustup show
   - cargo --version
   - rustup +nightly show
   - cargo +nightly --version
   - sccache -s
+  # TODO switch to the release branch when pr is ready
+  - curl -s https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.parity.io/parity/infrastructure/ci_cd/rusty-cachier/-/raw/master/client/install.sh | bash
+  - rusty-cachier --check
+  - $(rusty-cachier --inject)
 
 .docker-env:                       &docker-env
   image:                           "${CI_IMAGE}"
   before_script:
-    - *rust-info-script
+    - *docker-env-rust-prepare-script
   retry:
     max: 2
     when:
@@ -102,6 +118,8 @@ default:
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+    # TODO remove when pr is ready to be merged
+    - if: $CI_JOB_NAME == "test-linux-stable"
 
 .test-refs-no-trigger:             &test-refs-no-trigger
   rules:
@@ -113,6 +131,8 @@ default:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
     - if: $CI_COMMIT_REF_NAME =~ /^ci-release-.*$/
+    # TODO remove when pr is ready
+    - if: $CI_JOB_NAME == "test-linux-stable"
 
 .test-refs-no-trigger-prs-only:   &test-refs-no-trigger-prs-only
   rules:
@@ -121,6 +141,8 @@ default:
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+    # TODO remove when pr is ready to be merged
+    - if: $CI_JOB_NAME == "test-linux-stable"
 
 .test-refs-wasmer-sandbox:                        &test-refs-wasmer-sandbox
   rules:
@@ -204,10 +226,10 @@ default:
     GITHUB_TOKEN:
       vault:                       cicd/gitlab/parity/GITHUB_TOKEN@kv
       file:                        false
-    AWS_ACCESS_KEY_ID:
+    S3_AWS_ACCESS_KEY_ID:
       vault:                       cicd/gitlab/$CI_PROJECT_PATH/AWS_ACCESS_KEY_ID@kv
       file:                        false
-    AWS_SECRET_ACCESS_KEY:
+    S3_AWS_SECRET_ACCESS_KEY:
       vault:                       cicd/gitlab/$CI_PROJECT_PATH/AWS_SECRET_ACCESS_KEY@kv
       file:                        false
     AWX_TOKEN:
@@ -360,7 +382,7 @@ cargo-check-benches:
   before_script:
     # merges in the master branch on PRs
     - *merge-ref-into-master-script
-    - *rust-info-script
+    - *docker-env-rust-prepare-script
   script:
     - *cargo-check-benches-script
   tags:
@@ -449,10 +471,14 @@ test-linux-stable:                 &test-linux
     RUST_BACKTRACE:                1
     WASM_BUILD_NO_COLOR:           1
   script:
+    - rusty-cachier --fix-mtime
+    - rusty-cachier --download-cache
     # this job runs all tests in former runtime-benchmarks, frame-staking and wasmtime tests
     - time cargo test --workspace --locked --release --verbose --features runtime-benchmarks --manifest-path bin/node/cli/Cargo.toml
-    - time cargo test -p frame-support-test --features=conditional-storage --manifest-path frame/support/test/Cargo.toml --test pallet # does not reuse cache 1 min 44 sec
-    - SUBSTRATE_TEST_TIMEOUT=1 time cargo test -p substrate-test-utils --release --verbose --locked -- --ignored timeout
+    # TODO uncomment below when pr is ready
+    # - time cargo test -p frame-support-test --features=conditional-storage --manifest-path frame/support/test/Cargo.toml --test pallet # does not reuse cache 1 min 44 sec
+    # - SUBSTRATE_TEST_TIMEOUT=1 time cargo test -p substrate-test-utils --release --verbose --locked -- --ignored timeout
+    - rusty-cachier --upload-cache
     - sccache -s
 
 test-frame-examples-compile-to-wasm:
@@ -760,6 +786,8 @@ publish-s3-release:
     GIT_STRATEGY:                  none
     BUCKET:                        "releases.parity.io"
     PREFIX:                        "substrate/${ARCH}-${DOCKER_OS}"
+    AWS_ACCESS_KEY_ID:             $S3_AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY:         $S3_AWS_SECRET_ACCESS_KEY
   script:
     - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/$(cat ./artifacts/substrate/VERSION)/
     - echo "update objects in latest path"


### PR DESCRIPTION
_This PR isn't marked as draft because it requires full pipeline runs to check its correctness._

This PR makes the following changes to the project's pipeline:

* Use MinIO as `sccache`'s backend. Switch `sccache` storage backend setup from using per-host Redis instances to the single unified S3-compatible storage solution

* Introduce [dedicated `rusty-cachier` utility](https://gitlab.parity.io/parity/infrastructure/ci_cd/rusty-cachier) to the project pipeline to manage `CARGO_HOME` and `CARGO_TARGET_DIR` directories.

* Temporarily `unset` all Redis-related `sccache` variables until this PR lands to `master` and all WIP PRs are rebased/merged

Resolves paritytech/ci_cd#252 and paritytech/ci_cd#254.