### PR TITLE
Add attributes and documentation to fork_id

### DIFF
--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -165,7 +165,7 @@ struct ClientSpec<E> {
 	telemetry_endpoints: Option<TelemetryEndpoints>,
 	protocol_id: Option<String>,
 	/// Arbitrary string. Nodes will only synchronize with other nodes that have the same value
-	/// in their `fork_id`. This can be used in order to segregate nodes in case when multiple
+	/// in their `fork_id`. This can be used in order to segregate nodes in cases when multiple
 	/// chains have the same genesis hash.
 	#[serde(default = "Default::default", skip_serializing_if = "Option::is_none")]
 	fork_id: Option<String>,

--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -164,6 +164,10 @@ struct ClientSpec<E> {
 	boot_nodes: Vec<MultiaddrWithPeerId>,
 	telemetry_endpoints: Option<TelemetryEndpoints>,
 	protocol_id: Option<String>,
+	/// Arbitrary string. Nodes will only synchronize with other nodes that have the same value
+	/// in their `fork_id`. This can be used in order to segregate nodes in case when multiple
+	/// chains have the same genesis hash.
+	#[serde(default = "Default::default", skip_serializing_if = "Option::is_none")]
 	fork_id: Option<String>,
 	properties: Option<Properties>,
 	#[serde(flatten)]


### PR DESCRIPTION
cc https://github.com/paritytech/substrate/pull/10463

The overwhelming majority of the time the `fork_id` will be empty, so let's not include the field in chain specs if that's the case.
