### PR TITLE
Execute one contract in the context of another (support for Upgradable contracts)

### DIFF
--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -350,8 +350,9 @@ mod tests {
 			value: u64,
 			data: Vec<u8>,
 			allows_reentry: bool,
+			preserve_context: bool,
 		) -> Result<ExecReturnValue, ExecError> {
-			self.calls.push(CallEntry { to, value, data, allows_reentry });
+			self.calls.push(CallEntry { to, value, data, allows_reentry, preserve_context });
 			Ok(ExecReturnValue { flags: ReturnFlags::empty(), data: call_return_data() })
 		}
 		fn instantiate(
@@ -552,7 +553,13 @@ mod tests {
 
 		assert_eq!(
 			&mock_ext.calls,
-			&[CallEntry { to: ALICE, value: 6, data: vec![1, 2, 3, 4], allows_reentry: true }]
+			&[CallEntry {
+				to: ALICE,
+				value: 6,
+				data: vec![1, 2, 3, 4],
+				allows_reentry: true,
+				preserve_context: false
+			}]
 		);
 	}
 
@@ -606,7 +613,13 @@ mod tests {
 
 		assert_eq!(
 			&mock_ext.calls,
-			&[CallEntry { to: ALICE, value: 0x2a, data: input, allows_reentry: false }]
+			&[CallEntry {
+				to: ALICE,
+				value: 0x2a,
+				data: input,
+				allows_reentry: false,
+				preserve_context: false
+			}]
 		);
 	}
 
@@ -661,7 +674,13 @@ mod tests {
 		assert_eq!(result.data.0, input);
 		assert_eq!(
 			&mock_ext.calls,
-			&[CallEntry { to: ALICE, value: 0x2a, data: input, allows_reentry: true }]
+			&[CallEntry {
+				to: ALICE,
+				value: 0x2a,
+				data: input,
+				allows_reentry: true,
+				preserve_context: false
+			}]
 		);
 	}
 
@@ -708,7 +727,13 @@ mod tests {
 		assert_eq!(result.data, call_return_data());
 		assert_eq!(
 			&mock_ext.calls,
-			&[CallEntry { to: ALICE, value: 0x2a, data: input, allows_reentry: false }]
+			&[CallEntry {
+				to: ALICE,
+				value: 0x2a,
+				data: input,
+				allows_reentry: false,
+				preserve_context: false
+			}]
 		);
 	}
 
@@ -872,7 +897,13 @@ mod tests {
 
 		assert_eq!(
 			&mock_ext.calls,
-			&[CallEntry { to: ALICE, value: 6, data: vec![1, 2, 3, 4], allows_reentry: true }]
+			&[CallEntry {
+				to: ALICE,
+				value: 6,
+				data: vec![1, 2, 3, 4],
+				allows_reentry: true,
+				preserve_context: false
+			}]
 		);
 	}
 

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -299,6 +299,7 @@ mod tests {
 		value: u64,
 		data: Vec<u8>,
 		allows_reentry: bool,
+		preserve_context: bool,
 	}
 
 	pub struct MockExt {

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -338,6 +338,11 @@ bitflags! {
 		/// the callee (or any of its callees) is denied. This includes the first callee:
 		/// You cannot call into yourself with this flag set.
 		const ALLOW_REENTRY = 0b0000_1000;
+		/// Allow callee execution in the caller context
+		///
+		/// Provides functionality for creating library smart contract that can be upgraded
+		/// without the need of migrating data
+		const PRESERVE_CONTEXT = 0b0001_0000;
 	}
 }
 
@@ -658,8 +663,14 @@ where
 			self.charge_gas(RuntimeCosts::CallSurchargeTransfer)?;
 		}
 		let ext = &mut self.ext;
-		let call_outcome =
-			ext.call(gas, callee, value, input_data, flags.contains(CallFlags::ALLOW_REENTRY));
+		let call_outcome = ext.call(
+			gas,
+			callee,
+			value,
+			input_data,
+			flags.contains(CallFlags::ALLOW_REENTRY),
+			flags.contains(CallFlags::PRESERVE_CONTEXT),
+		);
 
 		// `TAIL_CALL` only matters on an `OK` result. Otherwise the call stack comes to
 		// a halt anyways without anymore code being executed.

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -17,6 +17,18 @@
 
 //! Environment definition of the wasm smart-contract runtime.
 
+use bitflags::bitflags;
+use codec::{Decode, DecodeAll, Encode, MaxEncodedLen};
+use pwasm_utils::parity_wasm::elements::ValueType;
+
+use frame_support::{dispatch::DispatchError, ensure, weights::Weight};
+use pallet_contracts_primitives::{ExecReturnValue, ReturnFlags};
+use sp_core::{crypto::UncheckedFrom, Bytes};
+use sp_io::hashing::{blake2_128, blake2_256, keccak_256, sha2_256};
+use sp_runtime::traits::{Bounded, Zero};
+use sp_sandbox::SandboxMemory;
+use sp_std::prelude::*;
+
 use crate::{
 	exec::{ExecError, ExecResult, Ext, StorageKey, TopicOf},
 	gas::{ChargedAmount, Token},
@@ -24,16 +36,6 @@ use crate::{
 	wasm::env_def::ConvertibleToWasm,
 	BalanceOf, CodeHash, Config, Error,
 };
-use bitflags::bitflags;
-use codec::{Decode, DecodeAll, Encode, MaxEncodedLen};
-use frame_support::{dispatch::DispatchError, ensure, weights::Weight};
-use pallet_contracts_primitives::{ExecReturnValue, ReturnFlags};
-use pwasm_utils::parity_wasm::elements::ValueType;
-use sp_core::{crypto::UncheckedFrom, Bytes};
-use sp_io::hashing::{blake2_128, blake2_256, keccak_256, sha2_256};
-use sp_runtime::traits::{Bounded, Zero};
-use sp_sandbox::SandboxMemory;
-use sp_std::prelude::*;
 
 /// Every error that can be returned to a contract when it calls any of the host functions.
 ///


### PR DESCRIPTION
This PR is a follow up to [#7](https://github.com/Supercolony-net/openbrush-contracts/issues/7#issue-915060111) (second reason).

It lets you execute one (callee) contract in the context of another (caller).
Therefore callee contract is a library contract that can be upgraded.
