### PR TITLE
staking: Remove `SessionInterface` super trait

### DIFF
--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -653,7 +653,7 @@ impl<AccountId, Balance: HasCompact + Zero> UnappliedSlash<AccountId, Balance> {
 /// Means for interacting with a specialized version of the `session` trait.
 ///
 /// This is needed because `Staking` sets the `ValidatorIdOf` of the `pallet_session::Config`
-pub trait SessionInterface<AccountId>: frame_system::Config {
+pub trait SessionInterface<AccountId> {
 	/// Disable the validator at the given index, returns `false` if the validator was already
 	/// disabled or the index is out of bounds.
 	fn disable_validator(validator_index: u32) -> bool;


### PR DESCRIPTION
This PR just removes the unused ` frame_system::Config` super trait from `SessionInterface`.