### PR TITLE
make inner field of pallet_identity::IdentityFields pub

### DIFF
--- a/frame/identity/src/types.rs
+++ b/frame/identity/src/types.rs
@@ -245,7 +245,7 @@ pub enum IdentityField {
 
 /// Wrapper type for `BitFlags<IdentityField>` that implements `Codec`.
 #[derive(Clone, Copy, PartialEq, Default, RuntimeDebug)]
-pub struct IdentityFields(pub(crate) BitFlags<IdentityField>);
+pub struct IdentityFields(pub BitFlags<IdentityField>);
 
 impl MaxEncodedLen for IdentityFields {
 	fn max_encoded_len() -> usize {


### PR DESCRIPTION
In `pallet_identity`, `IdentityFields` is a wrapper around `BitFlags` that implement `Codec`. However, the inner field is `pub(crate)`, which prevents (de)constructing it, which is changed to `pub` in this PR.