### PR TITLE
node-template README persistent db

### DIFF
--- a/bin/node-template/README.md
+++ b/bin/node-template/README.md
@@ -55,7 +55,7 @@ node.
 
 ### Single-Node Development Chain
 
-This command will start the single-node development chain with persistent state:
+This command will start the single-node development chain with non-persistent state:
 
 ```bash
 ./target/release/node-template --dev
@@ -71,6 +71,36 @@ Start the development chain with detailed logging:
 
 ```bash
 RUST_BACKTRACE=1 ./target/release/node-template -ldebug --dev
+```
+> Development chain means that the state of our chain will be in a tmp folder while the nodes are
+> running. Also, **alice** account will be authority and sudo account as declared in the [genesis
+> state](https://github.com/substrate-developer-hub/substrate-node-template/blob/main/node/src/chain_spec.rs#L49).
+> At the same time the following accounts will be prefunded:
+> - Alice
+> - Bob 
+> - Alice//stash
+> - Bob//stash
+
+In case of being interested in maintaining the chain' state futher in time a base path other than 
+a temporary directory must be added so the db can be stored in the provided folder. We could use 
+this folder to store different chain databases, as a different folder will be created per different
+ chain that is ran. The following commands shows how to use a newly created folder as our db base 
+ path.
+
+```bash
+// Create a folder to use as the db base path
+$ mkdir my-chain-state
+
+// Use of that folder to store the chain state
+$ ./target/release/node-template --dev --base-path ./my-chain-state/
+
+// Check the folder structure created inside the base path after running the chain
+$ ls ./my-chain-state
+chains
+$ ls ./my-chain-state/chains/
+dev
+$ ls ./my-chain-state/chains/dev
+db keystore network
 ```
 
 ### Connect with Polkadot-JS Apps Front-end


### PR DESCRIPTION
This PR introduces a minor change adding some more detail in how to run a development chain with a persistent db.
