### PR TITLE
Derive default for AccountIdLookup

### DIFF
--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -243,6 +243,7 @@ impl<T> Lookup for IdentityLookup<T> {
 }
 
 /// A lookup implementation returning the `AccountId` from a `MultiAddress`.
+#[derive(Default)]
 pub struct AccountIdLookup<AccountId, AccountIndex>(PhantomData<(AccountId, AccountIndex)>);
 impl<AccountId, AccountIndex> StaticLookup for AccountIdLookup<AccountId, AccountIndex>
 where


### PR DESCRIPTION
- [X] **Description:** You added a brief description of the PR, e.g.:
  - What does it do?
  Derive `Default` for `AccountIdLookup`.
  - What important points should reviewers know?
  This will be helpful for external construction of `AccountIdLookup`.
  - Is there something left for follow-up PRs?
    Just to make it easy to construction `AccountIdLookup` externally, it has already `pub` it, so why not derive `Default` by the way?

