### PR TITLE
Refactor `pallet-vesting` using `Get`

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1240,7 +1240,7 @@ impl pallet_vesting::Config for Runtime {
 	type WeightInfo = pallet_vesting::weights::SubstrateWeight<Runtime>;
 	// `VestingInfo` encode length is 36bytes. 28 schedules gets encoded as 1009 bytes, which is the
 	// highest number of schedules that encodes less than 2^10.
-	const MAX_VESTING_SCHEDULES: u32 = 28;
+	type MaxVestingSchedules = ConstU32<28>;
 }
 
 impl pallet_mmr::Config for Runtime {

--- a/frame/vesting/src/benchmarking.rs
+++ b/frame/vesting/src/benchmarking.rs
@@ -78,7 +78,7 @@ fn add_vesting_schedules<T: Config>(
 benchmarks! {
 	vest_locked {
 		let l in 0 .. MaxLocksOf::<T>::get() - 1;
-		let s in 1 .. T::MAX_VESTING_SCHEDULES;
+		let s in 1 .. T::MaxVestingSchedules::get();
 
 		let caller: T::AccountId = whitelisted_caller();
 		let caller_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(caller.clone());
@@ -106,7 +106,7 @@ benchmarks! {
 
 	vest_unlocked {
 		let l in 0 .. MaxLocksOf::<T>::get() - 1;
-		let s in 1 .. T::MAX_VESTING_SCHEDULES;
+		let s in 1 .. T::MaxVestingSchedules::get();
 
 		let caller: T::AccountId = whitelisted_caller();
 		let caller_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(caller.clone());
@@ -134,7 +134,7 @@ benchmarks! {
 
 	vest_other_locked {
 		let l in 0 .. MaxLocksOf::<T>::get() - 1;
-		let s in 1 .. T::MAX_VESTING_SCHEDULES;
+		let s in 1 .. T::MaxVestingSchedules::get();
 
 		let other: T::AccountId = account("other", 0, SEED);
 		let other_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(other.clone());
@@ -163,7 +163,7 @@ benchmarks! {
 
 	vest_other_unlocked {
 		let l in 0 .. MaxLocksOf::<T>::get() - 1;
-		let s in 1 .. T::MAX_VESTING_SCHEDULES;
+		let s in 1 .. T::MaxVestingSchedules::get();
 
 		let other: T::AccountId = account("other", 0, SEED);
 		let other_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(other.clone());
@@ -192,7 +192,7 @@ benchmarks! {
 
 	vested_transfer {
 		let l in 0 .. MaxLocksOf::<T>::get() - 1;
-		let s in 0 .. T::MAX_VESTING_SCHEDULES - 1;
+		let s in 0 .. T::MaxVestingSchedules::get() - 1;
 
 		let caller: T::AccountId = whitelisted_caller();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
@@ -229,7 +229,7 @@ benchmarks! {
 
 	force_vested_transfer {
 		let l in 0 .. MaxLocksOf::<T>::get() - 1;
-		let s in 0 .. T::MAX_VESTING_SCHEDULES - 1;
+		let s in 0 .. T::MaxVestingSchedules::get() - 1;
 
 		let source: T::AccountId = account("source", 0, SEED);
 		let source_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(source.clone());
@@ -267,7 +267,7 @@ benchmarks! {
 
 	not_unlocking_merge_schedules {
 		let l in 0 .. MaxLocksOf::<T>::get() - 1;
-		let s in 2 .. T::MAX_VESTING_SCHEDULES;
+		let s in 2 .. T::MaxVestingSchedules::get();
 
 		let caller: T::AccountId = account("caller", 0, SEED);
 		let caller_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(caller.clone());
@@ -314,7 +314,7 @@ benchmarks! {
 
 	unlocking_merge_schedules {
 		let l in 0 .. MaxLocksOf::<T>::get() - 1;
-		let s in 2 .. T::MAX_VESTING_SCHEDULES;
+		let s in 2 .. T::MaxVestingSchedules::get();
 
 		// Destination used just for currency transfers in asserts.
 		let test_dest: T::AccountId = account("test_dest", 0, SEED);

--- a/frame/vesting/src/migrations.rs
+++ b/frame/vesting/src/migrations.rs
@@ -44,10 +44,7 @@ pub mod v1 {
 			|_key, vesting_info| {
 				reads_writes += 1;
 				let v: Option<
-					BoundedVec<
-						VestingInfo<BalanceOf<T>, T::BlockNumber>,
-						MaxVestingSchedulesGet<T>,
-					>,
+					BoundedVec<VestingInfo<BalanceOf<T>, T::BlockNumber>, T::MaxVestingSchedules>,
 				> = vec![vesting_info].try_into().ok();
 
 				if v.is_none() {

--- a/frame/vesting/src/mock.rs
+++ b/frame/vesting/src/mock.rs
@@ -93,7 +93,7 @@ impl Config for Test {
 	type BlockNumberToBalance = Identity;
 	type Currency = Balances;
 	type Event = Event;
-	const MAX_VESTING_SCHEDULES: u32 = 3;
+	type MaxVestingSchedules = ConstU32<3>;
 	type MinVestedTransfer = MinVestedTransfer;
 	type WeightInfo = ();
 }

--- a/frame/vesting/src/tests.rs
+++ b/frame/vesting/src/tests.rs
@@ -402,7 +402,7 @@ fn vested_transfer_correctly_fails() {
 fn vested_transfer_allows_max_schedules() {
 	ExtBuilder::default().existential_deposit(ED).build().execute_with(|| {
 		let mut user_4_free_balance = Balances::free_balance(&4);
-		let max_schedules = <Test as Config>::MAX_VESTING_SCHEDULES;
+		let max_schedules = <Test as Config>::MaxVestingSchedules::get();
 		let sched = VestingInfo::new(
 			<Test as Config>::MinVestedTransfer::get(),
 			1, // Vest over 2 * 256 blocks.
@@ -547,7 +547,7 @@ fn force_vested_transfer_correctly_fails() {
 fn force_vested_transfer_allows_max_schedules() {
 	ExtBuilder::default().existential_deposit(ED).build().execute_with(|| {
 		let mut user_4_free_balance = Balances::free_balance(&4);
-		let max_schedules = <Test as Config>::MAX_VESTING_SCHEDULES;
+		let max_schedules = <Test as Config>::MaxVestingSchedules::get();
 		let sched = VestingInfo::new(
 			<Test as Config>::MinVestedTransfer::get(),
 			1, // Vest over 2 * 256 blocks.


### PR DESCRIPTION
### Description

I was going through `pallet-vesting` and noticed a `const` was being used for `Config` trait. I thought it would look nicer to use `Get`.

Changes:
- refactor `MAX_VESTING_SCHEDULES` -> `MaxVestingSchedules` bounded with `Get`
- remove redundant `Get<u32>` impl block
- remove `#[allow(non_snake_case)]` re: https://github.com/paritytech/substrate/issues/8826
- apply changes to `node-runtime`

#### Runtime Version
Does it require runtime version bump?

#### Polkadot Companion
coming up shortly
