### PR TITLE
bench-cli: Support `JSON` output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9063,9 +9063,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
 dependencies = [
  "serde_derive",
 ]
@@ -9091,9 +9091,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9102,9 +9102,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
  "itoa 1.0.1",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,6 +2038,7 @@ dependencies = [
  "parity-scale-codec",
  "paste 1.0.6",
  "scale-info",
+ "serde",
  "sp-api",
  "sp-application-crypto",
  "sp-io",
@@ -2066,6 +2067,7 @@ dependencies = [
  "sc-executor",
  "sc-service",
  "serde",
+ "serde_json",
  "sp-core",
  "sp-externalities",
  "sp-keystore",
@@ -9061,9 +9063,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -9089,9 +9091,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9100,9 +9102,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
  "itoa 1.0.1",
  "ryu",

--- a/frame/benchmarking/Cargo.toml
+++ b/frame/benchmarking/Cargo.toml
@@ -27,7 +27,7 @@ sp-storage = { version = "4.0.0", path = "../../primitives/storage", default-fea
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 log = { version = "0.4.14", default-features = false }
-serde = "1.0.132"
+serde = { version = "1.0.132", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3.4"
@@ -38,6 +38,7 @@ default = ["std"]
 std = [
 	"codec/std",
 	"scale-info/std",
+	"serde",
 	"sp-runtime-interface/std",
 	"sp-runtime/std",
 	"sp-api/std",

--- a/frame/benchmarking/Cargo.toml
+++ b/frame/benchmarking/Cargo.toml
@@ -27,6 +27,7 @@ sp-storage = { version = "4.0.0", path = "../../primitives/storage", default-fea
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 log = { version = "0.4.14", default-features = false }
+serde = "1.0.136"
 
 [dev-dependencies]
 hex-literal = "0.3.4"

--- a/frame/benchmarking/Cargo.toml
+++ b/frame/benchmarking/Cargo.toml
@@ -27,7 +27,7 @@ sp-storage = { version = "4.0.0", path = "../../primitives/storage", default-fea
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 log = { version = "0.4.14", default-features = false }
-serde = "1.0.136"
+serde = "1.0.132"
 
 [dev-dependencies]
 hex-literal = "0.3.4"

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -29,8 +29,8 @@ use sp_runtime::traits::TrailingZeroInput;
 use sp_std::{prelude::Box, vec::Vec};
 use sp_storage::TrackedStorageKey;
 
-#[cfg_attr(feature = "std", derive(Serialize))]
 /// An alphabet of possible parameters to use for benchmarking.
+#[cfg_attr(feature = "std", derive(Serialize))]
 #[derive(Encode, Decode, Clone, Copy, PartialEq, Debug)]
 #[allow(missing_docs)]
 #[allow(non_camel_case_types)]
@@ -70,8 +70,8 @@ impl std::fmt::Display for BenchmarkParameter {
 	}
 }
 
-#[cfg_attr(feature = "std", derive(Serialize))]
 /// The results of a single of benchmark.
+#[cfg_attr(feature = "std", derive(Serialize))]
 #[derive(Encode, Decode, Clone, PartialEq, Debug)]
 pub struct BenchmarkBatch {
 	/// The pallet containing this benchmark.
@@ -87,9 +87,9 @@ pub struct BenchmarkBatch {
 	pub results: Vec<BenchmarkResult>,
 }
 
-#[cfg_attr(feature = "std", derive(Serialize))]
 // TODO: could probably make API cleaner here.
 /// The results of a single of benchmark, where time and db results are separated.
+#[cfg_attr(feature = "std", derive(Serialize))]
 #[derive(Encode, Decode, Clone, PartialEq, Debug)]
 pub struct BenchmarkBatchSplitResults {
 	/// The pallet containing this benchmark.
@@ -107,10 +107,10 @@ pub struct BenchmarkBatchSplitResults {
 	pub db_results: Vec<BenchmarkResult>,
 }
 
-#[cfg_attr(feature = "std", derive(Serialize))]
 /// Result from running benchmarks on a FRAME pallet.
 /// Contains duration of the function call in nanoseconds along with the benchmark parameters
 /// used for that benchmark result.
+#[cfg_attr(feature = "std", derive(Serialize))]
 #[derive(Encode, Decode, Default, Clone, PartialEq, Debug)]
 pub struct BenchmarkResult {
 	pub components: Vec<(BenchmarkParameter, u32)>,
@@ -138,7 +138,8 @@ mod serde_as_str {
 	where
 		S: serde::Serializer,
 	{
-		serializer.collect_str(std::str::from_utf8(value).unwrap())
+		let s = std::str::from_utf8(value).map_err(serde::ser::Error::custom)?;
+		serializer.collect_str(s)
 	}
 }
 

--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -27,7 +27,8 @@ sp-state-machine = { version = "0.10.0", path = "../../../primitives/state-machi
 codec = { version = "2.0.0", package = "parity-scale-codec" }
 clap = { version = "3.0", features = ["derive"] }
 chrono = "0.4"
-serde = "1.0.132"
+serde = "1.0.136"
+serde_json = "1.0.78"
 handlebars = "4.1.6"
 Inflector = "0.11.4"
 linked-hash-map = "0.5.4"

--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -27,8 +27,8 @@ sp-state-machine = { version = "0.10.0", path = "../../../primitives/state-machi
 codec = { version = "2.0.0", package = "parity-scale-codec" }
 clap = { version = "3.0", features = ["derive"] }
 chrono = "0.4"
-serde = "1.0.136"
-serde_json = "1.0.78"
+serde = "1.0.132"
+serde_json = "1.0.74"
 handlebars = "4.1.6"
 Inflector = "0.11.4"
 linked-hash-map = "0.5.4"

--- a/utils/frame/benchmarking-cli/src/command.rs
+++ b/utils/frame/benchmarking-cli/src/command.rs
@@ -35,7 +35,7 @@ use sp_externalities::Extensions;
 use sp_keystore::{testing::KeyStore, KeystoreExt, SyncCryptoStorePtr};
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 use sp_state_machine::StateMachine;
-use std::{fmt::Debug, fs::File, io::prelude::*, sync::Arc, time};
+use std::{fmt::Debug, fs, sync::Arc, time};
 
 // This takes multiple benchmark batches and combines all the results where the pallet, instance,
 // and benchmark are the same.
@@ -379,8 +379,7 @@ impl BenchmarkCmd {
 				.map_err(|e| format!("Serializing into JSON: {:?}", e))?;
 
 			if let Some(path) = &self.json_file {
-				let mut fd = File::create(path)?;
-				fd.write_all(&json.into_bytes())?;
+				fs::write(path, &json.into_bytes())?;
 			} else {
 				println!("{}", json);
 				return Ok(true)

--- a/utils/frame/benchmarking-cli/src/command.rs
+++ b/utils/frame/benchmarking-cli/src/command.rs
@@ -35,7 +35,7 @@ use sp_externalities::Extensions;
 use sp_keystore::{testing::KeyStore, KeystoreExt, SyncCryptoStorePtr};
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 use sp_state_machine::StateMachine;
-use std::{fmt::Debug, sync::Arc, time};
+use std::{fmt::Debug, fs::File, io::prelude::*, sync::Arc, time};
 
 // This takes multiple benchmark batches and combines all the results where the pallet, instance,
 // and benchmark are the same.
@@ -357,53 +357,60 @@ impl BenchmarkCmd {
 		// are together.
 		let batches: Vec<BenchmarkBatchSplitResults> = combine_batches(batches, batches_db);
 
+		// Create the weights.rs file.
 		if let Some(output_path) = &self.output {
 			crate::writer::write_results(&batches, &storage_info, output_path, self)?;
 		}
 
+		// Jsonify the result and write it to a file or stdout if desired.
+		if !self.jsonify(&batches)? {
+			// Print the summary only if `jsonify` did not write to stdout.
+			self.print_summary(&batches, &storage_info)
+		}
+		Ok(())
+	}
+
+	/// Jsonifies the passed batches and writes them to stdout or into a file.
+	/// Can be configured via `--json` and `--json-file`.
+	/// Returns whether it wrote to stdout.
+	fn jsonify(&self, batches: &Vec<BenchmarkBatchSplitResults>) -> Result<bool> {
+		if self.json_output || self.json_file.is_some() {
+			let json = serde_json::to_string_pretty(&batches)
+				.map_err(|e| format!("Serializing into JSON: {:?}", e))?;
+
+			if let Some(path) = &self.json_file {
+				let mut fd = File::create(path)?;
+				fd.write_all(&json.into_bytes())?;
+			} else {
+				println!("{}", json);
+				return Ok(true)
+			}
+		}
+
+		Ok(false)
+	}
+
+	/// Prints the results as human-readable summary without raw timing data.
+	fn print_summary(
+		&self,
+		batches: &Vec<BenchmarkBatchSplitResults>,
+		storage_info: &Vec<StorageInfo>,
+	) {
 		for batch in batches.into_iter() {
 			// Print benchmark metadata
 			println!(
-				"Pallet: {:?}, Extrinsic: {:?}, Lowest values: {:?}, Highest values: {:?}, Steps: {:?}, Repeat: {:?}",
-				String::from_utf8(batch.pallet).expect("Encoded from String; qed"),
-				String::from_utf8(batch.benchmark).expect("Encoded from String; qed"),
-				self.lowest_range_values,
-				self.highest_range_values,
-				self.steps,
-				self.repeat,
-			);
+					"Pallet: {:?}, Extrinsic: {:?}, Lowest values: {:?}, Highest values: {:?}, Steps: {:?}, Repeat: {:?}",
+					String::from_utf8(batch.pallet.clone()).expect("Encoded from String; qed"),
+					String::from_utf8(batch.benchmark.clone()).expect("Encoded from String; qed"),
+					self.lowest_range_values,
+					self.highest_range_values,
+					self.steps,
+					self.repeat,
+				);
 
 			// Skip raw data + analysis if there are no results
 			if batch.time_results.is_empty() {
 				continue
-			}
-
-			if self.raw_data {
-				// Print the table header
-				batch.time_results[0]
-					.components
-					.iter()
-					.for_each(|param| print!("{:?},", param.0));
-
-				print!("extrinsic_time_ns,storage_root_time_ns,reads,repeat_reads,writes,repeat_writes,proof_size_bytes\n");
-				// Print the values
-				batch.time_results.iter().for_each(|result| {
-					let parameters = &result.components;
-					parameters.iter().for_each(|param| print!("{:?},", param.1));
-					// Print extrinsic time and storage root time
-					print!(
-						"{:?},{:?},{:?},{:?},{:?},{:?},{:?}\n",
-						result.extrinsic_time,
-						result.storage_root_time,
-						result.reads,
-						result.repeat_reads,
-						result.writes,
-						result.repeat_writes,
-						result.proof_size,
-					);
-				});
-
-				println!();
 			}
 
 			if !self.no_storage_info {
@@ -460,8 +467,6 @@ impl BenchmarkCmd {
 				println!("");
 			}
 		}
-
-		Ok(())
 	}
 }
 

--- a/utils/frame/benchmarking-cli/src/command.rs
+++ b/utils/frame/benchmarking-cli/src/command.rs
@@ -379,7 +379,7 @@ impl BenchmarkCmd {
 				.map_err(|e| format!("Serializing into JSON: {:?}", e))?;
 
 			if let Some(path) = &self.json_file {
-				fs::write(path, &json.into_bytes())?;
+				fs::write(path, json)?;
 			} else {
 				println!("{}", json);
 				return Ok(true)

--- a/utils/frame/benchmarking-cli/src/lib.rs
+++ b/utils/frame/benchmarking-cli/src/lib.rs
@@ -61,11 +61,11 @@ pub struct BenchmarkCmd {
 	pub external_repeat: u32,
 
 	/// Print the raw results in JSON format.
-	#[structopt(long = "json")]
+	#[clap(long = "json")]
 	pub json_output: bool,
 
-	/// Print the raw results in JSON format. Implies `--json`.
-	#[structopt(long = "json-file", parse(from_os_str))]
+	/// Write the raw results in JSON format into the give file.
+	#[clap(long, conflicts_with = "json-output")]
 	pub json_file: Option<PathBuf>,
 
 	/// Don't print the median-slopes linear regression analysis.
@@ -78,15 +78,15 @@ pub struct BenchmarkCmd {
 
 	/// Output the benchmarks to a Rust file at the given path.
 	#[clap(long)]
-	pub output: Option<std::path::PathBuf>,
+	pub output: Option<PathBuf>,
 
 	/// Add a header file to your outputted benchmarks
 	#[clap(long)]
-	pub header: Option<std::path::PathBuf>,
+	pub header: Option<PathBuf>,
 
 	/// Path to Handlebars template file used for outputting benchmark results. (Optional)
 	#[clap(long)]
-	pub template: Option<std::path::PathBuf>,
+	pub template: Option<PathBuf>,
 
 	/// Which analysis function to use when outputting benchmarks:
 	/// * min-squares (default)

--- a/utils/frame/benchmarking-cli/src/lib.rs
+++ b/utils/frame/benchmarking-cli/src/lib.rs
@@ -19,7 +19,7 @@ mod command;
 mod writer;
 
 use sc_cli::{ExecutionStrategy, WasmExecutionMethod};
-use std::fmt::Debug;
+use std::{fmt::Debug, path::PathBuf};
 
 // Add a more relaxed parsing for pallet names by allowing pallet directory names with `-` to be
 // used like crate names with `_`
@@ -60,9 +60,13 @@ pub struct BenchmarkCmd {
 	#[clap(long, default_value = "1")]
 	pub external_repeat: u32,
 
-	/// Print the raw results.
-	#[clap(long = "raw")]
-	pub raw_data: bool,
+	/// Print the raw results in JSON format.
+	#[structopt(long = "json")]
+	pub json_output: bool,
+
+	/// Print the raw results in JSON format. Implies `--json`.
+	#[structopt(long = "json-file", parse(from_os_str))]
+	pub json_file: Option<PathBuf>,
 
 	/// Don't print the median-slopes linear regression analysis.
 	#[clap(long)]


### PR DESCRIPTION
The current output of the benchmarking-cli uses a mix of human-readable text and csv.  
This MR updates it JSON to make it machine readable. Maybe needs the "breaking change" label, not sure.

- Add `--json` to the benchmarking-cli: Print the raw data as json to stdout
- Add `--json-file=path`: Write the raw data into a json file
- Remove the `--raw` option

Example [balances.json.txt](https://github.com/paritytech/substrate/files/7985847/balances.json.txt)
 