### PR TITLE
Replace libsecp256k1 with k256 in FRAME related code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,7 +1796,6 @@ checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
 dependencies = [
  "der",
  "elliptic-curve",
- "rfc6979",
  "signature",
 ]
 
@@ -3503,7 +3502,6 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sec1",
- "sha2 0.9.8",
 ]
 
 [[package]]
@@ -5701,13 +5699,11 @@ version = "4.0.0-dev"
 dependencies = [
  "assert_matches",
  "bitflags",
- "ecdsa",
  "env_logger 0.9.0",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "hex-literal",
- "k256",
  "log 0.4.14",
  "pallet-balances",
  "pallet-contracts-primitives",
@@ -5724,6 +5720,7 @@ dependencies = [
  "smallvec 1.7.0",
  "sp-core",
  "sp-io",
+ "sp-keystore",
  "sp-runtime",
  "sp-sandbox",
  "sp-std",
@@ -7710,17 +7707,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "448296241d034b96c11173591deaa1302f2c17b56092106c1f92c1bc0183a8c9"
 
 [[package]]
-name = "rfc6979"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
-dependencies = [
- "crypto-bigint",
- "hmac 0.11.0",
- "zeroize",
-]
-
-[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9428,7 +9414,6 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
 dependencies = [
- "digest 0.9.0",
  "rand_core 0.6.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base58"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +479,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "base64ct"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874f8444adcb4952a8bc51305c8be95c8ec8237bb0d2e78d2e039f771f8828a0"
 
 [[package]]
 name = "beef"
@@ -1067,6 +1079,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,6 +1409,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+dependencies = [
+ "generic-array 0.14.4",
+ "rand_core 0.6.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,6 +1595,15 @@ checksum = "f0f83e699727abca3c56e187945f303389590305ab2f0185ea445aa66e8d5f2a"
 dependencies = [
  "data-encoding",
  "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+dependencies = [
+ "const-oid",
 ]
 
 [[package]]
@@ -1750,6 +1789,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "signature",
+]
+
+[[package]]
 name = "ed25519"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1777,6 +1827,24 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "der",
+ "ff",
+ "generic-array 0.14.4",
+ "group",
+ "rand_core 0.6.2",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "enum-as-inner"
@@ -1937,6 +2005,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c4c9e43643f5a3be4ca5b67d26b98031ff9db6806c3440ae32e02e3ceac3f1b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ff"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
+dependencies = [
+ "rand_core 0.6.2",
+ "subtle",
 ]
 
 [[package]]
@@ -2617,6 +2695,17 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "group"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
+dependencies = [
+ "ff",
+ "rand_core 0.6.2",
+ "subtle",
 ]
 
 [[package]]
@@ -3401,6 +3490,18 @@ dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types 0.8.0",
+]
+
+[[package]]
+name = "k256"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc5937366afd3b38071f400d1ce5bd8b1d40b5083cc14e6f8dbcc4032a7f5bb"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ecdsa",
+ "elliptic-curve",
+ "sec1",
 ]
 
 [[package]]
@@ -5523,7 +5624,7 @@ dependencies = [
  "frame-system",
  "hex",
  "hex-literal",
- "libsecp256k1",
+ "k256",
  "log 0.4.14",
  "pallet-beefy",
  "pallet-mmr",
@@ -6864,6 +6965,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+dependencies = [
+ "der",
+ "spki",
+ "zeroize",
+]
 
 [[package]]
 name = "pkg-config"
@@ -9028,6 +9140,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+dependencies = [
+ "der",
+ "generic-array 0.14.4",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9285,9 +9410,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
+checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
+dependencies = [
+ "rand_core 0.6.2",
+]
 
 [[package]]
 name = "simba"
@@ -10223,6 +10351,16 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spki"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "ss58-registry"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,6 +1796,7 @@ checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
 dependencies = [
  "der",
  "elliptic-curve",
+ "rfc6979",
  "signature",
 ]
 
@@ -3502,6 +3503,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sec1",
+ "sha2 0.9.8",
 ]
 
 [[package]]
@@ -5699,12 +5701,13 @@ version = "4.0.0-dev"
 dependencies = [
  "assert_matches",
  "bitflags",
+ "ecdsa",
  "env_logger 0.9.0",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "hex-literal",
- "libsecp256k1",
+ "k256",
  "log 0.4.14",
  "pallet-balances",
  "pallet-contracts-primitives",
@@ -7707,6 +7710,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "448296241d034b96c11173591deaa1302f2c17b56092106c1f92c1bc0183a8c9"
 
 [[package]]
+name = "rfc6979"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+dependencies = [
+ "crypto-bigint",
+ "hmac 0.11.0",
+ "zeroize",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9414,6 +9428,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
 dependencies = [
+ "digest 0.9.0",
  "rand_core 0.6.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,6 +250,7 @@ hash-db = { opt-level = 3 }
 hmac = { opt-level = 3 }
 httparse = { opt-level = 3 }
 integer-sqrt = { opt-level = 3 }
+k256 = { opt-level = 3 }
 keccak = { opt-level = 3 }
 libm = { opt-level = 3 }
 librocksdb-sys = { opt-level = 3 }

--- a/frame/beefy-mmr/Cargo.toml
+++ b/frame/beefy-mmr/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/paritytech/substrate"
 [dependencies]
 hex = { version = "0.4", optional = true }
 codec = { version = "2.2.0", package = "parity-scale-codec", default-features = false, features = ["derive"] }
-libsecp256k1 = { version = "0.7.0", default-features = false }
+k256 = { version = "0.10.2", default-features = false, features = ["arithmetic"] }
 log = { version = "0.4.13", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.136", optional = true }
@@ -43,7 +43,7 @@ std = [
     "frame-support/std",
     "frame-system/std",
     "hex",
-    "libsecp256k1/std",
+    "k256/std",
     "log/std",
     "pallet-beefy/std",
     "pallet-mmr-primitives/std",

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -39,7 +39,6 @@ pallet-contracts-primitives = { version = "5.0.0", default-features = false, pat
 pallet-contracts-proc-macro = { version = "4.0.0-dev", path = "proc-macro" }
 sp-core = { version = "5.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "5.0.0", default-features = false, path = "../../primitives/io" }
-sp-keystore = { version = "0.11.0", default-features = false, path = "../../primitives/keystore" }
 sp-runtime = { version = "5.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-sandbox = { version = "0.10.0-dev", default-features = false, path = "../../primitives/sandbox" }
 sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
@@ -56,6 +55,7 @@ pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 pallet-timestamp = { version = "4.0.0-dev", path = "../timestamp" }
 pallet-randomness-collective-flip = { version = "4.0.0-dev", path = "../randomness-collective-flip" }
 pallet-utility = { version = "4.0.0-dev", path = "../utility" }
+sp-keystore = { version = "0.11.0", path = "../../primitives/keystore" }
 
 [features]
 default = ["std"]
@@ -66,7 +66,6 @@ std = [
 	"sp-core/std",
 	"sp-runtime/std",
 	"sp-io/std",
-	"sp-keystore/std",
 	"sp-std/std",
 	"sp-sandbox/std",
 	"frame-benchmarking/std",

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -28,8 +28,6 @@ smallvec = { version = "1", default-features = false, features = [
 wasmi-validation = { version = "0.4", default-features = false }
 
 # Only used in benchmarking to generate random contract code
-k256 = { version = "0.10.2", optional = true }
-ecdsa = { version = "0.13.4", optional = true }
 rand = { version = "0.8", optional = true, default-features = false }
 rand_pcg = { version = "0.3", optional = true }
 
@@ -41,6 +39,7 @@ pallet-contracts-primitives = { version = "5.0.0", default-features = false, pat
 pallet-contracts-proc-macro = { version = "4.0.0-dev", path = "proc-macro" }
 sp-core = { version = "5.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "5.0.0", default-features = false, path = "../../primitives/io" }
+sp-keystore = { version = "0.11.0", default-features = false, path = "../../primitives/keystore" }
 sp-runtime = { version = "5.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-sandbox = { version = "0.10.0-dev", default-features = false, path = "../../primitives/sandbox" }
 sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
@@ -67,6 +66,7 @@ std = [
 	"sp-core/std",
 	"sp-runtime/std",
 	"sp-io/std",
+	"sp-keystore/std",
 	"sp-std/std",
 	"sp-sandbox/std",
 	"frame-benchmarking/std",
@@ -81,8 +81,6 @@ std = [
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
-	"k256",
-	"ecdsa",
 	"rand",
 	"rand_pcg",
 	"unstable-interface",

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -28,7 +28,8 @@ smallvec = { version = "1", default-features = false, features = [
 wasmi-validation = { version = "0.4", default-features = false }
 
 # Only used in benchmarking to generate random contract code
-libsecp256k1 = { version = "0.7", optional = true, default-features = false, features = ["hmac", "static-context"] }
+k256 = { version = "0.10.2", optional = true }
+ecdsa = { version = "0.13.4", optional = true }
 rand = { version = "0.8", optional = true, default-features = false }
 rand_pcg = { version = "0.3", optional = true }
 
@@ -77,11 +78,11 @@ std = [
 	"pallet-contracts-proc-macro/full",
 	"log/std",
 	"rand/std",
-	"libsecp256k1/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
-	"libsecp256k1",
+	"k256",
+	"ecdsa",
 	"rand",
 	"rand_pcg",
 	"unstable-interface",

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -1869,9 +1869,9 @@ benchmarks! {
 
 		let message_hash = sp_io::hashing::blake2_256("Hello world".as_bytes());
 		let key_type = sp_core::crypto::KeyTypeId(*b"code");
-		let pub_key = sp_io::crypto::ecdsa_generate(key_type, None);
 		let signatures = (0..r * API_BENCHMARK_BATCH_SIZE)
 			.map(|i| {
+				let pub_key = sp_io::crypto::ecdsa_generate(key_type, None);
 				let sig = sp_io::crypto::ecdsa_sign_prehashed(key_type, &pub_key, &message_hash).expect("Generates signature");
 				AsRef::<[u8; 65]>::as_ref(&sig).to_vec()
 			})

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -1873,8 +1873,7 @@ benchmarks! {
 		let signatures = (0..r * API_BENCHMARK_BATCH_SIZE)
 			.map(|i| {
 				let sig = sp_io::crypto::ecdsa_sign_prehashed(key_type, &pub_key, &message_hash).expect("Generates signature");
-				let bytes: &[u8; 65] = sig.as_ref();
-				bytes.to_vec()
+				AsRef::<[u8; 65]>::as_ref(&sig).to_vec()
 			})
 			.collect::<Vec<_>>();
 		let signatures = signatures.iter().flatten().cloned().collect::<Vec<_>>();

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -43,7 +43,7 @@ use frame_system::{self as system, EventRecord, Phase};
 use pretty_assertions::assert_eq;
 use sp_core::Bytes;
 use sp_io::hashing::blake2_256;
-use sp_keystore::{KeystoreExt, testing::KeyStore};
+use sp_keystore::{testing::KeyStore, KeystoreExt};
 use sp_runtime::{
 	testing::{Header, H256},
 	traits::{BlakeTwo256, Convert, Hash, IdentityLookup},

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -43,12 +43,13 @@ use frame_system::{self as system, EventRecord, Phase};
 use pretty_assertions::assert_eq;
 use sp_core::Bytes;
 use sp_io::hashing::blake2_256;
+use sp_keystore::{KeystoreExt, testing::KeyStore};
 use sp_runtime::{
 	testing::{Header, H256},
 	traits::{BlakeTwo256, Convert, Hash, IdentityLookup},
 	AccountId32,
 };
-use std::cell::RefCell;
+use std::{cell::RefCell, sync::Arc};
 
 use crate as pallet_contracts;
 
@@ -322,6 +323,7 @@ impl ExtBuilder {
 			.assimilate_storage(&mut t)
 			.unwrap();
 		let mut ext = sp_io::TestExternalities::new(t);
+		ext.register_extension(KeystoreExt(Arc::new(KeyStore::new())));
 		ext.execute_with(|| System::set_block_number(1));
 		ext
 	}


### PR DESCRIPTION
This PR affects a very circumscribed section of two FRAME pallets:
- `beefy-mmr` ECDSA public key to ETH id conversion
- `contracts` benchmarking 

Motivations are mostly related to performance. Refer to [benches](https://github.com/davxy/crypto-benches) for details.

This PR somehow relates to https://github.com/paritytech/substrate/pull/10798 where `libsecp256k1` has been replaced with `secp256` for `sp-io` and `sp-core` crates.

In the future, when the performance gap is less important, the plan is to port everything to `k256` pure rust implementation.