### PR TITLE
Warn on chain selection error.

### DIFF
--- a/client/finality-grandpa/src/environment.rs
+++ b/client/finality-grandpa/src/environment.rs
@@ -1224,7 +1224,7 @@ where
 				.or_else(|| Some((target_header.hash(), *target_header.number())))
 		},
 		Err(e) => {
-			debug!(target: "afg", "Encountered error finding best chain containing {:?}: {:?}", block, e);
+			warn!(target: "afg", "Encountered error finding best chain containing {:?}: {:?}", block, e);
 			None
 		},
 	};


### PR DESCRIPTION
At least for Polkadot, this should not result in spam and a warning will
very likely indicate some serious issue.