### PR TITLE
Allow trailing commas for `bounded_vec!`

### DIFF
--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -1480,7 +1480,7 @@ fn rebond_is_fifo() {
 				active: 300,
 				unlocking: bounded_vec![
 					UnlockChunk { value: 400, era: 2 + 3 },
-					UnlockChunk { value: 300, era: 3 + 3 }
+					UnlockChunk { value: 300, era: 3 + 3 },
 				],
 				claimed_rewards: vec![],
 			})
@@ -1499,7 +1499,7 @@ fn rebond_is_fifo() {
 				unlocking: bounded_vec![
 					UnlockChunk { value: 400, era: 2 + 3 },
 					UnlockChunk { value: 300, era: 3 + 3 },
-					UnlockChunk { value: 200, era: 4 + 3 }
+					UnlockChunk { value: 200, era: 4 + 3 },
 				],
 				claimed_rewards: vec![],
 			})
@@ -1515,7 +1515,7 @@ fn rebond_is_fifo() {
 				active: 500,
 				unlocking: bounded_vec![
 					UnlockChunk { value: 400, era: 2 + 3 },
-					UnlockChunk { value: 100, era: 3 + 3 }
+					UnlockChunk { value: 100, era: 3 + 3 },
 				],
 				claimed_rewards: vec![],
 			})

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -123,7 +123,7 @@ impl TypeId for PalletId {
 #[macro_export]
 #[cfg(feature = "std")]
 macro_rules! bounded_vec {
-	($ ($values:expr),* ) => {
+	($ ($values:expr),* $(,)?) => {
 		{
 			use $crate::sp_std::convert::TryInto as _;
 			$crate::sp_std::vec![$($values),*].try_into().unwrap()


### PR DESCRIPTION
This PR makes a change to the `bounded_vec!` macro so trailing commas can be used.
