### PR TITLE
Minor tweaks suggested by clippy

### DIFF
--- a/primitives/api/proc-macro/src/decl_runtime_apis.rs
+++ b/primitives/api/proc-macro/src/decl_runtime_apis.rs
@@ -378,6 +378,7 @@ fn generate_call_api_at_calls(decl: &ItemTrait) -> Result<TokenStream> {
 		// Generate the generator function
 		result.push(quote!(
 			#[cfg(any(feature = "std", test))]
+			#[allow(clippy::too_many_arguments)]
 			pub fn #fn_name<
 				R: #crate_::Encode + #crate_::Decode + PartialEq,
 				NC: FnOnce() -> std::result::Result<R, #crate_::ApiError> + std::panic::UnwindSafe,

--- a/primitives/api/test/tests/runtime_calls.rs
+++ b/primitives/api/test/tests/runtime_calls.rs
@@ -59,7 +59,7 @@ fn calling_native_runtime_function_with_non_decodable_parameter() {
 		.build();
 	let runtime_api = client.runtime_api();
 	let block_id = BlockId::Number(client.chain_info().best_number);
-	runtime_api.fail_convert_parameter(&block_id, DecodeFails::new()).unwrap();
+	runtime_api.fail_convert_parameter(&block_id, DecodeFails::default()).unwrap();
 }
 
 #[test]

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -132,8 +132,7 @@ impl Transfer {
 	pub fn into_signed_tx(self) -> Extrinsic {
 		let signature = sp_keyring::AccountKeyring::from_public(&self.from)
 			.expect("Creates keyring from public key.")
-			.sign(&self.encode())
-			.into();
+			.sign(&self.encode());
 		Extrinsic::Transfer { transfer: self, signature, exhaust_resources_when_not_first: false }
 	}
 
@@ -144,8 +143,7 @@ impl Transfer {
 	pub fn into_resources_exhausting_tx(self) -> Extrinsic {
 		let signature = sp_keyring::AccountKeyring::from_public(&self.from)
 			.expect("Creates keyring from public key.")
-			.sign(&self.encode())
-			.into();
+			.sign(&self.encode());
 		Extrinsic::Transfer { transfer: self, signature, exhaust_resources_when_not_first: true }
 	}
 }
@@ -277,9 +275,9 @@ pub fn run_tests(mut input: &[u8]) -> Vec<u8> {
 	print("run_tests...");
 	let block = Block::decode(&mut input).unwrap();
 	print("deserialized block.");
-	let stxs = block.extrinsics.iter().map(Encode::encode).collect::<Vec<_>>();
+	let stxs = block.extrinsics.iter().map(Encode::encode);
 	print("reserialized transactions.");
-	[stxs.len() as u8].encode()
+	[stxs.count() as u8].encode()
 }
 
 /// A type that can not be decoded.
@@ -296,9 +294,9 @@ impl<B: BlockT> Encode for DecodeFails<B> {
 
 impl<B: BlockT> codec::EncodeLike for DecodeFails<B> {}
 
-impl<B: BlockT> DecodeFails<B> {
+impl<B: BlockT> Default for DecodeFails<B> {
 	/// Create a new instance.
-	pub fn new() -> DecodeFails<B> {
+	fn default() -> DecodeFails<B> {
 		DecodeFails { _phantom: Default::default() }
 	}
 }
@@ -436,8 +434,8 @@ impl From<frame_system::Origin<Runtime>> for Origin {
 		unimplemented!("Not required in tests!")
 	}
 }
-impl Into<Result<frame_system::Origin<Runtime>, Origin>> for Origin {
-	fn into(self) -> Result<frame_system::Origin<Runtime>, Origin> {
+impl From<Origin> for Result<frame_system::Origin<Runtime>, Origin> {
+	fn from(_origin: Origin) -> Result<frame_system::Origin<Runtime>, Origin> {
 		unimplemented!("Not required in tests!")
 	}
 }
@@ -651,12 +649,11 @@ fn code_using_trie() -> u64 {
 	let mut mdb = PrefixedMemoryDB::default();
 	let mut root = sp_std::default::Default::default();
 	let _ = {
-		let v = &pairs;
 		let mut t = TrieDBMut::<Hashing>::new(&mut mdb, &mut root);
-		for i in 0..v.len() {
-			let key: &[u8] = &v[i].0;
-			let val: &[u8] = &v[i].1;
-			if !t.insert(key, val).is_ok() {
+		for pair in &pairs {
+			let key: &[u8] = &pair.0;
+			let val: &[u8] = &pair.1;
+			if t.insert(key, val).is_err() {
 				return 101
 			}
 		}
@@ -761,7 +758,7 @@ cfg_if! {
 				fn fail_convert_parameter(_: DecodeFails<Block>) {}
 
 				fn fail_convert_return_value() -> DecodeFails<Block> {
-					DecodeFails::new()
+					DecodeFails::default()
 				}
 
 				fn function_signature_changed() -> u64 {
@@ -1015,7 +1012,7 @@ cfg_if! {
 				fn fail_convert_parameter(_: DecodeFails<Block>) {}
 
 				fn fail_convert_return_value() -> DecodeFails<Block> {
-					DecodeFails::new()
+					DecodeFails::default()
 				}
 
 				fn function_signature_changed() -> Vec<u64> {

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -295,7 +295,7 @@ impl<B: BlockT> Encode for DecodeFails<B> {
 impl<B: BlockT> codec::EncodeLike for DecodeFails<B> {}
 
 impl<B: BlockT> Default for DecodeFails<B> {
-	/// Create a new instance.
+	/// Create a default instance.
 	fn default() -> DecodeFails<B> {
 		DecodeFails { _phantom: Default::default() }
 	}
@@ -650,10 +650,8 @@ fn code_using_trie() -> u64 {
 	let mut root = sp_std::default::Default::default();
 	let _ = {
 		let mut t = TrieDBMut::<Hashing>::new(&mut mdb, &mut root);
-		for pair in &pairs {
-			let key: &[u8] = &pair.0;
-			let val: &[u8] = &pair.1;
-			if t.insert(key, val).is_err() {
+		for (key, value) in &pairs {
+			if t.insert(key, value).is_err() {
 				return 101
 			}
 		}

--- a/test-utils/runtime/transaction-pool/src/lib.rs
+++ b/test-utils/runtime/transaction-pool/src/lib.rs
@@ -179,13 +179,13 @@ impl TestApi {
 	/// Add a block to the internal state.
 	pub fn add_block(&self, block: Block, is_best_block: bool) {
 		let hash = block.header.hash();
-		let block_number = block.header.number().clone();
+		let block_number = block.header.number();
 
 		let mut chain = self.chain.write();
 		chain.block_by_hash.insert(hash, block.clone());
 		chain
 			.block_by_number
-			.entry(block_number)
+			.entry(*block_number)
 			.or_default()
 			.push((block, is_best_block.into()));
 	}
@@ -259,15 +259,13 @@ impl sc_transaction_pool::ChainApi for TestApi {
 				if !found_best {
 					return ready(Ok(Err(TransactionValidityError::Invalid(
 						InvalidTransaction::Custom(1),
-					)
-					.into())))
+					))))
 				}
 			},
 			Ok(None) =>
 				return ready(Ok(Err(TransactionValidityError::Invalid(
 					InvalidTransaction::Custom(2),
-				)
-				.into()))),
+				)))),
 			Err(e) => return ready(Err(e)),
 		}
 
@@ -283,9 +281,7 @@ impl sc_transaction_pool::ChainApi for TestApi {
 		};
 
 		if self.chain.read().invalid_hashes.contains(&self.hash_and_length(&uxt).0) {
-			return ready(Ok(Err(
-				TransactionValidityError::Invalid(InvalidTransaction::Custom(0)).into()
-			)))
+			return ready(Ok(Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(0)))))
 		}
 
 		let mut validity =
@@ -312,7 +308,7 @@ impl sc_transaction_pool::ChainApi for TestApi {
 		at: &BlockId<Self::Block>,
 	) -> Result<Option<<Self::Block as BlockT>::Hash>, Error> {
 		Ok(match at {
-			generic::BlockId::Hash(x) => Some(x.clone()),
+			generic::BlockId::Hash(x) => Some(*x),
 			generic::BlockId::Number(num) =>
 				self.chain.read().block_by_number.get(num).and_then(|blocks| {
 					blocks.iter().find(|b| b.1.is_best()).map(|b| b.0.header().hash())
@@ -371,6 +367,6 @@ impl sp_blockchain::HeaderMetadata<Block> for TestApi {
 pub fn uxt(who: AccountKeyring, nonce: Index) -> Extrinsic {
 	let dummy = codec::Decode::decode(&mut TrailingZeroInput::zeroes()).unwrap();
 	let transfer = Transfer { from: who.into(), to: dummy, nonce, amount: 1 };
-	let signature = transfer.using_encoded(|e| who.sign(e)).into();
+	let signature = transfer.using_encoded(|e| who.sign(e));
 	Extrinsic::Transfer { transfer, signature, exhaust_resources_when_not_first: false }
 }


### PR DESCRIPTION
These are trivial tweaks I found while upgrading to latest master. This also restores one suppression in macro-generated code unnecessarily removed in #10570 and causing extra warnings in downstream projects.