### PR TITLE
remote ext: make it possible to use an existing ws connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,7 +1438,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
 dependencies = [
- "sct",
+ "sct 0.6.0",
 ]
 
 [[package]]
@@ -2425,8 +2425,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a1387e07917c711fb4ee4f48ea0adb04a3c9739e53ef85bf43ae1edc2937a8b"
 dependencies = [
  "futures-io",
- "rustls",
- "webpki",
+ "rustls 0.19.1",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -2874,11 +2874,11 @@ dependencies = [
  "futures-util",
  "hyper 0.14.16",
  "log 0.4.14",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.19.1",
+ "rustls-native-certs 0.5.0",
  "tokio",
- "tokio-rustls",
- "webpki",
+ "tokio-rustls 0.22.0",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -3240,19 +3240,73 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373a33d987866ccfe1af4bc11b089dce941764313f9fd8b7cf13fcb51b72dc5"
 dependencies = [
- "jsonrpsee-proc-macros",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.4.1",
  "jsonrpsee-utils",
- "jsonrpsee-ws-client",
+ "jsonrpsee-ws-client 0.4.1",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05fd8cd6c6b1bbd06881d2cf88f1fc83cc36c98f2219090f839115fb4a956cb9"
+dependencies = [
+ "jsonrpsee-core",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-types 0.8.0",
+ "jsonrpsee-ws-client 0.8.0",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3303cdf246e6ab76e2866fb3d9acb6c76a068b1b28bd923a1b7a8122257ad7b5"
+dependencies = [
+ "futures 0.3.16",
+ "http",
+ "jsonrpsee-core",
+ "jsonrpsee-types 0.8.0",
+ "pin-project 1.0.10",
+ "rustls-native-certs 0.6.1",
+ "soketto 0.7.1",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.23.2",
+ "tokio-util",
+ "tracing",
+ "webpki-roots 0.22.2",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f220b5a238dc7992b90f1144fbf6eaa585872c9376afe6fe6863ffead6191bf3"
+dependencies = [
+ "anyhow",
+ "arrayvec 0.7.1",
+ "async-trait",
+ "beef",
+ "futures-channel",
+ "futures-util",
+ "hyper 0.14.16",
+ "jsonrpsee-types 0.8.0",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "soketto 0.7.1",
+ "thiserror",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.4.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d802063f7a3c867456955f9d2f15eb3ee0edb5ec9ec2b5526324756759221c0f"
+checksum = "4299ebf790ea9de1cb72e73ff2ae44c723ef264299e5e2d5ef46a371eb3ac3d8"
 dependencies = [
- "log 0.4.14",
  "proc-macro-crate 1.1.0",
  "proc-macro2",
  "quote",
@@ -3274,8 +3328,22 @@ dependencies = [
  "log 0.4.14",
  "serde",
  "serde_json",
- "soketto 0.7.0",
+ "soketto 0.7.1",
  "thiserror",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b3f601bbbe45cd63f5407b6f7d7950e08a7d4f82aa699ff41a4a5e9e54df58"
+dependencies = [
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -3286,7 +3354,7 @@ checksum = "0109c4f972058f3b1925b73a17210aff7b63b65967264d0045d15ee88fe84f0c"
 dependencies = [
  "arrayvec 0.7.1",
  "beef",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.4.1",
 ]
 
 [[package]]
@@ -3300,17 +3368,28 @@ dependencies = [
  "fnv",
  "futures 0.3.16",
  "http",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.4.1",
  "log 0.4.14",
  "pin-project 1.0.10",
- "rustls-native-certs",
+ "rustls-native-certs 0.5.0",
  "serde",
  "serde_json",
- "soketto 0.7.0",
+ "soketto 0.7.1",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.22.0",
  "tokio-util",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aff425cee7c779e33920913bc695447416078ee6d119f443f3060feffa4e86b5"
+dependencies = [
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types 0.8.0",
 ]
 
 [[package]]
@@ -3920,9 +3999,9 @@ dependencies = [
  "log 0.4.14",
  "quicksink",
  "rw-stream-sink",
- "soketto 0.7.0",
+ "soketto 0.7.1",
  "url 2.2.1",
- "webpki-roots",
+ "webpki-roots 0.21.0",
 ]
 
 [[package]]
@@ -4602,7 +4681,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.16",
  "hex-literal",
- "jsonrpsee-ws-client",
+ "jsonrpsee-ws-client 0.4.1",
  "log 0.4.14",
  "nix",
  "node-executor",
@@ -7427,7 +7506,7 @@ version = "0.10.0-dev"
 dependencies = [
  "env_logger 0.9.0",
  "frame-support",
- "jsonrpsee",
+ "jsonrpsee 0.8.0",
  "log 0.4.14",
  "pallet-elections-phragmen",
  "parity-scale-codec",
@@ -7559,8 +7638,20 @@ dependencies = [
  "base64 0.13.0",
  "log 0.4.14",
  "ring",
- "sct",
- "webpki",
+ "sct 0.6.0",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
+dependencies = [
+ "log 0.4.14",
+ "ring",
+ "sct 0.7.0",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -7570,9 +7661,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
 dependencies = [
  "openssl-probe",
- "rustls",
+ "rustls 0.19.1",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca9ebdfa27d3fc180e42879037b5338ab1c040c06affd00d8338598e7800943"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -8856,6 +8968,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9202,9 +9324,9 @@ dependencies = [
 
 [[package]]
 name = "soketto"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083624472e8817d44d02c0e55df043737ff11f279af924abdf93845717c2b75c"
+checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.1.0",
@@ -10647,9 +10769,20 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
- "rustls",
+ "rustls 0.19.1",
  "tokio",
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
+dependencies = [
+ "rustls 0.20.2",
+ "tokio",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -10941,7 +11074,7 @@ name = "try-runtime-cli"
 version = "0.10.0-dev"
 dependencies = [
  "clap 3.0.7",
- "jsonrpsee",
+ "jsonrpsee 0.4.1",
  "log 0.4.14",
  "parity-scale-codec",
  "remote-externalities",
@@ -11756,12 +11889,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
 dependencies = [
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
+dependencies = [
+ "webpki 0.22.0",
 ]
 
 [[package]]

--- a/utils/frame/remote-externalities/Cargo.toml
+++ b/utils/frame/remote-externalities/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-jsonrpsee = { version = "0.4.1", features = ["ws-client", "macros"] }
+jsonrpsee = { version = "0.8", features = ["ws-client", "macros"] }
 
 env_logger = "0.9"
 frame-support = { path = "../../../frame/support", optional = true, version = "4.0.0-dev" }

--- a/utils/frame/remote-externalities/src/lib.rs
+++ b/utils/frame/remote-externalities/src/lib.rs
@@ -23,9 +23,9 @@
 use codec::{Decode, Encode};
 
 use jsonrpsee::{
+	core::{client::ClientT, Error as RpcError},
 	proc_macros::rpc,
 	rpc_params,
-	types::{traits::Client, Error as RpcError},
 	ws_client::{WsClient, WsClientBuilder},
 };
 
@@ -44,6 +44,7 @@ use sp_runtime::traits::Block as BlockT;
 use std::{
 	fs,
 	path::{Path, PathBuf},
+	sync::Arc,
 };
 
 pub mod rpc_api;
@@ -123,21 +124,32 @@ impl<P: Into<PathBuf>> From<P> for SnapshotConfig {
 }
 
 /// Description of the transport protocol (for online execution).
-#[derive(Debug)]
-pub struct Transport {
-	uri: String,
-	client: Option<WsClient>,
+#[derive(Debug, Clone)]
+pub enum Transport {
+	/// Use the `URI` to open a new WebSocket connection.
+	Uri(String),
+	/// Use existing WebSocket connection.
+	RemoteClient(Arc<WsClient>),
 }
 
-impl Clone for Transport {
-	fn clone(&self) -> Self {
-		Self { uri: self.uri.clone(), client: None }
+impl Transport {
+	fn as_client(&self) -> Option<&WsClient> {
+		match self {
+			Self::RemoteClient(client) => Some(&*client),
+			_ => None,
+		}
 	}
 }
 
 impl From<String> for Transport {
-	fn from(t: String) -> Self {
-		Self { uri: t, client: None }
+	fn from(uri: String) -> Self {
+		Transport::Uri(uri)
+	}
+}
+
+impl From<Arc<WsClient>> for Transport {
+	fn from(client: Arc<WsClient>) -> Self {
+		Transport::RemoteClient(client)
 	}
 }
 
@@ -161,8 +173,7 @@ impl<B: BlockT> OnlineConfig<B> {
 	/// Return rpc (ws) client.
 	fn rpc_client(&self) -> &WsClient {
 		self.transport
-			.client
-			.as_ref()
+			.as_client()
 			.expect("ws client must have been initialized by now; qed.")
 	}
 }
@@ -170,7 +181,7 @@ impl<B: BlockT> OnlineConfig<B> {
 impl<B: BlockT> Default for OnlineConfig<B> {
 	fn default() -> Self {
 		Self {
-			transport: Transport { uri: DEFAULT_TARGET.to_owned(), client: None },
+			transport: Transport::Uri(DEFAULT_TARGET.to_owned()),
 			at: None,
 			state_snapshot: None,
 			pallets: vec![],
@@ -630,18 +641,27 @@ impl<B: BlockT + DeserializeOwned> Builder<B> {
 
 	pub(crate) async fn init_remote_client(&mut self) -> Result<(), &'static str> {
 		let mut online = self.as_online_mut();
-		log::debug!(target: LOG_TARGET, "initializing remote client to {:?}", online.transport.uri);
 
-		// First, initialize the ws client.
-		let ws_client = WsClientBuilder::default()
-			.max_request_body_size(u32::MAX)
-			.build(&online.transport.uri)
-			.await
-			.map_err(|e| {
-				log::error!(target: LOG_TARGET, "error: {:?}", e);
-				"failed to build ws client"
-			})?;
-		online.transport.client = Some(ws_client);
+		let maybe_transport = if let Transport::Uri(uri) = &online.transport {
+			log::debug!(target: LOG_TARGET, "initializing remote client to {:?}", uri);
+
+			// First, initialize the ws client.
+			let ws_client = WsClientBuilder::default()
+				.max_request_body_size(u32::MAX)
+				.build(&uri)
+				.await
+				.map_err(|e| {
+					log::error!(target: LOG_TARGET, "error: {:?}", e);
+					"failed to build ws client"
+				})?;
+			Some(Transport::RemoteClient(Arc::new(ws_client)))
+		} else {
+			None
+		};
+
+		if let Some(transport) = maybe_transport {
+			online.transport = transport;
+		}
 
 		// Then, if `at` is not set, set it.
 		if self.as_online().at.is_none() {

--- a/utils/frame/remote-externalities/src/rpc_api.rs
+++ b/utils/frame/remote-externalities/src/rpc_api.rs
@@ -19,8 +19,8 @@
 // TODO: Consolidate one off RPC calls https://github.com/paritytech/substrate/issues/8988
 
 use jsonrpsee::{
+	core::client::ClientT,
 	rpc_params,
-	types::traits::Client,
 	ws_client::{WsClient, WsClientBuilder},
 };
 use sp_runtime::{
@@ -73,7 +73,7 @@ where
 	Ok(signed_block.block)
 }
 
-/// Build a website client that connects to `from`.
+/// Build a websocket client that connects to `from`.
 async fn build_client<S: AsRef<str>>(from: S) -> Result<WsClient, String> {
 	WsClientBuilder::default()
 		.max_request_body_size(u32::MAX)


### PR DESCRIPTION
Introduced an `enum Transport` to decide whether to use a `existing connection` or `create a new connection URI`

The logic should be kept but after the ws connection is established the `URI` shouldn't be needed AFAIU, thus the enum.