### PR TITLE
Make some UI test expectations crisper

### DIFF
--- a/frame/support/test/tests/construct_runtime_ui/no_std_genesis_config.rs
+++ b/frame/support/test/tests/construct_runtime_ui/no_std_genesis_config.rs
@@ -3,12 +3,39 @@ use sp_runtime::{generic, traits::BlakeTwo256};
 use sp_core::sr25519;
 
 pub type Signature = sr25519::Signature;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, ()>;
 
 impl test_pallet::Config for Runtime {}
+
+impl frame_system::Config for Runtime {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type Origin = Origin;
+	type Index = u64;
+	type BlockNumber = u32;
+	type Call = Call;
+	type Hash = sp_runtime::testing::H256;
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = sp_runtime::traits::IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = frame_support::traits::ConstU32<250>;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
 
 construct_runtime! {
 	pub enum Runtime where
@@ -16,7 +43,7 @@ construct_runtime! {
 		NodeBlock = Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
-		System: system::{Pallet, Call, Storage, Config, Event<T>},
+		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: test_pallet::{Pallet, Config},
 	}
 }

--- a/frame/support/test/tests/construct_runtime_ui/no_std_genesis_config.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/no_std_genesis_config.stderr
@@ -1,73 +1,27 @@
 error: `Pallet` does not have the std feature enabled, this will cause the `test_pallet::GenesisConfig` type to be undefined.
-  --> $DIR/no_std_genesis_config.rs:13:1
+  --> tests/construct_runtime_ui/no_std_genesis_config.rs:40:1
    |
-13 | / construct_runtime! {
-14 | |     pub enum Runtime where
-15 | |         Block = Block,
-16 | |         NodeBlock = Block,
+40 | / construct_runtime! {
+41 | |     pub enum Runtime where
+42 | |         Block = Block,
+43 | |         NodeBlock = Block,
 ...  |
-21 | |     }
-22 | | }
+48 | |     }
+49 | | }
    | |_^
    |
    = note: this error originates in the macro `test_pallet::__substrate_genesis_config_check::is_std_enabled_for_genesis` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/no_std_genesis_config.rs:19:11
-   |
-19 |         System: system::{Pallet, Call, Storage, Config, Event<T>},
-   |                 ^^^^^^ use of undeclared crate or module `system`
-
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/no_std_genesis_config.rs:13:1
-   |
-13 | / construct_runtime! {
-14 | |     pub enum Runtime where
-15 | |         Block = Block,
-16 | |         NodeBlock = Block,
-...  |
-21 | |     }
-22 | | }
-   | |_^ not found in `system`
-   |
-   = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing this enum
-   |
-1  | use frame_system::RawOrigin;
-   |
-
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/no_std_genesis_config.rs:13:1
-   |
-13 | / construct_runtime! {
-14 | |     pub enum Runtime where
-15 | |         Block = Block,
-16 | |         NodeBlock = Block,
-...  |
-21 | |     }
-22 | | }
-   | |_^ not found in `system`
-   |
-   = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing one of these items
-   |
-1  | use frame_support_test::Pallet;
-   |
-1  | use frame_system::Pallet;
-   |
-1  | use test_pallet::Pallet;
-   |
-
 error[E0412]: cannot find type `GenesisConfig` in crate `test_pallet`
-  --> $DIR/no_std_genesis_config.rs:13:1
+  --> tests/construct_runtime_ui/no_std_genesis_config.rs:40:1
    |
-13 | / construct_runtime! {
-14 | |     pub enum Runtime where
-15 | |         Block = Block,
-16 | |         NodeBlock = Block,
+40 | / construct_runtime! {
+41 | |     pub enum Runtime where
+42 | |         Block = Block,
+43 | |         NodeBlock = Block,
 ...  |
-21 | |     }
-22 | | }
+48 | |     }
+49 | | }
    | |_^ not found in `test_pallet`
    |
    = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -76,14 +30,17 @@ help: consider importing this struct
 1  | use frame_system::GenesisConfig;
    |
 
-error[E0277]: the trait bound `Runtime: frame_system::pallet::Config` is not satisfied
-  --> $DIR/no_std_genesis_config.rs:11:6
+error[E0283]: type annotations needed
+  --> tests/construct_runtime_ui/no_std_genesis_config.rs:40:1
    |
