### PR TITLE
Moving `MAX_UNLOCKING_CHUNKS` to become a runtime parameter

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -562,6 +562,7 @@ impl pallet_staking::Config for Runtime {
 	// Alternatively, use pallet_staking::UseNominatorsMap<Runtime> to just use the nominators map.
 	// Note that the aforementioned does not scale to a very large number of nominators.
 	type SortedListProvider = BagsList;
+	type MaxUnlockingChunks = ConstU32<32>;
 	type WeightInfo = pallet_staking::weights::SubstrateWeight<Runtime>;
 	type BenchmarkingConfig = StakingBenchmarkingConfig;
 }

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -198,6 +198,7 @@ impl pallet_staking::Config for Test {
 	type ElectionProvider = onchain::OnChainSequentialPhragmen<Self>;
 	type GenesisElectionProvider = Self::ElectionProvider;
 	type SortedListProvider = pallet_staking::UseNominatorsMap<Self>;
+	type MaxUnlockingChunks = ConstU32<32>;
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -206,6 +206,7 @@ impl pallet_staking::Config for Test {
 	type ElectionProvider = onchain::OnChainSequentialPhragmen<Self>;
 	type GenesisElectionProvider = Self::ElectionProvider;
 	type SortedListProvider = pallet_staking::UseNominatorsMap<Self>;
+	type MaxUnlockingChunks = ConstU32<32>;
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -176,6 +176,7 @@ impl pallet_staking::Config for Test {
 	type ElectionProvider = onchain::OnChainSequentialPhragmen<Self>;
 	type GenesisElectionProvider = Self::ElectionProvider;
 	type SortedListProvider = pallet_staking::UseNominatorsMap<Self>;
+	type MaxUnlockingChunks = ConstU32<32>;
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -182,6 +182,7 @@ impl pallet_staking::Config for Test {
 	type ElectionProvider = onchain::OnChainSequentialPhragmen<Self>;
 	type GenesisElectionProvider = Self::ElectionProvider;
 	type SortedListProvider = pallet_staking::UseNominatorsMap<Self>;
+	type MaxUnlockingChunks = ConstU32<32>;
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/staking/README.md
+++ b/frame/staking/README.md
@@ -184,7 +184,7 @@ Validators and nominators are rewarded at the end of each era. The total reward 
 calculated using the era duration and the staking rate (the total amount of tokens staked by
 nominators and validators, divided by the total token supply). It aims to incentivize toward a
 defined staking rate. The full specification can be found
-[here](https://research.web3.foundation/en/latest/polkadot/economics/1-token-economics.html#inflation-model).
+[here](https://w3f-research.readthedocs.io/en/latest/polkadot/overview/2-token-economics.html#inflation-model).
 
 Total reward is split among validators and their nominators depending on the number of points
 they received during the era. Points are added to a validator using
@@ -229,7 +229,7 @@ call can be used to actually withdraw the funds.
 
 Note that there is a limitation to the number of fund-chunks that can be scheduled to be
 unlocked in the future via [`unbond`](https://docs.rs/pallet-staking/latest/pallet_staking/enum.Call.html#variant.unbond). In case this maximum
-(`MAX_UNLOCKING_CHUNKS`) is reached, the bonded account _must_ first wait until a successful
+(`MaxUnlockingChunks`) is reached, the bonded account _must_ first wait until a successful
 call to `withdraw_unbonded` to remove some of the chunks.
 
 ### Election Algorithm

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -618,7 +618,7 @@ benchmarks! {
 	}
 
 	rebond {
-		let l in 1 .. MAX_UNLOCKING_CHUNKS as u32;
+		let l in 1 .. <T as Config>::MaxUnlockingChunks::get();
 
 		// clean up any existing state.
 		clear_validators_and_nominators::<T>();
@@ -652,7 +652,7 @@ benchmarks! {
 		let mut staking_ledger = Ledger::<T>::get(controller.clone()).unwrap();
 
 		for _ in 0 .. l {
-			staking_ledger.unlocking.push(unlock_chunk.clone())
+			staking_ledger.unlocking.try_push(unlock_chunk.clone()).expect("Size is smaller than MaxUnlockingChunks, qed");
 		}
 		Ledger::<T>::insert(controller.clone(), staking_ledger.clone());
 		let original_bonded: BalanceOf<T> = staking_ledger.active;
@@ -702,7 +702,7 @@ benchmarks! {
 			stash: stash.clone(),
 			active: T::Currency::minimum_balance() - One::one(),
 			total: T::Currency::minimum_balance() - One::one(),
-			unlocking: vec![],
+			unlocking: Default::default(),
 			claimed_rewards: vec![],
 		};
 		Ledger::<T>::insert(&controller, l);
@@ -788,7 +788,7 @@ benchmarks! {
 
 	#[extra]
 	do_slash {
-		let l in 1 .. MAX_UNLOCKING_CHUNKS as u32;
+		let l in 1 .. <T as Config>::MaxUnlockingChunks::get();
 		let (stash, controller) = create_stash_controller::<T>(0, 100, Default::default())?;
 		let mut staking_ledger = Ledger::<T>::get(controller.clone()).unwrap();
 		let unlock_chunk = UnlockChunk::<BalanceOf<T>> {
@@ -796,7 +796,7 @@ benchmarks! {
 			era: EraIndex::zero(),
 		};
 		for _ in 0 .. l {
-			staking_ledger.unlocking.push(unlock_chunk.clone())
+			staking_ledger.unlocking.try_push(unlock_chunk.clone()).expect("Size is smaller than MaxUnlockingChunks, qed");
 		}
 		Ledger::<T>::insert(controller, staking_ledger);
 		let slash_amount = T::Currency::minimum_balance() * 10u32.into();

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -271,6 +271,7 @@ impl crate::pallet::pallet::Config for Test {
 	type GenesisElectionProvider = Self::ElectionProvider;
 	// NOTE: consider a macro and use `UseNominatorsMap<Self>` as well.
 	type SortedListProvider = BagsList;
+	type MaxUnlockingChunks = ConstU32<32>;
 	type BenchmarkingConfig = TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -203,7 +203,7 @@ impl<T: Config> Pallet<T> {
 	/// This will also update the stash lock.
 	pub(crate) fn update_ledger(
 		controller: &T::AccountId,
-		ledger: &StakingLedger<T::AccountId, BalanceOf<T>>,
+		ledger: &StakingLedger<T::AccountId, BalanceOf<T>, T::MaxUnlockingChunks>,
 	) {
 		T::Currency::set_lock(STAKING_ID, &ledger.stash, ledger.total, WithdrawReasons::all());
 		<Ledger<T>>::insert(controller, ledger);
@@ -928,7 +928,7 @@ impl<T: Config> ElectionDataProvider for Pallet<T> {
 				stash: voter.clone(),
 				active: stake,
 				total: stake,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![],
 			},
 		);
@@ -946,7 +946,7 @@ impl<T: Config> ElectionDataProvider for Pallet<T> {
 				stash: target.clone(),
 				active: stake,
 				total: stake,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![],
 			},
 		);
@@ -983,7 +983,7 @@ impl<T: Config> ElectionDataProvider for Pallet<T> {
 					stash: v.clone(),
 					active: stake,
 					total: stake,
-					unlocking: vec![],
+					unlocking: Default::default(),
 					claimed_rewards: vec![],
 				},
 			);
@@ -1004,7 +1004,7 @@ impl<T: Config> ElectionDataProvider for Pallet<T> {
 					stash: v.clone(),
 					active: stake,
 					total: stake,
-					unlocking: vec![],
+					unlocking: Default::default(),
 					claimed_rewards: vec![],
 				},
 			);

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -20,7 +20,7 @@
 use super::{Event, *};
 use frame_election_provider_support::{ElectionProvider, SortedListProvider, Support};
 use frame_support::{
-	assert_noop, assert_ok,
+	assert_noop, assert_ok, bounded_vec,
 	dispatch::WithPostDispatchInfo,
 	pallet_prelude::*,
 	traits::{Currency, Get, ReservableCurrency},
@@ -104,7 +104,7 @@ fn basic_setup_works() {
 				stash: 11,
 				total: 1000,
 				active: 1000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![]
 			})
 		);
@@ -115,7 +115,7 @@ fn basic_setup_works() {
 				stash: 21,
 				total: 1000,
 				active: 1000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![]
 			})
 		);
@@ -138,7 +138,7 @@ fn basic_setup_works() {
 				stash: 101,
 				total: 500,
 				active: 500,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![]
 			})
 		);
@@ -382,7 +382,7 @@ fn staking_should_work() {
 				stash: 3,
 				total: 1500,
 				active: 1500,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![0],
 			})
 		);
@@ -936,7 +936,7 @@ fn reward_destination_works() {
 				stash: 11,
 				total: 1000,
 				active: 1000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![],
 			})
 		);
@@ -959,7 +959,7 @@ fn reward_destination_works() {
 				stash: 11,
 				total: 1000 + total_payout_0,
 				active: 1000 + total_payout_0,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![0],
 			})
 		);
