### PR TITLE
fixed regression in inline docs

### DIFF
--- a/frame/nicks/src/lib.rs
+++ b/frame/nicks/src/lib.rs
@@ -181,7 +181,7 @@ pub mod pallet {
 
 		/// Remove an account's name and take charge of the deposit.
 		///
-		/// Fails if `who` has not been named. The deposit is dealt with through `T::Slashed`
+		/// Fails if `target` has not been named. The deposit is dealt with through `T::Slashed`
 		/// imbalance handler.
 		///
 		/// The dispatch origin for this call must match `T::ForceOrigin`.


### PR DESCRIPTION
- [x] **Description:**
  - Fixed a small error in the inline docs. Probably a regression, the variable is called `target` and now `who` (anymore).
- [x] **Docs:** I updated the inline comments which means an update to the [rustdocs](https://docs.substrate.io/rustdocs/latest/pallet_nicks/pallet/struct.Pallet.html#method.kill_name) is advised.

