### PR TITLE
fix offchain-worker std features

### DIFF
--- a/frame/examples/offchain-worker/Cargo.toml
+++ b/frame/examples/offchain-worker/Cargo.toml
@@ -36,7 +36,7 @@ std = [
 	"lite-json/std",
 	"sp-core/std",
 	"sp-io/std",
-	"sp-keystore",
+	"sp-keystore/std",
 	"sp-runtime/std",
 	"sp-std/std",
 	"log/std",


### PR DESCRIPTION
Just a minor fix.
Fix the missing std in Cargo.toml