### PR TITLE
Factor out checks for staking's  `bond` & `nominate`

### DIFF
--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -32,7 +32,7 @@ use frame_support::{
 use frame_system::pallet_prelude::BlockNumberFor;
 use pallet_session::historical;
 use sp_runtime::{
-	traits::{Bounded, Convert, SaturatedConversion, Saturating, Zero},
+	traits::{Bounded, Convert, SaturatedConversion, Saturating, StaticLookup, Zero},
 	Perbill,
 };
 use sp_staking::{
@@ -847,6 +847,89 @@ impl<T: Config> Pallet<T> {
 			weight,
 			DispatchClass::Mandatory,
 		);
+	}
+
+	/// Checks for [`Self::bond`] that can be completed at the beginning of the calls logic.
+	pub(crate) fn do_bond_checks(
+		stash: &T::AccountId,
+		controller: &T::AccountId,
+		value: BalanceOf<T>,
+	) -> Result<(), DispatchError> {
+		if Bonded::<T>::contains_key(&stash) {
+			Err(Error::<T>::AlreadyBonded)?
+		}
+
+		if Ledger::<T>::contains_key(&controller) {
+			Err(Error::<T>::AlreadyPaired)?
+		}
+
+		// Reject a bond which is considered to be _dust_.
+		if value < T::Currency::minimum_balance() {
+			Err(Error::<T>::InsufficientBond)?
+		}
+
+		Ok(())
+	}
+
+	/// Checks for [`Self::nominate`] that must be called prior to
+	/// [`Self::do_unchecked_nominate_writes`].
+	pub(crate) fn do_nominate_checks(
+		controller: &T::AccountId,
+		targets: Vec<<T::Lookup as StaticLookup>::Source>,
+	) -> Result<(T::AccountId, BoundedVec<T::AccountId, T::MaxNominations>), DispatchError> {
+		let ledger = Self::ledger(controller).ok_or(Error::<T>::NotController)?;
+		ensure!(ledger.active >= MinNominatorBond::<T>::get(), Error::<T>::InsufficientBond);
+
+		// Only check limits if they are not already a nominator.
+		if !Nominators::<T>::contains_key(&ledger.stash) {
+			// If this error is reached, we need to adjust the `MinNominatorBond` and start
+			// calling `chill_other`. Until then, we explicitly block new nominators to protect
+			// the runtime.
+			if let Some(max_nominators) = MaxNominatorsCount::<T>::get() {
+				ensure!(Nominators::<T>::count() < max_nominators, Error::<T>::TooManyNominators);
+			}
+		}
+
+		ensure!(!targets.is_empty(), Error::<T>::EmptyTargets);
+		ensure!(targets.len() <= T::MaxNominations::get() as usize, Error::<T>::TooManyTargets);
+
+		let old =
+			Nominators::<T>::get(&ledger.stash).map_or_else(Vec::new, |x| x.targets.into_inner());
+
+		let targets: BoundedVec<_, _> = targets
+			.into_iter()
+			.map(|t| T::Lookup::lookup(t).map_err(DispatchError::from))
+			.map(|n| {
+				n.and_then(|n| {
+					if old.contains(&n) || !Validators::<T>::get(&n).blocked {
+						Ok(n)
+					} else {
+						Err(Error::<T>::BadTarget.into())
+					}
+				})
+			})
+			.collect::<Result<Vec<_>, _>>()?
+			.try_into()
+			.map_err(|_| Error::<T>::TooManyNominators)?;
+
+		Ok((ledger.stash, targets))
+	}
+
+	/// Write the information for nominating. The caller must first call
+	/// [`Self::do_nominate_checks`].
+	pub(crate) fn do_unchecked_nominate_writes(
+		stash: &T::AccountId,
+		targets: BoundedVec<T::AccountId, T::MaxNominations>,
+	) {
+		let nominations = Nominations {
+			targets,
+			// Initial nominations are considered submitted at era 0. See `Nominations` doc.
+			submitted_in: Self::current_era().unwrap_or(0),
+			suppressed: false,
+		};
+
+		Self::do_remove_validator(&stash);
+		Self::do_add_nominator(&stash, nominations);
 	}
 }
 

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -850,7 +850,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Checks for [`Self::bond`] that can be completed at the beginning of the calls logic.
-	pub(crate) fn do_bond_checks(
+	pub(crate) fn ensure_can_bond(
 		stash: &T::AccountId,
 		controller: &T::AccountId,
 		value: BalanceOf<T>,
@@ -873,7 +873,7 @@ impl<T: Config> Pallet<T> {
 
 	/// Checks for [`Self::nominate`] that must be called prior to
 	/// [`Self::do_unchecked_nominate_writes`].
-	pub(crate) fn do_nominate_checks(
+	pub(crate) fn ensure_can_nominate(
 		controller: &T::AccountId,
 		targets: Vec<<T::Lookup as StaticLookup>::Source>,
 	) -> Result<(T::AccountId, BoundedVec<T::AccountId, T::MaxNominations>), DispatchError> {
@@ -916,8 +916,8 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Write the information for nominating. The caller must first call
-	/// [`Self::do_nominate_checks`].
-	pub(crate) fn do_unchecked_nominate_writes(
+	/// [`Self::ensure_can_nominate`].
+	pub(crate) fn do_unchecked_nominate(
 		stash: &T::AccountId,
 		targets: BoundedVec<T::AccountId, T::MaxNominations>,
 	) {

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -739,7 +739,7 @@ pub mod pallet {
 			let stash = ensure_signed(origin)?;
 			let controller = T::Lookup::lookup(controller)?;
 
-			Self::do_bond_checks(&stash, &controller, value)?;
+			Self::ensure_can_bond(&stash, &controller, value)?;
 
 			frame_system::Pallet::<T>::inc_consumers(&stash).map_err(|_| Error::<T>::BadState)?;
 
@@ -991,8 +991,8 @@ pub mod pallet {
 			targets: Vec<<T::Lookup as StaticLookup>::Source>,
 		) -> DispatchResult {
 			let controller = ensure_signed(origin)?;
-			let (stash, targets) = Self::do_nominate_checks(&controller, targets)?;
-			Self::do_unchecked_nominate_writes(&stash, targets);
+			let (stash, targets) = Self::ensure_can_nominate(&controller, targets)?;
+			Self::do_unchecked_nominate(&stash, targets);
 			Ok(())
 		}
 


### PR DESCRIPTION
This is a back port from https://github.com/paritytech/substrate/pull/10694.

The new functions factored out here will be used to implement a new `PoolsInterface`:

https://github.com/paritytech/substrate/blob/732c30b75ee7b97d787fe4ff3447150eef7bfa9b/frame/staking/src/pallet/impls.rs#L1440-L1477

The idea is these checks can be exposed by `trait PoolsInterface`. Additionally, since the nominate checks map & collect the targets, we avoid redundant memory usage and computation by piping the targets from the check into a write function. The plan is for this nominate write function to also be exposed by the `PoolsInterface` so the pool can call the check, do some other checks, and then input the targets into the write function. 

I still not sure this is the right approach as it makes the `PoolsInterface` a bit more leaky, so this needs some discussion.
