### PR TITLE
Fix beefy mock ecdsa keys

### DIFF
--- a/frame/beefy-mmr/src/mock.rs
+++ b/frame/beefy-mmr/src/mock.rs
@@ -158,9 +158,12 @@ impl pallet_session::SessionManager<u64> for MockSessionManager {
 
 // Note, that we can't use `UintAuthorityId` here. Reason is that the implementation
 // of `to_public_key()` assumes, that a public key is 32 bytes long. This is true for
-// ed25519 and sr25519 but *not* for ecdsa. An ecdsa public key is 33 bytes.
+// ed25519 and sr25519 but *not* for ecdsa. A compressed ecdsa public key is 33 bytes,
+// with the first one containing information to reconstruct the uncompressed key.
 pub fn mock_beefy_id(id: u8) -> BeefyId {
-	let buf: [u8; 33] = [id; 33];
+	let mut buf: [u8; 33] = [id; 33];
+	// Set to something valid.
+	buf[0] = 0x02;
 	let pk = Public::from_raw(buf);
 	BeefyId::from(pk)
 }

--- a/frame/beefy-mmr/src/tests.rs
+++ b/frame/beefy-mmr/src/tests.rs
@@ -71,7 +71,7 @@ fn should_contain_mmr_digest() {
 		assert_eq!(
 			System::digest().logs,
 			vec![beefy_log(ConsensusLog::MmrRoot(
-				hex!("f3e3afbfa69e89cd1e99f8d3570155962f3346d1d8758dc079be49ef70387758").into()
+				hex!("969d516e5279540ef38e4a710fb0645cab4c3b01e528be7285b85ec9c5fb55c8").into()
 			))]
 		);
 
@@ -82,13 +82,13 @@ fn should_contain_mmr_digest() {
 			System::digest().logs,
 			vec![
 				beefy_log(ConsensusLog::MmrRoot(
-					hex!("f3e3afbfa69e89cd1e99f8d3570155962f3346d1d8758dc079be49ef70387758").into()
+					hex!("969d516e5279540ef38e4a710fb0645cab4c3b01e528be7285b85ec9c5fb55c8").into()
 				)),
 				beefy_log(ConsensusLog::AuthoritiesChange(
 					ValidatorSet::new(vec![mock_beefy_id(3), mock_beefy_id(4),], 1,).unwrap()
 				)),
 				beefy_log(ConsensusLog::MmrRoot(
-					hex!("7d4ae4524bae75d52b63f08eab173b0c263eb95ae2c55c3a1d871241bd0cc559").into()
+					hex!("8c42b7b040d262f7f2e26abeb61ab0c3c448f60c7f2f19e6ca0035d9bb3ae7e2").into()
 				)),
 			]
 		);
@@ -111,7 +111,7 @@ fn should_contain_valid_leaf_data() {
 			beefy_next_authority_set: BeefyNextAuthoritySet {
 				id: 1,
 				len: 2,
-				root: hex!("01b1a742589773fc054c8f5021a456316ffcec0370b25678b0696e116d1ef9ae")
+				root: hex!("176e73f1bf656478b728e28dd1a7733c98621b8acf830bff585949763dca7a96")
 					.into(),
 			},
 			parachain_heads: hex!(

--- a/frame/beefy/src/mock.rs
+++ b/frame/beefy/src/mock.rs
@@ -122,9 +122,12 @@ impl pallet_session::SessionManager<u64> for MockSessionManager {
 
 // Note, that we can't use `UintAuthorityId` here. Reason is that the implementation
 // of `to_public_key()` assumes, that a public key is 32 bytes long. This is true for
-// ed25519 and sr25519 but *not* for ecdsa. An ecdsa public key is 33 bytes.
+// ed25519 and sr25519 but *not* for ecdsa. A compressed ecdsa public key is 33 bytes,
+// with the first one containing information to reconstruct the uncompressed key.
 pub fn mock_beefy_id(id: u8) -> BeefyId {
-	let buf: [u8; 33] = [id; 33];
+	let mut buf: [u8; 33] = [id; 33];
+	// Set to something valid.
+	buf[0] = 0x02;
 	let pk = Public::from_raw(buf);
 	BeefyId::from(pk)
 }


### PR DESCRIPTION
Compressed ECDSA keys requires to have a valid first byte (0x02 || 0x03) in order to allow public key recovery.

Nevertheless the test was working because of the `unwrap_or_default()` at the end of the [conversion method](https://github.com/paritytech/substrate/blob/2d8b02af1852d51b7d6a15d6d98b41b76bac614a/frame/beefy-mmr/src/lib.rs#L78-L89) (i.e. the invalid keys were converted to an empty vector).
