### PR TITLE
contracts: add `seal_origin()`, `seal_code_hash` and `seal_own_code_hash` to API

### DIFF
--- a/frame/contracts/src/schedule.rs
+++ b/frame/contracts/src/schedule.rs
@@ -268,6 +268,9 @@ pub struct HostFnWeights<T: Config> {
 	/// Weight of calling `seal_code_hash`.
 	pub code_hash: Weight,
 
+	/// Weight of calling `seal_own_code_hash`.
+	pub own_code_hash: Weight,
+
 	/// Weight of calling `seal_caller_is_origin`.
 	pub caller_is_origin: Weight,
 
@@ -591,6 +594,7 @@ impl<T: Config> Default for HostFnWeights<T> {
 			caller: cost_batched!(seal_caller),
 			is_contract: cost_batched!(seal_is_contract),
 			code_hash: cost_batched!(seal_code_hash),
+			own_code_hash: cost_batched!(seal_own_code_hash),
 			caller_is_origin: cost_batched!(seal_caller_is_origin),
 			origin: cost_batched!(seal_origin),
 			address: cost_batched!(seal_address),

--- a/frame/contracts/src/schedule.rs
+++ b/frame/contracts/src/schedule.rs
@@ -265,6 +265,9 @@ pub struct HostFnWeights<T: Config> {
 	/// Weight of calling `seal_is_contract`.
 	pub is_contract: Weight,
 
+	/// Weight of calling `seal_code_hash`.
+	pub code_hash: Weight,
+
 	/// Weight of calling `seal_caller_is_origin`.
 	pub caller_is_origin: Weight,
 
@@ -587,6 +590,7 @@ impl<T: Config> Default for HostFnWeights<T> {
 		Self {
 			caller: cost_batched!(seal_caller),
 			is_contract: cost_batched!(seal_is_contract),
+			code_hash: cost_batched!(seal_code_hash),
 			caller_is_origin: cost_batched!(seal_caller_is_origin),
 			origin: cost_batched!(seal_origin),
 			address: cost_batched!(seal_address),

--- a/frame/contracts/src/schedule.rs
+++ b/frame/contracts/src/schedule.rs
@@ -268,6 +268,9 @@ pub struct HostFnWeights<T: Config> {
 	/// Weight of calling `seal_caller_is_origin`.
 	pub caller_is_origin: Weight,
 
+	/// Weight of calling `seal_origin`.
+	pub origin: Weight,
+
 	/// Weight of calling `seal_address`.
 	pub address: Weight,
 
@@ -585,6 +588,7 @@ impl<T: Config> Default for HostFnWeights<T> {
 			caller: cost_batched!(seal_caller),
 			is_contract: cost_batched!(seal_is_contract),
 			caller_is_origin: cost_batched!(seal_caller_is_origin),
+			origin: cost_batched!(seal_origin),
 			address: cost_batched!(seal_address),
 			gas_left: cost_batched!(seal_gas_left),
 			balance: cost_batched!(seal_balance),

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -301,6 +301,8 @@ pub const BOB: AccountId32 = AccountId32::new([2u8; 32]);
 pub const CHARLIE: AccountId32 = AccountId32::new([3u8; 32]);
 pub const DJANGO: AccountId32 = AccountId32::new([4u8; 32]);
 
+pub const HASH: H256 = H256::repeat_byte(0x10);
+
 pub const GAS_LIMIT: Weight = 100_000_000_000;
 
 pub struct ExtBuilder {

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -2393,7 +2393,7 @@ mod tests {
 
 	(func (export "call")
 		;; fill the buffer with the code hash.
-		(call $seal_code_hash 
+		(call $seal_code_hash
 			(i32.const 0) ;; input: address_ptr (before call)
 			(i32.const 0) ;; output: code_hash_ptr (after call)
 			(i32.const 32) ;; same 32 bytes length for input and output
@@ -2445,8 +2445,8 @@ mod tests {
 	)
 
 	(func (export "call")
-		;; fill the buffer with the code hash.
-		(call $seal_own_code_hash 
+		;; fill the buffer with the code hash
+		(call $seal_own_code_hash
 			(i32.const 0)  ;; output: code_hash_ptr
 			(i32.const 32) ;; 32 bytes length of code_hash output
 		)

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -148,6 +148,8 @@ pub enum RuntimeCosts {
 	/// Weight of calling `seal_code_hash`.
 	#[cfg(feature = "unstable-interface")]
 	CodeHash,
+	#[cfg(feature = "unstable-interface")]
+	OwnCodeHash,
 	/// Weight of calling `seal_caller_is_origin`.
 	#[cfg(feature = "unstable-interface")]
 	CallerIsOrigin,
@@ -246,6 +248,8 @@ impl RuntimeCosts {
 			IsContract => s.is_contract,
 			#[cfg(feature = "unstable-interface")]
 			CodeHash => s.code_hash,
+			#[cfg(feature = "unstable-interface")]
+			OwnCodeHash => s.own_code_hash,
 			#[cfg(feature = "unstable-interface")]
 			CallerIsOrigin => s.caller_is_origin,
 			#[cfg(feature = "unstable-interface")]
@@ -1413,6 +1417,19 @@ define_env!(Env, <E: Ext>,
 		} else {
 			Ok(ReturnCode::KeyNotFound)
 		}
+	},
+
+	// Retrieve own code hash for current contract
+	//
+	// # Parameters
+	//
+	// - `out_ptr`: pointer to the linear memory where the returning value is written to.
+	// - `out_len_ptr`: in-out pointer into linear memory where the buffer length
+	//   is read from and the value length is written to.
+	[__unstable__] seal_own_code_hash(ctx, out_ptr: u32, out_len_ptr: u32) => {
+		ctx.charge_gas(RuntimeCosts::OwnCodeHash)?;
+		let code_hash_encoded = &ctx.ext.own_code_hash().encode();
+		Ok(ctx.write_sandbox_output(out_ptr, out_len_ptr, code_hash_encoded, false, already_charged)?)
 	},
 
 	// Checks whether the caller of the current contract is the origin of the whole call stack.

--- a/frame/contracts/src/weights.rs
+++ b/frame/contracts/src/weights.rs
@@ -57,6 +57,7 @@ pub trait WeightInfo {
 	fn seal_caller(r: u32, ) -> Weight;
 	fn seal_is_contract(r: u32, ) -> Weight;
 	fn seal_caller_is_origin(r: u32, ) -> Weight;
+	fn seal_origin(r: u32, ) -> Weight;
 	fn seal_address(r: u32, ) -> Weight;
 	fn seal_gas_left(r: u32, ) -> Weight;
 	fn seal_balance(r: u32, ) -> Weight;
@@ -284,6 +285,17 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Contracts CodeStorage (r:1 w:0)
 	// Storage: Timestamp Now (r:1 w:0)
 	fn seal_caller_is_origin(r: u32, ) -> Weight {
+		(213_550_000 as Weight)
+			// Standard Error: 63_000
+			.saturating_add((21_519_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(T::DbWeight::get().reads(4 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// Storage: System Account (r:1 w:0)
+	// Storage: Contracts ContractInfoOf (r:1 w:1)
+	// Storage: Contracts CodeStorage (r:1 w:0)
+	// Storage: Timestamp Now (r:1 w:0)
+	fn seal_origin(r: u32, ) -> Weight {
 		(213_550_000 as Weight)
 			// Standard Error: 63_000
 			.saturating_add((21_519_000 as Weight).saturating_mul(r as Weight))
@@ -1175,6 +1187,17 @@ impl WeightInfo for () {
 	// Storage: Contracts CodeStorage (r:1 w:0)
 	// Storage: Timestamp Now (r:1 w:0)
 	fn seal_caller_is_origin(r: u32, ) -> Weight {
+		(213_550_000 as Weight)
+			// Standard Error: 63_000
+			.saturating_add((21_519_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+	}
+	// Storage: System Account (r:1 w:0)
+	// Storage: Contracts ContractInfoOf (r:1 w:1)
+	// Storage: Contracts CodeStorage (r:1 w:0)
+	// Storage: Timestamp Now (r:1 w:0)
+	fn seal_origin(r: u32, ) -> Weight {
 		(213_550_000 as Weight)
 			// Standard Error: 63_000
 			.saturating_add((21_519_000 as Weight).saturating_mul(r as Weight))

--- a/frame/contracts/src/weights.rs
+++ b/frame/contracts/src/weights.rs
@@ -56,6 +56,7 @@ pub trait WeightInfo {
 	fn remove_code() -> Weight;
 	fn seal_caller(r: u32, ) -> Weight;
 	fn seal_is_contract(r: u32, ) -> Weight;
+	fn seal_code_hash(r: u32, ) -> Weight;
 	fn seal_caller_is_origin(r: u32, ) -> Weight;
 	fn seal_origin(r: u32, ) -> Weight;
 	fn seal_address(r: u32, ) -> Weight;
@@ -279,6 +280,18 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().reads((100 as Weight).saturating_mul(r as Weight)))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// Storage: System Account (r:1 w:0)
+	// Storage: Contracts ContractInfoOf (r:1 w:1)
+	// Storage: Contracts CodeStorage (r:1 w:0)
+	// Storage: Timestamp Now (r:1 w:0)
+	fn seal_code_hash(r: u32, ) -> Weight {
+		(102_073_000 as Weight)
+			// Standard Error: 843_000
+			.saturating_add((369_025_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
+			.saturating_add(RocksDbWeight::get().reads((100 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 	// Storage: System Account (r:1 w:0)
 	// Storage: Contracts ContractInfoOf (r:1 w:1)
@@ -1175,6 +1188,18 @@ impl WeightInfo for () {
 	// Storage: Contracts CodeStorage (r:1 w:0)
 	// Storage: Timestamp Now (r:1 w:0)
 	fn seal_is_contract(r: u32, ) -> Weight {
+		(102_073_000 as Weight)
+			// Standard Error: 843_000
+			.saturating_add((369_025_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
+			.saturating_add(RocksDbWeight::get().reads((100 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+	}
+	// Storage: System Account (r:1 w:0)
+	// Storage: Contracts ContractInfoOf (r:1 w:1)
+	// Storage: Contracts CodeStorage (r:1 w:0)
+	// Storage: Timestamp Now (r:1 w:0)
+	fn seal_code_hash(r: u32, ) -> Weight {
 		(102_073_000 as Weight)
 			// Standard Error: 843_000
 			.saturating_add((369_025_000 as Weight).saturating_mul(r as Weight))

--- a/frame/contracts/src/weights.rs
+++ b/frame/contracts/src/weights.rs
@@ -57,6 +57,7 @@ pub trait WeightInfo {
 	fn seal_caller(r: u32, ) -> Weight;
 	fn seal_is_contract(r: u32, ) -> Weight;
 	fn seal_code_hash(r: u32, ) -> Weight;
+	fn seal_own_code_hash(r: u32, ) -> Weight;
 	fn seal_caller_is_origin(r: u32, ) -> Weight;
 	fn seal_origin(r: u32, ) -> Weight;
 	fn seal_address(r: u32, ) -> Weight;
@@ -286,6 +287,18 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Contracts CodeStorage (r:1 w:0)
 	// Storage: Timestamp Now (r:1 w:0)
 	fn seal_code_hash(r: u32, ) -> Weight {
+		(102_073_000 as Weight)
+			// Standard Error: 843_000
+			.saturating_add((369_025_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
+			.saturating_add(RocksDbWeight::get().reads((100 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+	}
+	// Storage: System Account (r:1 w:0)
+	// Storage: Contracts ContractInfoOf (r:1 w:1)
+	// Storage: Contracts CodeStorage (r:1 w:0)
+	// Storage: Timestamp Now (r:1 w:0)
+	fn seal_own_code_hash(r: u32, ) -> Weight {
 		(102_073_000 as Weight)
 			// Standard Error: 843_000
 			.saturating_add((369_025_000 as Weight).saturating_mul(r as Weight))
@@ -1200,6 +1213,18 @@ impl WeightInfo for () {
 	// Storage: Contracts CodeStorage (r:1 w:0)
 	// Storage: Timestamp Now (r:1 w:0)
 	fn seal_code_hash(r: u32, ) -> Weight {
+		(102_073_000 as Weight)
+			// Standard Error: 843_000
+			.saturating_add((369_025_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
+			.saturating_add(RocksDbWeight::get().reads((100 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+	}
+	// Storage: System Account (r:1 w:0)
+	// Storage: Contracts ContractInfoOf (r:1 w:1)
+	// Storage: Contracts CodeStorage (r:1 w:0)
+	// Storage: Timestamp Now (r:1 w:0)
+	fn seal_own_code_hash(r: u32, ) -> Weight {
 		(102_073_000 as Weight)
 			// Standard Error: 843_000
 			.saturating_add((369_025_000 as Weight).saturating_mul(r as Weight))


### PR DESCRIPTION
This is a follow-up to [#10789](https://github.com/paritytech/substrate/pull/10789) to add the following functions to contracts API:

```rust
fn origin() -> &AccountId;
fn code_hash(&AccountId) -> Option<CodeHash>;
fn own_code_hash() -> &CodeHash;
```
