### PR TITLE
Improve Force Insert Keep Left for BoundedVec

### DIFF
--- a/frame/support/src/storage/bounded_vec.rs
+++ b/frame/support/src/storage/bounded_vec.rs
@@ -222,16 +222,17 @@ impl<T, S: Get<u32>> BoundedVec<T, S> {
 	/// Returns `true` if the item was inserted.
 	pub fn force_insert_keep_left(&mut self, index: usize, element: T) -> bool {
 		// Check against panics.
-		if Self::bound() < index || self.len() < index {
+		if Self::bound() < index || self.len() < index || Self::bound() == 0 {
 			return false
 		}
 		// Noop condition.
 		if Self::bound() == index && self.len() <= Self::bound() {
 			return false
 		}
-		// Cannot panic since self.len() >= index;
+		// Cannot panic since `Self.bound() > 0`
+		self.0.truncate(Self::bound() - 1);
+		// Cannot panic since `self.len() >= index`;
 		self.0.insert(index, element);
-		self.0.truncate(Self::bound());
 		true
 	}
 


### PR DESCRIPTION
This small change improves the `force_insert_keep_left` API by first truncating the Vec, and then inserting the element, rather than inserting and then truncating. This prevents a potential memory allocation which may be needed to accept an additional element into the vector.