### PR TITLE
Add host function that enforces transaction nesting depth

### DIFF
--- a/primitives/externalities/src/lib.rs
+++ b/primitives/externalities/src/lib.rs
@@ -188,6 +188,11 @@ pub trait Externalities: ExtensionStore {
 	/// Changes made without any open transaction are committed immediately.
 	fn storage_start_transaction(&mut self);
 
+	/// Same as `storage_start_transaction` but with enforcing a maximum nesting depth.
+	///
+	/// Will return an `Err` when it would otherwise violate the supplied `max_depth`.
+	fn storage_start_transaction_with_limit(&mut self, max_depth: u32) -> Result<(), ()>;
+
 	/// Rollback the last transaction started by `storage_start_transaction`.
 	///
 	/// Any changes made during that storage transaction are discarded. Returns an error when

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -235,7 +235,7 @@ pub trait Storage {
 
 	/// Start a new nested transaction while enforcing a maximum nesting depth.
 	///
-	/// This function is equal to [`Self::start_transaction`] with the exception that it
+	/// This function is equal to `start_transaction` with the exception that it
 	/// will return an error then it would otherwise violate the supplied `max_depth`. The
 	/// parameter describes the maximum allowed nesting depth.
 	fn start_transaction_with_limit(&mut self, max_depth: u32) -> Result<(), ()> {

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -233,6 +233,15 @@ pub trait Storage {
 		self.storage_start_transaction();
 	}
 
+	/// Start a new nested transaction while enforcing a maximum nesting depth.
+	///
+	/// This function is equal to [`Self::start_transaction`] with the exception that it
+	/// will return an error then it would otherwise violate the supplied `max_depth`. The
+	/// parameter describes the maximum allowed nesting depth.
+	fn start_transaction_with_limit(&mut self, max_depth: u32) -> Result<(), ()> {
+		self.storage_start_transaction_with_limit(max_depth)
+	}
+
 	/// Rollback the last transaction started by `start_transaction`.
 	///
 	/// Any changes made during that transaction are discarded.

--- a/primitives/state-machine/src/basic.rs
+++ b/primitives/state-machine/src/basic.rs
@@ -323,6 +323,10 @@ impl Externalities for BasicExternalities {
 		unimplemented!("Transactions are not supported by BasicExternalities");
 	}
 
+	fn storage_start_transaction_with_limit(&mut self, _: u32) -> Result<(), ()> {
+		unimplemented!("Transactions are not supported by BasicExternalities");
+	}
+
 	fn storage_rollback_transaction(&mut self) -> Result<(), ()> {
 		unimplemented!("Transactions are not supported by BasicExternalities");
 	}

--- a/primitives/state-machine/src/overlayed_changes/changeset.rs
+++ b/primitives/state-machine/src/overlayed_changes/changeset.rs
@@ -214,6 +214,11 @@ impl<K: Ord + Hash + Clone, V> OverlayedMap<K, V> {
 		self.changes.is_empty()
 	}
 
+	/// Returns how many storage transactions are currently open.
+	pub fn depth(&self) -> usize {
+		self.dirty_keys.len()
+	}
+
 	/// Get an optional reference to the value stored for the specified key.
 	pub fn get<Q>(&self, key: &Q) -> Option<&OverlayedEntry<V>>
 	where

--- a/primitives/state-machine/src/read_only.rs
+++ b/primitives/state-machine/src/read_only.rs
@@ -161,6 +161,10 @@ impl<'a, H: Hasher, B: 'a + Backend<H>> Externalities for ReadOnlyExternalities<
 		unimplemented!("Transactions are not supported by ReadOnlyExternalities");
 	}
 
+	fn storage_start_transaction_with_limit(&mut self, _: u32) -> Result<(), ()> {
+		unimplemented!("Transactions are not supported by ReadOnlyExternalities");
+	}
+
 	fn storage_rollback_transaction(&mut self) -> Result<(), ()> {
 		unimplemented!("Transactions are not supported by ReadOnlyExternalities");
 	}

--- a/primitives/tasks/src/async_externalities.rs
+++ b/primitives/tasks/src/async_externalities.rs
@@ -142,6 +142,10 @@ impl Externalities for AsyncExternalities {
 		unimplemented!("Transactions are not supported by AsyncExternalities");
 	}
 
+	fn storage_start_transaction_with_limit(&mut self, _: u32) -> Result<(), ()> {
+		unimplemented!("Transactions are not supported by AsyncExternalities");
+	}
+
 	fn storage_rollback_transaction(&mut self) -> Result<(), ()> {
 		unimplemented!("Transactions are not supported by AsyncExternalities");
 	}


### PR DESCRIPTION
The client does not enforce any limit on the nesting depth when the runtime spawns a new storage transaction. Without a limit a user could construct (without other barriers) a `Call` like `batch(batch(batch(write_many_keys)))`.

We clearly want a limit here. @shawntabrizi and me came to the conclusion that the most efficient solution would be to fuse this operation with when we are calling into the client to create a new transaction anyways.

This adds:
```rust
/// Start a new nested transaction while enforcing a maximum nesting depth.
///
/// This function is equal to [`Self::start_transaction`] with the exception that it
/// will return an error then it would otherwise violate the supplied `max_depth`. The
/// parameter describes the maximum allowed nesting depth.
fn start_transaction_with_limit(&mut self, max_depth: u32) -> Result<(), ()> {
	self.storage_start_transaction_with_limit(max_depth)
}
```

Needed for #10806