### PR TITLE
frame/bench-cli: fix log formatting

### DIFF
--- a/utils/frame/benchmarking-cli/src/command.rs
+++ b/utils/frame/benchmarking-cli/src/command.rs
@@ -333,14 +333,14 @@ impl BenchmarkCmd {
 						if elapsed >= time::Duration::from_secs(5) {
 							timer = time::SystemTime::now();
 							log::info!(
-								"Running Benchmark:\t{}\t{}\t{}/{}\t{}/{}",
+								"Running Benchmark: {}.{} {}/{} {}/{}",
 								String::from_utf8(pallet.clone())
 									.expect("Encoded from String; qed"),
 								String::from_utf8(extrinsic.clone())
 									.expect("Encoded from String; qed"),
-								s, // todo show step
+								s + 1, // s starts at 0. todo show step
 								self.steps,
-								r,
+								r + 1,
 								self.external_repeat,
 							);
 						}


### PR DESCRIPTION
- Fix the progress log of benchmarks by adding spaces. `\t` seems to be ignored by the logger :man_shrugging:  
- Let the counter indices in the progress start at `1` instead of `0`. 

**Old output:**
```pre
Benchmark:frame_benchmarkinghashing5/500/1
```

**New output:**
```pre
Running Benchmark: frame_benchmarking.hashing 20/20 1/1
```