### PR TITLE
Fix typo

### DIFF
--- a/primitives/state-machine/src/overlayed_changes/mod.rs
+++ b/primitives/state-machine/src/overlayed_changes/mod.rs
@@ -104,7 +104,7 @@ pub struct OverlayedChanges {
 	stats: StateMachineStats,
 }
 
-/// Transcation index operation.
+/// Transaction index operation.
 #[derive(Debug, Clone)]
 pub enum IndexOperation {
 	/// Insert transaction into index.


### PR DESCRIPTION
Caught a typo in the docs: Transcation -> Transaction