### PR TITLE
wasm-builder: Enable all features when running `cargo metadata`

### DIFF
--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -31,7 +31,7 @@ use toml::value::Table;
 
 use build_helper::rerun_if_changed;
 
-use cargo_metadata::{Metadata, MetadataCommand};
+use cargo_metadata::{CargoOpt, Metadata, MetadataCommand};
 
 use walkdir::WalkDir;
 
@@ -88,6 +88,7 @@ fn crate_metadata(cargo_manifest: &Path) -> Metadata {
 
 	let crate_metadata = MetadataCommand::new()
 		.manifest_path(cargo_manifest)
+		.features(CargoOpt::AllFeatures)
 		.exec()
 		.expect("`cargo metadata` can not fail on project `Cargo.toml`; qed");
 


### PR DESCRIPTION
This is required for projects like Cumulus that have dependencies on `westend-runtime`, but this
runtime is only added when the `runtime-benchmarks` feature is enabled. By having all features
"enabled" in `cargo metadata` we ensure that all crates can be found.