-11 | impl test_pallet::Config for Runtime {}
-   |      ^^^^^^^^^^^^^^^^^^^ the trait `frame_system::pallet::Config` is not implemented for `Runtime`
+40 | / construct_runtime! {
+41 | |     pub enum Runtime where
+42 | |         Block = Block,
+43 | |         NodeBlock = Block,
+...  |
+48 | |     }
+49 | | }
+   | |_^ cannot infer type
    |
-note: required by a bound in `Config`
-  --> $DIR/lib.rs:30:20
-   |
-30 |     pub trait Config: frame_system::Config {}
-   |                       ^^^^^^^^^^^^^^^^^^^^ required by this bound in `Config`
+   = note: cannot satisfy `_: std::default::Default`
+   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/frame/support/test/tests/construct_runtime_ui/undefined_call_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_call_part.rs
@@ -12,12 +12,39 @@ mod pallet {
 }
 
 pub type Signature = sr25519::Signature;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, ()>;
 
 impl pallet::Config for Runtime {}
+
+impl frame_system::Config for Runtime {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type Origin = Origin;
+	type Index = u64;
+	type BlockNumber = u32;
+	type Call = Call;
+	type Hash = sp_runtime::testing::H256;
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = sp_runtime::traits::IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = frame_support::traits::ConstU32<250>;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
 
 construct_runtime! {
 	pub enum Runtime where
@@ -25,7 +52,7 @@ construct_runtime! {
 		NodeBlock = Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
-		System: system::{Pallet, Call, Storage, Config, Event<T>},
+		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: pallet::{Pallet, Call},
 	}
 }

--- a/frame/support/test/tests/construct_runtime_ui/undefined_call_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_call_part.stderr
@@ -1,76 +1,16 @@
 error: `Pallet` does not have #[pallet::call] defined, perhaps you should remove `Call` from construct_runtime?
-  --> $DIR/undefined_call_part.rs:5:1
+  --> tests/construct_runtime_ui/undefined_call_part.rs:5:1
    |
 5  |   #[frame_support::pallet]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
 ...  |
-30 | |     }
-31 | | }
+57 | |     }
+58 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `pallet::__substrate_call_check::is_call_part_defined` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_call_part.rs:28:11
-   |
-28 |         System: system::{Pallet, Call, Storage, Config, Event<T>},
-   |                 ^^^^^^ use of undeclared crate or module `system`
-
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_call_part.rs:22:1
-   |
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
-...  |
-30 | |     }
-31 | | }
-   | |_^ not found in `system`
-   |
-   = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing this enum
-   |
-1  | use frame_system::RawOrigin;
-   |
-
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_call_part.rs:22:1
-   |
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
-...  |
-30 | |     }
-31 | | }
-   | |_^ not found in `system`
-   |
-   = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing one of these items
-   |
-1  | use crate::pallet::Pallet;
-   |
-1  | use frame_support_test::Pallet;
-   |
-1  | use frame_system::Pallet;
-   |
-1  | use test_pallet::Pallet;
-   |
-
-error[E0277]: the trait bound `Runtime: frame_system::Config` is not satisfied
-  --> $DIR/undefined_call_part.rs:20:6
-   |
-20 | impl pallet::Config for Runtime {}
-   |      ^^^^^^^^^^^^^^ the trait `frame_system::Config` is not implemented for `Runtime`
-   |
-note: required by a bound in `pallet::Config`
-  --> $DIR/undefined_call_part.rs:8:20
-   |
-8  |     pub trait Config: frame_system::Config {}
-   |                       ^^^^^^^^^^^^^^^^^^^^ required by this bound in `pallet::Config`

--- a/frame/support/test/tests/construct_runtime_ui/undefined_event_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_event_part.rs
@@ -12,12 +12,39 @@ mod pallet {
 }
 
 pub type Signature = sr25519::Signature;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, ()>;
 
 impl pallet::Config for Runtime {}
