### PR TITLE
add into function for PrefixIterator

### DIFF
--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -802,6 +802,18 @@ pub struct PrefixIterator<T, OnRemoval = ()> {
 	phantom: core::marker::PhantomData<OnRemoval>,
 }
 
+impl<T, OnRemoval1> PrefixIterator<T, OnRemoval1> {
+	pub fn into<OnRemoval2>(self) -> PrefixIterator<T, OnRemoval2> {
+		PrefixIterator::<T, OnRemoval2> {
+			prefix: self.prefix,
+			previous_key: self.previous_key,
+			drain: self.drain,
+			closure: self.closure,
+			phantom: Default::default(),
+		}
+	}
+}
+
 /// Trait for specialising on removal logic of [`PrefixIterator`].
 pub trait PrefixIteratorOnRemoval {
 	/// This function is called whenever a key/value is removed.

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -803,7 +803,8 @@ pub struct PrefixIterator<T, OnRemoval = ()> {
 }
 
 impl<T, OnRemoval1> PrefixIterator<T, OnRemoval1> {
-	pub fn into_other<OnRemoval2>(self) -> PrefixIterator<T, OnRemoval2> {
+	/// Converts to the same iterator but with the different 'OnRemoval' type
+	pub fn convert_on_removal<OnRemoval2>(self) -> PrefixIterator<T, OnRemoval2> {
 		PrefixIterator::<T, OnRemoval2> {
 			prefix: self.prefix,
 			previous_key: self.previous_key,

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -803,7 +803,7 @@ pub struct PrefixIterator<T, OnRemoval = ()> {
 }
 
 impl<T, OnRemoval1> PrefixIterator<T, OnRemoval1> {
-	pub fn into<OnRemoval2>(self) -> PrefixIterator<T, OnRemoval2> {
+	pub fn into_other<OnRemoval2>(self) -> PrefixIterator<T, OnRemoval2> {
 		PrefixIterator::<T, OnRemoval2> {
 			prefix: self.prefix,
 			previous_key: self.previous_key,

--- a/frame/support/src/storage/types/counted_map.rs
+++ b/frame/support/src/storage/types/counted_map.rs
@@ -285,14 +285,7 @@ where
 	///
 	/// NOTE: If a value failed to decode because storage is corrupted then it is skipped.
 	pub fn iter_values() -> crate::storage::PrefixIterator<Value, OnRemovalCounterUpdate<Prefix>> {
-		let map_iterator = <Self as MapWrapper>::Map::iter_values();
-		crate::storage::PrefixIterator {
-			prefix: map_iterator.prefix,
-			previous_key: map_iterator.previous_key,
-			drain: map_iterator.drain,
-			closure: map_iterator.closure,
-			phantom: Default::default(),
-		}
+		<Self as MapWrapper>::Map::iter_values().into()
 	}
 
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.
@@ -374,28 +367,14 @@ where
 	///
 	/// If you alter the map while doing this, you'll get undefined results.
 	pub fn iter() -> crate::storage::PrefixIterator<(Key, Value), OnRemovalCounterUpdate<Prefix>> {
-		let map_iterator = <Self as MapWrapper>::Map::iter();
-		crate::storage::PrefixIterator {
-			prefix: map_iterator.prefix,
-			previous_key: map_iterator.previous_key,
-			drain: map_iterator.drain,
-			closure: map_iterator.closure,
-			phantom: Default::default(),
-		}
+		<Self as MapWrapper>::Map::iter().into()
 	}
 
 	/// Remove all elements from the map and iterate through them in no particular order.
 	///
 	/// If you add elements to the map while doing this, you'll get undefined results.
 	pub fn drain() -> crate::storage::PrefixIterator<(Key, Value), OnRemovalCounterUpdate<Prefix>> {
-		let map_iterator = <Self as MapWrapper>::Map::drain();
-		crate::storage::PrefixIterator {
-			prefix: map_iterator.prefix,
-			previous_key: map_iterator.previous_key,
-			drain: map_iterator.drain,
-			closure: map_iterator.closure,
-			phantom: Default::default(),
-		}
+		<Self as MapWrapper>::Map::drain().into()
 	}
 
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.
@@ -420,14 +399,7 @@ where
 	pub fn iter_from(
 		starting_raw_key: Vec<u8>,
 	) -> crate::storage::PrefixIterator<(Key, Value), OnRemovalCounterUpdate<Prefix>> {
-		let map_iterator = <Self as MapWrapper>::Map::iter_from(starting_raw_key);
-		crate::storage::PrefixIterator {
-			prefix: map_iterator.prefix,
-			previous_key: map_iterator.previous_key,
-			drain: map_iterator.drain,
-			closure: map_iterator.closure,
-			phantom: Default::default(),
-		}
+		<Self as MapWrapper>::Map::iter_from(starting_raw_key).into()
 	}
 }
 

--- a/frame/support/src/storage/types/counted_map.rs
+++ b/frame/support/src/storage/types/counted_map.rs
@@ -285,7 +285,7 @@ where
 	///
 	/// NOTE: If a value failed to decode because storage is corrupted then it is skipped.
 	pub fn iter_values() -> crate::storage::PrefixIterator<Value, OnRemovalCounterUpdate<Prefix>> {
-		<Self as MapWrapper>::Map::iter_values().into()
+		<Self as MapWrapper>::Map::iter_values().into_other()
 	}
 
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.
@@ -367,14 +367,14 @@ where
 	///
 	/// If you alter the map while doing this, you'll get undefined results.
 	pub fn iter() -> crate::storage::PrefixIterator<(Key, Value), OnRemovalCounterUpdate<Prefix>> {
-		<Self as MapWrapper>::Map::iter().into()
+		<Self as MapWrapper>::Map::iter().into_other()
 	}
 
 	/// Remove all elements from the map and iterate through them in no particular order.
 	///
 	/// If you add elements to the map while doing this, you'll get undefined results.
 	pub fn drain() -> crate::storage::PrefixIterator<(Key, Value), OnRemovalCounterUpdate<Prefix>> {
-		<Self as MapWrapper>::Map::drain().into()
+		<Self as MapWrapper>::Map::drain().into_other()
 	}
 
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.
@@ -399,7 +399,7 @@ where
 	pub fn iter_from(
 		starting_raw_key: Vec<u8>,
 	) -> crate::storage::PrefixIterator<(Key, Value), OnRemovalCounterUpdate<Prefix>> {
-		<Self as MapWrapper>::Map::iter_from(starting_raw_key).into()
+		<Self as MapWrapper>::Map::iter_from(starting_raw_key).into_other()
 	}
 }
 

--- a/frame/support/src/storage/types/counted_map.rs
+++ b/frame/support/src/storage/types/counted_map.rs
@@ -285,7 +285,7 @@ where
 	///
 	/// NOTE: If a value failed to decode because storage is corrupted then it is skipped.
 	pub fn iter_values() -> crate::storage::PrefixIterator<Value, OnRemovalCounterUpdate<Prefix>> {
-		<Self as MapWrapper>::Map::iter_values().into_other()
+		<Self as MapWrapper>::Map::iter_values().convert_on_removal()
 	}
 
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.
@@ -367,14 +367,14 @@ where
 	///
 	/// If you alter the map while doing this, you'll get undefined results.
 	pub fn iter() -> crate::storage::PrefixIterator<(Key, Value), OnRemovalCounterUpdate<Prefix>> {
-		<Self as MapWrapper>::Map::iter().into_other()
+		<Self as MapWrapper>::Map::iter().convert_on_removal()
 	}
 
 	/// Remove all elements from the map and iterate through them in no particular order.
 	///
 	/// If you add elements to the map while doing this, you'll get undefined results.
 	pub fn drain() -> crate::storage::PrefixIterator<(Key, Value), OnRemovalCounterUpdate<Prefix>> {
-		<Self as MapWrapper>::Map::drain().into_other()
+		<Self as MapWrapper>::Map::drain().convert_on_removal()
 	}
 
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.
@@ -399,7 +399,7 @@ where
 	pub fn iter_from(
 		starting_raw_key: Vec<u8>,
 	) -> crate::storage::PrefixIterator<(Key, Value), OnRemovalCounterUpdate<Prefix>> {
-		<Self as MapWrapper>::Map::iter_from(starting_raw_key).into_other()
+		<Self as MapWrapper>::Map::iter_from(starting_raw_key).convert_on_removal()
 	}
 }
 


### PR DESCRIPTION
Small refactor, add `into` function which conveerts `PrefixIterator<T, O1>` into another `PrefixIterator<T, O2>`