### PR TITLE
Update new whitelist pallet to new primitive versions

### DIFF
--- a/frame/whitelist/Cargo.toml
+++ b/frame/whitelist/Cargo.toml
@@ -17,14 +17,14 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../primitives/api" }
 sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "5.0.0", default-features = false, path = "../../primitives/io" }
-sp-runtime = { version = "5.0.0", default-features = false, path = "../../primitives/runtime" }
+sp-io = { version = "6.0.0", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "6.0.0", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-core = { version = "5.0.0", path = "../../primitives/core" }
+sp-core = { version = "6.0.0", path = "../../primitives/core" }
 pallet-preimage = { version = "4.0.0-dev", path = "../preimage/" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances/" }
 


### PR DESCRIPTION
#10937 was force merged minutes after https://github.com/paritytech/substrate/pull/10159 which added a new pallet. So the versions need updating