+
+impl frame_system::Config for Runtime {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type Origin = Origin;
+	type Index = u64;
+	type BlockNumber = u32;
+	type Call = Call;
+	type Hash = sp_runtime::testing::H256;
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = sp_runtime::traits::IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = frame_support::traits::ConstU32<250>;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
 
 construct_runtime! {
 	pub enum Runtime where
@@ -25,7 +52,7 @@ construct_runtime! {
 		NodeBlock = Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
-		System: system::{Pallet, Call, Storage, Config, Event<T>},
+		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: pallet::{Pallet, Event},
 	}
 }

--- a/frame/support/test/tests/construct_runtime_ui/undefined_event_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_event_part.stderr
@@ -1,36 +1,30 @@
 error: `Pallet` does not have #[pallet::event] defined, perhaps you should remove `Event` from construct_runtime?
-  --> $DIR/undefined_event_part.rs:5:1
+  --> tests/construct_runtime_ui/undefined_event_part.rs:5:1
    |
 5  |   #[frame_support::pallet]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
 ...  |
-30 | |     }
-31 | | }
+57 | |     }
+58 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `pallet::__substrate_event_check::is_event_part_defined` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_event_part.rs:28:11
-   |
-28 |         System: system::{Pallet, Call, Storage, Config, Event<T>},
-   |                 ^^^^^^ use of undeclared crate or module `system`
-
 error[E0412]: cannot find type `Event` in module `pallet`
-  --> $DIR/undefined_event_part.rs:22:1
+  --> tests/construct_runtime_ui/undefined_event_part.rs:49:1
    |
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
 ...  |
-30 | |     }
-31 | | }
+57 | |     }
+58 | | }
    | |_^ not found in `pallet`
    |
    = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -40,15 +34,15 @@ help: consider importing this enum
    |
 
 error[E0412]: cannot find type `Event` in module `pallet`
-  --> $DIR/undefined_event_part.rs:22:1
+  --> tests/construct_runtime_ui/undefined_event_part.rs:49:1
    |
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
 ...  |
-30 | |     }
-31 | | }
+57 | |     }
+58 | | }
    | |_^ not found in `pallet`
    |
    = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -58,57 +52,3 @@ help: consider importing one of these items
    |
 1  | use frame_system::Event;
    |
-
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_event_part.rs:22:1
-   |
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
-...  |
-30 | |     }
-31 | | }
-   | |_^ not found in `system`
-   |
-   = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing this enum
-   |
-1  | use frame_system::RawOrigin;
-   |
-
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_event_part.rs:22:1
-   |
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
-...  |
-30 | |     }
-31 | | }
-   | |_^ not found in `system`
-   |
-   = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing one of these items
-   |
-1  | use crate::pallet::Pallet;
-   |
-1  | use frame_support_test::Pallet;
-   |
-1  | use frame_system::Pallet;
-   |
-1  | use test_pallet::Pallet;
-   |
-
-error[E0277]: the trait bound `Runtime: frame_system::Config` is not satisfied
-  --> $DIR/undefined_event_part.rs:20:6
-   |
-20 | impl pallet::Config for Runtime {}
-   |      ^^^^^^^^^^^^^^ the trait `frame_system::Config` is not implemented for `Runtime`
-   |
-note: required by a bound in `pallet::Config`
-  --> $DIR/undefined_event_part.rs:8:20
-   |
-8  |     pub trait Config: frame_system::Config {}
-   |                       ^^^^^^^^^^^^^^^^^^^^ required by this bound in `pallet::Config`

--- a/frame/support/test/tests/construct_runtime_ui/undefined_genesis_config_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_genesis_config_part.rs
@@ -12,12 +12,39 @@ mod pallet {
 }
 
 pub type Signature = sr25519::Signature;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, ()>;
 
 impl pallet::Config for Runtime {}
