### PR TITLE
Remove some last `AccountId32::default()` leftovers

### DIFF
--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -987,8 +987,11 @@ where
 }
 
 pub struct EnsureMember<AccountId, I: 'static>(PhantomData<(AccountId, I)>);
-impl<O: Into<Result<RawOrigin<AccountId, I>, O>> + From<RawOrigin<AccountId, I>>, I, AccountId>
-	EnsureOrigin<O> for EnsureMember<AccountId, I>
+impl<
+		O: Into<Result<RawOrigin<AccountId, I>, O>> + From<RawOrigin<AccountId, I>>,
+		I,
+		AccountId: Decode,
+	> EnsureOrigin<O> for EnsureMember<AccountId, I>
 {
 	type Success = AccountId;
 	fn try_origin(o: O) -> Result<Self::Success, O> {

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -987,11 +987,8 @@ where
 }
 
 pub struct EnsureMember<AccountId, I: 'static>(PhantomData<(AccountId, I)>);
-impl<
-		O: Into<Result<RawOrigin<AccountId, I>, O>> + From<RawOrigin<AccountId, I>>,
-		AccountId: Default,
-		I,
-	> EnsureOrigin<O> for EnsureMember<AccountId, I>
+impl<O: Into<Result<RawOrigin<AccountId, I>, O>> + From<RawOrigin<AccountId, I>>, I, AccountId>
+	EnsureOrigin<O> for EnsureMember<AccountId, I>
 {
 	type Success = AccountId;
 	fn try_origin(o: O) -> Result<Self::Success, O> {
@@ -1003,7 +1000,10 @@ impl<
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn successful_origin() -> O {
-		O::from(RawOrigin::Member(Default::default()))
+		let zero_account_id =
+			AccountId::decode(&mut sp_runtime::traits::TrailingZeroInput::zeroes())
+				.expect("infinite length input; no invalid inputs for type; qed");
+		O::from(RawOrigin::Member(zero_account_id))
 	}
 }
 

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -478,9 +478,7 @@ pub trait Public: ByteArray + Derive + CryptoType + PartialEq + Eq + Clone + Sen
 }
 
 /// An opaque 32-byte cryptographic identifier.
-#[derive(
-	Clone, Eq, PartialEq, Ord, PartialOrd, Default, Encode, Decode, MaxEncodedLen, TypeInfo,
-)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, MaxEncodedLen, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Hash))]
 pub struct AccountId32([u8; 32]);
 
@@ -541,9 +539,9 @@ impl<'a> sp_std::convert::TryFrom<&'a [u8]> for AccountId32 {
 	type Error = ();
 	fn try_from(x: &'a [u8]) -> Result<AccountId32, ()> {
 		if x.len() == 32 {
-			let mut r = AccountId32::default();
-			r.0.copy_from_slice(x);
-			Ok(r)
+			let mut data = [0; 32];
+			data.copy_from_slice(x);
+			Ok(AccountId32(data))
 		} else {
 			Err(())
 		}


### PR DESCRIPTION
As we removed `Default` of account id, we have overseen some last bits. This pr removes these last
bits.

polkadot companion: https://github.com/paritytech/polkadot/pull/4765

