### PR TITLE
Add `MaxEncodeLen` to `implement_per_thing!`

### DIFF
--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -432,7 +432,7 @@ pub mod pallet {
 }
 
 // Test that a pallet with non generic event and generic genesis_config is correctly handled
-// and that a pallet without the attribute generate_storage_info is correctly handled.
+// and that a pallet with the attribute without_storage_info is correctly handled.
 #[frame_support::pallet]
 pub mod pallet2 {
 	use super::{SomeAssociation1, SomeType1};

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -535,27 +535,6 @@ pub mod pallet4 {
 	impl<T: Config> Pallet<T> {}
 }
 
-/// Test that `Percent`, `PerU16`, `Permill`, `Perbill` and `Perquintill`
-/// can be used as storage values.
-#[frame_support::pallet]
-pub mod pallet5 {
-	use frame_support::pallet_prelude::StorageValue;
-	use sp_arithmetic::*;
-
-	#[pallet::config]
-	pub trait Config: frame_system::Config {}
-
-	#[pallet::pallet]
-	pub struct Pallet<T>(_);
-
-	#[pallet::storage]
-	pub type SomeValue<T: Config> =
-		StorageValue<_, (Percent, PerU16, Permill, Perbill, Perquintill)>;
-
-	#[pallet::call]
-	impl<T: Config> Pallet<T> {}
-}
-
 frame_support::parameter_types!(
 	pub const MyGetParam3: u32 = 12;
 );

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -535,6 +535,27 @@ pub mod pallet4 {
 	impl<T: Config> Pallet<T> {}
 }
 
+/// Test that `Percent`, `PerU16`, `Permill`, `Perbill` and `Perquintill`
+/// can be used as storage values.
+#[frame_support::pallet]
+pub mod pallet5 {
+	use frame_support::pallet_prelude::StorageValue;
+	use sp_arithmetic::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::storage]
+	pub type SomeValue<T: Config> =
+		StorageValue<_, (Percent, PerU16, Permill, Perbill, Perquintill)>;
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
+}
+
 frame_support::parameter_types!(
 	pub const MyGetParam3: u32 = 12;
 );

--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -907,6 +907,15 @@ macro_rules! implement_per_thing {
 			}
 
 			#[test]
+			fn has_max_encoded_len() {
+				struct AsMaxEncodedLen<T: codec::MaxEncodedLen> {
+					_data: T,
+				}
+
+				let _ = AsMaxEncodedLen { _data: $name(1) };
+			}
+
+			#[test]
 			fn fail_on_invalid_encoded_value() {
 				let value = <$upper_type>::from($max) * 2;
 				let casted = value as $type;

--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -411,6 +411,7 @@ where
 	rem_mul_div_inner.into()
 }
 
+/// A test that the output of this macro can be used as storage value is in frame-support.
 macro_rules! implement_per_thing {
 	(
 		$name:ident,
@@ -1534,6 +1535,7 @@ macro_rules! implement_per_thing {
 	};
 }
 
+/// A test that the output of this macro can be used as storage value is in frame-support.
 macro_rules! implement_per_thing_with_perthousand {
 	(
 		$name:ident,

--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -411,7 +411,6 @@ where
 	rem_mul_div_inner.into()
 }
 
-/// A test that the output of this macro can be used as storage value is in frame-support.
 macro_rules! implement_per_thing {
 	(
 		$name:ident,
@@ -1544,7 +1543,6 @@ macro_rules! implement_per_thing {
 	};
 }
 
-/// A test that the output of this macro can be used as storage value is in frame-support.
 macro_rules! implement_per_thing_with_perthousand {
 	(
 		$name:ident,

--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -425,7 +425,7 @@ macro_rules! implement_per_thing {
 		///
 		#[doc = $title]
 		#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-		#[derive(Encode, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, RuntimeDebug, scale_info::TypeInfo)]
+		#[derive(Encode, Copy, Clone, PartialEq, Eq, codec::MaxEncodedLen, PartialOrd, Ord, RuntimeDebug, scale_info::TypeInfo)]
 		pub struct $name($type);
 
 		/// Implementation makes any compact encoding of `PerThing::Inner` valid,


### PR DESCRIPTION
- Add `MaxEncodeLen` to `implement_per_thing!`
- Test that Percent et.al. can be used in Storage. :point_right: I'm open to have a better way to test this.

Closes #10712