+
+impl frame_system::Config for Runtime {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type Origin = Origin;
+	type Index = u64;
+	type BlockNumber = u32;
+	type Call = Call;
+	type Hash = sp_runtime::testing::H256;
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = sp_runtime::traits::IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = frame_support::traits::ConstU32<250>;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
 
 construct_runtime! {
 	pub enum Runtime where
@@ -25,7 +52,7 @@ construct_runtime! {
 		NodeBlock = Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
-        System: system::{Pallet, Call, Storage, Config, Event<T>},
+        System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: pallet::{Pallet, Config},
 	}
 }

--- a/frame/support/test/tests/construct_runtime_ui/undefined_genesis_config_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_genesis_config_part.stderr
@@ -1,78 +1,30 @@
 error: `Pallet` does not have #[pallet::genesis_config] defined, perhaps you should remove `Config` from construct_runtime?
-  --> $DIR/undefined_genesis_config_part.rs:5:1
+  --> tests/construct_runtime_ui/undefined_genesis_config_part.rs:5:1
    |
 5  |   #[frame_support::pallet]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
 ...  |
-30 | |     }
-31 | | }
+57 | |     }
+58 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `pallet::__substrate_genesis_config_check::is_genesis_config_defined` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_genesis_config_part.rs:28:17
-   |
-28 |         System: system::{Pallet, Call, Storage, Config, Event<T>},
-   |                 ^^^^^^ use of undeclared crate or module `system`
-
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_genesis_config_part.rs:22:1
-   |
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
-...  |
-30 | |     }
-31 | | }
-   | |_^ not found in `system`
-   |
-   = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing this enum
-   |
-1  | use frame_system::RawOrigin;
-   |
-
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_genesis_config_part.rs:22:1
-   |
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
-...  |
-30 | |     }
-31 | | }
-   | |_^ not found in `system`
-   |
-   = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing one of these items
-   |
-1  | use crate::pallet::Pallet;
-   |
-1  | use frame_support_test::Pallet;
-   |
-1  | use frame_system::Pallet;
-   |
-1  | use test_pallet::Pallet;
-   |
-
 error[E0412]: cannot find type `GenesisConfig` in module `pallet`
-  --> $DIR/undefined_genesis_config_part.rs:22:1
+  --> tests/construct_runtime_ui/undefined_genesis_config_part.rs:49:1
    |
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
 ...  |
-30 | |     }
-31 | | }
+57 | |     }
+58 | | }
    | |_^ not found in `pallet`
    |
    = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -81,14 +33,17 @@ help: consider importing this struct
 1  | use frame_system::GenesisConfig;
    |
 
-error[E0277]: the trait bound `Runtime: frame_system::Config` is not satisfied
-  --> $DIR/undefined_genesis_config_part.rs:20:6
+error[E0283]: type annotations needed
+  --> tests/construct_runtime_ui/undefined_genesis_config_part.rs:49:1
    |
-20 | impl pallet::Config for Runtime {}
-   |      ^^^^^^^^^^^^^^ the trait `frame_system::Config` is not implemented for `Runtime`
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
+...  |
+57 | |     }
+58 | | }
+   | |_^ cannot infer type
    |
-note: required by a bound in `pallet::Config`
-  --> $DIR/undefined_genesis_config_part.rs:8:20
-   |
-8  |     pub trait Config: frame_system::Config {}
-   |                       ^^^^^^^^^^^^^^^^^^^^ required by this bound in `pallet::Config`
+   = note: cannot satisfy `_: std::default::Default`
+   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/frame/support/test/tests/construct_runtime_ui/undefined_inherent_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_inherent_part.rs
@@ -12,12 +12,39 @@ mod pallet {
 }
 
 pub type Signature = sr25519::Signature;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, ()>;
 
 impl pallet::Config for Runtime {}
+
+impl frame_system::Config for Runtime {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type Origin = Origin;
+	type Index = u64;
+	type BlockNumber = u32;
+	type Call = Call;
+	type Hash = sp_runtime::testing::H256;
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = sp_runtime::traits::IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = frame_support::traits::ConstU32<250>;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
 
 construct_runtime! {
 	pub enum Runtime where
@@ -25,7 +52,7 @@ construct_runtime! {
 		NodeBlock = Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
-		System: system::{Pallet, Call, Storage, Config, Event<T>},
+		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: pallet::{Pallet, Inherent},
 	}
 }

--- a/frame/support/test/tests/construct_runtime_ui/undefined_inherent_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_inherent_part.stderr
@@ -1,76 +1,116 @@
 error: `Pallet` does not have #[pallet::inherent] defined, perhaps you should remove `Inherent` from construct_runtime?
-  --> $DIR/undefined_inherent_part.rs:5:1
+  --> tests/construct_runtime_ui/undefined_inherent_part.rs:5:1
    |
 5  |   #[frame_support::pallet]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
 ...  |
-30 | |     }
-31 | | }
+57 | |     }
+58 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `pallet::__substrate_inherent_check::is_inherent_part_defined` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_inherent_part.rs:28:11
+error[E0599]: no function or associated item named `create_inherent` found for struct `pallet::Pallet` in the current scope
+  --> tests/construct_runtime_ui/undefined_inherent_part.rs:49:1
    |
