### PR TITLE
feat: add a slot result handler for every slot result

### DIFF
--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -217,6 +217,7 @@ where
 		sync_oracle,
 		create_inherent_data_providers,
 		can_author_with,
+		|_slot| {}
 	))
 }
 

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -516,6 +516,7 @@ where
 		sync_oracle,
 		create_inherent_data_providers,
 		can_author_with,
+		|_slot| {},
 	);
 
 	let (worker_tx, worker_rx) = channel(HANDLE_BUFFER_SIZE);


### PR DESCRIPTION
Add a handler for every slot result.
This is convenient for sub-services that need to process Result Slot related data, such as to store some Proof data.