### PR TITLE
tracing: Adds `init_for_tests`

### DIFF
--- a/primitives/tracing/src/lib.rs
+++ b/primitives/tracing/src/lib.rs
@@ -108,12 +108,29 @@ pub use crate::types::{WASM_NAME_KEY, WASM_TARGET_KEY, WASM_TRACE_IDENTIFIER};
 mod types;
 
 /// Try to init a simple tracing subscriber with log compatibility layer.
+///
 /// Ignores any error. Useful for testing.
 #[cfg(feature = "std")]
 pub fn try_init_simple() {
 	let _ = tracing_subscriber::fmt()
 		.with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
 		.with_writer(std::io::stderr)
+		.try_init();
+}
+
+/// Init a tracing subscriber for logging in tests.
+///
+/// Be aware that this enables `TRACE` by default. It also ignores any error
+/// while setting up the logger.
+///
+/// The logs are not shown by default, logs are only shown when the test fails
+/// or if [`nocapture`](https://doc.rust-lang.org/cargo/commands/cargo-test.html#display-options)
+/// is being used.
+#[cfg(feature = "std")]
+pub fn init_for_tests() {
+	let _ = tracing_subscriber::fmt()
+		.with_max_level(tracing::Level::TRACE)
+		.with_test_writer()
 		.try_init();
 }
 
@@ -126,20 +143,20 @@ pub fn try_init_simple() {
 ///
 /// ```
 /// sp_tracing::within_span! {
-/// 		sp_tracing::Level::TRACE,
+///     sp_tracing::Level::TRACE,
 ///     "test-span";
 ///     1 + 1;
 ///     // some other complex code
 /// }
 ///
 /// sp_tracing::within_span! {
-/// 		sp_tracing::span!(sp_tracing::Level::WARN, "warn-span", you_can_pass="any params");
+///     sp_tracing::span!(sp_tracing::Level::WARN, "warn-span", you_can_pass="any params");
 ///     1 + 1;
 ///     // some other complex code
 /// }
 ///
 /// sp_tracing::within_span! {
-/// 		sp_tracing::debug_span!("debug-span", you_can_pass="any params");
+///     sp_tracing::debug_span!("debug-span", you_can_pass="any params");
 ///     1 + 1;
 ///     // some other complex code
 /// }


### PR DESCRIPTION
This function is useful for tests. It will enable `TRACE` logging and also uses the libtest aware writer.

