### PR TITLE
Bring back MaxNominations as a metadata constant

### DIFF
--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -96,6 +96,7 @@ pub mod pallet {
 		>;
 
 		/// Maximum number of nominations per nominator.
+		#[pallet::constant]
 		type MaxNominations: Get<u32>;
 
 		/// Tokens have been minted and are unused for validator-reward.


### PR DESCRIPTION
accidentally removed in https://github.com/paritytech/substrate/pull/10601.