### PR TITLE
Groundwork to store validators also in a bags-list instance (2)

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -49,6 +49,7 @@ use pallet_grandpa::{
 };
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_session::historical as pallet_session_historical;
+use pallet_staking::UseValidatorsMap;
 pub use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use pallet_transaction_payment::{FeeDetails, RuntimeDispatchInfo};
 use sp_api::impl_runtime_apis;
@@ -555,9 +556,8 @@ impl pallet_staking::Config for Runtime {
 	type OffendingValidatorsThreshold = OffendingValidatorsThreshold;
 	type ElectionProvider = ElectionProviderMultiPhase;
 	type GenesisElectionProvider = onchain::OnChainSequentialPhragmen<Self>;
-	// Alternatively, use pallet_staking::UseNominatorsMap<Runtime> to just use the nominators map.
-	// Note that the aforementioned does not scale to a very large number of nominators.
-	type SortedListProvider = BagsList;
+	type VoterList = BagsList;
+	type TargetList = UseValidatorsMap<Self>;
 	type WeightInfo = pallet_staking::weights::SubstrateWeight<Runtime>;
 	type BenchmarkingConfig = StakingBenchmarkingConfig;
 }

--- a/frame/multisig/src/lib.rs
+++ b/frame/multisig/src/lib.rs
@@ -24,12 +24,11 @@
 //! ## Overview
 //!
 //! This pallet contains functionality for multi-signature dispatch, a (potentially) stateful
