### PR TITLE
Replace libsecp256k1 with secp256k1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8203,7 +8203,6 @@ version = "0.10.0-dev"
 dependencies = [
  "hex-literal",
  "lazy_static",
- "libsecp256k1",
  "log 0.4.14",
  "lru 0.6.6",
  "parity-scale-codec",
@@ -8979,6 +8978,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7883017d5b21f011ef8040ea9c6c7ac90834c0df26a69e4c0b06276151f125"
+dependencies = [
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9611,6 +9628,7 @@ dependencies = [
  "regex",
  "scale-info",
  "schnorrkel",
+ "secp256k1",
  "secrecy",
  "serde",
  "serde_json",
@@ -9723,6 +9741,7 @@ dependencies = [
  "log 0.4.14",
  "parity-scale-codec",
  "parking_lot 0.11.2",
+ "secp256k1",
  "sp-core",
  "sp-externalities",
  "sp-keystore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,6 +262,7 @@ percent-encoding = { opt-level = 3 }
 primitive-types = { opt-level = 3 }
 ring = { opt-level = 3 }
 rustls = { opt-level = 3 }
+secp256k1 = { opt-level = 3 }
 sha2 = { opt-level = 3 }
 sha3 = { opt-level = 3 }
 smallvec = { opt-level = 3 }

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -32,7 +32,6 @@ sc-executor-wasmi = { version = "0.10.0-dev", path = "wasmi" }
 sc-executor-wasmtime = { version = "0.10.0-dev", path = "wasmtime", optional = true }
 parking_lot = "0.11.2"
 log = "0.4.8"
-libsecp256k1 = "0.7"
 sp-core-hashing-proc-macro = { version = "4.0.0-dev", path = "../../primitives/core/hashing/proc-macro" }
 lru = "0.6.6"
 

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -59,6 +59,7 @@ hex = { version = "0.4", default-features = false, optional = true }
 twox-hash = { version = "1.6.2", default-features = false, optional = true }
 libsecp256k1 = { version = "0.7", default-features = false, features = ["hmac", "static-context"], optional = true }
 merlin = { version = "2.0", default-features = false, optional = true }
+secp256k1 = { version = "0.21.2", default-features = false, optional = true, features = ["recovery"] }
 ss58-registry = { version = "1.11.0", default-features = false }
 sp-core-hashing = { version = "4.0.0", path = "./hashing", default-features = false, optional = true }
 sp-runtime-interface = { version = "5.0.0", default-features = false, path = "../runtime-interface" }
@@ -112,6 +113,7 @@ std = [
 	"regex",
 	"num-traits/std",
 	"tiny-keccak",
+	"secp256k1/std",
 	"sp-core-hashing/std",
 	"sp-debug-derive/std",
 	"sp-externalities",
@@ -138,6 +140,7 @@ full_crypto = [
 	"sha2",
 	"twox-hash",
 	"libsecp256k1",
+	"secp256k1",
 	"sp-core-hashing",
 	"sp-runtime-interface/disable_target_static_assertions",
 	"merlin",

--- a/primitives/core/src/ecdsa.rs
+++ b/primitives/core/src/ecdsa.rs
@@ -15,9 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// tag::description[]
-//! Simple ECDSA API.
-// end::description[]
+//! Simple ECDSA secp256k1 API.
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
@@ -37,13 +35,22 @@ use crate::{
 #[cfg(feature = "std")]
 use bip39::{Language, Mnemonic, MnemonicType};
 #[cfg(feature = "full_crypto")]
-use core::convert::{TryFrom, TryInto};
+use core::convert::TryFrom;
 #[cfg(feature = "full_crypto")]
-use libsecp256k1::{PublicKey, SecretKey};
+use secp256k1::{
+	ecdsa::{RecoverableSignature, RecoveryId},
+	Message, PublicKey, SecretKey,
+};
 #[cfg(feature = "std")]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "full_crypto")]
 use sp_std::vec::Vec;
+
+// Secp256k1 context construction is heavy, better to do it once.
+#[cfg(feature = "full_crypto")]
+lazy_static::lazy_static! {
+	static ref SECP256K1: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
+}
 
 /// An identifier used to match public keys against ecdsa keys
 pub const CRYPTO_ID: CryptoTypeId = CryptoTypeId(*b"ecds");
@@ -57,7 +64,17 @@ type Seed = [u8; 32];
 /// The ECDSA compressed public key.
 #[cfg_attr(feature = "full_crypto", derive(Hash))]
 #[derive(
-	Clone, Encode, Decode, PassByInner, MaxEncodedLen, TypeInfo, Eq, PartialEq, PartialOrd, Ord,
+	Clone,
+	Copy,
+	Encode,
+	Decode,
+	PassByInner,
+	MaxEncodedLen,
+	TypeInfo,
+	Eq,
+	PartialEq,
+	PartialOrd,
+	Ord,
 )]
 pub struct Public(pub [u8; 33]);
 
@@ -75,10 +92,16 @@ impl Public {
 	/// This will convert the full public key into the compressed format.
 	#[cfg(feature = "std")]
 	pub fn from_full(full: &[u8]) -> Result<Self, ()> {
-		libsecp256k1::PublicKey::parse_slice(full, None)
-			.map(|k| k.serialize_compressed())
-			.map(Self)
-			.map_err(|_| ())
+		let pubkey = if full.len() == 64 {
+			// Tag it as uncompressed public key.
+			let mut tagged_full = [0u8; 65];
+			tagged_full[0] = 0x04;
+			tagged_full[1..].copy_from_slice(full);
+			secp256k1::PublicKey::from_slice(&tagged_full)
+		} else {
+			secp256k1::PublicKey::from_slice(full)
+		};
+		pubkey.map(|k| Self(k.serialize())).map_err(|_| ())
 	}
 }
 
@@ -305,43 +328,31 @@ impl Signature {
 	/// Recover the public key from this signature and a message.
 	#[cfg(feature = "full_crypto")]
 	pub fn recover<M: AsRef<[u8]>>(&self, message: M) -> Option<Public> {
-		let message = libsecp256k1::Message::parse(&blake2_256(message.as_ref()));
-		let sig: (_, _) = self.try_into().ok()?;
-		libsecp256k1::recover(&message, &sig.0, &sig.1)
-			.ok()
-			.map(|recovered| Public(recovered.serialize_compressed()))
+		self.recover_prehashed(&blake2_256(message.as_ref()))
 	}
 
 	/// Recover the public key from this signature and a pre-hashed message.
 	#[cfg(feature = "full_crypto")]
 	pub fn recover_prehashed(&self, message: &[u8; 32]) -> Option<Public> {
-		let message = libsecp256k1::Message::parse(message);
-
-		let sig: (_, _) = self.try_into().ok()?;
-
-		libsecp256k1::recover(&message, &sig.0, &sig.1)
+		let rid = RecoveryId::from_i32(self.0[64] as i32).ok()?;
+		let sig = RecoverableSignature::from_compact(&self.0[..64], rid).ok()?;
+		let message = Message::from_slice(message).expect("Message is 32 bytes; qed");
+		SECP256K1
+			.recover_ecdsa(&message, &sig)
 			.ok()
-			.map(|key| Public(key.serialize_compressed()))
+			.map(|pubkey| Public(pubkey.serialize()))
 	}
 }
 
 #[cfg(feature = "full_crypto")]
-impl From<(libsecp256k1::Signature, libsecp256k1::RecoveryId)> for Signature {
-	fn from(x: (libsecp256k1::Signature, libsecp256k1::RecoveryId)) -> Signature {
+impl From<RecoverableSignature> for Signature {
+	fn from(recsig: RecoverableSignature) -> Signature {
 		let mut r = Self::default();
-		r.0[0..64].copy_from_slice(&x.0.serialize()[..]);
-		r.0[64] = x.1.serialize();
+		let (recid, sig) = recsig.serialize_compact();
+		r.0[..64].copy_from_slice(&sig);
+		// This is safe due to the limited range of possible valid ids.
+		r.0[64] = recid.to_i32() as u8;
 		r
-	}
-}
-
-#[cfg(feature = "full_crypto")]
-impl<'a> TryFrom<&'a Signature> for (libsecp256k1::Signature, libsecp256k1::RecoveryId) {
-	type Error = ();
-	fn try_from(
-		x: &'a Signature,
-	) -> Result<(libsecp256k1::Signature, libsecp256k1::RecoveryId), Self::Error> {
-		parse_signature_standard(&x.0).map_err(|_| ())
 	}
 }
 
@@ -366,7 +377,7 @@ pub enum DeriveError {
 #[cfg(feature = "full_crypto")]
 #[derive(Clone)]
 pub struct Pair {
-	public: PublicKey,
+	public: Public,
 	secret: SecretKey,
 }
 
@@ -420,8 +431,9 @@ impl TraitPair for Pair {
 	/// You should never need to use this; generate(), generate_with_phrase
 	fn from_seed_slice(seed_slice: &[u8]) -> Result<Pair, SecretStringError> {
 		let secret =
-			SecretKey::parse_slice(seed_slice).map_err(|_| SecretStringError::InvalidSeedLength)?;
-		let public = PublicKey::from_secret_key(&secret);
+			SecretKey::from_slice(seed_slice).map_err(|_| SecretStringError::InvalidSeedLength)?;
+		let public = PublicKey::from_secret_key(&SECP256K1, &secret);
+		let public = Public(public.serialize());
 		Ok(Pair { public, secret })
 	}
 
@@ -431,7 +443,7 @@ impl TraitPair for Pair {
 		path: Iter,
 		_seed: Option<Seed>,
 	) -> Result<(Pair, Option<Seed>), DeriveError> {
-		let mut acc = self.secret.serialize();
+		let mut acc = self.seed();
 		for j in path {
 			match j {
 				DeriveJunction::Soft(_cc) => return Err(DeriveError::SoftKeyInPath),
@@ -443,25 +455,19 @@ impl TraitPair for Pair {
 
 	/// Get the public key.
 	fn public(&self) -> Public {
-		Public(self.public.serialize_compressed())
+		self.public
 	}
 
 	/// Sign a message.
 	fn sign(&self, message: &[u8]) -> Signature {
-		let message = libsecp256k1::Message::parse(&blake2_256(message));
-		libsecp256k1::sign(&message, &self.secret).into()
+		self.sign_prehashed(&blake2_256(message))
 	}
 
 	/// Verify a signature on a message. Returns true if the signature is good.
 	fn verify<M: AsRef<[u8]>>(sig: &Self::Signature, message: M, pubkey: &Self::Public) -> bool {
-		let message = libsecp256k1::Message::parse(&blake2_256(message.as_ref()));
-		let sig: (_, _) = match sig.try_into() {
-			Ok(x) => x,
-			_ => return false,
-		};
-		match libsecp256k1::recover(&message, &sig.0, &sig.1) {
-			Ok(actual) => pubkey.0[..] == actual.serialize_compressed()[..],
-			_ => false,
+		match sig.recover(message) {
+			Some(actual) => actual == *pubkey,
+			None => false,
 		}
 	}
 
@@ -470,16 +476,12 @@ impl TraitPair for Pair {
 	/// This doesn't use the type system to ensure that `sig` and `pubkey` are the correct
 	/// size. Use it only if you're coming from byte buffers and need the speed.
 	fn verify_weak<P: AsRef<[u8]>, M: AsRef<[u8]>>(sig: &[u8], message: M, pubkey: P) -> bool {
-		let message = libsecp256k1::Message::parse(&blake2_256(message.as_ref()));
 		if sig.len() != 65 {
 			return false
 		}
-		let (sig, ri) = match parse_signature_standard(&sig) {
-			Ok(sigri) => sigri,
-			_ => return false,
-		};
-		match libsecp256k1::recover(&message, &sig, &ri) {
-			Ok(actual) => pubkey.as_ref() == &actual.serialize()[1..],
+		let sig = Signature::from_slice(sig);
+		match sig.recover(message) {
+			Some(actual) => actual.as_ref() == pubkey.as_ref(),
 			_ => false,
 		}
 	}
@@ -494,7 +496,7 @@ impl TraitPair for Pair {
 impl Pair {
 	/// Get the seed for this key.
 	pub fn seed(&self) -> Seed {
-		self.secret.serialize()
+		self.secret.serialize_secret()
 	}
 
 	/// Exactly as `from_string` except that if no matches are found then, the the first 32
@@ -511,57 +513,40 @@ impl Pair {
 
 	/// Sign a pre-hashed message
 	pub fn sign_prehashed(&self, message: &[u8; 32]) -> Signature {
-		let message = libsecp256k1::Message::parse(message);
-		libsecp256k1::sign(&message, &self.secret).into()
+		let message = Message::from_slice(message).expect("Message is 32 bytes; qed");
+		SECP256K1.sign_ecdsa_recoverable(&message, &self.secret).into()
 	}
 
 	/// Verify a signature on a pre-hashed message. Return `true` if the signature is valid
 	/// and thus matches the given `public` key.
 	pub fn verify_prehashed(sig: &Signature, message: &[u8; 32], public: &Public) -> bool {
-		let message = libsecp256k1::Message::parse(message);
-
-		let sig: (_, _) = match sig.try_into() {
-			Ok(x) => x,
-			_ => return false,
-		};
-
-		match libsecp256k1::recover(&message, &sig.0, &sig.1) {
-			Ok(actual) => public.0[..] == actual.serialize_compressed()[..],
-			_ => false,
+		match sig.recover_prehashed(message) {
+			Some(actual) => actual == *public,
+			None => false,
 		}
 	}
 
 	/// Verify a signature on a message. Returns true if the signature is good.
-	/// Parses Signature using parse_overflowing_slice
+	/// Parses Signature using parse_overflowing_slice.
+	#[deprecated(note = "please use `verify` instead")]
 	pub fn verify_deprecated<M: AsRef<[u8]>>(sig: &Signature, message: M, pubkey: &Public) -> bool {
 		let message = libsecp256k1::Message::parse(&blake2_256(message.as_ref()));
-		let (sig, ri) = match parse_signature_overflowing(&sig.0) {
-			Ok(sigri) => sigri,
+
+		let parse_signature_overflowing = |x: [u8; 65]| {
+			let sig = libsecp256k1::Signature::parse_overflowing_slice(&x[..64]).ok()?;
+			let rid = libsecp256k1::RecoveryId::parse(x[64]).ok()?;
+			Some((sig, rid))
+		};
+
+		let (sig, rid) = match parse_signature_overflowing(sig.0) {
+			Some(sigri) => sigri,
 			_ => return false,
 		};
-		match libsecp256k1::recover(&message, &sig, &ri) {
-			Ok(actual) => pubkey.0[..] == actual.serialize_compressed()[..],
+		match libsecp256k1::recover(&message, &sig, &rid) {
+			Ok(actual) => pubkey.0 == actual.serialize_compressed(),
 			_ => false,
 		}
 	}
-}
-
-#[cfg(feature = "full_crypto")]
-fn parse_signature_standard(
-	x: &[u8],
-) -> Result<(libsecp256k1::Signature, libsecp256k1::RecoveryId), libsecp256k1::Error> {
-	let sig = libsecp256k1::Signature::parse_standard_slice(&x[..64])?;
-	let ri = libsecp256k1::RecoveryId::parse(x[64])?;
-	Ok((sig, ri))
-}
-
-#[cfg(feature = "full_crypto")]
-fn parse_signature_overflowing(
-	x: &[u8],
-) -> Result<(libsecp256k1::Signature, libsecp256k1::RecoveryId), libsecp256k1::Error> {
-	let sig = libsecp256k1::Signature::parse_overflowing_slice(&x[..64])?;
-	let ri = libsecp256k1::RecoveryId::parse(x[64])?;
-	Ok((sig, ri))
 }
 
 impl CryptoType for Public {
@@ -582,12 +567,9 @@ impl CryptoType for Pair {
 #[cfg(test)]
 mod test {
 	use super::*;
-	use crate::{
-		crypto::{
-			set_default_ss58_version, PublicError, Ss58AddressFormat, Ss58AddressFormatRegistry,
-			DEV_PHRASE,
-		},
-		keccak_256,
+	use crate::crypto::{
+		set_default_ss58_version, PublicError, Ss58AddressFormat, Ss58AddressFormatRegistry,
+		DEV_PHRASE,
 	};
 	use hex_literal::hex;
 	use serde_json;
@@ -806,22 +788,20 @@ mod test {
 		// `msg` shouldn't be mangled
 		let msg = [0u8; 32];
 		let sig1 = pair.sign_prehashed(&msg);
-		let sig2: Signature =
-			libsecp256k1::sign(&libsecp256k1::Message::parse(&msg), &pair.secret).into();
-
+		let sig2: Signature = {
+			let message = Message::from_slice(&msg).unwrap();
+			SECP256K1.sign_ecdsa_recoverable(&message, &pair.secret).into()
+		};
 		assert_eq!(sig1, sig2);
 
 		// signature is actually different
 		let sig2 = pair.sign(&msg);
-
 		assert_ne!(sig1, sig2);
 
 		// using pre-hashed `msg` works
-		let msg = keccak_256(b"this should be hashed");
-		let sig1 = pair.sign_prehashed(&msg);
-		let sig2: Signature =
-			libsecp256k1::sign(&libsecp256k1::Message::parse(&msg), &pair.secret).into();
-
+		let msg = b"this should be hashed";
+		let sig1 = pair.sign_prehashed(&blake2_256(msg));
+		let sig2 = pair.sign(msg);
 		assert_eq!(sig1, sig2);
 	}
 
@@ -830,12 +810,12 @@ mod test {
 		let (pair, _, _) = Pair::generate_with_phrase(Some("password"));
 
 		// `msg` and `sig` match
-		let msg = keccak_256(b"this should be hashed");
+		let msg = blake2_256(b"this should be hashed");
 		let sig = pair.sign_prehashed(&msg);
 		assert!(Pair::verify_prehashed(&sig, &msg, &pair.public()));
 
 		// `msg` and `sig` don't match
-		let msg = keccak_256(b"this is a different message");
+		let msg = blake2_256(b"this is a different message");
 		assert!(!Pair::verify_prehashed(&sig, &msg, &pair.public()));
 	}
 
@@ -844,7 +824,7 @@ mod test {
 		let (pair, _, _) = Pair::generate_with_phrase(Some("password"));
 
 		// recovered key matches signing key
-		let msg = keccak_256(b"this should be hashed");
+		let msg = blake2_256(b"this should be hashed");
 		let sig = pair.sign_prehashed(&msg);
 		let key = sig.recover_prehashed(&msg).unwrap();
 		assert_eq!(pair.public(), key);
@@ -853,7 +833,7 @@ mod test {
 		assert!(Pair::verify_prehashed(&sig, &msg, &key));
 
 		// recovered key and signing key don't match
-		let msg = keccak_256(b"this is a different message");
+		let msg = blake2_256(b"this is a different message");
 		let key = sig.recover_prehashed(&msg).unwrap();
 		assert_ne!(pair.public(), key);
 	}

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -30,6 +30,7 @@ sp-tracing = { version = "4.0.0", default-features = false, path = "../tracing" 
 log = { version = "0.4.8", optional = true }
 futures = { version = "0.3.1", features = ["thread-pool"], optional = true }
 parking_lot = { version = "0.11.2", optional = true }
+secp256k1 = { version = "0.21.2", default-features = false, features = [ "recovery", "alloc" ] }
 tracing = { version = "0.1.29", default-features = false }
 tracing-core = { version = "0.1.17", default-features = false}
 

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -66,6 +66,11 @@ use sp_runtime_interface::{
 
 use codec::{Decode, Encode};
 
+use secp256k1::{
+	ecdsa::{RecoverableSignature, RecoveryId},
+	Message, Secp256k1,
+};
+
 #[cfg(feature = "std")]
 use sp_externalities::{Externalities, ExternalitiesExt};
 
@@ -843,6 +848,7 @@ pub trait Crypto {
 	///
 	/// Returns `true` when the verification was successful.
 	fn ecdsa_verify(sig: &ecdsa::Signature, msg: &[u8], pub_key: &ecdsa::Public) -> bool {
+		#[allow(deprecated)]
 		ecdsa::Pair::verify_deprecated(sig, msg, pub_key)
 	}
 
@@ -895,14 +901,15 @@ pub trait Crypto {
 		sig: &[u8; 65],
 		msg: &[u8; 32],
 	) -> Result<[u8; 64], EcdsaVerifyError> {
-		let rs = libsecp256k1::Signature::parse_overflowing_slice(&sig[0..64])
-			.map_err(|_| EcdsaVerifyError::BadRS)?;
-		let v = libsecp256k1::RecoveryId::parse(
-			if sig[64] > 26 { sig[64] - 27 } else { sig[64] } as u8
+		let rid = libsecp256k1::RecoveryId::parse(
+			if sig[64] > 26 { sig[64] - 27 } else { sig[64] } as u8,
 		)
 		.map_err(|_| EcdsaVerifyError::BadV)?;
-		let pubkey = libsecp256k1::recover(&libsecp256k1::Message::parse(msg), &rs, &v)
-			.map_err(|_| EcdsaVerifyError::BadSignature)?;
+		let sig = libsecp256k1::Signature::parse_overflowing_slice(&sig[..64])
+			.map_err(|_| EcdsaVerifyError::BadRS)?;
+		let msg = libsecp256k1::Message::parse(msg);
+		let pubkey =
+			libsecp256k1::recover(&msg, &sig, &rid).map_err(|_| EcdsaVerifyError::BadSignature)?;
 		let mut res = [0u8; 64];
 		res.copy_from_slice(&pubkey.serialize()[1..65]);
 		Ok(res)
@@ -920,16 +927,16 @@ pub trait Crypto {
 		sig: &[u8; 65],
 		msg: &[u8; 32],
 	) -> Result<[u8; 64], EcdsaVerifyError> {
-		let rs = libsecp256k1::Signature::parse_standard_slice(&sig[0..64])
+		let ctx = Secp256k1::new(); // TODO: this can be a static
+
+		let rid = RecoveryId::from_i32(if sig[64] > 26 { sig[64] - 27 } else { sig[64] } as i32)
+			.map_err(|_| EcdsaVerifyError::BadV)?;
+		let sig = RecoverableSignature::from_compact(&sig[..64], rid)
 			.map_err(|_| EcdsaVerifyError::BadRS)?;
-		let v = libsecp256k1::RecoveryId::parse(
-			if sig[64] > 26 { sig[64] - 27 } else { sig[64] } as u8
-		)
-		.map_err(|_| EcdsaVerifyError::BadV)?;
-		let pubkey = libsecp256k1::recover(&libsecp256k1::Message::parse(msg), &rs, &v)
-			.map_err(|_| EcdsaVerifyError::BadSignature)?;
+		let msg = Message::from_slice(msg).expect("Message is 32 bytes; qed");
+		let pubkey = ctx.recover_ecdsa(&msg, &sig).map_err(|_| EcdsaVerifyError::BadSignature)?;
 		let mut res = [0u8; 64];
-		res.copy_from_slice(&pubkey.serialize()[1..65]);
+		res.copy_from_slice(&pubkey.serialize_uncompressed()[1..]);
 		Ok(res)
 	}
 
@@ -943,14 +950,15 @@ pub trait Crypto {
 		sig: &[u8; 65],
 		msg: &[u8; 32],
 	) -> Result<[u8; 33], EcdsaVerifyError> {
-		let rs = libsecp256k1::Signature::parse_overflowing_slice(&sig[0..64])
-			.map_err(|_| EcdsaVerifyError::BadRS)?;
-		let v = libsecp256k1::RecoveryId::parse(
-			if sig[64] > 26 { sig[64] - 27 } else { sig[64] } as u8
+		let rid = libsecp256k1::RecoveryId::parse(
+			if sig[64] > 26 { sig[64] - 27 } else { sig[64] } as u8,
 		)
 		.map_err(|_| EcdsaVerifyError::BadV)?;
-		let pubkey = libsecp256k1::recover(&libsecp256k1::Message::parse(msg), &rs, &v)
-			.map_err(|_| EcdsaVerifyError::BadSignature)?;
+		let sig = libsecp256k1::Signature::parse_overflowing_slice(&sig[0..64])
+			.map_err(|_| EcdsaVerifyError::BadRS)?;
+		let msg = libsecp256k1::Message::parse(msg);
+		let pubkey =
+			libsecp256k1::recover(&msg, &sig, &rid).map_err(|_| EcdsaVerifyError::BadSignature)?;
 		Ok(pubkey.serialize_compressed())
 	}
 
@@ -965,15 +973,15 @@ pub trait Crypto {
 		sig: &[u8; 65],
 		msg: &[u8; 32],
 	) -> Result<[u8; 33], EcdsaVerifyError> {
-		let rs = libsecp256k1::Signature::parse_standard_slice(&sig[0..64])
+		let ctx = Secp256k1::new(); // TODO: this can be static
+
+		let rid = RecoveryId::from_i32(if sig[64] > 26 { sig[64] - 27 } else { sig[64] } as i32)
+			.map_err(|_| EcdsaVerifyError::BadV)?;
+		let sig = RecoverableSignature::from_compact(&sig[..64], rid)
 			.map_err(|_| EcdsaVerifyError::BadRS)?;
-		let v = libsecp256k1::RecoveryId::parse(
-			if sig[64] > 26 { sig[64] - 27 } else { sig[64] } as u8
-		)
-		.map_err(|_| EcdsaVerifyError::BadV)?;
-		let pubkey = libsecp256k1::recover(&libsecp256k1::Message::parse(msg), &rs, &v)
-			.map_err(|_| EcdsaVerifyError::BadSignature)?;
-		Ok(pubkey.serialize_compressed())
+		let msg = Message::from_slice(msg).expect("Message is 32 bytes; qed");
+		let pubkey = ctx.recover_ecdsa(&msg, &sig).map_err(|_| EcdsaVerifyError::BadSignature)?;
+		Ok(pubkey.serialize())
 	}
 }
 


### PR DESCRIPTION
Closes #8089

[libsecp256k](https://crates.io/crates/libsecp256k1) has been replaced by [secp256k1](https://crates.io/crates/secp256k1).

According to the [benchmarks](https://github.com/davxy/crypto-benches) the latter has been found to be faster by a factor of three/four.

The interfaces are unchanged.

