### PR TITLE
Enable the `parking_lot` feature for `tokio`

### DIFF
--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -126,7 +126,7 @@ platforms = "2.0"
 async-std = { version = "1.10.0", features = ["attributes"] }
 soketto = "0.4.2"
 criterion = { version = "0.3.5", features = ["async_tokio"] }
-tokio = { version = "1.15", features = ["macros", "time"] }
+tokio = { version = "1.15", features = ["macros", "time", "parking_lot"] }
 jsonrpsee-ws-client = "0.4.1"
 wait-timeout = "0.2"
 remote-externalities = { path = "../../../utils/frame/remote-externalities" }

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -28,7 +28,7 @@ serde = "1.0.136"
 serde_json = "1.0.74"
 thiserror = "1.0.30"
 tiny-bip39 = "0.8.2"
-tokio = { version = "1.15", features = ["signal", "rt-multi-thread"] }
+tokio = { version = "1.15", features = ["signal", "rt-multi-thread", "parking_lot"] }
 
 parity-scale-codec = "2.3.1"
 sc-client-api = { version = "4.0.0-dev", path = "../api" }

--- a/client/rpc-servers/Cargo.toml
+++ b/client/rpc-servers/Cargo.toml
@@ -19,7 +19,7 @@ pubsub = { package = "jsonrpc-pubsub", version = "18.0.0" }
 log = "0.4.8"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.10.0-dev"}
 serde_json = "1.0.74"
-tokio = "1.15"
+tokio = { version = "1.15", features = ["parking_lot"] }
 http = { package = "jsonrpc-http-server", version = "18.0.0" }
 ipc = { package = "jsonrpc-ipc-server", version = "18.0.0" }
 ws = { package = "jsonrpc-ws-server", version = "18.0.0" }

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -78,7 +78,7 @@ parity-util-mem = { version = "0.10.2", default-features = false, features = [
 	"primitive-types",
 ] }
 async-trait = "0.1.50"
-tokio = { version = "1.15", features = ["time", "rt-multi-thread"] }
+tokio = { version = "1.15", features = ["time", "rt-multi-thread", "parking_lot"] }
 tempfile = "3.1.0"
 directories = "4.0.1"
 

--- a/utils/prometheus/Cargo.toml
+++ b/utils/prometheus/Cargo.toml
@@ -18,7 +18,7 @@ prometheus = { version = "0.13.0", default-features = false }
 futures-util = { version = "0.3.19", default-features = false, features = ["io"] }
 thiserror = "1.0"
 async-std = { version = "1.10.0", features = ["unstable"] }
-tokio = "1.15"
+tokio = { version = "1.15", features = ["parking_lot"] }
 hyper = { version = "0.14.16", default-features = false, features = ["http1", "server", "tcp"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This reduces the CPU usage by few percent. (It's hard to estimate the exact figure since the effects of this are not localized to a single place; eyeballing it it should be at least 3~4% less CPU.)