### PR TITLE
Split peer slots between full and light nodes

### DIFF
--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -86,9 +86,12 @@ pub struct NetworkParams {
 	#[structopt(long = "out-peers", value_name = "COUNT", default_value = "25")]
 	pub out_peers: u32,
 
-	/// Specify the maximum number of incoming connections we're accepting.
+	/// Maximum number of inbound full nodes peers.
 	#[structopt(long = "in-peers", value_name = "COUNT", default_value = "25")]
 	pub in_peers: u32,
+	/// Maximum number of inbound light nodes peers.
+	#[structopt(long = "in-peers-light", value_name = "COUNT", default_value = "100")]
+	pub in_peers_light: u32
 
 	/// Disable mDNS discovery.
 	///
@@ -203,7 +206,7 @@ impl NetworkParams {
 			boot_nodes,
 			net_config_path,
 			default_peers_set: SetConfig {
-				in_peers: self.in_peers,
+				in_peers: self.in_peers + self.in_peers_light,
 				out_peers: self.out_peers,
 				reserved_nodes: self.reserved_nodes.clone(),
 				non_reserved_mode: if self.reserved_only {
@@ -212,6 +215,7 @@ impl NetworkParams {
 					NonReservedPeerMode::Accept
 				},
 			},
+			default_peers_set_num_full: self.in_peers + self.out_peers,
 			listen_addresses,
 			public_addresses,
 			extra_sets: Vec::new(),

--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -91,7 +91,7 @@ pub struct NetworkParams {
 	pub in_peers: u32,
 	/// Maximum number of inbound light nodes peers.
 	#[structopt(long = "in-peers-light", value_name = "COUNT", default_value = "100")]
-	pub in_peers_light: u32
+	pub in_peers_light: u32,
 
 	/// Disable mDNS discovery.
 	///

--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -416,6 +416,11 @@ pub struct NetworkConfiguration {
 	pub request_response_protocols: Vec<RequestResponseConfig>,
 	/// Configuration for the default set of nodes used for block syncing and transactions.
 	pub default_peers_set: SetConfig,
+	/// Number of substreams to reserve for full nodes for block syncing and transactions.
+	/// Any other slot will be dedicated to light nodes.
+	///
+	/// This value is implicitly capped to `default_set.out_peers + default_set.in_peers`.
+	pub default_peers_set_num_full: u32,
 	/// Configuration for extra sets of nodes.
 	pub extra_sets: Vec<NonDefaultSetConfig>,
 	/// Client identifier. Sent over the wire for debugging purposes.
@@ -473,6 +478,7 @@ impl NetworkConfiguration {
 		node_key: NodeKeyConfig,
 		net_config_path: Option<PathBuf>,
 	) -> Self {
+		let default_peers_set = SetConfig::default();
 		Self {
 			net_config_path,
 			listen_addresses: Vec::new(),
@@ -480,7 +486,8 @@ impl NetworkConfiguration {
 			boot_nodes: Vec::new(),
 			node_key,
 			request_response_protocols: Vec::new(),
-			default_peers_set: Default::default(),
+			default_peers_set_num_full: default_peers_set.in_peers + default_peers_set.out_peers,
+			default_peers_set,
 			extra_sets: Vec::new(),
 			client_version: client_version.into(),
 			node_name: node_name.into(),

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -166,13 +166,19 @@ pub struct Protocol<B: BlockT> {
 	pending_messages: VecDeque<CustomMessageOutcome<B>>,
 	config: ProtocolConfig,
 	genesis_hash: B::Hash,
+	/// State machine that handles the list of in-progress requests. Only full node peers are
+	/// registered.
 	sync: ChainSync<B>,
-	// All connected peers
+	// All connected peers. Contains both full and light node peers.
 	peers: HashMap<PeerId, Peer<B>>,
 	chain: Arc<dyn Client<B>>,
 	/// List of nodes for which we perform additional logging because they are important for the
 	/// user.
 	important_peers: HashSet<PeerId>,
+	/// Value that was passed as part of the configuration. Used to cap the number of full nodes.
+	default_peers_set_num_full: usize,
+	/// Number of slots to allocate to light nodes.
+	default_peers_set_num_light: usize,
 	/// Used to report reputation changes.
 	peerset_handle: sc_peerset::PeersetHandle,
 	/// Handles opening the unique substream and sending and receiving raw messages.
@@ -428,6 +434,11 @@ impl<B: BlockT> Protocol<B> {
 			genesis_hash: info.genesis_hash,
 			sync,
 			important_peers,
+			default_peers_set_num_full: network_config.default_peers_set_num_full as usize,
+			default_peers_set_num_light: {
+				let total = network_config.default_peers_set.out_peers + network_config.default_peers_set.in_peers;
+				total.saturating_sub(network_config.default_peers_set_num_full) as usize
+			},
 			peerset_handle: peerset_handle.clone(),
 			behaviour,
 			notification_protocols: network_config
@@ -806,6 +817,19 @@ impl<B: BlockT> Protocol<B> {
 				self.behaviour.disconnect_peer(&who, HARDCODED_PEERSETS_SYNC);
 				return Err(())
 			}
+		}
+
+		if status.roles.is_full() && self.sync.num_peers() >= self.default_peers_set_num_full {
+			debug!(target: "sync", "Too many full nodes, rejecting {}", who);
+			self.behaviour.disconnect_peer(&who, HARDCODED_PEERSETS_SYNC);
+			return Err(())
+		} else if status.roles.is_light() &&
+			(self.peers.len() - self.sync.num_peers()) < self.default_peers_set_num_light
+		{
+			// Make sure that not all slots are occupied by light clients.
+			debug!(target: "sync", "Too many light nodes, rejecting {}", who);
+			self.behaviour.disconnect_peer(&who, HARDCODED_PEERSETS_SYNC);
+			return Err(())
 		}
 
 		let peer = Peer {

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -436,7 +436,8 @@ impl<B: BlockT> Protocol<B> {
 			important_peers,
 			default_peers_set_num_full: network_config.default_peers_set_num_full as usize,
 			default_peers_set_num_light: {
-				let total = network_config.default_peers_set.out_peers + network_config.default_peers_set.in_peers;
+				let total = network_config.default_peers_set.out_peers +
+					network_config.default_peers_set.in_peers;
 				total.saturating_sub(network_config.default_peers_set_num_full) as usize
 			},
 			peerset_handle: peerset_handle.clone(),

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -824,7 +824,9 @@ impl<B: BlockT> Protocol<B> {
 			debug!(target: "sync", "Too many full nodes, rejecting {}", who);
 			self.behaviour.disconnect_peer(&who, HARDCODED_PEERSETS_SYNC);
 			return Err(())
-		} else if status.roles.is_light() &&
+		}
+
+		if status.roles.is_light() &&
 			(self.peers.len() - self.sync.num_peers()) < self.default_peers_set_num_light
 		{
 			// Make sure that not all slots are occupied by light clients.

--- a/client/network/src/protocol/sync.rs
+++ b/client/network/src/protocol/sync.rs
@@ -648,6 +648,11 @@ impl<B: BlockT> ChainSync<B> {
 		self.downloaded_blocks
 	}
 
+	/// Returns the current number of peers stored within this state machine.
+	pub fn num_peers(&self) -> usize {
+		self.peers.len()
+	}
+
 	/// Handle a new connected peer.
 	///
 	/// Call this method whenever we connect to a new peer.

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -808,8 +808,7 @@ where
 			let (handler, protocol_config) = StateRequestHandler::new(
 				&protocol_id,
 				client.clone(),
-				config.network.default_peers_set.in_peers as usize +
-					config.network.default_peers_set.out_peers as usize,
+				config.network.default_peers_set_num_full as usize,
 			);
 			spawn_handle.spawn("state-request-handler", Some("networking"), handler.run());
 			protocol_config


### PR DESCRIPTION
Close https://github.com/paritytech/substrate/issues/8610

This PR adds a new CLI option `--in-peers-light` whose value defaults to 100.
The "existing slots" (`--out-peers` and `--in-peers`) are now reserved only for full nodes, and these 100 new additional slots are reserved for light clients.

Note that this concerns only the syncing, transactions, and GrandPa/Beefy protocols/peer sets. The parachains-related code and any other user-added protocol isn't concerned.

## Motivation

The problem that this PR solves is that, currently, all the "in peers" of all nodes are always full. Since there is an equal number of "out peers" and "in peers", each full node on the network brings as many slots as it consumes.

Because some nodes are unfortunately behind a NAT, there are actually fewer available "in peers" than there are "out peers" being consumed, making the problem worse.

The obvious solution to that problem would be to increase the number of "in peers". While this solves the problem in theory, in practice older nodes have more chances of being discovered, and these older nodes would likely become full while younger nodes would not receive as many "in peers".

Having for example 125 full nodes connected to you consumes a huge amount of resources, as a node sends all transactions and GrandPa messages to all full nodes it is connected to.

This PR proposes another solution: the number of "in peers" for full nodes doesn't change, but we add new "in peers" specifically for light nodes. Having a light node connected to you consumes significantly fewer resources.

## Actual behavior

For pragmatic reasons, the actual behavior of this PR is not what I've just described.
The code that assigns slots (the peerset) isn't aware of in/out slots, and I am too scared to do the necessary refactoring (https://github.com/paritytech/substrate/issues/5685), as each big refactoring has lead to months of tedious debugging sessions.

Instead, in practice the node can right now open outbound substreams towards light clients.
This means that a certain number of slots, both out and in, are dedicated to full nodes, and the rest is dedicated to light nodes.

I think that this is fine, especially because light clients are typically unreachable and will be purged quite rapidly, and because light clients are not discoverable through the DHT but only because they've connected to us in the past.
