### PR TITLE
add LiquidTotalIssuance

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -830,6 +830,7 @@ impl pallet_democracy::Config for Runtime {
 	type MaxVotes = frame_support::traits::ConstU32<100>;
 	type WeightInfo = pallet_democracy::weights::SubstrateWeight<Runtime>;
 	type MaxProposals = MaxProposals;
+	type LiquidTotalIssuance = pallet_balances::BalancesTotalIssuance<Self>;
 }
 
 parameter_types! {

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -2189,3 +2189,11 @@ where
 		Self::update_locks(who, &locks[..]);
 	}
 }
+
+pub struct BalancesTotalIssuance<T, I = ()>(sp_std::marker::PhantomData<(T, I)>);
+
+impl<T: Config<I>, I: 'static> Get<T::Balance> for BalancesTotalIssuance<T, I> {
+	fn get() -> T::Balance {
+		Pallet::<T, I>::total_issuance()
+	}
+}

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -370,7 +370,7 @@ pub mod pallet {
 		type MaxProposals: Get<u32>;
 
 		/// The maximumal possible amount of tokens that can participate in the governance.
-		/// 
+		///
 		/// Note: This is not a constant.
 		type LiquidTotalIssuance: Get<BalanceOf<Self>>;
 	}

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -368,6 +368,10 @@ pub mod pallet {
 		/// The maximum number of public proposals that can exist at any time.
 		#[pallet::constant]
 		type MaxProposals: Get<u32>;
+
+		/// The maximumal possible amount of tokens that can participate in the governance.
+		/// Note: This is not a constant.
+		type LiquidTotalIssuance: Get<BalanceOf<Self>>;
 	}
 
 	// TODO: Refactor public proposal queue into its own pallet.
@@ -1705,7 +1709,7 @@ impl<T: Config> Pallet<T> {
 		index: ReferendumIndex,
 		status: ReferendumStatus<T::BlockNumber, T::Hash, BalanceOf<T>>,
 	) -> bool {
-		let total_issuance = T::Currency::total_issuance();
+		let total_issuance = T::LiquidTotalIssuance::get();
 		let approved = status.threshold.approved(status.tally, total_issuance);
 
 		if approved {

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -370,6 +370,7 @@ pub mod pallet {
 		type MaxProposals: Get<u32>;
 
 		/// The maximumal possible amount of tokens that can participate in the governance.
+		/// 
 		/// Note: This is not a constant.
 		type LiquidTotalIssuance: Get<BalanceOf<Self>>;
 	}

--- a/frame/democracy/src/tests.rs
+++ b/frame/democracy/src/tests.rs
@@ -184,6 +184,7 @@ impl Config for Test {
 	type PalletsOrigin = OriginCaller;
 	type WeightInfo = ();
 	type MaxProposals = ConstU32<100>;
+	type LiquidTotalIssuance = pallet_balances::BalancesTotalIssuance<Self>;
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {


### PR DESCRIPTION
Some of the tokens are out of circulation and simply cannot participate governance (e.g. the one locked for crowdloan). It will be unfair to include those into consideration for majority voting calculation.

This allow the runtime to configure what's the right number to be used.

Let me know if this is the right way and then I will do the companion PR.