### PR TITLE
Switch from `pwasm-utils` to `wasm-instrument`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8123,13 +8123,13 @@ dependencies = [
  "derive_more",
  "environmental",
  "parity-scale-codec",
- "pwasm-utils",
  "sc-allocator",
  "sp-core",
  "sp-maybe-compressed-blob",
  "sp-serializer",
  "sp-wasm-interface",
  "thiserror",
+ "wasm-instrument",
  "wasmer",
  "wasmer-compiler-singlepass",
  "wasmi",
@@ -11333,6 +11333,15 @@ dependencies = [
  "log 0.4.14",
  "parity-wasm 0.32.0",
  "rustc-demangle",
+]
+
+[[package]]
+name = "wasm-instrument"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e67369bb53d409b67e57ef31797b1b2d628955fc82f86f2ea78bb403acc7c73"
+dependencies = [
+ "parity-wasm 0.42.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5492,7 +5492,6 @@ dependencies = [
  "pallet-utility",
  "parity-scale-codec",
  "pretty_assertions",
- "pwasm-utils",
  "rand 0.8.4",
  "rand_pcg 0.3.1",
  "scale-info",
@@ -5503,6 +5502,7 @@ dependencies = [
  "sp-runtime",
  "sp-sandbox",
  "sp-std",
+ "wasm-instrument",
  "wasmi-validation",
  "wat",
 ]
@@ -6972,17 +6972,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3abf49e5417290756acfd26501536358560c4a5cc4a0934d390939acb3e7083a"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "pwasm-utils"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "880b3384fb00b8f6ecccd5d358b93bd2201900ae3daad213791d1864f6441f5c"
-dependencies = [
- "byteorder",
- "log 0.4.14",
- "parity-wasm 0.42.2",
 ]
 
 [[package]]

--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 derive_more = "0.99.16"
-pwasm-utils = "0.18.2"
+wasm-instrument = "0.1"
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 wasmi = "0.9.1"
 sp-core = { version = "4.1.0-dev", path = "../../../primitives/core" }

--- a/client/executor/common/src/runtime_blob/data_segments_snapshot.rs
+++ b/client/executor/common/src/runtime_blob/data_segments_snapshot.rs
@@ -18,8 +18,8 @@
 
 use super::RuntimeBlob;
 use crate::error::{self, Error};
-use pwasm_utils::parity_wasm::elements::Instruction;
 use std::mem;
+use wasm_instrument::parity_wasm::elements::Instruction;
 
 /// This is a snapshot of data segments specialzied for a particular instantiation.
 ///

--- a/client/executor/common/src/runtime_blob/runtime_blob.rs
+++ b/client/executor/common/src/runtime_blob/runtime_blob.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::error::WasmError;
-use pwasm_utils::{
+use wasm_instrument::{
 	export_mutable_globals,
 	parity_wasm::elements::{deserialize_buffer, serialize, DataSegment, Internal, Module},
 };
@@ -84,7 +84,7 @@ impl RuntimeBlob {
 	/// depth of the wasm operand stack.
 	pub fn inject_stack_depth_metering(self, stack_depth_limit: u32) -> Result<Self, WasmError> {
 		let injected_module =
-			pwasm_utils::stack_height::inject_limiter(self.raw_module, stack_depth_limit).map_err(
+			wasm_instrument::inject_stack_limiter(self.raw_module, stack_depth_limit).map_err(
 				|e| WasmError::Other(format!("cannot inject the stack limiter: {:?}", e)),
 			)?;
 

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "2.2.0", default-features = 
 ] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 log = { version = "0.4", default-features = false }
-pwasm-utils = { version = "0.18.2", default-features = false }
+wasm-instrument = { version = "0.1", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 smallvec = { version = "1", default-features = false, features = [
 	"const_generics",
@@ -71,7 +71,7 @@ std = [
 	"frame-benchmarking/std",
 	"frame-support/std",
 	"frame-system/std",
-	"pwasm-utils/std",
+	"wasm-instrument/std",
 	"wasmi-validation/std",
 	"pallet-contracts-primitives/std",
 	"pallet-contracts-proc-macro/full",

--- a/frame/contracts/src/benchmarking/code.rs
+++ b/frame/contracts/src/benchmarking/code.rs
@@ -26,13 +26,6 @@
 
 use crate::Config;
 use frame_support::traits::Get;
-use pwasm_utils::parity_wasm::{
-	builder,
-	elements::{
-		self, BlockType, CustomSection, External, FuncBody, Instruction, Instructions, Module,
-		Section, ValueType,
-	},
-};
 use sp_core::crypto::UncheckedFrom;
 use sp_runtime::traits::Hash;
 use sp_sandbox::{
@@ -40,6 +33,13 @@ use sp_sandbox::{
 	SandboxEnvironmentBuilder, SandboxMemory,
 };
 use sp_std::{borrow::ToOwned, prelude::*};
+use wasm_instrument::parity_wasm::{
+	builder,
+	elements::{
+		self, BlockType, CustomSection, External, FuncBody, Instruction, Instructions, Module,
+		Section, ValueType,
+	},
+};
 
 /// The location where to put the genrated code.
 pub enum Location {
@@ -562,10 +562,10 @@ where
 fn inject_gas_metering<T: Config>(module: Module) -> Module {
 	let schedule = T::Schedule::get();
 	let gas_rules = schedule.rules(&module);
-	pwasm_utils::inject_gas_counter(module, &gas_rules, "seal0").unwrap()
+	wasm_instrument::gas_metering::inject(module, &gas_rules, "seal0").unwrap()
 }
 
 fn inject_stack_metering<T: Config>(module: Module) -> Module {
 	let height = T::Schedule::get().limits.stack_height;
-	pwasm_utils::stack_height::inject_limiter(module, height).unwrap()
+	wasm_instrument::inject_stack_limiter(module, height).unwrap()
 }

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -39,12 +39,12 @@ use codec::Encode;
 use frame_benchmarking::{account, benchmarks, whitelisted_caller};
 use frame_support::weights::Weight;
 use frame_system::RawOrigin;
-use pwasm_utils::parity_wasm::elements::{BlockType, BrTableData, Instruction, ValueType};
 use sp_runtime::{
 	traits::{Bounded, Hash},
 	Perbill,
 };
 use sp_std::prelude::*;
+use wasm_instrument::parity_wasm::elements::{BlockType, BrTableData, Instruction, ValueType};
 
 /// How many batches we do per API benchmark.
 const API_BENCHMARK_BATCHES: u32 = 20;

--- a/frame/contracts/src/wasm/env_def/macros.rs
+++ b/frame/contracts/src/wasm/env_def/macros.rs
@@ -28,7 +28,7 @@ macro_rules! convert_args {
 macro_rules! gen_signature {
 	( ( $( $params: ty ),* ) ) => (
 		{
-			pwasm_utils::parity_wasm::elements::FunctionType::new(
+			wasm_instrument::parity_wasm::elements::FunctionType::new(
 				convert_args!($($params),*), vec![],
 			)
 		}
@@ -36,7 +36,7 @@ macro_rules! gen_signature {
 
 	( ( $( $params: ty ),* ) -> $returns: ty ) => (
 		{
-			pwasm_utils::parity_wasm::elements::FunctionType::new(
+			wasm_instrument::parity_wasm::elements::FunctionType::new(
 				convert_args!($($params),*),
 				vec![{use $crate::wasm::env_def::ConvertibleToWasm; <$returns>::VALUE_TYPE}],
 			)
@@ -220,7 +220,7 @@ macro_rules! define_env {
 			fn can_satisfy(
 				module: &[u8],
 				name: &[u8],
-				func_type: &pwasm_utils::parity_wasm::elements::FunctionType,
+				func_type: &wasm_instrument::parity_wasm::elements::FunctionType,
 			) -> bool
 			{
 				#[cfg(not(feature = "unstable-interface"))]
@@ -260,9 +260,9 @@ mod tests {
 		wasm::{runtime::TrapReason, tests::MockExt, Runtime},
 		Weight,
 	};
-	use pwasm_utils::parity_wasm::elements::{FunctionType, ValueType};
 	use sp_runtime::traits::Zero;
 	use sp_sandbox::{ReturnValue, Value};
+	use wasm_instrument::parity_wasm::elements::{FunctionType, ValueType};
 
 	struct TestRuntime {
 		value: u32,

--- a/frame/contracts/src/wasm/env_def/mod.rs
+++ b/frame/contracts/src/wasm/env_def/mod.rs
@@ -18,8 +18,8 @@
 use super::Runtime;
 use crate::exec::Ext;
 
-use pwasm_utils::parity_wasm::elements::{FunctionType, ValueType};
 use sp_sandbox::Value;
+use wasm_instrument::parity_wasm::elements::{FunctionType, ValueType};
 
 #[macro_use]
 pub mod macros;

--- a/frame/contracts/src/wasm/prepare.rs
+++ b/frame/contracts/src/wasm/prepare.rs
@@ -26,9 +26,11 @@ use crate::{
 	AccountIdOf, Config, Schedule,
 };
 use codec::{Encode, MaxEncodedLen};
-use pwasm_utils::parity_wasm::elements::{self, External, Internal, MemoryType, Type, ValueType};
 use sp_runtime::traits::Hash;
 use sp_std::prelude::*;
+use wasm_instrument::parity_wasm::elements::{
+	self, External, Internal, MemoryType, Type, ValueType,
+};
 
 /// Imported memory must be located inside this module. The reason for hardcoding is that current
 /// compiler toolchains might not support specifying other modules than "env" for memory imports.
@@ -182,17 +184,16 @@ impl<'a, T: Config> ContractModule<'a, T> {
 
 	fn inject_gas_metering(self) -> Result<Self, &'static str> {
 		let gas_rules = self.schedule.rules(&self.module);
-		let contract_module = pwasm_utils::inject_gas_counter(self.module, &gas_rules, "seal0")
-			.map_err(|_| "gas instrumentation failed")?;
+		let contract_module =
+			wasm_instrument::gas_metering::inject(self.module, &gas_rules, "seal0")
+				.map_err(|_| "gas instrumentation failed")?;
 		Ok(ContractModule { module: contract_module, schedule: self.schedule })
 	}
 
 	fn inject_stack_height_metering(self) -> Result<Self, &'static str> {
-		let contract_module = pwasm_utils::stack_height::inject_limiter(
-			self.module,
-			self.schedule.limits.stack_height,
-		)
-		.map_err(|_| "stack height instrumentation failed")?;
+		let contract_module =
+			wasm_instrument::inject_stack_limiter(self.module, self.schedule.limits.stack_height)
+				.map_err(|_| "stack height instrumentation failed")?;
 		Ok(ContractModule { module: contract_module, schedule: self.schedule })
 	}
 

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -29,12 +29,12 @@ use bitflags::bitflags;
 use codec::{Decode, DecodeAll, Encode, MaxEncodedLen};
 use frame_support::{dispatch::DispatchError, ensure, weights::Weight};
 use pallet_contracts_primitives::{ExecReturnValue, ReturnFlags};
-use pwasm_utils::parity_wasm::elements::ValueType;
 use sp_core::{crypto::UncheckedFrom, Bytes};
 use sp_io::hashing::{blake2_128, blake2_256, keccak_256, sha2_256};
 use sp_runtime::traits::{Bounded, Zero};
 use sp_sandbox::SandboxMemory;
 use sp_std::prelude::*;
+use wasm_instrument::parity_wasm::elements::ValueType;
 
 /// Every error that can be returned to a contract when it calls any of the host functions.
 ///


### PR DESCRIPTION
The crate `pwasm-utils` contains a lot of unused code and us largely unmaintained. The only parts of it that are in production use (by parity) is the stack height metering and gas instrumentation. All the "optimization" parts and CLI utils are provided by `binaryen`.

For that reason I created [a new repository](https://github.com/paritytech/wasm-instrument) where I removed all the unused functionality and cleaned up the documentation. [The old repository](https://github.com/paritytech/wasm-utils) should be archived after we made the switch with substrate.

This PR switches to the new crate `wasm-instrument`. No functionality changes where made when cleaning up the code.