### PR TITLE
[ci] pipeline chores

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -782,13 +782,14 @@ publish-rustdoc:
     INDEX_TPL:                     ".maintain/docs-index-tpl.ejs"
     # Where the `/latest` symbolic link links to. One of the $RUSTDOCS_DEPLOY_REFS value.
     LATEST:                        "monthly-2021-09+1"
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "pipeline"
-      when: never
-    - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME =~ /^monthly-20[0-9]{2}-[0-9]{2}.*$/  # to support: monthly-2021-09+1
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+  <<: *test-refs
+  # rules:
+  #   - if: $CI_PIPELINE_SOURCE == "pipeline"
+  #     when: never
+  #   - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME == "master"
+  #   - if: $CI_COMMIT_REF_NAME == "master"
+  #   - if: $CI_COMMIT_REF_NAME =~ /^monthly-20[0-9]{2}-[0-9]{2}.*$/  # to support: monthly-2021-09+1
+  #   - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   # `needs:` can be removed after CI image gets nonroot. In this case `needs:` stops other
   # artifacts from being dowloaded by this job.
   needs:
@@ -801,8 +802,6 @@ publish-rustdoc:
     # whole space-separated value.
     - '[[ " ${RUSTDOCS_DEPLOY_REFS} " =~ " ${CI_COMMIT_REF_NAME} " ]] || exit 0'
     # setup ssh
-    # FIXME: add ssh to docker image
-    - apt-get update && apt-get install -y ssh
     - eval $(ssh-agent)
     - ssh-add - <<< ${GITHUB_SSH_PRIV_KEY}
     - mkdir ~/.ssh && touch ~/.ssh/known_hosts
@@ -814,40 +813,40 @@ publish-rustdoc:
     - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     - git fetch origin gh-pages
     # Install `ejs` and generate index.html based on RUSTDOCS_DEPLOY_REFS