@@ -987,7 +987,7 @@ fn reward_destination_works() {
 				stash: 11,
 				total: 1000 + total_payout_0,
 				active: 1000 + total_payout_0,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![0, 1],
 			})
 		);
@@ -1016,7 +1016,7 @@ fn reward_destination_works() {
 				stash: 11,
 				total: 1000 + total_payout_0,
 				active: 1000 + total_payout_0,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![0, 1, 2],
 			})
 		);
@@ -1081,7 +1081,7 @@ fn bond_extra_works() {
 				stash: 11,
 				total: 1000,
 				active: 1000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![],
 			})
 		);
@@ -1098,7 +1098,7 @@ fn bond_extra_works() {
 				stash: 11,
 				total: 1000 + 100,
 				active: 1000 + 100,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![],
 			})
 		);
@@ -1112,7 +1112,7 @@ fn bond_extra_works() {
 				stash: 11,
 				total: 1000000,
 				active: 1000000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![],
 			})
 		);
@@ -1150,7 +1150,7 @@ fn bond_extra_and_withdraw_unbonded_works() {
 				stash: 11,
 				total: 1000,
 				active: 1000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![],
 			})
 		);
@@ -1168,7 +1168,7 @@ fn bond_extra_and_withdraw_unbonded_works() {
 				stash: 11,
 				total: 1000 + 100,
 				active: 1000 + 100,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![],
 			})
 		);
