### PR TITLE
Use qualified syntax for `retain_mut`

### DIFF
--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -753,7 +753,7 @@ where
 		slot: Slot,
 		epoch_descriptor: &ViableEpochDescriptor<B::Hash, NumberFor<B>, Epoch>,
 	) {
-		self.slot_notification_sinks.lock().retain_mut(|sink| {
+		RetainMut::retain_mut(&mut *self.slot_notification_sinks.lock(), |sink| {
 			match sink.try_send((slot, epoch_descriptor.clone())) {
 				Ok(()) => true,
 				Err(e) =>

--- a/client/transaction-pool/src/graph/validated_pool.rs
+++ b/client/transaction-pool/src/graph/validated_pool.rs
@@ -203,7 +203,7 @@ impl<B: ChainApi> ValidatedPool<B> {
 				let imported = self.pool.write().import(tx)?;
 
 				if let base::Imported::Ready { ref hash, .. } = imported {
-					self.import_notification_sinks.lock().retain_mut(|sink| {
+					RetainMut::retain_mut(&mut *self.import_notification_sinks.lock(), |sink| {
 						match sink.try_send(*hash) {
 							Ok(()) => true,
 							Err(e) =>


### PR DESCRIPTION
Recent std contains a feature-gated implementaion of `retain_mut`. To avoid ambiguity, this PR uses qualified syntax to explicitly call `RetainMut::retain_mut`.

Please review carefully, since the PR touches consensus code.
