### PR TITLE
Use storage transaction when running with proof recorder

### DIFF
--- a/client/service/src/client/call_executor.rs
+++ b/client/service/src/client/call_executor.rs
@@ -246,8 +246,10 @@ where
 					&runtime_code,
 					self.spawn_handle.clone(),
 				)
+				.with_storage_transaction_cache(
+					storage_transaction_cache.as_mut().map(|c| &mut **c),
+				)
 				.set_parent_hash(at_hash);
-				// TODO: https://github.com/paritytech/substrate/issues/4455
 				state_machine.execute_using_consensus_failure_handler(
 					execution_manager,
 					native_call.map(|n| || (n)().map_err(|e| Box::new(e) as Box<_>)),

--- a/primitives/state-machine/src/backend.rs
+++ b/primitives/state-machine/src/backend.rs
@@ -40,7 +40,7 @@ pub trait Backend<H: Hasher>: sp_std::fmt::Debug {
 	type Transaction: Consolidate + Default + Send;
 
 	/// Type of trie backend storage.
-	type TrieBackendStorage: TrieBackendStorage<H>;
+	type TrieBackendStorage: TrieBackendStorage<H, Overlay = Self::Transaction>;
 
 	/// Get keyed storage or None if there is nothing associated.
 	fn storage(&self, key: &[u8]) -> Result<Option<StorageValue>, Self::Error>;


### PR DESCRIPTION
This will enable parachains to re-import a block without re-executing it.

Fixes: https://github.com/paritytech/substrate/issues/4455
