### PR TITLE
Bump `wasm-instrument` 0.1.0 -> 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11444,9 +11444,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-instrument"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e67369bb53d409b67e57ef31797b1b2d628955fc82f86f2ea78bb403acc7c73"
+checksum = "962e5b0401bbb6c887f54e69b8c496ea36f704df65db73e81fd5ff8dc3e63a9f"
 dependencies = [
  "parity-wasm 0.42.2",
 ]

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -270,7 +270,7 @@ benchmarks! {
 	// We cannot let `c` grow to the maximum code size because the code is not allowed
 	// to be larger than the maximum size **after instrumentation**.
 	instantiate_with_code {
-		let c in 0 .. Perbill::from_percent(50).mul_ceil(T::Schedule::get().limits.code_len / 1024);
+		let c in 0 .. Perbill::from_percent(49).mul_ceil(T::Schedule::get().limits.code_len) / 1024;
 		let s in 0 .. code::max_pages::<T>() * 64;
 		let salt = vec![42u8; (s * 1024) as usize];
 		let value = T::Currency::minimum_balance();

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -2196,7 +2196,7 @@ fn upload_code_works() {
 					phase: Phase::Initialization,
 					event: Event::Balances(pallet_balances::Event::Reserved {
 						who: ALICE,
-						amount: 180,
+						amount: 240,
 					}),
 					topics: vec![],
 				},
@@ -2275,7 +2275,7 @@ fn remove_code_works() {
 					phase: Phase::Initialization,
 					event: Event::Balances(pallet_balances::Event::Reserved {
 						who: ALICE,
-						amount: 180,
+						amount: 240,
 					}),
 					topics: vec![],
 				},
@@ -2288,7 +2288,7 @@ fn remove_code_works() {
 					phase: Phase::Initialization,
 					event: Event::Balances(pallet_balances::Event::Unreserved {
 						who: ALICE,
-						amount: 180,
+						amount: 240,
 					}),
 					topics: vec![],
 				},
@@ -2330,7 +2330,7 @@ fn remove_code_wrong_origin() {
 					phase: Phase::Initialization,
 					event: Event::Balances(pallet_balances::Event::Reserved {
 						who: ALICE,
-						amount: 180,
+						amount: 240,
 					}),
 					topics: vec![],
 				},
@@ -2461,7 +2461,7 @@ fn instantiate_with_zero_balance_works() {
 					phase: Phase::Initialization,
 					event: Event::Balances(pallet_balances::Event::Reserved {
 						who: ALICE,
-						amount: 180,
+						amount: 240,
 					}),
 					topics: vec![],
 				},
@@ -2561,7 +2561,7 @@ fn instantiate_with_below_existential_deposit_works() {
 					phase: Phase::Initialization,
 					event: Event::Balances(pallet_balances::Event::Reserved {
 						who: ALICE,
-						amount: 180,
+						amount: 240,
 					}),
 					topics: vec![],
 				},


### PR DESCRIPTION
Fix for the stack height metering. It increases the size of the dummy contract used in some `pallet-contracts` tests. This is why some changes there were necessary.