@@ -1189,7 +1189,7 @@ fn bond_extra_and_withdraw_unbonded_works() {
 				stash: 11,
 				total: 1000 + 100,
 				active: 1000 + 100,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![],
 			})
 		);
@@ -1207,7 +1207,7 @@ fn bond_extra_and_withdraw_unbonded_works() {
 				stash: 11,
 				total: 1000 + 100,
 				active: 100,
-				unlocking: vec![UnlockChunk { value: 1000, era: 2 + 3 }],
+				unlocking: bounded_vec![UnlockChunk { value: 1000, era: 2 + 3 }],
 				claimed_rewards: vec![]
 			}),
 		);
@@ -1220,7 +1220,7 @@ fn bond_extra_and_withdraw_unbonded_works() {
 				stash: 11,
 				total: 1000 + 100,
 				active: 100,
-				unlocking: vec![UnlockChunk { value: 1000, era: 2 + 3 }],
+				unlocking: bounded_vec![UnlockChunk { value: 1000, era: 2 + 3 }],
 				claimed_rewards: vec![]
 			}),
 		);
@@ -1236,7 +1236,7 @@ fn bond_extra_and_withdraw_unbonded_works() {
 				stash: 11,
 				total: 1000 + 100,
 				active: 100,
-				unlocking: vec![UnlockChunk { value: 1000, era: 2 + 3 }],
+				unlocking: bounded_vec![UnlockChunk { value: 1000, era: 2 + 3 }],
 				claimed_rewards: vec![]
 			}),
 		);
@@ -1252,7 +1252,7 @@ fn bond_extra_and_withdraw_unbonded_works() {
 				stash: 11,
 				total: 100,
 				active: 100,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![]
 			}),
 		);
