### PR TITLE
Bump sp-version to 5.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10123,7 +10123,7 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "4.0.0-dev"
+version = "5.0.0"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10139,7 +10139,7 @@ dependencies = [
 
 [[package]]
 name = "sp-version-proc-macro"
-version = "4.0.0-dev"
+version = "4.0.0"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10139,7 +10139,7 @@ dependencies = [
 
 [[package]]
 name = "sp-version-proc-macro"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -36,7 +36,7 @@ sp-runtime = { version = "5.0.0", default-features = false, path = "../../../pri
 sp-session = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/session" }
 sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-transaction-pool = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/transaction-pool" }
-sp-version = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/version" }
+sp-version = { version = "5.0.0", default-features = false, path = "../../../primitives/version" }
 
 # Used for the node template's RPCs
 frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, path = "../../../frame/system/rpc/runtime-api/" }

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -38,7 +38,7 @@ sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../..
 sp-keyring = { version = "5.0.0", optional = true, path = "../../../primitives/keyring" }
 sp-session = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/session" }
 sp-transaction-pool = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/transaction-pool" }
-sp-version = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/version" }
+sp-version = { version = "5.0.0", default-features = false, path = "../../../primitives/version" }
 sp-npos-elections = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/npos-elections" }
 sp-io = { version = "5.0.0", default-features = false, path = "../../../primitives/io" }
 sp-sandbox = { version = "0.10.0-dev", default-features = false, path = "../../../primitives/sandbox" }

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -44,7 +44,7 @@ sp-keyring = { version = "5.0.0", path = "../../primitives/keyring" }
 sp-keystore = { version = "0.11.0", path = "../../primitives/keystore" }
 sp-panic-handler = { version = "4.0.0", path = "../../primitives/panic-handler" }
 sp-runtime = { version = "5.0.0", path = "../../primitives/runtime" }
-sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
+sp-version = { version = "5.0.0", path = "../../primitives/version" }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -26,7 +26,7 @@ num-bigint = "0.2.3"
 num-rational = "0.2.2"
 num-traits = "0.2.8"
 serde = { version = "1.0.132", features = ["derive"] }
-sp-version = { version = "4.0.0-dev", path = "../../../primitives/version" }
+sp-version = { version = "5.0.0", path = "../../../primitives/version" }
 sp-io = { version = "5.0.0", path = "../../../primitives/io" }
 sp-inherents = { version = "4.0.0-dev", path = "../../../primitives/inherents" }
 sc-telemetry = { version = "4.0.0-dev", path = "../../telemetry" }

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -19,7 +19,7 @@ sp-io = { version = "5.0.0", path = "../../primitives/io" }
 sp-core = { version = "5.0.0", path = "../../primitives/core" }
 sp-tasks = { version = "4.0.0-dev", path = "../../primitives/tasks" }
 sp-trie = { version = "5.0.0", path = "../../primitives/trie" }
-sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
+sp-version = { version = "5.0.0", path = "../../primitives/version" }
 sp-panic-handler = { version = "4.0.0", path = "../../primitives/panic-handler" }
 wasmi = "0.9.1"
 lazy_static = "1.4.0"

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -24,7 +24,7 @@ parking_lot = "0.11.2"
 thiserror = "1.0"
 
 sp-core = { version = "5.0.0", path = "../../primitives/core" }
-sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
+sp-version = { version = "5.0.0", path = "../../primitives/version" }
 sp-runtime = { version = "5.0.0", path = "../../primitives/runtime" }
 sc-chain-spec = { path = "../chain-spec", version = "4.0.0-dev" }
 serde = { version = "1.0.132", features = ["derive"] }

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -22,7 +22,7 @@ jsonrpc-pubsub = "18.0.0"
 log = "0.4.8"
 sp-core = { version = "5.0.0", path = "../../primitives/core" }
 rpc = { package = "jsonrpc-core", version = "18.0.0" }
-sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
+sp-version = { version = "5.0.0", path = "../../primitives/version" }
 serde_json = "1.0.74"
 sp-session = { version = "4.0.0-dev", path = "../../primitives/session" }
 sp-offchain = { version = "4.0.0-dev", path = "../../primitives/offchain" }

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -40,7 +40,7 @@ sp-runtime = { version = "5.0.0", path = "../../primitives/runtime" }
 sp-trie = { version = "5.0.0", path = "../../primitives/trie" }
 sp-externalities = { version = "0.11.0", path = "../../primitives/externalities" }
 sc-utils = { version = "4.0.0-dev", path = "../utils" }
-sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
+sp-version = { version = "5.0.0", path = "../../primitives/version" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sp-core = { version = "5.0.0", path = "../../primitives/core" }
 sp-keystore = { version = "0.11.0", path = "../../primitives/keystore" }

--- a/frame/executive/Cargo.toml
+++ b/frame/executive/Cargo.toml
@@ -31,7 +31,7 @@ sp-core = { version = "5.0.0", path = "../../primitives/core" }
 sp-io = { version = "5.0.0", path = "../../primitives/io" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 pallet-transaction-payment = { version = "4.0.0-dev", path = "../transaction-payment" }
-sp-version = { version = "4.0.0-dev", path = "../../primitives/version" }
+sp-version = { version = "5.0.0", path = "../../primitives/version" }
 sp-inherents = { version = "4.0.0-dev", path = "../../primitives/inherents" }
 
 [features]

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -22,7 +22,7 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../" 
 sp-runtime = { version = "5.0.0", default-features = false, path = "../../../primitives/runtime" }
 sp-core = { version = "5.0.0", default-features = false, path = "../../../primitives/core" }
 sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
-sp-version = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/version" }
+sp-version = { version = "5.0.0", default-features = false, path = "../../../primitives/version" }
 trybuild = "1.0.53"
 pretty_assertions = "1.0.0"
 rustversion = "1.0.6"

--- a/frame/support/test/compile_pass/Cargo.toml
+++ b/frame/support/test/compile_pass/Cargo.toml
@@ -16,7 +16,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-core = { version = "5.0.0", default-features = false, path = "../../../../primitives/core" }
 sp-runtime = { version = "5.0.0", default-features = false, path = "../../../../primitives/runtime" }
-sp-version = { version = "4.0.0-dev", default-features = false, path = "../../../../primitives/version" }
+sp-version = { version = "5.0.0", default-features = false, path = "../../../../primitives/version" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../../" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../../system" }
 

--- a/frame/system/Cargo.toml
+++ b/frame/system/Cargo.toml
@@ -20,7 +20,7 @@ sp-core = { version = "5.0.0", default-features = false, path = "../../primitive
 sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "5.0.0", path = "../../primitives/io", default-features = false }
 sp-runtime = { version = "5.0.0", default-features = false, path = "../../primitives/runtime" }
-sp-version = { version = "4.0.0-dev", default-features = false, path = "../../primitives/version" }
+sp-version = { version = "5.0.0", default-features = false, path = "../../primitives/version" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 log = { version = "0.4.14", default-features = false }
 

--- a/primitives/api/Cargo.toml
+++ b/primitives/api/Cargo.toml
@@ -18,7 +18,7 @@ sp-api-proc-macro = { version = "4.0.0-dev", path = "proc-macro" }
 sp-core = { version = "5.0.0", default-features = false, path = "../core" }
 sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 sp-runtime = { version = "5.0.0", default-features = false, path = "../runtime" }
-sp-version = { version = "4.0.0-dev", default-features = false, path = "../version" }
+sp-version = { version = "5.0.0", default-features = false, path = "../version" }
 sp-state-machine = { version = "0.11.0", optional = true, path = "../state-machine" }
 hash-db = { version = "0.15.2", optional = true }
 thiserror = { version = "1.0.30", optional = true }

--- a/primitives/api/test/Cargo.toml
+++ b/primitives/api/test/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sp-api = { version = "4.0.0-dev", path = "../" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }
-sp-version = { version = "4.0.0-dev", path = "../../version" }
+sp-version = { version = "5.0.0", path = "../../version" }
 sp-tracing = { version = "4.0.0", path = "../../tracing" }
 sp-runtime = { version = "5.0.0", path = "../../runtime" }
 sp-consensus = { version = "0.10.0-dev", path = "../../consensus/common" }

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -25,7 +25,7 @@ sp-inherents = { version = "4.0.0-dev", path = "../../inherents" }
 sp-state-machine = { version = "0.11.0", path = "../../state-machine" }
 futures-timer = "3.0.1"
 sp-std = { version = "4.0.0", path = "../../std" }
-sp-version = { version = "4.0.0-dev", path = "../../version" }
+sp-version = { version = "5.0.0", path = "../../version" }
 sp-runtime = { version = "5.0.0", path = "../../runtime" }
 thiserror = "1.0.30"
 

--- a/primitives/version/Cargo.toml
+++ b/primitives/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-version"
-version = "4.0.0-dev"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 sp-runtime = { version = "5.0.0", default-features = false, path = "../runtime" }
-sp-version-proc-macro = { version = "4.0.0-dev", default-features = false, path = "proc-macro" }
+sp-version-proc-macro = { version = "4.0.0", default-features = false, path = "proc-macro" }
 parity-wasm = { version = "0.42.2", optional = true }
 sp-core-hashing-proc-macro = { version = "4.0.0-dev", path = "../core/hashing/proc-macro" }
 thiserror = { version = "1.0.30", optional = true }

--- a/primitives/version/Cargo.toml
+++ b/primitives/version/Cargo.toml
@@ -20,9 +20,9 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 sp-runtime = { version = "5.0.0", default-features = false, path = "../runtime" }
-sp-version-proc-macro = { version = "5.0.0", default-features = false, path = "proc-macro" }
+sp-version-proc-macro = { version = "4.0.0", default-features = false, path = "proc-macro" }
 parity-wasm = { version = "0.42.2", optional = true }
-sp-core-hashing-proc-macro = { version = "4.0.0-dev", path = "../core/hashing/proc-macro" }
+sp-core-hashing-proc-macro = { version = "4.0.0", path = "../core/hashing/proc-macro" }
 thiserror = { version = "1.0.30", optional = true }
 
 [features]

--- a/primitives/version/Cargo.toml
+++ b/primitives/version/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 sp-runtime = { version = "5.0.0", default-features = false, path = "../runtime" }
-sp-version-proc-macro = { version = "4.0.0", default-features = false, path = "proc-macro" }
+sp-version-proc-macro = { version = "5.0.0", default-features = false, path = "proc-macro" }
 parity-wasm = { version = "0.42.2", optional = true }
 sp-core-hashing-proc-macro = { version = "4.0.0-dev", path = "../core/hashing/proc-macro" }
 thiserror = { version = "1.0.30", optional = true }

--- a/primitives/version/proc-macro/Cargo.toml
+++ b/primitives/version/proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-version-proc-macro"
-version = "4.0.0"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/primitives/version/proc-macro/Cargo.toml
+++ b/primitives/version/proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-version-proc-macro"
-version = "4.0.0-dev"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -22,4 +22,4 @@ proc-macro2 = "1.0.36"
 codec = { package = "parity-scale-codec", version = "2.0.0", features = [ "derive" ] }
 
 [dev-dependencies]
-sp-version = { version = "4.0.0-dev", path = ".." }
+sp-version = { version = "5.0.0", path = ".." }

--- a/primitives/version/proc-macro/Cargo.toml
+++ b/primitives/version/proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-version-proc-macro"
-version = "5.0.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -28,7 +28,7 @@ sp-std = { version = "4.0.0", default-features = false, path = "../../primitives
 sp-runtime-interface = { version = "5.0.0", default-features = false, path = "../../primitives/runtime-interface" }
 sp-io = { version = "5.0.0", default-features = false, path = "../../primitives/io" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../../frame/support" }
-sp-version = { version = "4.0.0-dev", default-features = false, path = "../../primitives/version" }
+sp-version = { version = "5.0.0", default-features = false, path = "../../primitives/version" }
 sp-session = { version = "4.0.0-dev", default-features = false, path = "../../primitives/session" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../primitives/api" }
 sp-runtime = { version = "5.0.0", default-features = false, path = "../../primitives/runtime" }

--- a/utils/frame/remote-externalities/Cargo.toml
+++ b/utils/frame/remote-externalities/Cargo.toml
@@ -25,7 +25,7 @@ serde = "1.0.132"
 sp-io = { version = "5.0.0", path = "../../../primitives/io" }
 sp-core = { version = "5.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "5.0.0", path = "../../../primitives/runtime" }
-sp-version = { version = "4.0.0-dev", path = "../../../primitives/version" }
+sp-version = { version = "5.0.0", path = "../../../primitives/version" }
 
 [dev-dependencies]
 tokio = { version = "1.15", features = ["macros", "rt-multi-thread"] }

--- a/utils/frame/try-runtime/cli/Cargo.toml
+++ b/utils/frame/try-runtime/cli/Cargo.toml
@@ -29,7 +29,7 @@ sp-core = { version = "5.0.0", path = "../../../../primitives/core" }
 sp-io = { version = "5.0.0", path = "../../../../primitives/io" }
 sp-keystore = { version = "0.11.0", path = "../../../../primitives/keystore" }
 sp-externalities = { version = "0.11.0", path = "../../../../primitives/externalities" }
-sp-version = { version = "4.0.0-dev", path = "../../../../primitives/version" }
+sp-version = { version = "5.0.0", path = "../../../../primitives/version" }
 
 remote-externalities = { version = "0.10.0-dev", path = "../../remote-externalities" }
 jsonrpsee = { version = "0.4.1", default-features = false, features = ["ws-client"] }


### PR DESCRIPTION
We'd like to release `sp-version` 5.0.0 to align with other recent 5.0.0 releases for `subxt`.

`sp-version` 4.0.0 had already been released but the version in use in substrate is still marked as `4.0.0-dev`, so I'm bumping up to 5.0.0 to set this straight, and to update it to point at other 5.0.0 versions which are already present in substrate for consistency.

`sp-version-proc-macro` had been released at 4.0.0 but was still stuck at 4.0.0-dev here, so I "fixed" that up to 4.0.0 to align with the already-released crate. Suggest to bump to 5.0.0-dev next time changes are made to this crate.