-28 |         System: system::{Pallet, Call, Storage, Config, Event<T>},
-   |                 ^^^^^^ use of undeclared crate or module `system`
-
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_inherent_part.rs:22:1
-   |
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
+11 |       pub struct Pallet<T>(_);
+   |       ------------------------ function or associated item `create_inherent` not found for this
+...
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
 ...  |
-30 | |     }
-31 | | }
-   | |_^ not found in `system`
+57 | |     }
+58 | | }
+   | |_^ function or associated item not found in `pallet::Pallet<Runtime>`
    |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `create_inherent`, perhaps you need to implement it:
+           candidate #1: `ProvideInherent`
    = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing this enum
-   |
-1  | use frame_system::RawOrigin;
-   |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_inherent_part.rs:22:1
+error[E0599]: no function or associated item named `is_inherent` found for struct `pallet::Pallet` in the current scope
+  --> tests/construct_runtime_ui/undefined_inherent_part.rs:49:1
    |
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
+11 |       pub struct Pallet<T>(_);
+   |       ------------------------ function or associated item `is_inherent` not found for this
+...
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
 ...  |
-30 | |     }
-31 | | }
-   | |_^ not found in `system`
+57 | |     }
+58 | | }
+   | |_^ function or associated item not found in `pallet::Pallet<Runtime>`
    |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `is_inherent`, perhaps you need to implement it:
+           candidate #1: `ProvideInherent`
    = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing one of these items
-   |
-1  | use crate::pallet::Pallet;
-   |
-1  | use frame_support_test::Pallet;
-   |
-1  | use frame_system::Pallet;
-   |
-1  | use test_pallet::Pallet;
-   |
 
-error[E0277]: the trait bound `Runtime: frame_system::Config` is not satisfied
-  --> $DIR/undefined_inherent_part.rs:20:6
+error[E0599]: no function or associated item named `check_inherent` found for struct `pallet::Pallet` in the current scope
+  --> tests/construct_runtime_ui/undefined_inherent_part.rs:49:1
    |
-20 | impl pallet::Config for Runtime {}
-   |      ^^^^^^^^^^^^^^ the trait `frame_system::Config` is not implemented for `Runtime`
+11 |       pub struct Pallet<T>(_);
+   |       ------------------------ function or associated item `check_inherent` not found for this
+...
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
+...  |
+57 | |     }
+58 | | }
+   | |_^ function or associated item not found in `pallet::Pallet<Runtime>`
    |
-note: required by a bound in `pallet::Config`
-  --> $DIR/undefined_inherent_part.rs:8:20
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `check_inherent`, perhaps you need to implement it:
+           candidate #1: `ProvideInherent`
+   = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0599]: no associated item named `INHERENT_IDENTIFIER` found for struct `pallet::Pallet` in the current scope
+  --> tests/construct_runtime_ui/undefined_inherent_part.rs:49:1
    |
-8  |     pub trait Config: frame_system::Config {}
-   |                       ^^^^^^^^^^^^^^^^^^^^ required by this bound in `pallet::Config`
+11 |       pub struct Pallet<T>(_);
+   |       ------------------------ associated item `INHERENT_IDENTIFIER` not found for this
+...
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
+...  |
+57 | |     }
+58 | | }
+   | |_^ associated item not found in `pallet::Pallet<Runtime>`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `INHERENT_IDENTIFIER`, perhaps you need to implement it:
+           candidate #1: `ProvideInherent`
+   = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0599]: no function or associated item named `is_inherent_required` found for struct `pallet::Pallet` in the current scope
+  --> tests/construct_runtime_ui/undefined_inherent_part.rs:49:1
+   |
+11 |       pub struct Pallet<T>(_);
+   |       ------------------------ function or associated item `is_inherent_required` not found for this
+...
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
+...  |
+57 | |     }
+58 | | }
+   | |_^ function or associated item not found in `pallet::Pallet<Runtime>`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `is_inherent_required`, perhaps you need to implement it:
+           candidate #1: `ProvideInherent`
+   = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/frame/support/test/tests/construct_runtime_ui/undefined_origin_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_origin_part.rs
@@ -12,12 +12,39 @@ mod pallet {
 }
 
 pub type Signature = sr25519::Signature;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, ()>;
 
 impl pallet::Config for Runtime {}
