### PR TITLE
Slots: Log total proposing duration as milliseconds

### DIFF
--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -654,10 +654,10 @@ pub fn proposing_remaining_duration<Block: BlockT>(
 
 		debug!(
 			target: log_target,
-			"No block for {} slots. Applying {} lenience, total proposing duration: {}",
+			"No block for {} slots. Applying {} lenience, total proposing duration: {}ms",
 			slot_info.slot.saturating_sub(parent_slot + 1),
 			slot_lenience_type.as_str(),
-			lenient_proposing_duration.as_secs(),
+			lenient_proposing_duration.as_millis(),
 		);
 
 		lenient_proposing_duration


### PR DESCRIPTION
Parachains have currently a total proposing time of 500ms, so it this
currently always prints `0`. While actually the value is not `0` ;)