-//! operation, allowing multiple signed
-//! origins (accounts) to coordinate and dispatch a call from a well-known origin, derivable
-//! deterministically from the set of account IDs and the threshold number of accounts from the
-//! set that must approve it. In the case that the threshold is just one then this is a stateless
-//! operation. This is useful for multisig wallets where cryptographic threshold signatures are
-//! not available or desired.
+//! operation, allowing multiple signed origins (accounts) to coordinate and dispatch a call from a
+//! well-known origin, derivable deterministically from the set of account IDs and the threshold
+//! number of accounts from the set that must approve it. In the case that the threshold is just one
+//! then this is a stateless operation. This is useful for multisig wallets where cryptographic
+//! threshold signatures are not available or desired.
 //!
 //! ## Interface
 //!

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -189,7 +189,7 @@ impl<T: Config> ListScenario<T> {
 
 		// find a destination weight that will trigger the worst case scenario
 		let dest_weight_as_vote =
-			T::SortedListProvider::weight_update_worst_case(&origin_stash1, is_increase);
+			T::VoterList::weight_update_worst_case(&origin_stash1, is_increase);
 
 		let total_issuance = T::Currency::total_issuance();
 
@@ -316,7 +316,7 @@ benchmarks! {
 		let scenario = ListScenario::<T>::new(origin_weight, true)?;
 		let controller = scenario.origin_controller1.clone();
 		let stash = scenario.origin_stash1.clone();
-		assert!(T::SortedListProvider::contains(&stash));
+		assert!(T::VoterList::contains(&stash));
 
 		let ed = T::Currency::minimum_balance();
 		let mut ledger = Ledger::<T>::get(&controller).unwrap();
@@ -328,7 +328,7 @@ benchmarks! {
 	}: withdraw_unbonded(RawOrigin::Signed(controller.clone()), s)
 	verify {
 		assert!(!Ledger::<T>::contains_key(controller));
-		assert!(!T::SortedListProvider::contains(&stash));
+		assert!(!T::VoterList::contains(&stash));
 	}
 
 	validate {
@@ -338,14 +338,14 @@ benchmarks! {
 			Default::default(),
 		)?;
 		// because it is chilled.
-		assert!(!T::SortedListProvider::contains(&stash));
+		assert!(!T::VoterList::contains(&stash));
 
 		let prefs = ValidatorPrefs::default();
 		whitelist_account!(controller);
 	}: _(RawOrigin::Signed(controller), prefs)
 	verify {
 		assert!(Validators::<T>::contains_key(&stash));
-		assert!(T::SortedListProvider::contains(&stash));
+		assert!(T::VoterList::contains(&stash));
 	}
 
 	kick {
@@ -430,14 +430,14 @@ benchmarks! {
 		).unwrap();
 
 		assert!(!Nominators::<T>::contains_key(&stash));
-		assert!(!T::SortedListProvider::contains(&stash));
+		assert!(!T::VoterList::contains(&stash));
 
 		let validators = create_validators::<T>(n, 100).unwrap();
 		whitelist_account!(controller);
 	}: _(RawOrigin::Signed(controller), validators)
 	verify {
 		assert!(Nominators::<T>::contains_key(&stash));
-		assert!(T::SortedListProvider::contains(&stash))
+		assert!(T::VoterList::contains(&stash))
 	}
 
 	chill {
@@ -451,12 +451,12 @@ benchmarks! {
 		let scenario = ListScenario::<T>::new(origin_weight, true)?;
 		let controller = scenario.origin_controller1.clone();
 		let stash = scenario.origin_stash1.clone();
-		assert!(T::SortedListProvider::contains(&stash));
+		assert!(T::VoterList::contains(&stash));
 
 		whitelist_account!(controller);
 	}: _(RawOrigin::Signed(controller))
 	verify {
-		assert!(!T::SortedListProvider::contains(&stash));
+		assert!(!T::VoterList::contains(&stash));
 	}
 
 	set_payee {
@@ -519,13 +519,13 @@ benchmarks! {
 		let scenario = ListScenario::<T>::new(origin_weight, true)?;
 		let controller = scenario.origin_controller1.clone();
 		let stash = scenario.origin_stash1.clone();
-		assert!(T::SortedListProvider::contains(&stash));
+		assert!(T::VoterList::contains(&stash));
 		add_slashing_spans::<T>(&stash, s);
 
 	}: _(RawOrigin::Root, stash.clone(), s)
 	verify {
 		assert!(!Ledger::<T>::contains_key(&controller));
-		assert!(!T::SortedListProvider::contains(&stash));
+		assert!(!T::VoterList::contains(&stash));
 	}
 
 	cancel_deferred_slash {
@@ -704,13 +704,13 @@ benchmarks! {
 		Ledger::<T>::insert(&controller, l);
 
 		assert!(Bonded::<T>::contains_key(&stash));
-		assert!(T::SortedListProvider::contains(&stash));
+		assert!(T::VoterList::contains(&stash));
 
 		whitelist_account!(controller);
 	}: _(RawOrigin::Signed(controller), stash.clone(), s)
 	verify {
 		assert!(!Bonded::<T>::contains_key(&stash));
-		assert!(!T::SortedListProvider::contains(&stash));
+		assert!(!T::VoterList::contains(&stash));
 	}
 
 	new_era {
@@ -844,7 +844,7 @@ benchmarks! {
 			v, n, T::MaxNominations::get() as usize, false, None
 		)?;
 	}: {
-		let targets = <Staking<T>>::get_npos_targets();
+		let targets = <Staking<T>>::get_npos_targets(None);
 		assert_eq!(targets.len() as u32, v);
 	}
 
@@ -878,7 +878,7 @@ benchmarks! {
 		let scenario = ListScenario::<T>::new(origin_weight, true)?;
 		let controller = scenario.origin_controller1.clone();
 		let stash = scenario.origin_stash1.clone();
-		assert!(T::SortedListProvider::contains(&stash));
+		assert!(T::VoterList::contains(&stash));
 
 		Staking::<T>::set_staking_configs(
 			RawOrigin::Root.into(),
@@ -893,7 +893,7 @@ benchmarks! {
 		let caller = whitelisted_caller();
 	}: _(RawOrigin::Signed(caller), controller.clone())
 	verify {
-		assert!(!T::SortedListProvider::contains(&stash));
+		assert!(!T::VoterList::contains(&stash));
 	}
 
 	force_apply_min_commission {

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -767,11 +767,12 @@ enum Releases {
 	V2_0_0,
 	V3_0_0,
 	V4_0_0,
-	V5_0_0, // blockable validators.
-	V6_0_0, // removal of all storage associated with offchain phragmen.
-	V7_0_0, // keep track of number of nominators / validators in map
-	V8_0_0, // populate `SortedListProvider`.
-	V9_0_0, // inject validators into `SortedListProvider` as well.
+	V5_0_0,  // blockable validators.
+	V6_0_0,  // removal of all storage associated with offchain phragmen.
+	V7_0_0,  // keep track of number of nominators / validators in map
+	V8_0_0,  // populate `VoterList`.
+	V9_0_0,  // inject validators into `NPoSVoteProvider` as well.
+	V10_0_0, // inject validator into `NPoSTargetList`.
 }
 
 impl Default for Releases {

--- a/frame/staking/src/migrations.rs
+++ b/frame/staking/src/migrations.rs
@@ -22,21 +22,21 @@ use frame_support::traits::OnRuntimeUpgrade;
 
 /// Migration implementation that injects all validators into sorted list.
 ///
-/// This is only useful for chains that started their `SortedListProvider` just based on nominators.
-pub struct InjectValidatorsIntoSortedListProvider<T>(sp_std::marker::PhantomData<T>);
-impl<T: Config> OnRuntimeUpgrade for InjectValidatorsIntoSortedListProvider<T> {
+/// This is only useful for chains that started their `VoterList` just based on nominators.
+pub struct InjectValidatorsIntoVoterList<T>(sp_std::marker::PhantomData<T>);
+impl<T: Config> OnRuntimeUpgrade for InjectValidatorsIntoVoterList<T> {
 	fn on_runtime_upgrade() -> Weight {
 		if StorageVersion::<T>::get() == Releases::V8_0_0 {
 			for (v, _) in Validators::<T>::iter() {
 				let weight = Pallet::<T>::vote_weight(&v);
-				let _ = T::SortedListProvider::on_insert(v.clone(), weight).map_err(|err| {
-					log!(warn, "failed to insert {:?} into SortedListProvider: {:?}", v, err)
+				let _ = T::VoterList::on_insert(v.clone(), weight).map_err(|err| {
+					log!(warn, "failed to insert {:?} into VoterList: {:?}", v, err)
 				});
 			}
 
 			T::BlockWeights::get().max_block
 		} else {
-			log!(warn, "InjectValidatorsIntoSortedListProvider being executed on the wrong storage version, expected Releases::V8_0_0");
+			log!(warn, "InjectValidatorsIntoVoterList being executed on the wrong storage version, expected Releases::V8_0_0");
 			T::DbWeight::get().reads(1)
 		}
 	}
@@ -49,7 +49,7 @@ impl<T: Config> OnRuntimeUpgrade for InjectValidatorsIntoSortedListProvider<T> {
 			"must upgrade linearly"
 		);
 
-		let prev_count = T::SortedListProvider::count();
+		let prev_count = T::VoterList::count();
 		Self::set_temp_storage(prev_count, "prev");
 		Ok(())
 	}
@@ -57,7 +57,7 @@ impl<T: Config> OnRuntimeUpgrade for InjectValidatorsIntoSortedListProvider<T> {
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade() -> Result<(), &'static str> {
 		use frame_support::traits::OnRuntimeUpgradeHelpersExt;
-		let post_count = T::SortedListProvider::count();
+		let post_count = T::VoterList::count();
 		let prev_count = Self::get_temp_storage::<u32>("prev").unwrap();
 		let validators = Validators::<T>::count();
 		assert!(post_count == prev_count + validators);
@@ -87,11 +87,11 @@ pub mod v8 {
 		if StorageVersion::<T>::get() == crate::Releases::V7_0_0 {
 			crate::log!(info, "migrating staking to Releases::V8_0_0");
 
-			let migrated = T::SortedListProvider::unsafe_regenerate(
+			let migrated = T::VoterList::unsafe_regenerate(
 				Nominators::<T>::iter().map(|(id, _)| id),
 				Pallet::<T>::weight_of_fn(),
 			);
-			debug_assert_eq!(T::SortedListProvider::sanity_check(), Ok(()));
+			debug_assert_eq!(T::VoterList::sanity_check(), Ok(()));
 
 			StorageVersion::<T>::put(crate::Releases::V8_0_0);
 			crate::log!(
@@ -108,8 +108,7 @@ pub mod v8 {
 
 	#[cfg(feature = "try-runtime")]
 	pub fn post_migrate<T: Config>() -> Result<(), &'static str> {
-		T::SortedListProvider::sanity_check()
-			.map_err(|_| "SortedListProvider is not in a sane state.")?;
+		T::VoterList::sanity_check().map_err(|_| "VoterList is not in a sane state.")?;
 		crate::log!(info, "👜 staking bags-list migration passes POST migrate checks ✅",);
 		Ok(())
 	}

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -270,7 +270,8 @@ impl crate::pallet::pallet::Config for Test {
 	type ElectionProvider = onchain::OnChainSequentialPhragmen<Self>;
 	type GenesisElectionProvider = Self::ElectionProvider;
 	// NOTE: consider a macro and use `UseNominatorsAndValidatorsMap<Self>` as well.
-	type SortedListProvider = BagsList;
+	type VoterList = BagsList;
+	type TargetList = UseValidatorsMap<Self>;
 	type BenchmarkingConfig = TestBenchmarkingConfig;
 	type WeightInfo = ();
 }
@@ -539,8 +540,8 @@ fn check_count() {
 	assert_eq!(nominator_count, Nominators::<Test>::count());
 	assert_eq!(validator_count, Validators::<Test>::count());
 
-	// the voters that the `SortedListProvider` list is storing for us.
-	let external_voters = <Test as Config>::SortedListProvider::count();
+	// the voters that the `VoterList` list is storing for us.
+	let external_voters = <Test as Config>::VoterList::count();
 	assert_eq!(external_voters, nominator_count + validator_count);
 }
 

--- a/frame/staking/src/testing_utils.rs
+++ b/frame/staking/src/testing_utils.rs
@@ -38,11 +38,11 @@ const SEED: u32 = 0;
 pub fn clear_validators_and_nominators<T: Config>() {
 	Validators::<T>::remove_all();
 
-	// whenever we touch nominators counter we should update `T::SortedListProvider` as well.
+	// whenever we touch nominators counter we should update `T::VoterList` as well.
 	Nominators::<T>::remove_all();
 
 	// NOTE: safe to call outside block production
-	T::SortedListProvider::unsafe_clear();
+	T::VoterList::unsafe_clear();
 }
 
 /// Grab a funded user.

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -4056,7 +4056,7 @@ mod election_data_provider {
 			.set_status(41, StakerStatus::Validator)
 			.build_and_execute(|| {
 				// sum of all nominators who'd be voters (1), plus the self-votes (4).
-				assert_eq!(<Test as Config>::SortedListProvider::count(), 5);
+				assert_eq!(<Test as Config>::VoterList::count(), 5);
 
 				// if limits is less..
 				assert_eq!(Staking::voters(Some(1)).unwrap().len(), 1);
@@ -4090,7 +4090,7 @@ mod election_data_provider {
 			.build_and_execute(|| {
 				// all voters ordered by stake,
 				assert_eq!(
-					<Test as Config>::SortedListProvider::iter().collect::<Vec<_>>(),
+					<Test as Config>::VoterList::iter().collect::<Vec<_>>(),
 					vec![61, 71, 81, 11, 21, 31]
 				);
 
@@ -4132,7 +4132,7 @@ mod election_data_provider {
 			.build_and_execute(|| {
 				// given our voters ordered by stake,
 				assert_eq!(
-					<Test as Config>::SortedListProvider::iter().collect::<Vec<_>>(),
+					<Test as Config>::VoterList::iter().collect::<Vec<_>>(),
 					vec![11, 21, 31, 61, 71, 81]
 				);
 
@@ -4679,10 +4679,10 @@ mod sorted_list_provider {
 			// given
 			let pre_insert_voter_count =
 				(Nominators::<Test>::count() + Validators::<Test>::count()) as u32;
-			assert_eq!(<Test as Config>::SortedListProvider::count(), pre_insert_voter_count);
+			assert_eq!(<Test as Config>::VoterList::count(), pre_insert_voter_count);
 
 			assert_eq!(
-				<Test as Config>::SortedListProvider::iter().collect::<Vec<_>>(),
+				<Test as Config>::VoterList::iter().collect::<Vec<_>>(),
 				vec![11, 21, 31, 101]
 			);
 
@@ -4690,10 +4690,10 @@ mod sorted_list_provider {
 			assert_ok!(Staking::nominate(Origin::signed(100), vec![41]));
 
 			// then counts don't change
-			assert_eq!(<Test as Config>::SortedListProvider::count(), pre_insert_voter_count);
+			assert_eq!(<Test as Config>::VoterList::count(), pre_insert_voter_count);
 			// and the list is the same
 			assert_eq!(
-				<Test as Config>::SortedListProvider::iter().collect::<Vec<_>>(),
+				<Test as Config>::VoterList::iter().collect::<Vec<_>>(),
 				vec![11, 21, 31, 101]
 			);
 		});
@@ -4705,23 +4705,17 @@ mod sorted_list_provider {
 			// given
 			let pre_insert_voter_count =
 				(Nominators::<Test>::count() + Validators::<Test>::count()) as u32;
-			assert_eq!(<Test as Config>::SortedListProvider::count(), pre_insert_voter_count);
+			assert_eq!(<Test as Config>::VoterList::count(), pre_insert_voter_count);
 
-			assert_eq!(
-				<Test as Config>::SortedListProvider::iter().collect::<Vec<_>>(),
-				vec![11, 21, 31]
-			);
+			assert_eq!(<Test as Config>::VoterList::iter().collect::<Vec<_>>(), vec![11, 21, 31]);
 
 			// when account 11 re-validates
 			assert_ok!(Staking::validate(Origin::signed(10), Default::default()));
 
 			// then counts don't change
-			assert_eq!(<Test as Config>::SortedListProvider::count(), pre_insert_voter_count);
+			assert_eq!(<Test as Config>::VoterList::count(), pre_insert_voter_count);
 			// and the list is the same
-			assert_eq!(
-				<Test as Config>::SortedListProvider::iter().collect::<Vec<_>>(),
-				vec![11, 21, 31]
-			);
+			assert_eq!(<Test as Config>::VoterList::iter().collect::<Vec<_>>(), vec![11, 21, 31]);
 		});
 	}
 }

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -38,18 +38,18 @@ macro_rules! defensive {
 		frame_support::log::error!(
 			target: "runtime",
 			"{}",
-			$crate::traits::misc::DEFENSIVE_OP_PUBLIC_ERROR
+			$crate::traits::DEFENSIVE_OP_PUBLIC_ERROR
 		);
-		debug_assert!(false, "{}", $crate::traits::misc::DEFENSIVE_OP_INTERNAL_ERROR);
+		debug_assert!(false, "{}", $crate::traits::DEFENSIVE_OP_INTERNAL_ERROR);
 	};
 	($error:tt) => {
 		frame_support::log::error!(
 			target: "runtime",
 			"{}: {:?}",
-			$crate::traits::misc::DEFENSIVE_OP_PUBLIC_ERROR,
+			$crate::traits::DEFENSIVE_OP_PUBLIC_ERROR,
 			$error
 		);
-		debug_assert!(false, "{}: {:?}", $crate::traits::misc::DEFENSIVE_OP_INTERNAL_ERROR, $error);
+		debug_assert!(false, "{}: {:?}", $crate::traits::DEFENSIVE_OP_INTERNAL_ERROR, $error);
 	}
 }
 


### PR DESCRIPTION
This PR adds the groundwork to store validators in bags-list, sorted based on stake. This builds on top of #10821 and should be merged after it.

Similar to what we did with nominators, we can deploy this in multiple stages: 

1. current code can be deployed as is
2. Then, we can update staking to `Release::V10`, and migrate all validators to the bags-list, but use a hypothetical `UseValidatorsMapAndUpdateBagsList`.
3. Once confident, we switch to `type TargetList = ValidatorsBagsList`. 