### PR TITLE
Add Storage Info to Various Pallets

### DIFF
--- a/frame/atomic-swap/src/lib.rs
+++ b/frame/atomic-swap/src/lib.rs
@@ -44,6 +44,7 @@ mod tests;
 
 use codec::{Decode, Encode};
 use frame_support::{
+	pallet_prelude::MaxEncodedLen,
 	dispatch::DispatchResult,
 	traits::{BalanceStatus, Currency, Get, ReservableCurrency},
 	weights::Weight,
@@ -59,8 +60,9 @@ use sp_std::{
 };
 
 /// Pending atomic swap operation.
-#[derive(Clone, Eq, PartialEq, RuntimeDebugNoBound, Encode, Decode, TypeInfo)]
+#[derive(Clone, Eq, PartialEq, RuntimeDebugNoBound, Encode, Decode, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
+#[codec(mel_bound(T: Config))]
 pub struct PendingSwap<T: Config> {
 	/// Source of the swap.
 	pub source: T::AccountId,
@@ -93,8 +95,9 @@ pub trait SwapAction<AccountId, T: Config> {
 }
 
 /// A swap action that only allows transferring balances.
-#[derive(Clone, RuntimeDebug, Eq, PartialEq, Encode, Decode, TypeInfo)]
+#[derive(Clone, RuntimeDebug, Eq, PartialEq, Encode, Decode, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(C))]
+#[codec(mel_bound(C: ReservableCurrency<AccountId>))]
 pub struct BalanceSwapAction<AccountId, C: ReservableCurrency<AccountId>> {
 	value: <C as Currency<AccountId>>::Balance,
 	_marker: PhantomData<C>,
@@ -165,7 +168,7 @@ pub mod pallet {
 		/// The overarching event type.
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		/// Swap action.
-		type SwapAction: SwapAction<Self::AccountId, Self> + Parameter;
+		type SwapAction: SwapAction<Self::AccountId, Self> + Parameter + MaxEncodedLen;
 		/// Limit of proof size.
 		///
 		/// Atomic swap is only atomic if once the proof is revealed, both parties can submit the
@@ -182,7 +185,6 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(PhantomData<T>);
 
 	#[pallet::storage]
@@ -193,6 +195,9 @@ pub mod pallet {
 		Blake2_128Concat,
 		HashedProof,
 		PendingSwap<T>,
+		OptionQuery,
+		GetDefault,
+		ConstU32<300_000>,
 	>;
 
 	#[pallet::error]

--- a/frame/atomic-swap/src/lib.rs
+++ b/frame/atomic-swap/src/lib.rs
@@ -44,8 +44,8 @@ mod tests;
 
 use codec::{Decode, Encode};
 use frame_support::{
-	pallet_prelude::MaxEncodedLen,
 	dispatch::DispatchResult,
+	pallet_prelude::MaxEncodedLen,
 	traits::{BalanceStatus, Currency, Get, ReservableCurrency},
 	weights::Weight,
 	RuntimeDebugNoBound,

--- a/frame/bounties/src/lib.rs
+++ b/frame/bounties/src/lib.rs
@@ -107,7 +107,7 @@ type PositiveImbalanceOf<T> = pallet_treasury::PositiveImbalanceOf<T>;
 pub type BountyIndex = u32;
 
 /// A bounty proposal.
-#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub struct Bounty<AccountId, Balance, BlockNumber> {
 	/// The account proposing it.
 	proposer: AccountId,
@@ -133,7 +133,7 @@ impl<AccountId: PartialEq + Clone + Ord, Balance, BlockNumber: Clone>
 }
 
 /// The status of a bounty proposal.
-#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub enum BountyStatus<AccountId, BlockNumber> {
 	/// The bounty is proposed and waiting for approval.
 	Proposed,
@@ -180,7 +180,6 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]
@@ -224,6 +223,10 @@ pub mod pallet {
 
 		/// The child-bounty manager.
 		type ChildBountyManager: ChildBountyManager<BalanceOf<Self>>;
+
+		/// Maximum number of approved bounties queued.
+		#[pallet::constant]
+		type MaxBountiesQueued: Get<u32>;
 	}
 
 	#[pallet::error]
@@ -249,6 +252,8 @@ pub mod pallet {
 		Premature,
 		/// The bounty cannot be closed because it has active child-bounties.
 		HasActiveChildBounty,
+		/// Too many approvals are already queued.
+		TooManyQueued,
 	}
 
 	#[pallet::event]
@@ -288,12 +293,13 @@ pub mod pallet {
 	/// The description of each bounty.
 	#[pallet::storage]
 	#[pallet::getter(fn bounty_descriptions)]
-	pub type BountyDescriptions<T: Config> = StorageMap<_, Twox64Concat, BountyIndex, Vec<u8>>;
+	pub type BountyDescriptions<T: Config> =
+		StorageMap<_, Twox64Concat, BountyIndex, BoundedVec<u8, T::MaximumReasonLength>>;
 
 	/// Bounty indices that have been approved but not yet funded.
 	#[pallet::storage]
 	#[pallet::getter(fn bounty_approvals)]
-	pub type BountyApprovals<T: Config> = StorageValue<_, Vec<BountyIndex>, ValueQuery>;
+	pub type BountyApprovals<T: Config> = StorageValue<_, BoundedVec<BountyIndex, T::MaxBountiesQueued>, ValueQuery>;
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
@@ -341,7 +347,7 @@ pub mod pallet {
 
 				bounty.status = BountyStatus::Approved;
 
-				BountyApprovals::<T>::append(bounty_id);
+				BountyApprovals::<T>::try_append(bounty_id).map_err(|()| Error::<T>::TooManyQueued)?;
 
 				Ok(())
 			})?;
@@ -780,17 +786,15 @@ impl<T: Config> Pallet<T> {
 		description: Vec<u8>,
 		value: BalanceOf<T>,
 	) -> DispatchResult {
-		ensure!(
-			description.len() <= T::MaximumReasonLength::get() as usize,
-			Error::<T>::ReasonTooBig
-		);
+		let bounded_description: BoundedVec<_, _> =
+			description.try_into().map_err(|()| Error::<T>::ReasonTooBig)?;
 		ensure!(value >= T::BountyValueMinimum::get(), Error::<T>::InvalidValue);
 
 		let index = Self::bounty_count();
 
 		// reserve deposit for new bounty
 		let bond = T::BountyDepositBase::get() +
-			T::DataDepositPerByte::get() * (description.len() as u32).into();
+			T::DataDepositPerByte::get() * (bounded_description.len() as u32).into();
 		T::Currency::reserve(&proposer, bond)
 			.map_err(|_| Error::<T>::InsufficientProposersBalance)?;
 
@@ -806,7 +810,7 @@ impl<T: Config> Pallet<T> {
 		};
 
 		Bounties::<T>::insert(index, &bounty);
-		BountyDescriptions::<T>::insert(index, description);
+		BountyDescriptions::<T>::insert(index, bounded_description);
 
 		Self::deposit_event(Event::<T>::BountyProposed { index });
 

--- a/frame/bounties/src/lib.rs
+++ b/frame/bounties/src/lib.rs
@@ -299,7 +299,8 @@ pub mod pallet {
 	/// Bounty indices that have been approved but not yet funded.
 	#[pallet::storage]
 	#[pallet::getter(fn bounty_approvals)]
-	pub type BountyApprovals<T: Config> = StorageValue<_, BoundedVec<BountyIndex, T::MaxBountiesQueued>, ValueQuery>;
+	pub type BountyApprovals<T: Config> =
+		StorageValue<_, BoundedVec<BountyIndex, T::MaxBountiesQueued>, ValueQuery>;
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
@@ -347,7 +348,8 @@ pub mod pallet {
 
 				bounty.status = BountyStatus::Approved;
 
-				BountyApprovals::<T>::try_append(bounty_id).map_err(|()| Error::<T>::TooManyQueued)?;
+				BountyApprovals::<T>::try_append(bounty_id)
+					.map_err(|()| Error::<T>::TooManyQueued)?;
 
 				Ok(())
 			})?;

--- a/frame/bounties/src/tests.rs
+++ b/frame/bounties/src/tests.rs
@@ -139,6 +139,7 @@ impl Config for Test {
 	type MaximumReasonLength = ConstU32<16384>;
 	type WeightInfo = ();
 	type ChildBountyManager = ();
+	type MaxBountiesQueued = ConstU32<100>;
 }
 
 type TreasuryError = pallet_treasury::Error<Test>;

--- a/frame/gilt/src/lib.rs
+++ b/frame/gilt/src/lib.rs
@@ -112,7 +112,8 @@ pub mod pallet {
 			+ sp_std::fmt::Debug
 			+ Default
 			+ From<u64>
-			+ TypeInfo;
+			+ TypeInfo
+			+ MaxEncodedLen;
 
 		/// Origin required for setting the target proportion to be under gilt.
 		type AdminOrigin: EnsureOrigin<Self::Origin>;
@@ -178,11 +179,12 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 
 	/// A single bid on a gilt, an item of a *queue* in `Queues`.
-	#[derive(Clone, Eq, PartialEq, Default, Encode, Decode, RuntimeDebug, TypeInfo)]
+	#[derive(
+		Clone, Eq, PartialEq, Default, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen,
+	)]
 	pub struct GiltBid<Balance, AccountId> {
 		/// The amount bid.
 		pub amount: Balance,
@@ -191,7 +193,9 @@ pub mod pallet {
 	}
 
 	/// Information representing an active gilt.
-	#[derive(Clone, Eq, PartialEq, Default, Encode, Decode, RuntimeDebug, TypeInfo)]
+	#[derive(
+		Clone, Eq, PartialEq, Default, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen,
+	)]
 	pub struct ActiveGilt<Balance, AccountId, BlockNumber> {
 		/// The proportion of the effective total issuance (i.e. accounting for any eventual gilt
 		/// expansion or contraction that may eventually be claimed).
@@ -215,7 +219,9 @@ pub mod pallet {
 	/// `issuance - frozen + proportion * issuance`
 	///
 	/// where `issuance = total_issuance - IgnoredIssuance`
-	#[derive(Clone, Eq, PartialEq, Default, Encode, Decode, RuntimeDebug, TypeInfo)]
+	#[derive(
+		Clone, Eq, PartialEq, Default, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen,
+	)]
 	pub struct ActiveGiltsTotal<Balance> {
 		/// The total amount of funds held in reserve for all active gilts.
 		pub frozen: Balance,
@@ -233,12 +239,18 @@ pub mod pallet {
 	/// The vector is indexed by duration in `Period`s, offset by one, so information on the queue
 	/// whose duration is one `Period` would be storage `0`.
 	#[pallet::storage]
-	pub type QueueTotals<T> = StorageValue<_, Vec<(u32, BalanceOf<T>)>, ValueQuery>;
+	pub type QueueTotals<T: Config> =
+		StorageValue<_, BoundedVec<(u32, BalanceOf<T>), T::QueueCount>, ValueQuery>;
 
 	/// The queues of bids ready to become gilts. Indexed by duration (in `Period`s).
 	#[pallet::storage]
-	pub type Queues<T: Config> =
-		StorageMap<_, Blake2_128Concat, u32, Vec<GiltBid<BalanceOf<T>, T::AccountId>>, ValueQuery>;
+	pub type Queues<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		u32,
+		BoundedVec<GiltBid<BalanceOf<T>, T::AccountId>, T::QueueCount>,
+		ValueQuery,
+	>;
 
 	/// Information relating to the gilts currently active.
 	#[pallet::storage]
@@ -265,7 +277,11 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig {
 		fn build(&self) {
-			QueueTotals::<T>::put(vec![(0, BalanceOf::<T>::zero()); T::QueueCount::get() as usize]);
+			let unbounded = vec![(0, BalanceOf::<T>::zero()); T::QueueCount::get() as usize];
+			let bounded: BoundedVec<_, _> = unbounded
+				.try_into()
+				.expect("QueueTotals should support up to QueueCount items. qed");
+			QueueTotals::<T>::put(bounded);
 		}
 	}
 
@@ -366,7 +382,7 @@ pub mod pallet {
 						T::Currency::unreserve(&bid.who, bid.amount);
 						(0, amount - bid.amount)
 					} else {
-						q.insert(0, bid);
+						q.try_insert(0, bid).expect("verified queue was not full above. qed.");
 						(1, amount)
 					};
 
@@ -379,7 +395,7 @@ pub mod pallet {
 				},
 			)?;
 			QueueTotals::<T>::mutate(|qs| {
-				qs.resize(queue_count, (0, Zero::zero()));
+				qs.bounded_resize(queue_count, (0, Zero::zero()));
 				qs[queue_index].0 += net.0;
 				qs[queue_index].1 = qs[queue_index].1.saturating_add(net.1);
 			});
@@ -415,7 +431,7 @@ pub mod pallet {
 			})?;
 
 			QueueTotals::<T>::mutate(|qs| {
-				qs.resize(queue_count, (0, Zero::zero()));
+				qs.bounded_resize(queue_count, (0, Zero::zero()));
 				qs[queue_index].0 = new_len;
 				qs[queue_index].1 = qs[queue_index].1.saturating_sub(bid.amount);
 			});
@@ -592,7 +608,8 @@ pub mod pallet {
 								if remaining < bid.amount {
 									let overflow = bid.amount - remaining;
 									bid.amount = remaining;
-									q.push(GiltBid { amount: overflow, who: bid.who.clone() });
+									q.try_push(GiltBid { amount: overflow, who: bid.who.clone() })
+										.expect("just popped, so there must be space. qed");
 								}
 								let amount = bid.amount;
 								// Can never overflow due to block above.

--- a/frame/indices/src/lib.rs
+++ b/frame/indices/src/lib.rs
@@ -56,7 +56,8 @@ pub mod pallet {
 			+ Codec
 			+ Default
 			+ AtLeast32Bit
-			+ Copy;
+			+ Copy
+			+ MaxEncodedLen;
 
 		/// The currency trait.
 		type Currency: ReservableCurrency<Self::AccountId>;
@@ -74,7 +75,6 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(PhantomData<T>);
 
 	#[pallet::call]

--- a/frame/randomness-collective-flip/src/lib.rs
+++ b/frame/randomness-collective-flip/src/lib.rs
@@ -91,7 +91,7 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
-	#[pallet::without_storage_info]
+	//#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]
@@ -103,9 +103,7 @@ pub mod pallet {
 			let parent_hash = <frame_system::Pallet<T>>::parent_hash();
 
 			<RandomMaterial<T>>::mutate(|ref mut values| {
-				if values.len() < RANDOM_MATERIAL_LEN as usize {
-					values.push(parent_hash)
-				} else {
+				if values.try_push(parent_hash).is_err() {
 					let index = block_number_to_index::<T>(block_number);
 					values[index] = parent_hash;
 				}
@@ -120,7 +118,8 @@ pub mod pallet {
 	/// the oldest hash.
 	#[pallet::storage]
 	#[pallet::getter(fn random_material)]
-	pub(super) type RandomMaterial<T: Config> = StorageValue<_, Vec<T::Hash>, ValueQuery>;
+	pub(super) type RandomMaterial<T: Config> =
+		StorageValue<_, BoundedVec<T::Hash, ConstU32<RANDOM_MATERIAL_LEN>>, ValueQuery>;
 }
 
 impl<T: Config> Randomness<T::Hash, T::BlockNumber> for Pallet<T> {

--- a/frame/recovery/src/mock.rs
+++ b/frame/recovery/src/mock.rs
@@ -22,7 +22,7 @@ use super::*;
 use crate as recovery;
 use frame_support::{
 	parameter_types,
-	traits::{ConstU16, ConstU32, ConstU64, OnFinalize, OnInitialize},
+	traits::{ConstU32, ConstU64, OnFinalize, OnInitialize},
 };
 use sp_core::H256;
 use sp_runtime::{
@@ -105,7 +105,7 @@ impl Config for Test {
 	type Currency = Balances;
 	type ConfigDepositBase = ConfigDepositBase;
 	type FriendDepositFactor = FriendDepositFactor;
-	type MaxFriends = ConstU16<3>;
+	type MaxFriends = ConstU32<3>;
 	type RecoveryDeposit = RecoveryDeposit;
 }
 

--- a/frame/recovery/src/tests.rs
+++ b/frame/recovery/src/tests.rs
@@ -254,7 +254,8 @@ fn initiate_recovery_works() {
 		// Deposit is reserved
 		assert_eq!(Balances::reserved_balance(1), 10);
 		// Recovery status object is created correctly
-		let recovery_status = ActiveRecovery { created: 0, deposit: 10, friends: vec![] };
+		let recovery_status =
+			ActiveRecovery { created: 0, deposit: 10, friends: Default::default() };
 		assert_eq!(<ActiveRecoveries<Test>>::get(&5, &1), Some(recovery_status));
 		// Multiple users can attempt to recover the same account
 		assert_ok!(Recovery::initiate_recovery(Origin::signed(2), 5));
@@ -314,7 +315,8 @@ fn vouch_recovery_works() {
 		assert_ok!(Recovery::vouch_recovery(Origin::signed(4), 5, 1));
 		assert_ok!(Recovery::vouch_recovery(Origin::signed(3), 5, 1));
 		// Final recovery status object is updated correctly
-		let recovery_status = ActiveRecovery { created: 0, deposit: 10, friends: vec![2, 3, 4] };
+		let recovery_status =
+			ActiveRecovery { created: 0, deposit: 10, friends: vec![2, 3, 4].try_into().unwrap() };
 		assert_eq!(<ActiveRecoveries<Test>>::get(&5, &1), Some(recovery_status));
 	});
 }


### PR DESCRIPTION
This PR updates some of the easy pallets to not use `#[pallet::without_storage_info]`.

No underlying logical changes should be found here.