+
+impl frame_system::Config for Runtime {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type Origin = Origin;
+	type Index = u64;
+	type BlockNumber = u32;
+	type Call = Call;
+	type Hash = sp_runtime::testing::H256;
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = sp_runtime::traits::IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = frame_support::traits::ConstU32<250>;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
 
 construct_runtime! {
 	pub enum Runtime where
@@ -25,7 +52,7 @@ construct_runtime! {
 		NodeBlock = Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
-		System: system::{Pallet, Call, Storage, Config, Event<T>},
+		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: pallet::{Pallet, Origin},
 	}
 }

--- a/frame/support/test/tests/construct_runtime_ui/undefined_origin_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_origin_part.stderr
@@ -1,54 +1,30 @@
 error: `Pallet` does not have #[pallet::origin] defined, perhaps you should remove `Origin` from construct_runtime?
-  --> $DIR/undefined_origin_part.rs:5:1
+  --> tests/construct_runtime_ui/undefined_origin_part.rs:5:1
    |
 5  |   #[frame_support::pallet]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
 ...  |
-30 | |     }
-31 | | }
+57 | |     }
+58 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `pallet::__substrate_origin_check::is_origin_part_defined` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_origin_part.rs:28:11
-   |
-28 |         System: system::{Pallet, Call, Storage, Config, Event<T>},
-   |                 ^^^^^^ use of undeclared crate or module `system`
-
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_origin_part.rs:22:1
-   |
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
-...  |
-30 | |     }
-31 | | }
-   | |_^ not found in `system`
-   |
-   = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing this enum
-   |
-1  | use frame_system::RawOrigin;
-   |
-
 error[E0412]: cannot find type `Origin` in module `pallet`
-  --> $DIR/undefined_origin_part.rs:22:1
+  --> tests/construct_runtime_ui/undefined_origin_part.rs:49:1
    |
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
 ...  |
-30 | |     }
-31 | | }
+57 | |     }
+58 | | }
    | |_^ not found in `pallet`
    |
    = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -58,15 +34,15 @@ help: consider importing this type alias
    |
 
 error[E0412]: cannot find type `Origin` in module `pallet`
-  --> $DIR/undefined_origin_part.rs:22:1
+  --> tests/construct_runtime_ui/undefined_origin_part.rs:49:1
    |
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
 ...  |
-30 | |     }
-31 | | }
+57 | |     }
+58 | | }
    | |_^ not found in `pallet`
    |
    = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -77,38 +53,16 @@ help: consider importing one of these items
 1  | use frame_system::Origin;
    |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_origin_part.rs:22:1
+error[E0282]: type annotations needed
+  --> tests/construct_runtime_ui/undefined_origin_part.rs:49:1
    |
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
 ...  |
-30 | |     }
-31 | | }
-   | |_^ not found in `system`
+57 | |     }
+58 | | }
+   | |_^ cannot infer type for type parameter `AccountId` declared on the enum `RawOrigin`
    |
    = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing one of these items
-   |
-1  | use crate::pallet::Pallet;
-   |
-1  | use frame_support_test::Pallet;
-   |
-1  | use frame_system::Pallet;
-   |
-1  | use test_pallet::Pallet;
-   |
-
-error[E0277]: the trait bound `Runtime: frame_system::Config` is not satisfied
-  --> $DIR/undefined_origin_part.rs:20:6
-   |
-20 | impl pallet::Config for Runtime {}
-   |      ^^^^^^^^^^^^^^ the trait `frame_system::Config` is not implemented for `Runtime`
-   |
-note: required by a bound in `pallet::Config`
-  --> $DIR/undefined_origin_part.rs:8:20
-   |
-8  |     pub trait Config: frame_system::Config {}
-   |                       ^^^^^^^^^^^^^^^^^^^^ required by this bound in `pallet::Config`

--- a/frame/support/test/tests/construct_runtime_ui/undefined_validate_unsigned_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_validate_unsigned_part.rs
@@ -12,12 +12,39 @@ mod pallet {
 }
 
 pub type Signature = sr25519::Signature;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, ()>;
 
 impl pallet::Config for Runtime {}
