### PR TITLE
Further reduce the CPU overhead of networking metrics

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -496,7 +496,7 @@ impl<B: BlockT> Protocol<B> {
 
 	/// Returns the number of peers we're connected to.
 	pub fn num_connected_peers(&self) -> usize {
-		self.peers.values().count()
+		self.peers.len()
 	}
 
 	/// Returns the number of peers we're connected to and that are being queried.

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -465,10 +465,10 @@ impl<B: BlockT> Protocol<B> {
 		self.behaviour.open_peers()
 	}
 
-	/// Returns the list of all the peers that the peerset currently requests us to be connected
+	/// Returns the number of all the peers that the peerset currently requests us to be connected
 	/// to on the default set.
-	pub fn requested_peers(&self) -> impl Iterator<Item = &PeerId> {
-		self.behaviour.requested_peers(HARDCODED_PEERSETS_SYNC)
+	pub fn requested_peers_count(&self) -> usize {
+		self.behaviour.requested_peers_count(HARDCODED_PEERSETS_SYNC)
 	}
 
 	/// Returns the number of discovered nodes that we keep in memory.

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -2108,10 +2108,10 @@ impl<B: BlockT + 'static, H: ExHashT> Future for NetworkWorker<B, H> {
 				.peerset_num_discovered
 				.set(this.network_service.behaviour_mut().user_protocol().num_discovered_peers()
 					as u64);
-			metrics.peerset_num_requested.set(
-				this.network_service.behaviour_mut().user_protocol().requested_peers().count()
-					as u64,
-			);
+			metrics
+				.peerset_num_requested
+				.set(this.network_service.behaviour_mut().user_protocol().requested_peers_count()
+					as u64);
 			metrics.pending_connections.set(
 				Swarm::network_info(&this.network_service).connection_counters().num_pending()
 					as u64,


### PR DESCRIPTION
This reduces the CPU usage by ~2%.

Besides eyeballing it I also ran this on a node with the `debug_assert_eq` in the `requested_peers_count` changed to `assert_eq` and it didn't trigger, so I think I covered every possible codepath. (I could have done it semi-automatically like [in my previous PR](https://github.com/paritytech/substrate/pull/10842), but since that approach wasn't received very enthusiastically I just did it manually here everywhere the state might change.)