@@ -1263,7 +1263,8 @@ fn bond_extra_and_withdraw_unbonded_works() {
 fn too_many_unbond_calls_should_not_work() {
 	ExtBuilder::default().build_and_execute(|| {
 		// locked at era 0 until 3
-		for _ in 0..MAX_UNLOCKING_CHUNKS - 1 {
+		let max: u32 = <Test as Config>::MaxUnlockingChunks::get();
+		for _ in 0..max - 1 {
 			assert_ok!(Staking::unbond(Origin::signed(10), 1));
 		}
 
@@ -1310,7 +1311,7 @@ fn rebond_works() {
 				stash: 11,
 				total: 1000,
 				active: 1000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![],
 			})
 		);
@@ -1329,7 +1330,7 @@ fn rebond_works() {
 				stash: 11,
 				total: 1000,
 				active: 100,
-				unlocking: vec![UnlockChunk { value: 900, era: 2 + 3 }],
+				unlocking: bounded_vec![UnlockChunk { value: 900, era: 2 + 3 }],
 				claimed_rewards: vec![],
 			})
 		);
@@ -1342,7 +1343,7 @@ fn rebond_works() {
 				stash: 11,
 				total: 1000,
 				active: 1000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![],
 			})
 		);
@@ -1355,7 +1356,7 @@ fn rebond_works() {
 				stash: 11,
 				total: 1000,
 				active: 100,
-				unlocking: vec![UnlockChunk { value: 900, era: 5 }],
+				unlocking: bounded_vec![UnlockChunk { value: 900, era: 5 }],
 				claimed_rewards: vec![],
 			})
 		);
@@ -1368,7 +1369,7 @@ fn rebond_works() {
 				stash: 11,
 				total: 1000,
 				active: 600,
-				unlocking: vec![UnlockChunk { value: 400, era: 5 }],
+				unlocking: bounded_vec![UnlockChunk { value: 400, era: 5 }],
 				claimed_rewards: vec![],
 			})
 		);
@@ -1381,7 +1382,7 @@ fn rebond_works() {
 				stash: 11,
 				total: 1000,
 				active: 1000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![],
 			})
 		);
@@ -1396,10 +1397,10 @@ fn rebond_works() {
 				stash: 11,
 				total: 1000,
 				active: 100,
-				unlocking: vec![
+				unlocking: bounded_vec![
 					UnlockChunk { value: 300, era: 5 },
 					UnlockChunk { value: 300, era: 5 },
-					UnlockChunk { value: 300, era: 5 },
+					UnlockChunk { value: 300, era: 5 }
 				],
 				claimed_rewards: vec![],
 			})
@@ -1413,9 +1414,9 @@ fn rebond_works() {
 				stash: 11,
 				total: 1000,
 				active: 600,
-				unlocking: vec![
+				unlocking: bounded_vec![
 					UnlockChunk { value: 300, era: 5 },
-					UnlockChunk { value: 100, era: 5 },
+					UnlockChunk { value: 100, era: 5 }
 				],
 				claimed_rewards: vec![],
 			})
@@ -1443,7 +1444,7 @@ fn rebond_is_fifo() {
 				stash: 11,
 				total: 1000,
 				active: 1000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![],
 			})
 		);
@@ -1458,7 +1459,7 @@ fn rebond_is_fifo() {
 				stash: 11,
 				total: 1000,
 				active: 600,
-				unlocking: vec![UnlockChunk { value: 400, era: 2 + 3 },],
+				unlocking: bounded_vec![UnlockChunk { value: 400, era: 2 + 3 }],
 				claimed_rewards: vec![],
 			})
 		);
@@ -1473,9 +1474,9 @@ fn rebond_is_fifo() {
 				stash: 11,
 				total: 1000,
 				active: 300,
-				unlocking: vec![
+				unlocking: bounded_vec![
 					UnlockChunk { value: 400, era: 2 + 3 },
-					UnlockChunk { value: 300, era: 3 + 3 },
+					UnlockChunk { value: 300, era: 3 + 3 }
 				],
 				claimed_rewards: vec![],
 			})
