### PR TITLE
Allow the treasury to have a maximum bound on the bond

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -880,6 +880,7 @@ impl pallet_treasury::Config for Runtime {
 	type OnSlash = ();
 	type ProposalBond = ProposalBond;
 	type ProposalBondMinimum = ProposalBondMinimum;
+	type ProposalBondMaximum = ();
 	type SpendPeriod = SpendPeriod;
 	type Burn = Burn;
 	type BurnDestination = ();

--- a/docs/Upgrading-2.0-to-3.0.md
+++ b/docs/Upgrading-2.0-to-3.0.md
@@ -199,6 +199,7 @@ As mentioned above, Bounties, Tips and Lottery have been extracted out of treasu
  	type OnSlash = ();
  	type ProposalBond = ProposalBond;
  	type ProposalBondMinimum = ProposalBondMinimum;
+	type ProposalBondMaximum = ();
  	type SpendPeriod = SpendPeriod;
  	type Burn = Burn;
 +	type BurnDestination = ();

--- a/frame/bounties/src/tests.rs
+++ b/frame/bounties/src/tests.rs
@@ -117,6 +117,7 @@ impl pallet_treasury::Config for Test {
 	type OnSlash = ();
 	type ProposalBond = ProposalBond;
 	type ProposalBondMinimum = ConstU64<1>;
+	type ProposalBondMaximum = ();
 	type SpendPeriod = ConstU64<2>;
 	type Burn = Burn;
 	type BurnDestination = (); // Just gets burned.

--- a/frame/child-bounties/src/tests.rs
+++ b/frame/child-bounties/src/tests.rs
@@ -121,6 +121,7 @@ impl pallet_treasury::Config for Test {
 	type OnSlash = ();
 	type ProposalBond = ProposalBond;
 	type ProposalBondMinimum = ConstU64<1>;
+	type ProposalBondMaximum = ();
 	type SpendPeriod = ConstU64<2>;
 	type Burn = Burn;
 	type BurnDestination = ();

--- a/frame/tips/src/tests.rs
+++ b/frame/tips/src/tests.rs
@@ -137,6 +137,7 @@ impl pallet_treasury::Config for Test {
 	type OnSlash = ();
 	type ProposalBond = ProposalBond;
 	type ProposalBondMinimum = ConstU64<1>;
+	type ProposalBondMaximum = ();
 	type SpendPeriod = ConstU64<2>;
 	type Burn = Burn;
 	type BurnDestination = (); // Just gets burned.

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -409,7 +409,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// The needed bond for a proposal whose spend is `value`.
 	fn calculate_bond(value: BalanceOf<T, I>) -> BalanceOf<T, I> {
 		let mut r = T::ProposalBondMinimum::get().max(T::ProposalBond::get() * value);
-		T::ProposalBondMaximum::get().map(|m| r = r.min(m));
+		if let Some(m) = T::ProposalBondMaximum::get() {
+			r = r.min(m);
+		}
 		r
 	}
 

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -168,6 +168,10 @@ pub mod pallet {
 		#[pallet::constant]
 		type ProposalBondMinimum: Get<BalanceOf<Self, I>>;
 
+		/// Maximum amount of funds that should be placed in a deposit for making a proposal.
+		#[pallet::constant]
+		type ProposalBondMaximum: Get<Option<BalanceOf<Self, I>>>;
+
 		/// Period between successive spends.
 		#[pallet::constant]
 		type SpendPeriod: Get<Self::BlockNumber>;
@@ -404,7 +408,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	/// The needed bond for a proposal whose spend is `value`.
 	fn calculate_bond(value: BalanceOf<T, I>) -> BalanceOf<T, I> {
-		T::ProposalBondMinimum::get().max(T::ProposalBond::get() * value)
+		let mut r = T::ProposalBondMinimum::get().max(T::ProposalBond::get() * value);
+		T::ProposalBondMaximum::get().map(|m| r = r.min(m));
+		r
 	}
 
 	/// Spend some money! returns number of approvals before spend.

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -115,6 +115,7 @@ impl Config for Test {
 	type OnSlash = ();
 	type ProposalBond = ProposalBond;
 	type ProposalBondMinimum = ConstU64<1>;
+	type ProposalBondMaximum = ();
 	type SpendPeriod = ConstU64<2>;
 	type Burn = Burn;
 	type BurnDestination = (); // Just gets burned.


### PR DESCRIPTION
Polkadot companion: https://github.com/paritytech/polkadot/pull/4739

Allow the treasury to have an upper limit to the size of bond required for proposals.