### PR TITLE
staking: Remove `Reward` from `Config`

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -539,7 +539,6 @@ impl pallet_staking::Config for Runtime {
 	type RewardRemainder = Treasury;
 	type Event = Event;
 	type Slash = Treasury; // send the slashed funds to the treasury.
-	type Reward = (); // rewards are minted from the void
 	type SessionsPerEra = SessionsPerEra;
 	type BondingDuration = BondingDuration;
 	type SlashDeferDuration = SlashDeferDuration;

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -184,7 +184,6 @@ impl pallet_staking::Config for Test {
 	type Event = Event;
 	type Currency = Balances;
 	type Slash = ();
-	type Reward = ();
 	type SessionsPerEra = SessionsPerEra;
 	type BondingDuration = BondingDuration;
 	type SlashDeferDuration = SlashDeferDuration;

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -192,7 +192,6 @@ impl pallet_staking::Config for Test {
 	type Event = Event;
 	type Currency = Balances;
 	type Slash = ();
-	type Reward = ();
 	type SessionsPerEra = SessionsPerEra;
 	type BondingDuration = BondingDuration;
 	type SlashDeferDuration = SlashDeferDuration;

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -163,7 +163,6 @@ impl pallet_staking::Config for Test {
 	type RewardRemainder = ();
 	type Event = Event;
 	type Slash = ();
-	type Reward = ();
 	type SessionsPerEra = ();
 	type SlashDeferDuration = ();
 	type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -169,7 +169,6 @@ impl pallet_staking::Config for Test {
 	type RewardRemainder = ();
 	type Event = Event;
 	type Slash = ();
-	type Reward = ();
 	type SessionsPerEra = ();
 	type SlashDeferDuration = ();
 	type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -257,7 +257,6 @@ impl crate::pallet::pallet::Config for Test {
 	type RewardRemainder = RewardRemainderMock;
 	type Event = Event;
 	type Slash = ();
-	type Reward = ();
 	type SessionsPerEra = SessionsPerEra;
 	type SlashDeferDuration = SlashDeferDuration;
 	type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -40,9 +40,8 @@ pub use impls::*;
 
 use crate::{
 	log, slashing, weights::WeightInfo, ActiveEraInfo, BalanceOf, EraPayout, EraRewardPoints,
-	Exposure, Forcing, NegativeImbalanceOf, Nominations, Releases,
-	RewardDestination, SessionInterface, StakingLedger, UnappliedSlash, UnlockChunk,
-	ValidatorPrefs,
+	Exposure, Forcing, NegativeImbalanceOf, Nominations, Releases, RewardDestination,
+	SessionInterface, StakingLedger, UnappliedSlash, UnlockChunk, ValidatorPrefs,
 };
 
 pub const MAX_UNLOCKING_CHUNKS: usize = 32;

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -40,7 +40,7 @@ pub use impls::*;
 
 use crate::{
 	log, slashing, weights::WeightInfo, ActiveEraInfo, BalanceOf, EraPayout, EraRewardPoints,
-	Exposure, Forcing, NegativeImbalanceOf, Nominations, PositiveImbalanceOf, Releases,
+	Exposure, Forcing, NegativeImbalanceOf, Nominations, Releases,
 	RewardDestination, SessionInterface, StakingLedger, UnappliedSlash, UnlockChunk,
 	ValidatorPrefs,
 };
@@ -107,9 +107,6 @@ pub mod pallet {
 
 		/// Handler for the unbalanced reduction when slashing a staker.
 		type Slash: OnUnbalanced<NegativeImbalanceOf<Self>>;
-
-		/// Handler for the unbalanced increment when rewarding a staker.
-		type Reward: OnUnbalanced<PositiveImbalanceOf<Self>>;
 
 		/// Number of sessions per era.
 		#[pallet::constant]


### PR DESCRIPTION
The staking `Config` has `type Reward: OnUnbalanced<PositiveImbalanceOf<Self>>;` that was originally intended to handle the positive imbalance from paying out stakers. 

It appears the usage of `Reward` was removed here: https://github.com/paritytech/substrate/pull/4474/files#diff-847a61d013ce4aedef41be8e70a2b09d96eb3ac5d5ce3d3da45e03915ab1fa90L1431

Currently this hook is not called anywhere in the code. Right now we account for the positive imbalance by implicitly dropping it (`make_payout` returns the positive imbalance from `T::Currency::deposit_into_existing` with the reward amount): 

https://github.com/paritytech/substrate/blob/adc95f06936dbdec9479958b13255fcad033264f/frame/staking/src/pallet/impls.rs#L170-L193

I am not sure of the original intention, but presumably it could be used for deducting the imbalance from some other account type abstraction (ref: https://substrate.stackexchange.com/questions/276/customising-staker-reward-payment/330#330). However, exposing something like this would needlessly increase the complexity for the polkadot use case.

polkadot companion: https://github.com/paritytech/polkadot/pull/4946