@@ -1491,10 +1492,10 @@ fn rebond_is_fifo() {
 				stash: 11,
 				total: 1000,
 				active: 100,
-				unlocking: vec![
+				unlocking: bounded_vec![
 					UnlockChunk { value: 400, era: 2 + 3 },
 					UnlockChunk { value: 300, era: 3 + 3 },
-					UnlockChunk { value: 200, era: 4 + 3 },
+					UnlockChunk { value: 200, era: 4 + 3 }
 				],
 				claimed_rewards: vec![],
 			})
@@ -1508,9 +1509,9 @@ fn rebond_is_fifo() {
 				stash: 11,
 				total: 1000,
 				active: 500,
-				unlocking: vec![
+				unlocking: bounded_vec![
 					UnlockChunk { value: 400, era: 2 + 3 },
-					UnlockChunk { value: 100, era: 3 + 3 },
+					UnlockChunk { value: 100, era: 3 + 3 }
 				],
 				claimed_rewards: vec![],
 			})
@@ -1540,7 +1541,7 @@ fn rebond_emits_right_value_in_event() {
 				stash: 11,
 				total: 1000,
 				active: 100,
-				unlocking: vec![UnlockChunk { value: 900, era: 1 + 3 }],
+				unlocking: bounded_vec![UnlockChunk { value: 900, era: 1 + 3 }],
 				claimed_rewards: vec![],
 			})
 		);
@@ -1553,7 +1554,7 @@ fn rebond_emits_right_value_in_event() {
 				stash: 11,
 				total: 1000,
 				active: 200,
-				unlocking: vec![UnlockChunk { value: 800, era: 1 + 3 }],
+				unlocking: bounded_vec![UnlockChunk { value: 800, era: 1 + 3 }],
 				claimed_rewards: vec![],
 			})
 		);
@@ -1568,7 +1569,7 @@ fn rebond_emits_right_value_in_event() {
 				stash: 11,
 				total: 1000,
 				active: 1000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![],
 			})
 		);
@@ -1604,7 +1605,7 @@ fn reward_to_stake_works() {
 					stash: 21,
 					total: 69,
 					active: 69,
-					unlocking: vec![],
+					unlocking: Default::default(),
 					claimed_rewards: vec![],
 				},
 			);
@@ -1665,7 +1666,7 @@ fn reap_stash_works() {
 					stash: 11,
 					total: 5,
 					active: 5,
-					unlocking: vec![],
+					unlocking: Default::default(),
 					claimed_rewards: vec![],
 				},
 			);
@@ -1784,7 +1785,7 @@ fn bond_with_no_staked_value() {
 					stash: 1,
 					active: 0,
 					total: 5,
-					unlocking: vec![UnlockChunk { value: 5, era: 3 }],
+					unlocking: bounded_vec![UnlockChunk { value: 5, era: 3 }],
 					claimed_rewards: vec![],
 				})
 			);
@@ -3354,7 +3355,7 @@ fn test_payout_stakers() {
 				stash: 11,
 				total: 1000,
 				active: 1000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![1]
 			})
 		);
@@ -3376,7 +3377,7 @@ fn test_payout_stakers() {
 				stash: 11,
 				total: 1000,
 				active: 1000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: (1..=14).collect()
 			})
 		);
@@ -3397,7 +3398,7 @@ fn test_payout_stakers() {
 				stash: 11,
 				total: 1000,
 				active: 1000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![15, 98]
 			})
 		);
@@ -3412,7 +3413,7 @@ fn test_payout_stakers() {
 				stash: 11,
 				total: 1000,
 				active: 1000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![15, 23, 42, 69, 98]
 			})
 		);
@@ -3607,7 +3608,7 @@ fn bond_during_era_correctly_populates_claimed_rewards() {
 				stash: 9,
 				total: 1000,
 				active: 1000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: vec![],
 			})
 		);
@@ -3619,7 +3620,7 @@ fn bond_during_era_correctly_populates_claimed_rewards() {
 				stash: 11,
 				total: 1000,
 				active: 1000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: (0..5).collect(),
 			})
 		);
@@ -3631,7 +3632,7 @@ fn bond_during_era_correctly_populates_claimed_rewards() {
 				stash: 13,
 				total: 1000,
 				active: 1000,
-				unlocking: vec![],
+				unlocking: Default::default(),
 				claimed_rewards: (15..99).collect(),
 			})
 		);
