### PR TITLE
frame-support: Use logging for printing corrupted state

### DIFF
--- a/frame/support/src/storage/child.rs
+++ b/frame/support/src/storage/child.rs
@@ -34,8 +34,9 @@ pub fn get<T: Decode + Sized>(child_info: &ChildInfo, key: &[u8]) -> Option<T> {
 			sp_io::default_child_storage::get(storage_key, key).and_then(|v| {
 				Decode::decode(&mut &v[..]).map(Some).unwrap_or_else(|_| {
 					// TODO #3700: error should be handleable.
-					crate::runtime_print!(
-						"ERROR: Corrupted state in child trie at {:?}/{:?}",
+					log::error!(
+						target: "runtime::storage",
+						"Corrupted state in child trie at {:?}/{:?}",
 						storage_key,
 						key,
 					);

--- a/frame/support/src/storage/unhashed.rs
+++ b/frame/support/src/storage/unhashed.rs
@@ -25,7 +25,11 @@ pub fn get<T: Decode + Sized>(key: &[u8]) -> Option<T> {
 	sp_io::storage::get(key).and_then(|val| {
 		Decode::decode(&mut &val[..]).map(Some).unwrap_or_else(|_| {
 			// TODO #3700: error should be handleable.
-			crate::runtime_print!("ERROR: Corrupted state at {:?}", key);
+			log::error!(
+				target: "runtime::storage",
+				"Corrupted state at {:?}",
+				key,
+			);
 			None
 		})
 	})


### PR DESCRIPTION
`runtime_print!` is printed by default using `debug`, aka not being visible. With `log::error!` it
will be printed directly to the user. Production networks like Polkadot disable logging, but for
them we run special nodes that have logging enabled.

