### PR TITLE
wasm-builder: Support latest nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4916,7 +4916,6 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-io",
- "sp-keyring",
  "sp-npos-elections",
  "sp-offchain",
  "sp-runtime",

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -276,5 +276,3 @@ contracts-unstable-interface = ["pallet-contracts/unstable-interface"]
 # specified on the command line.
 # Don't use that on a production chain.
 wasmer-sandbox = ["sp-sandbox/wasmer-sandbox"]
-
-frame-benchmarking = ["hex-literal"]

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -35,7 +35,6 @@ sp-std = { version = "4.0.0", default-features = false, path = "../../../primiti
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/api" }
 sp-runtime = { version = "5.0.0", default-features = false, path = "../../../primitives/runtime" }
 sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/staking" }
-sp-keyring = { version = "5.0.0", optional = true, path = "../../../primitives/keyring" }
 sp-session = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/session" }
 sp-transaction-pool = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/transaction-pool" }
 sp-version = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/version" }
@@ -153,7 +152,6 @@ std = [
 	"sp-runtime/std",
 	"sp-staking/std",
 	"pallet-staking/std",
-	"sp-keyring",
 	"sp-session/std",
 	"pallet-sudo/std",
 	"frame-support/std",
@@ -178,7 +176,7 @@ std = [
 	"log/std",
 	"frame-try-runtime/std",
 	"sp-npos-elections/std",
-  	"sp-io/std",
+	"sp-io/std",
 	"pallet-child-bounties/std",
 ]
 runtime-benchmarks = [
@@ -278,3 +276,5 @@ contracts-unstable-interface = ["pallet-contracts/unstable-interface"]
 # specified on the command line.
 # Don't use that on a production chain.
 wasmer-sandbox = ["sp-sandbox/wasmer-sandbox"]
+
+frame-benchmarking = ["hex-literal"]

--- a/primitives/keyring/Cargo.toml
+++ b/primitives/keyring/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
-
 [dependencies]
 sp-core = { version = "5.0.0", path = "../core" }
 sp-runtime = { version = "5.0.0", path = "../runtime" }


### PR DESCRIPTION
With latest nightly, aka rust version 1.60+ namespaced features are added. This changes the handling
of optional dependencies. We currently have features that enable optional dependencies when `std` is
enabled. This was before no problem, but now the wasm-builder detects them as enabled. To support
the transition period until 1.60 is released as stable, this pr adds an heuristic to not enable these
optional crates in the wasm build when they are enabled in the `std` feature. This heuristic fails
when someones enables these optional dependencies from the outside as well as via the `std` feature,
however we hope that no one is doing this at the moment. When namespaced features are enabled, these
dependencies needs to be enabled using `dep:dependency-name` to solve this properly.

https://doc.rust-lang.org/cargo/reference/unstable.html#namespaced-features

Fixes: https://github.com/paritytech/substrate/issues/10767