### PR TITLE
maybe_total_supply in pallet-assets

### DIFF
--- a/frame/assets/src/functions.rs
+++ b/frame/assets/src/functions.rs
@@ -55,7 +55,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	/// Get the total supply of an asset `id`.
 	pub fn total_supply(id: T::AssetId) -> T::Balance {
-		Asset::<T, I>::get(id).map(|x| x.supply).unwrap_or_else(Zero::zero)
+		Self::maybe_total_supply(id).unwrap_or_else(Zero::zero)
+	}
+
+	/// Get the total supply of an asset `id` if the asset exists.
+	pub fn maybe_total_supply(id: T::AssetId) -> Option<T::Balance> {
+		Asset::<T, I>::get(id).map(|x| x.supply)
 	}
 
 	pub(super) fn new_account(

--- a/frame/assets/src/functions.rs
+++ b/frame/assets/src/functions.rs
@@ -55,7 +55,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	/// Get the total supply of an asset `id`.
 	pub fn total_supply(id: T::AssetId) -> T::Balance {
-		Self::maybe_total_supply(id).unwrap_or_else(Zero::zero)
+		Self::maybe_total_supply(id).unwrap_or_default()
 	}
 
 	/// Get the total supply of an asset `id` if the asset exists.


### PR DESCRIPTION
Adds _maybe_total_supply_ to to pallet-assets functions. The previous _total_supply_ function does not allow us to distinguish between an assetId that does not exist or an assetId that exists but for which no tokens were minted.

The new _maybe_total_supply_  allows us to receive, similar to _maybe_balance_, an Option value. This would return None for a non-existent assetId.