### PR TITLE
Update docs/README.adoc

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -190,7 +190,7 @@ You will also need to install the following packages:
 
  - Linux:
 [source, shell]
-sudo apt install cmake pkg-config libssl-dev git clang libclang-dev
+sudo apt install cmake pkg-config libssl-dev git clang libclang-dev llvm
 
 - Linux on ARM:
 `rust-lld` is required for linking wasm, but is missing on non Tier 1 platforms.


### PR DESCRIPTION
install `llvm` and `llvm-config --prefix` can find the `libclang` path.

https://github.com/KyleMayes/clang-sys/blob/14560fa4a2643ea40f13cd515267d7230b0aaf7a/build/common.rs#L261