### PR TITLE
Fix #10688 being misimplemented

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -827,7 +827,7 @@ impl<B: BlockT> Protocol<B> {
 		}
 
 		if status.roles.is_light() &&
-			(self.peers.len() - self.sync.num_peers()) < self.default_peers_set_num_light
+			(self.peers.len() - self.sync.num_peers()) >= self.default_peers_set_num_light
 		{
 			// Make sure that not all slots are occupied by light clients.
 			debug!(target: "sync", "Too many light nodes, rejecting {}", who);


### PR DESCRIPTION
cc https://github.com/paritytech/substrate/pull/10688

So apparently I'm failing at basic logic.

This properly implements the check:
`if current_connected_light_clients >= num_light_clients_allowed { reject }`
