### PR TITLE
bench/cli: extend --extrinsic name filtering

### DIFF
--- a/utils/frame/benchmarking-cli/src/command.rs
+++ b/utils/frame/benchmarking-cli/src/command.rs
@@ -120,7 +120,8 @@ impl BenchmarkCmd {
 		let pallet = self.pallet.clone().unwrap_or_else(|| String::new());
 		let pallet = pallet.as_bytes();
 		let extrinsic = self.extrinsic.clone().unwrap_or_else(|| String::new());
-		let extrinsic = extrinsic.as_bytes();
+		let extrinsic_split:Vec<&str> = extrinsic.split(',').collect();
+		let extrinsic: Vec<_> = extrinsic_split.iter().map(|x| x.trim().as_bytes()).collect();
 
 		let genesis_storage = spec.build_storage()?;
 		let mut changes = Default::default();
@@ -176,7 +177,8 @@ impl BenchmarkCmd {
 			.filter(|item| pallet.is_empty() || pallet == &b"*"[..] || pallet == &item.pallet[..])
 			.for_each(|item| {
 				for benchmark in &item.benchmarks {
-					if extrinsic.is_empty() || extrinsic == &b"*"[..] || extrinsic == benchmark.name
+					let benchmark_name = &benchmark.name;
+					if extrinsic.is_empty() || extrinsic.contains(&&b"*"[..]) || extrinsic.contains(&&benchmark_name[..])
 					{
 						benchmarks_to_run.push((
 							item.pallet.clone(),

--- a/utils/frame/benchmarking-cli/src/command.rs
+++ b/utils/frame/benchmarking-cli/src/command.rs
@@ -120,7 +120,7 @@ impl BenchmarkCmd {
 		let pallet = self.pallet.clone().unwrap_or_else(|| String::new());
 		let pallet = pallet.as_bytes();
 		let extrinsic = self.extrinsic.clone().unwrap_or_else(|| String::new());
-		let extrinsic_split:Vec<&str> = extrinsic.split(',').collect();
+		let extrinsic_split: Vec<&str> = extrinsic.split(',').collect();
 		let extrinsic: Vec<_> = extrinsic_split.iter().map(|x| x.trim().as_bytes()).collect();
 
 		let genesis_storage = spec.build_storage()?;
@@ -178,7 +178,9 @@ impl BenchmarkCmd {
 			.for_each(|item| {
 				for benchmark in &item.benchmarks {
 					let benchmark_name = &benchmark.name;
-					if extrinsic.is_empty() || extrinsic.contains(&&b"*"[..]) || extrinsic.contains(&&benchmark_name[..])
+					if extrinsic.is_empty() ||
+						extrinsic.contains(&&b"*"[..]) ||
+						extrinsic.contains(&&benchmark_name[..])
 					{
 						benchmarks_to_run.push((
 							item.pallet.clone(),

--- a/utils/frame/benchmarking-cli/src/command.rs
+++ b/utils/frame/benchmarking-cli/src/command.rs
@@ -121,7 +121,7 @@ impl BenchmarkCmd {
 		let pallet = pallet.as_bytes();
 		let extrinsic = self.extrinsic.clone().unwrap_or_else(|| String::new());
 		let extrinsic_split: Vec<&str> = extrinsic.split(',').collect();
-		let extrinsic: Vec<_> = extrinsic_split.iter().map(|x| x.trim().as_bytes()).collect();
+		let extrinsics: Vec<_> = extrinsic_split.iter().map(|x| x.trim().as_bytes()).collect();
 
 		let genesis_storage = spec.build_storage()?;
 		let mut changes = Default::default();
@@ -179,8 +179,8 @@ impl BenchmarkCmd {
 				for benchmark in &item.benchmarks {
 					let benchmark_name = &benchmark.name;
 					if extrinsic.is_empty() ||
-						extrinsic.contains(&&b"*"[..]) ||
-						extrinsic.contains(&&benchmark_name[..])
+						extrinsic.as_bytes() == &b"*"[..] ||
+						extrinsics.contains(&&benchmark_name[..])
 					{
 						benchmarks_to_run.push((
 							item.pallet.clone(),


### PR DESCRIPTION
make extrinsic argument contain list of comma separated extrinsic names as described in this issue #10665

Polkadot address: 12ZNas89oEagaxLVNbpqmvfMxdrGrqN7gJKSpwthTUPZsrku