### PR TITLE
frame/benchmarking: baseline weights independent of complexity params

### DIFF
--- a/frame/benchmarking/src/baseline.rs
+++ b/frame/benchmarking/src/baseline.rs
@@ -45,7 +45,7 @@ pub trait Config: frame_system::Config {}
 
 benchmarks! {
 	addition {
-		let i in 0 .. 1_000_000;
+		let i = 1_000_000;
 		let mut start = 0;
 	}: {
 		(0..i).for_each(|_| start += 1);
@@ -54,7 +54,7 @@ benchmarks! {
 	}
 
 	subtraction {
-		let i in 0 .. 1_000_000;
+		let i = 1_000_000;
 		let mut start = u32::MAX;
 	}: {
 		(0..i).for_each(|_| start -= 1);

--- a/frame/benchmarking/src/baseline.rs
+++ b/frame/benchmarking/src/baseline.rs
@@ -63,7 +63,7 @@ benchmarks! {
 	}
 
 	multiplication {
-		let i in 0 .. 1_000_000;
+		let i = 1_000_000;
 		let mut out = 0;
 	}:  {
 		(1..=i).for_each(|j| out = 2 * j);
@@ -72,7 +72,7 @@ benchmarks! {
 	}
 
 	division {
-		let i in 0 .. 1_000_000;
+		let i = 1_000_000;
 		let mut out = 0;
 	}: {
 		(0..=i).for_each(|j| out = j / 2);

--- a/frame/benchmarking/src/weights.rs
+++ b/frame/benchmarking/src/weights.rs
@@ -44,10 +44,10 @@ use sp_std::marker::PhantomData;
 
 /// Weight functions needed for frame_benchmarking.
 pub trait WeightInfo {
-	fn addition(i: u32, ) -> Weight;
-	fn subtraction(i: u32, ) -> Weight;
-	fn multiplication(i: u32, ) -> Weight;
-	fn division(i: u32, ) -> Weight;
+	fn addition() -> Weight;
+	fn subtraction() -> Weight;
+	fn multiplication() -> Weight;
+	fn division() -> Weight;
 	fn hashing(i: u32, ) -> Weight;
 	fn sr25519_verification(i: u32, ) -> Weight;
 	fn storage_read(i: u32, ) -> Weight;
@@ -57,16 +57,16 @@ pub trait WeightInfo {
 /// Weights for frame_benchmarking using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	fn addition(_i: u32, ) -> Weight {
+	fn addition() -> Weight {
 		(284_000 as Weight)
 	}
-	fn subtraction(_i: u32, ) -> Weight {
+	fn subtraction() -> Weight {
 		(279_000 as Weight)
 	}
-	fn multiplication(_i: u32, ) -> Weight {
+	fn multiplication() -> Weight {
 		(278_000 as Weight)
 	}
-	fn division(_i: u32, ) -> Weight {
+	fn division() -> Weight {
 		(274_000 as Weight)
 	}
 	fn hashing(i: u32, ) -> Weight {
@@ -97,13 +97,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
-	fn addition(_i: u32, ) -> Weight {
+	fn addition() -> Weight {
 		(284_000 as Weight)
 	}
-	fn subtraction(_i: u32, ) -> Weight {
+	fn subtraction() -> Weight {
 		(279_000 as Weight)
 	}
-	fn multiplication(_i: u32, ) -> Weight {
+	fn multiplication() -> Weight {
 		(278_000 as Weight)
 	}
 	fn division(_i: u32, ) -> Weight {

--- a/frame/benchmarking/src/weights.rs
+++ b/frame/benchmarking/src/weights.rs
@@ -44,10 +44,10 @@ use sp_std::marker::PhantomData;
 
 /// Weight functions needed for frame_benchmarking.
 pub trait WeightInfo {
-	fn addition() -> Weight;
-	fn subtraction() -> Weight;
-	fn multiplication() -> Weight;
-	fn division() -> Weight;
+	fn addition(i: u32, ) -> Weight;
+	fn subtraction(i: u32, ) -> Weight;
+	fn multiplication(i: u32, ) -> Weight;
+	fn division(i: u32, ) -> Weight;
 	fn hashing(i: u32, ) -> Weight;
 	fn sr25519_verification(i: u32, ) -> Weight;
 	fn storage_read(i: u32, ) -> Weight;
@@ -57,16 +57,16 @@ pub trait WeightInfo {
 /// Weights for frame_benchmarking using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	fn addition() -> Weight {
+	fn addition(_i: u32, ) -> Weight {
 		(284_000 as Weight)
 	}
-	fn subtraction() -> Weight {
+	fn subtraction(_i: u32, ) -> Weight {
 		(279_000 as Weight)
 	}
-	fn multiplication() -> Weight {
+	fn multiplication(_i: u32, ) -> Weight {
 		(278_000 as Weight)
 	}
-	fn division() -> Weight {
+	fn division(_i: u32, ) -> Weight {
 		(274_000 as Weight)
 	}
 	fn hashing(i: u32, ) -> Weight {
@@ -97,13 +97,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
-	fn addition() -> Weight {
+	fn addition(_i: u32, ) -> Weight {
 		(284_000 as Weight)
 	}
-	fn subtraction() -> Weight {
+	fn subtraction(_i: u32, ) -> Weight {
 		(279_000 as Weight)
 	}
-	fn multiplication() -> Weight {
+	fn multiplication(_i: u32, ) -> Weight {
 		(278_000 as Weight)
 	}
 	fn division(_i: u32, ) -> Weight {


### PR DESCRIPTION
remove complexity  `i` param as  described in this issue #10638

Polkadot address: 12ZNas89oEagaxLVNbpqmvfMxdrGrqN7gJKSpwthTUPZsrku