@@ -3850,7 +3851,7 @@ fn cannot_rebond_to_lower_than_ed() {
 					stash: 21,
 					total: 10 * 1000,
 					active: 10 * 1000,
-					unlocking: vec![],
+					unlocking: Default::default(),
 					claimed_rewards: vec![]
 				}
 			);
@@ -3864,7 +3865,7 @@ fn cannot_rebond_to_lower_than_ed() {
 					stash: 21,
 					total: 10 * 1000,
 					active: 0,
-					unlocking: vec![UnlockChunk { value: 10 * 1000, era: 3 }],
+					unlocking: bounded_vec![UnlockChunk { value: 10 * 1000, era: 3 }],
 					claimed_rewards: vec![]
 				}
 			);
@@ -3887,7 +3888,7 @@ fn cannot_bond_extra_to_lower_than_ed() {
 					stash: 21,
 					total: 10 * 1000,
 					active: 10 * 1000,
-					unlocking: vec![],
+					unlocking: Default::default(),
 					claimed_rewards: vec![]
 				}
 			);
@@ -3901,7 +3902,7 @@ fn cannot_bond_extra_to_lower_than_ed() {
 					stash: 21,
 					total: 10 * 1000,
 					active: 0,
-					unlocking: vec![UnlockChunk { value: 10 * 1000, era: 3 }],
+					unlocking: bounded_vec![UnlockChunk { value: 10 * 1000, era: 3 }],
 					claimed_rewards: vec![]
 				}
 			);
@@ -3928,7 +3929,7 @@ fn do_not_die_when_active_is_ed() {
 					stash: 21,
 					total: 1000 * ed,
 					active: 1000 * ed,
-					unlocking: vec![],
+					unlocking: Default::default(),
 					claimed_rewards: vec![]
 				}
 			);
@@ -3945,7 +3946,7 @@ fn do_not_die_when_active_is_ed() {
 					stash: 21,
 					total: ed,
 					active: ed,
-					unlocking: vec![],
+					unlocking: Default::default(),
 					claimed_rewards: vec![]
 				}
 			);

--- a/frame/support/src/storage/bounded_vec.rs
+++ b/frame/support/src/storage/bounded_vec.rs
@@ -26,9 +26,9 @@ use crate::{
 use codec::{Decode, Encode, EncodeLike, MaxEncodedLen};
 use core::{
 	ops::{Deref, Index, IndexMut},
-	slice::SliceIndex,
+	slice::{IterMut, SliceIndex},
 };
-use sp_std::{marker::PhantomData, prelude::*};
+use sp_std::{marker::PhantomData, ops::RangeBounds, prelude::*, vec::Drain};
 
 /// A bounded vector.
 ///
@@ -126,6 +126,24 @@ impl<T, S> BoundedVec<T, S> {
 	/// Panics if `index` is out of bounds.
 	pub fn remove(&mut self, index: usize) -> T {
 		self.0.remove(index)
+	}
+
+	/// Exactly the same semantics as [`Vec::drain`].
+	pub fn drain<R>(&mut self, range: R) -> Drain<'_, T>
+	where
+		R: RangeBounds<usize>,
+	{
+		self.0.drain(range)
+	}
+
+	/// Exactly the same semantics as the underlying [`[]::last_mut`].
+	pub fn last_mut(&mut self) -> Option<&mut T> {
+		self.0.last_mut()
+	}
+
+	/// Exactly the same semantics as [`[]::iter_mut`].
+	pub fn iter_mut(&mut self) -> IterMut<'_, T> {
+		self.0.iter_mut()
 	}
 
 	/// Exactly the same semantics as [`Vec::swap_remove`].


### PR DESCRIPTION
Part of #9864, one little step at a time at making pallet-staking "bounded".

Fixes part of #8629.

# Summary of changes below:

* Fixed error in URL link.
* Moving `MAX_UNLOCKING_CHUNKS` from being a constant to becoming a runtime parameter `MaxUnlockingChunks`.
* Bounding `StakingLedger`.
* Adding some utilities to `BoundedVec`.


Polkadot companion: paritytech/polkadot#4811

@kianenigma 