-    - yarn global add ejs
-    - 'ejs ${INDEX_TPL} -i "{\"deploy_refs\":\"${RUSTDOCS_DEPLOY_REFS}\",\"repo_name\":\"${CI_PROJECT_NAME}\",\"latest\":\"${LATEST}\"}" > /tmp/index.html'
-    # Save README and docs
-    - cp -r ./crate-docs/ /tmp/doc/
-    - cp README.md /tmp/doc/
-    - git checkout gh-pages
-    # Remove directories no longer necessary, as specified in $RUSTDOCS_DEPLOY_REFS.
-    # Also ensure $RUSTDOCS_DEPLOY_REFS is not just empty spaces.
-    # Even though this block spans multiple lines, they are concatenated to run as a single line
-    #   command, so note for the semi-colons in the inner-most code block.
-    - if [[ ! -z ${RUSTDOCS_DEPLOY_REFS// } ]]; then
-        for FILE in *; do
-          if [[ ! " $RUSTDOCS_DEPLOY_REFS " =~ " $FILE " ]]; then
-            echo "Removing ${FILE}...";
-            rm -rf $FILE;
-          fi
-        done
-      fi
-    # Move the index page & built back
-    - mv -f /tmp/index.html .
-    # Ensure the destination dir doesn't exist.
-    - rm -rf ${CI_COMMIT_REF_NAME}
-    - mv -f /tmp/doc ${CI_COMMIT_REF_NAME}
-    # Add the symlink
-    - '[[ -e "$LATEST" ]] && ln -sf "${LATEST}" latest'
-    # Upload files
-    - git add --all --force
-    # `git commit` has an exit code of > 0 if there is nothing to commit.
-    # This causes GitLab to exit immediately and marks this job failed.
-    # We don't want to mark the entire job failed if there's nothing to
-    # publish though, hence the `|| true`.
-    - git commit -m "___Updated docs for ${CI_COMMIT_REF_NAME}___" ||
-        echo "___Nothing to commit___"
-    - git push origin gh-pages --force
+    # - yarn global add ejs
+    # - 'ejs ${INDEX_TPL} -i "{\"deploy_refs\":\"${RUSTDOCS_DEPLOY_REFS}\",\"repo_name\":\"${CI_PROJECT_NAME}\",\"latest\":\"${LATEST}\"}" > /tmp/index.html'
+    # # Save README and docs
+    # - cp -r ./crate-docs/ /tmp/doc/
+    # - cp README.md /tmp/doc/
+    # - git checkout gh-pages
+    # # Remove directories no longer necessary, as specified in $RUSTDOCS_DEPLOY_REFS.
+    # # Also ensure $RUSTDOCS_DEPLOY_REFS is not just empty spaces.
+    # # Even though this block spans multiple lines, they are concatenated to run as a single line
+    # #   command, so note for the semi-colons in the inner-most code block.
+    # - if [[ ! -z ${RUSTDOCS_DEPLOY_REFS// } ]]; then
+    #     for FILE in *; do
+    #       if [[ ! " $RUSTDOCS_DEPLOY_REFS " =~ " $FILE " ]]; then
+    #         echo "Removing ${FILE}...";
+    #         rm -rf $FILE;
+    #       fi
+    #     done
+    #   fi
+    # # Move the index page & built back
+    # - mv -f /tmp/index.html .
+    # # Ensure the destination dir doesn't exist.
+    # - rm -rf ${CI_COMMIT_REF_NAME}
+    # - mv -f /tmp/doc ${CI_COMMIT_REF_NAME}
+    # # Add the symlink
+    # - '[[ -e "$LATEST" ]] && ln -sf "${LATEST}" latest'
+    # # Upload files
+    # - git add --all --force
+    # # `git commit` has an exit code of > 0 if there is nothing to commit.
+    # # This causes GitLab to exit immediately and marks this job failed.
+    # # We don't want to mark the entire job failed if there's nothing to
+    # # publish though, hence the `|| true`.
+    # - git commit -m "___Updated docs for ${CI_COMMIT_REF_NAME}___" ||
+    #     echo "___Nothing to commit___"
+    # - git push origin gh-pages --force
   after_script:
     - rm -rf .git/ ./*
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -782,14 +782,13 @@ publish-rustdoc:
     INDEX_TPL:                     ".maintain/docs-index-tpl.ejs"
     # Where the `/latest` symbolic link links to. One of the $RUSTDOCS_DEPLOY_REFS value.
     LATEST:                        "monthly-2021-09+1"
-  <<: *test-refs
-  # rules:
-  #   - if: $CI_PIPELINE_SOURCE == "pipeline"
-  #     when: never
-  #   - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME == "master"
-  #   - if: $CI_COMMIT_REF_NAME == "master"
-  #   - if: $CI_COMMIT_REF_NAME =~ /^monthly-20[0-9]{2}-[0-9]{2}.*$/  # to support: monthly-2021-09+1
-  #   - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "pipeline"
+      when: never
+    - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME =~ /^monthly-20[0-9]{2}-[0-9]{2}.*$/  # to support: monthly-2021-09+1
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   # `needs:` can be removed after CI image gets nonroot. In this case `needs:` stops other
   # artifacts from being dowloaded by this job.
   needs:
@@ -800,7 +799,7 @@ publish-rustdoc:
     # exit immediately.
     # Putting spaces at the front and back to ensure we are not matching just any substring, but the
     # whole space-separated value.
-    # - '[[ " ${RUSTDOCS_DEPLOY_REFS} " =~ " ${CI_COMMIT_REF_NAME} " ]] || exit 0'
+    - '[[ " ${RUSTDOCS_DEPLOY_REFS} " =~ " ${CI_COMMIT_REF_NAME} " ]] || exit 0'
     # setup ssh
     - eval $(ssh-agent)
     - ssh-add - <<< ${GITHUB_SSH_PRIV_KEY}
@@ -813,40 +812,40 @@ publish-rustdoc:
     - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     - git fetch origin gh-pages
     # Install `ejs` and generate index.html based on RUSTDOCS_DEPLOY_REFS
-    # - yarn global add ejs
-    # - 'ejs ${INDEX_TPL} -i "{\"deploy_refs\":\"${RUSTDOCS_DEPLOY_REFS}\",\"repo_name\":\"${CI_PROJECT_NAME}\",\"latest\":\"${LATEST}\"}" > /tmp/index.html'
-    # # Save README and docs
-    # - cp -r ./crate-docs/ /tmp/doc/
-    # - cp README.md /tmp/doc/
-    # - git checkout gh-pages
-    # # Remove directories no longer necessary, as specified in $RUSTDOCS_DEPLOY_REFS.
-    # # Also ensure $RUSTDOCS_DEPLOY_REFS is not just empty spaces.
-    # # Even though this block spans multiple lines, they are concatenated to run as a single line
-    # #   command, so note for the semi-colons in the inner-most code block.
-    # - if [[ ! -z ${RUSTDOCS_DEPLOY_REFS// } ]]; then
-    #     for FILE in *; do
-    #       if [[ ! " $RUSTDOCS_DEPLOY_REFS " =~ " $FILE " ]]; then
-    #         echo "Removing ${FILE}...";
-    #         rm -rf $FILE;
-    #       fi
-    #     done
-    #   fi
-    # # Move the index page & built back
-    # - mv -f /tmp/index.html .
-    # # Ensure the destination dir doesn't exist.
-    # - rm -rf ${CI_COMMIT_REF_NAME}
-    # - mv -f /tmp/doc ${CI_COMMIT_REF_NAME}
-    # # Add the symlink
-    # - '[[ -e "$LATEST" ]] && ln -sf "${LATEST}" latest'
-    # # Upload files
-    # - git add --all --force
-    # # `git commit` has an exit code of > 0 if there is nothing to commit.
-    # # This causes GitLab to exit immediately and marks this job failed.
-    # # We don't want to mark the entire job failed if there's nothing to
-    # # publish though, hence the `|| true`.
-    # - git commit -m "___Updated docs for ${CI_COMMIT_REF_NAME}___" ||
-    #     echo "___Nothing to commit___"
-    # - git push origin gh-pages --force
+    - yarn global add ejs
+    - 'ejs ${INDEX_TPL} -i "{\"deploy_refs\":\"${RUSTDOCS_DEPLOY_REFS}\",\"repo_name\":\"${CI_PROJECT_NAME}\",\"latest\":\"${LATEST}\"}" > /tmp/index.html'
+    # Save README and docs
+    - cp -r ./crate-docs/ /tmp/doc/
+    - cp README.md /tmp/doc/
+    - git checkout gh-pages
+    # Remove directories no longer necessary, as specified in $RUSTDOCS_DEPLOY_REFS.
+    # Also ensure $RUSTDOCS_DEPLOY_REFS is not just empty spaces.
+    # Even though this block spans multiple lines, they are concatenated to run as a single line
+    #   command, so note for the semi-colons in the inner-most code block.
+    - if [[ ! -z ${RUSTDOCS_DEPLOY_REFS// } ]]; then
+        for FILE in *; do
+          if [[ ! " $RUSTDOCS_DEPLOY_REFS " =~ " $FILE " ]]; then
+            echo "Removing ${FILE}...";
+            rm -rf $FILE;
+          fi
+        done
+      fi
+    # Move the index page & built back
+    - mv -f /tmp/index.html .
+    # Ensure the destination dir doesn't exist.
+    - rm -rf ${CI_COMMIT_REF_NAME}
+    - mv -f /tmp/doc ${CI_COMMIT_REF_NAME}
+    # Add the symlink
+    - '[[ -e "$LATEST" ]] && ln -sf "${LATEST}" latest'
+    # Upload files
+    - git add --all --force
+    # `git commit` has an exit code of > 0 if there is nothing to commit.
+    # This causes GitLab to exit immediately and marks this job failed.
+    # We don't want to mark the entire job failed if there's nothing to
+    # publish though, hence the `|| true`.
+    - git commit -m "___Updated docs for ${CI_COMMIT_REF_NAME}___" ||
+        echo "___Nothing to commit___"
+    - git push origin gh-pages --force
   after_script:
     - rm -rf .git/ ./*
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,6 @@ variables:                         &default-vars
   VAULT_SERVER_URL:                "https://vault.parity-mgmt-vault.parity.io"
   VAULT_AUTH_PATH:                 "gitlab-parity-io-jwt"
   VAULT_AUTH_ROLE:                 "cicd_gitlab_parity_${CI_PROJECT_NAME}"
-  PIPELINE_SCRIPTS_TAG:            "v0.4"
 
 default:
   cache:                           {}
@@ -571,6 +570,8 @@ cargo-check-macos:
     - osx
 
 #### stage:                        build
+
+# PIPELINE_SCRIPTS_TAG can be found in the project variables
 
 .check-dependent-project:          &check-dependent-project
   stage:                           build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -800,7 +800,7 @@ publish-rustdoc:
     # exit immediately.
     # Putting spaces at the front and back to ensure we are not matching just any substring, but the
     # whole space-separated value.
-    - '[[ " ${RUSTDOCS_DEPLOY_REFS} " =~ " ${CI_COMMIT_REF_NAME} " ]] || exit 0'
+    # - '[[ " ${RUSTDOCS_DEPLOY_REFS} " =~ " ${CI_COMMIT_REF_NAME} " ]] || exit 0'
     # setup ssh
     - eval $(ssh-agent)
     - ssh-add - <<< ${GITHUB_SSH_PRIV_KEY}


### PR DESCRIPTION
Removes ssh installation in the `publish-rustdocs` job because the `node:16` image already has ssh client

Closes https://github.com/paritytech/ci_cd/issues/274