### PR TITLE
Reduce CPU overhead of gossip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom 0.2.3",
  "once_cell",
@@ -8333,6 +8333,7 @@ dependencies = [
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
 dependencies = [
+ "ahash",
  "assert_matches",
  "async-trait",
  "dyn-clone",
@@ -8491,6 +8492,7 @@ dependencies = [
 name = "sc-network-gossip"
 version = "0.10.0-dev"
 dependencies = [
+ "ahash",
  "async-std",
  "futures 0.3.16",
  "futures-timer",

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -22,6 +22,7 @@ futures-timer = "3.0.1"
 log = "0.4.8"
 parking_lot = "0.11.2"
 rand = "0.8.4"
+ahash = "0.7.6"
 parity-scale-codec = { version = "2.3.1", features = ["derive"] }
 sp-application-crypto = { version = "5.0.0", path = "../../primitives/application-crypto" }
 sp-arithmetic = { version = "4.0.0", path = "../../primitives/arithmetic" }

--- a/client/network-gossip/Cargo.toml
+++ b/client/network-gossip/Cargo.toml
@@ -20,6 +20,7 @@ futures-timer = "3.0.1"
 libp2p = { version = "0.40.0", default-features = false }
 log = "0.4.8"
 lru = "0.7.0"
+ahash = "0.7.6"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", path = "../../utils/prometheus" }
 sc-network = { version = "0.10.0-dev", path = "../network" }
 sp-runtime = { version = "5.0.0", path = "../../primitives/runtime" }

--- a/client/network-gossip/src/state_machine.rs
+++ b/client/network-gossip/src/state_machine.rs
@@ -18,19 +18,13 @@
 
 use crate::{MessageIntent, Network, ValidationResult, Validator, ValidatorContext};
 
+use ahash::AHashSet;
 use libp2p::PeerId;
 use lru::LruCache;
 use prometheus_endpoint::{register, Counter, PrometheusError, Registry, U64};
 use sc_network::ObservedRole;
 use sp_runtime::traits::{Block as BlockT, Hash, HashFor};
-use std::{
-	borrow::Cow,
-	collections::{HashMap, HashSet},
-	iter,
-	sync::Arc,
-	time,
-	time::Instant,
-};
+use std::{borrow::Cow, collections::HashMap, iter, sync::Arc, time, time::Instant};
 
 // FIXME: Add additional spam/DoS attack protection: https://github.com/paritytech/substrate/issues/1115
 // NOTE: The current value is adjusted based on largest production network deployment (Kusama) and
@@ -56,7 +50,7 @@ mod rep {
 }
 
 struct PeerConsensus<H> {
-	known_messages: HashSet<H>,
+	known_messages: AHashSet<H>,
 }
 
 /// Topic stream message with sender.
@@ -204,7 +198,8 @@ impl<B: BlockT> ConsensusGossip<B> {
 			?role,
 			"Registering peer",
 		);
-		self.peers.insert(who.clone(), PeerConsensus { known_messages: HashSet::new() });
+		self.peers
+			.insert(who.clone(), PeerConsensus { known_messages: Default::default() });
 
 		let validator = self.validator.clone();
 		let mut context = NetworkContext { gossip: self, network };


### PR DESCRIPTION
This reduces the CPU usage by ~3.8%.

This was achieved by strategically replacing Rust's standard hash function with the one from the [`ahash` crate](https://crates.io/crates/ahash). I've only done this where it matters, that is - I haven't replaced it everywhere, just in places where it makes a measurable real world impact.

`ahash` should also be DoS-resistant, so this should essentially be free performance.