+
+impl frame_system::Config for Runtime {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type Origin = Origin;
+	type Index = u64;
+	type BlockNumber = u32;
+	type Call = Call;
+	type Hash = sp_runtime::testing::H256;
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = sp_runtime::traits::IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = frame_support::traits::ConstU32<250>;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
 
 construct_runtime! {
 	pub enum Runtime where
@@ -25,7 +52,7 @@ construct_runtime! {
 		NodeBlock = Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
-		System: system::{Pallet, Call, Storage, Config, Event<T>},
+		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: pallet::{Pallet, ValidateUnsigned},
 	}
 }

--- a/frame/support/test/tests/construct_runtime_ui/undefined_validate_unsigned_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_validate_unsigned_part.stderr
@@ -1,76 +1,67 @@
 error: `Pallet` does not have #[pallet::validate_unsigned] defined, perhaps you should remove `ValidateUnsigned` from construct_runtime?
-  --> $DIR/undefined_validate_unsigned_part.rs:5:1
+  --> tests/construct_runtime_ui/undefined_validate_unsigned_part.rs:5:1
    |
 5  |   #[frame_support::pallet]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
 ...  |
-30 | |     }
-31 | | }
+57 | |     }
+58 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `pallet::__substrate_validate_unsigned_check::is_validate_unsigned_part_defined` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_validate_unsigned_part.rs:28:11
+error[E0599]: no variant or associated item named `Pallet` found for enum `Call` in the current scope
+  --> tests/construct_runtime_ui/undefined_validate_unsigned_part.rs:56:3
    |
-28 |         System: system::{Pallet, Call, Storage, Config, Event<T>},
-   |                 ^^^^^^ use of undeclared crate or module `system`
+49 | construct_runtime! {
+   | ------------------ variant or associated item `Pallet` not found here
+...
+56 |         Pallet: pallet::{Pallet, ValidateUnsigned},
+   |         ^^^^^^ variant or associated item not found in `Call`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_validate_unsigned_part.rs:22:1
+error[E0599]: no function or associated item named `pre_dispatch` found for struct `pallet::Pallet` in the current scope
+  --> tests/construct_runtime_ui/undefined_validate_unsigned_part.rs:49:1
    |
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
+11 |       pub struct Pallet<T>(_);
+   |       ------------------------ function or associated item `pre_dispatch` not found for this
+...
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
 ...  |
-30 | |     }
-31 | | }
-   | |_^ not found in `system`
+57 | |     }
+58 | | }
+   | |_^ function or associated item not found in `pallet::Pallet<Runtime>`
    |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following traits define an item `pre_dispatch`, perhaps you need to implement one of them:
+           candidate #1: `SignedExtension`
+           candidate #2: `ValidateUnsigned`
    = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing this enum
-   |
-1  | use frame_system::RawOrigin;
-   |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `system`
-  --> $DIR/undefined_validate_unsigned_part.rs:22:1
+error[E0599]: no function or associated item named `validate_unsigned` found for struct `pallet::Pallet` in the current scope
+  --> tests/construct_runtime_ui/undefined_validate_unsigned_part.rs:49:1
    |
-22 | / construct_runtime! {
-23 | |     pub enum Runtime where
-24 | |         Block = Block,
-25 | |         NodeBlock = Block,
+11 |       pub struct Pallet<T>(_);
+   |       ------------------------ function or associated item `validate_unsigned` not found for this
+...
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
 ...  |
-30 | |     }
-31 | | }
-   | |_^ not found in `system`
+57 | |     }
+58 | | }
+   | |_^ function or associated item not found in `pallet::Pallet<Runtime>`
    |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following traits define an item `validate_unsigned`, perhaps you need to implement one of them:
+           candidate #1: `SignedExtension`
+           candidate #2: `ValidateUnsigned`
    = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing one of these items
-   |
-1  | use crate::pallet::Pallet;
-   |
-1  | use frame_support_test::Pallet;
-   |
-1  | use frame_system::Pallet;
-   |
-1  | use test_pallet::Pallet;
-   |
-
-error[E0277]: the trait bound `Runtime: frame_system::Config` is not satisfied
-  --> $DIR/undefined_validate_unsigned_part.rs:20:6
-   |
-20 | impl pallet::Config for Runtime {}
-   |      ^^^^^^^^^^^^^^ the trait `frame_system::Config` is not implemented for `Runtime`
-   |
-note: required by a bound in `pallet::Config`
-  --> $DIR/undefined_validate_unsigned_part.rs:8:20
-   |
-8  |     pub trait Config: frame_system::Config {}
-   |                       ^^^^^^^^^^^^^^^^^^^^ required by this bound in `pallet::Config`


### PR DESCRIPTION
This  cleans up some construct runtiime UI test expectations, so that they contain a lot less extraneous error messages.