### PR TITLE
Don't create DB leaves when syncing historic blocks

### DIFF
--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -3348,5 +3348,4 @@ pub(crate) mod tests {
 		insert_header_no_head(&backend, 1, block0, [1; 32].into());
 		assert_eq!(backend.blockchain().leaves().unwrap(), vec![block2_a]);
 	}
-
 }

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -1472,7 +1472,8 @@ impl<Block: BlockT> Backend<Block> {
 			}
 
 			if !existing_header {
-				{
+				// Add a new leaf if the block is outside the block gap.
+				if block_gap.map_or(true, |(start, _)| number != start) {
 					let mut leaves = self.blockchain.leaves.write();
 					leaves.import(hash, number, parent_hash);
 					leaves.prepare_transaction(

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -1472,8 +1472,8 @@ impl<Block: BlockT> Backend<Block> {
 			}
 
 			if !existing_header {
-				// Add a new leaf if the block is outside the block gap.
-				if block_gap.map_or(true, |(start, _)| number != start) {
+				// Add a new leaf if the block has the potential to be finalized.
+				if number > last_finalized_num || last_finalized_num.is_zero() {
 					let mut leaves = self.blockchain.leaves.write();
 					leaves.import(hash, number, parent_hash);
 					leaves.prepare_transaction(
@@ -2329,6 +2329,29 @@ pub(crate) mod tests {
 		backend.commit_operation(op)?;
 
 		Ok(header_hash)
+	}
+
+	pub fn insert_header_no_head(
+		backend: &Backend<Block>,
+		number: u64,
+		parent_hash: H256,
+		extrinsics_root: H256,
+	) -> H256 {
+		use sp_runtime::testing::Digest;
+
+		let digest = Digest::default();
+		let header = Header {
+			number,
+			parent_hash,
+			state_root: BlakeTwo256::trie_root(Vec::new(), StateVersion::V1),
+			digest,
+			extrinsics_root,
+		};
+		let header_hash = header.hash();
+		let mut op = backend.begin_operation().unwrap();
+		op.set_block_data(header, None, None, None, NewBlockState::Normal).unwrap();
+		backend.commit_operation(op).unwrap();
+		header_hash
 	}
 
 	#[test]
@@ -3310,4 +3333,20 @@ pub(crate) mod tests {
 			e @ _ => panic!("Unexpected error {:?}", e),
 		}
 	}
+
+	#[test]
+	fn test_leaves_not_created_for_ancient_blocks() {
+		let backend: Backend<Block> = Backend::new_test(10, 10);
+		let block0 = insert_header(&backend, 0, Default::default(), None, Default::default());
+
+		let block1_a = insert_header(&backend, 1, block0, None, Default::default());
+		let block2_a = insert_header(&backend, 2, block1_a, None, Default::default());
+		backend.finalize_block(BlockId::hash(block1_a), None).unwrap();
+		assert_eq!(backend.blockchain().leaves().unwrap(), vec![block2_a]);
+
+		// Insert a fork prior to finalization point. Leave should not be created.
+		insert_header_no_head(&backend, 1, block0, [1; 32].into());
+		assert_eq!(backend.blockchain().leaves().unwrap(), vec![block2_a]);
+	}
+
 }


### PR DESCRIPTION
After the warp sync we don't want to create leaves in the database when importing ancient block history. Otherwise GRANDPA might request a path from each leaf to the last finalised block, which may potentially be huge.
