### PR TITLE
CI: use fetch-depth=1 for 'check labels'

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           # Fetch the history up to the latest master.
-          fetch-depth: ${{ git rev-list --count origin/master..$HEAD_SHA }}
+          fetch-depth: $( git rev-list --count origin/master..$HEAD_SHA )
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
         env:

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Check labels

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -10,9 +10,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 1
+          # Fetch the history up to the latest master.
+          fetch-depth: ${{ git rev-list --count origin/master..$HEAD_SHA }}
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       - name: Check labels
         run: bash ${{ github.workspace }}/.maintain/github/check_labels.sh
         env:


### PR DESCRIPTION
- Use `fetch-depth: 1` for 'check labels' CI step

0: clone all history, 1: clone the state at the last commit.  
This should reduce the time for the `check labels` step from 1:30 to 4 s :tada: 