### PR TITLE
Bump sp-keyring to 4.1.0-dev so that we can publish 4.0.0 in the past

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9611,7 +9611,7 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "4.0.0-dev"
+version = "4.1.0-dev"
 dependencies = [
  "lazy_static",
  "sp-core",

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -52,7 +52,7 @@ sp-runtime = { version = "4.0.0", path = "../../../primitives/runtime" }
 sp-timestamp = { version = "4.0.0-dev", path = "../../../primitives/timestamp" }
 sp-authorship = { version = "4.0.0-dev", path = "../../../primitives/authorship" }
 sp-inherents = { version = "4.0.0-dev", path = "../../../primitives/inherents" }
-sp-keyring = { version = "4.0.0-dev", path = "../../../primitives/keyring" }
+sp-keyring = { version = "4.1.0-dev", path = "../../../primitives/keyring" }
 sp-keystore = { version = "0.10.0", path = "../../../primitives/keystore" }
 sp-consensus = { version = "0.10.0-dev", path = "../../../primitives/consensus/common" }
 sp-transaction-pool = { version = "4.0.0-dev", path = "../../../primitives/transaction-pool" }

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -38,7 +38,7 @@ sp-application-crypto = { version = "4.0.0", path = "../../../primitives/applica
 sp-consensus-babe = { version = "0.10.0-dev", path = "../../../primitives/consensus/babe" }
 sp-runtime = { version = "4.0.0", path = "../../../primitives/runtime" }
 sp-externalities = { version = "0.10.0", path = "../../../primitives/externalities" }
-sp-keyring = { version = "4.0.0-dev", path = "../../../primitives/keyring" }
+sp-keyring = { version = "4.1.0-dev", path = "../../../primitives/keyring" }
 wat = "1.0"
 futures = "0.3.9"
 

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -35,7 +35,7 @@ sp-std = { version = "4.0.0", default-features = false, path = "../../../primiti
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/api" }
 sp-runtime = { version = "4.0.0", default-features = false, path = "../../../primitives/runtime" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/staking" }
-sp-keyring = { version = "4.0.0-dev", optional = true, path = "../../../primitives/keyring" }
+sp-keyring = { version = "4.1.0-dev", optional = true, path = "../../../primitives/keyring" }
 sp-session = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/session" }
 sp-transaction-pool = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/transaction-pool" }
 sp-version = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/version" }

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -24,7 +24,7 @@ sc-client-db = { version = "0.10.0-dev", path = "../../../client/db/", features 
 sc-client-api = { version = "4.0.0-dev", path = "../../../client/api/" }
 sc-consensus = { version = "0.10.0-dev", path = "../../../client/consensus/common" }
 codec = { package = "parity-scale-codec", version = "2.0.0" }
-sp-keyring = { version = "4.0.0-dev", path = "../../../primitives/keyring" }
+sp-keyring = { version = "4.1.0-dev", path = "../../../primitives/keyring" }
 node-executor = { version = "3.0.0-dev", path = "../executor" }
 node-primitives = { version = "2.0.0", path = "../primitives" }
 node-runtime = { version = "3.0.0-dev", path = "../runtime" }

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -36,7 +36,7 @@ sp-core = { version = "4.1.0-dev", path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0", path = "../../primitives/keystore" }
 sc-service = { version = "0.10.0-dev", default-features = false, path = "../service" }
 sc-telemetry = { version = "4.0.0-dev", path = "../telemetry" }
-sp-keyring = { version = "4.0.0-dev", path = "../../primitives/keyring" }
+sp-keyring = { version = "4.1.0-dev", path = "../../primitives/keyring" }
 names = { version = "0.12.0", default-features = false }
 structopt = "0.3.25"
 sc-tracing = { version = "4.0.0-dev", path = "../tracing" }

--- a/client/consensus/aura/Cargo.toml
+++ b/client/consensus/aura/Cargo.toml
@@ -41,7 +41,7 @@ getrandom = { version = "0.2", features = ["js"], optional = true }
 
 [dev-dependencies]
 sp-timestamp = { version = "4.0.0-dev", path = "../../../primitives/timestamp" }
-sp-keyring = { version = "4.0.0-dev", path = "../../../primitives/keyring" }
+sp-keyring = { version = "4.1.0-dev", path = "../../../primitives/keyring" }
 sp-tracing = { version = "4.0.0", path = "../../../primitives/tracing" }
 sc-keystore = { version = "4.0.0-dev", path = "../../keystore" }
 sc-network = { version = "0.10.0-dev", path = "../../network" }

--- a/client/consensus/babe/rpc/Cargo.toml
+++ b/client/consensus/babe/rpc/Cargo.toml
@@ -34,7 +34,7 @@ sp-keystore = { version = "0.10.0", path = "../../../../primitives/keystore" }
 [dev-dependencies]
 sc-consensus = { version = "0.10.0-dev", path = "../../../consensus/common" }
 serde_json = "1.0.74"
-sp-keyring = { version = "4.0.0-dev", path = "../../../../primitives/keyring" }
+sp-keyring = { version = "4.1.0-dev", path = "../../../../primitives/keyring" }
 sc-keystore = { version = "4.0.0-dev", path = "../../../keystore" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../../test-utils/runtime/client" }
 tempfile = "3.1.0"

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -55,7 +55,7 @@ finality-grandpa = { version = "0.14.1", features = [
 ] }
 sc-network = { version = "0.10.0-dev", path = "../network" }
 sc-network-test = { version = "0.8.0", path = "../network/test" }
-sp-keyring = { version = "4.0.0-dev", path = "../../primitives/keyring" }
+sp-keyring = { version = "4.1.0-dev", path = "../../primitives/keyring" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }
 sp-tracing = { version = "4.0.0", path = "../../primitives/tracing" }
 tokio = "1.15"

--- a/client/finality-grandpa/rpc/Cargo.toml
+++ b/client/finality-grandpa/rpc/Cargo.toml
@@ -34,5 +34,5 @@ sc-rpc = { version = "4.0.0-dev", path = "../../rpc", features = [
 ] }
 sp-core = { version = "4.1.0-dev", path = "../../../primitives/core" }
 sp-finality-grandpa = { version = "4.0.0-dev", path = "../../../primitives/finality-grandpa" }
-sp-keyring = { version = "4.0.0-dev", path = "../../../primitives/keyring" }
+sp-keyring = { version = "4.1.0-dev", path = "../../../primitives/keyring" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }

--- a/frame/grandpa/Cargo.toml
+++ b/frame/grandpa/Cargo.toml
@@ -33,7 +33,7 @@ log = { version = "0.4.14", default-features = false }
 [dev-dependencies]
 frame-benchmarking = { version = "4.0.0-dev", path = "../benchmarking" }
 grandpa = { package = "finality-grandpa", version = "0.14.1", features = ["derive-codec"] }
-sp-keyring = { version = "4.0.0-dev", path = "../../primitives/keyring" }
+sp-keyring = { version = "4.1.0-dev", path = "../../primitives/keyring" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 pallet-offences = { version = "4.0.0-dev", path = "../offences" }
 pallet-staking = { version = "4.0.0-dev", path = "../staking" }

--- a/frame/indices/Cargo.toml
+++ b/frame/indices/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-sp-keyring = { version = "4.0.0-dev", optional = true, path = "../../primitives/keyring" }
+sp-keyring = { version = "4.1.0-dev", optional = true, path = "../../primitives/keyring" }
 sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "4.0.0-dev", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "4.0.0", default-features = false, path = "../../primitives/runtime" }

--- a/primitives/keyring/Cargo.toml
+++ b/primitives/keyring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-keyring"
-version = "4.0.0-dev"
+version = "4.1.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/test-utils/client/Cargo.toml
+++ b/test-utils/client/Cargo.toml
@@ -31,7 +31,7 @@ sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }
 sp-core = { version = "4.1.0-dev", path = "../../primitives/core" }
 sp-keystore = { version = "0.10.0", path = "../../primitives/keystore" }
-sp-keyring = { version = "4.0.0-dev", path = "../../primitives/keyring" }
+sp-keyring = { version = "4.1.0-dev", path = "../../primitives/keyring" }
 sp-runtime = { version = "4.0.0", path = "../../primitives/runtime" }
 sp-state-machine = { version = "0.10.0", path = "../../primitives/state-machine" }
 async-trait = "0.1.50"

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -20,7 +20,7 @@ sp-block-builder = { version = "4.0.0-dev", default-features = false, path = "..
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../../primitives/inherents" }
-sp-keyring = { version = "4.0.0-dev", optional = true, path = "../../primitives/keyring" }
+sp-keyring = { version = "4.1.0-dev", optional = true, path = "../../primitives/keyring" }
 memory-db = { version = "0.27.0", default-features = false }
 sp-offchain = { version = "4.0.0-dev", default-features = false, path = "../../primitives/offchain" }
 sp-core = { version = "4.1.0-dev", default-features = false, path = "../../primitives/core" }


### PR DESCRIPTION
Not too long ago `sp-core`/`sp-runtime`/`sp-version` from Substrate were published to crates.io at 4.0.0, to make it possible to also publish `subxt`, which relies on them.

However, `subxt` also wants to use `sp-keyring` as a dev dependency, which was not published at that point. The result is that for local dev, `sp-keyring` pulls in a different version of `sp-core` than the 4.0.0 also requested, leading to duplocate trait issues and such.

Fortunately, at the tag `publish-sp-version-v4.0.0` on Substrate, `sp-keyring` is relying on 4.0.0 crates only, and so if it had been published as well at that point things would have been perfect.

This PR bumps `sp-keyring` to `4.1.0-dev` to allow us to retrospectively publish `sp-keyring 4.0.0` to crates.io at the Substrate tag `publish-sp-version-v4.0.0` and make `subxt` happy again.
