### PR TITLE
Make FRAME traits generic over `Weight`

### DIFF
--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -84,7 +84,7 @@ pub mod pallet {
 	pub struct Pallet<T>(sp_std::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		fn on_initialize(_: T::BlockNumber) -> Weight {
 			if let Some(new_slot) = Self::current_slot_from_digests() {
 				let current_slot = CurrentSlot::<T>::get();

--- a/frame/authorship/src/lib.rs
+++ b/frame/authorship/src/lib.rs
@@ -160,7 +160,7 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		fn on_initialize(now: T::BlockNumber) -> Weight {
 			let uncle_generations = T::UncleGenerations::get();
 			// prune uncles that are older than the allowed number of generations.

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -328,7 +328,7 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		/// Initialization
 		fn on_initialize(now: BlockNumberFor<T>) -> Weight {
 			Self::do_initialize(now);

--- a/frame/bags-list/src/lib.rs
+++ b/frame/bags-list/src/lib.rs
@@ -217,7 +217,7 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		fn integrity_test() {
 			// ensure they are strictly increasing, this also implies that duplicates are detected.
 			assert!(

--- a/frame/bags-list/src/migrations.rs
+++ b/frame/bags-list/src/migrations.rs
@@ -18,6 +18,7 @@
 //! The migrations of this pallet.
 
 use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
+use sp_runtime::traits::Zero;
 
 /// A struct that does not migration, but only checks that the counter prefix exists and is correct.
 pub struct CheckCounterPrefix<T: crate::Config>(sp_std::marker::PhantomData<T>);

--- a/frame/bags-list/src/migrations.rs
+++ b/frame/bags-list/src/migrations.rs
@@ -17,8 +17,7 @@
 
 //! The migrations of this pallet.
 
-use frame_support::traits::OnRuntimeUpgrade;
-use frame_support::weights::Weight;
+use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
 
 /// A struct that does not migration, but only checks that the counter prefix exists and is correct.
 pub struct CheckCounterPrefix<T: crate::Config>(sp_std::marker::PhantomData<T>);

--- a/frame/bags-list/src/migrations.rs
+++ b/frame/bags-list/src/migrations.rs
@@ -18,12 +18,13 @@
 //! The migrations of this pallet.
 
 use frame_support::traits::OnRuntimeUpgrade;
+use frame_support::weights::Weight;
 
 /// A struct that does not migration, but only checks that the counter prefix exists and is correct.
 pub struct CheckCounterPrefix<T: crate::Config>(sp_std::marker::PhantomData<T>);
-impl<T: crate::Config> OnRuntimeUpgrade for CheckCounterPrefix<T> {
-	fn on_runtime_upgrade() -> frame_support::weights::Weight {
-		0
+impl<T: crate::Config> OnRuntimeUpgrade<Weight> for CheckCounterPrefix<T> {
+	fn on_runtime_upgrade() -> Weight {
+		Zero::zero()
 	}
 
 	#[cfg(feature = "try-runtime")]

--- a/frame/beefy/src/lib.rs
+++ b/frame/beefy/src/lib.rs
@@ -55,7 +55,7 @@ pub mod pallet {
 	pub struct Pallet<T>(PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/bounties/src/tests.rs
+++ b/frame/bounties/src/tests.rs
@@ -217,7 +217,7 @@ fn accepted_spend_proposal_ignored_outside_spend_period() {
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
 		assert_ok!(Treasury::approve_proposal(Origin::root(), 0));
 
-		<Treasury as OnInitialize<u64>>::on_initialize(1);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(1);
 		assert_eq!(Balances::free_balance(3), 0);
 		assert_eq!(Treasury::pot(), 100);
 	});
@@ -230,7 +230,7 @@ fn unused_pot_should_diminish() {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 		assert_eq!(Balances::total_issuance(), init_total_issuance + 100);
 
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 50);
 		assert_eq!(Balances::total_issuance(), init_total_issuance + 50);
 	});
@@ -244,7 +244,7 @@ fn rejected_spend_proposal_ignored_on_spend_period() {
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
 		assert_ok!(Treasury::reject_proposal(Origin::root(), 0));
 
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 		assert_eq!(Balances::free_balance(3), 0);
 		assert_eq!(Treasury::pot(), 50);
 	});
@@ -298,7 +298,7 @@ fn accepted_spend_proposal_enacted_on_spend_period() {
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
 		assert_ok!(Treasury::approve_proposal(Origin::root(), 0));
 
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 		assert_eq!(Balances::free_balance(3), 100);
 		assert_eq!(Treasury::pot(), 0);
 	});
@@ -313,11 +313,11 @@ fn pot_underflow_should_not_diminish() {
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 150, 3));
 		assert_ok!(Treasury::approve_proposal(Origin::root(), 0));
 
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 100); // Pot hasn't changed
 
 		assert_ok!(Balances::deposit_into_existing(&Treasury::account_id(), 100));
-		<Treasury as OnInitialize<u64>>::on_initialize(4);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(4);
 		assert_eq!(Balances::free_balance(3), 150); // Fund has been spent
 		assert_eq!(Treasury::pot(), 25); // Pot has finally changed
 	});
@@ -335,13 +335,13 @@ fn treasury_account_doesnt_get_deleted() {
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), treasury_balance, 3));
 		assert_ok!(Treasury::approve_proposal(Origin::root(), 0));
 
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 100); // Pot hasn't changed
 
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), Treasury::pot(), 3));
 		assert_ok!(Treasury::approve_proposal(Origin::root(), 1));
 
-		<Treasury as OnInitialize<u64>>::on_initialize(4);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(4);
 		assert_eq!(Treasury::pot(), 0); // Pot is emptied
 		assert_eq!(Balances::free_balance(Treasury::account_id()), 1); // but the account is still there
 	});
@@ -366,7 +366,7 @@ fn inexistent_account_works() {
 		assert_ok!(Treasury::approve_proposal(Origin::root(), 0));
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 1, 3));
 		assert_ok!(Treasury::approve_proposal(Origin::root(), 1));
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 0); // Pot hasn't changed
 		assert_eq!(Balances::free_balance(3), 0); // Balance of `3` hasn't changed
 
@@ -374,7 +374,7 @@ fn inexistent_account_works() {
 		assert_eq!(Treasury::pot(), 99); // Pot now contains funds
 		assert_eq!(Balances::free_balance(Treasury::account_id()), 100); // Account does exist
 
-		<Treasury as OnInitialize<u64>>::on_initialize(4);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(4);
 
 		assert_eq!(Treasury::pot(), 0); // Pot has changed
 		assert_eq!(Balances::free_balance(3), 99); // Balance of `3` has changed
@@ -497,7 +497,7 @@ fn approve_bounty_works() {
 		assert_eq!(Balances::reserved_balance(0), deposit);
 		assert_eq!(Balances::free_balance(0), 100 - deposit);
 
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		// return deposit
 		assert_eq!(Balances::reserved_balance(0), 0);
@@ -536,7 +536,7 @@ fn assign_curator_works() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_noop!(
 			Bounties::propose_curator(Origin::root(), 0, 4, 50),
@@ -594,7 +594,7 @@ fn unassign_curator_works() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 4, 4));
 
@@ -650,7 +650,7 @@ fn award_and_claim_bounty_works() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 4, 4));
 		assert_ok!(Bounties::accept_curator(Origin::signed(4), 0));
@@ -679,7 +679,7 @@ fn award_and_claim_bounty_works() {
 		assert_noop!(Bounties::claim_bounty(Origin::signed(1), 0), Error::<Test>::Premature);
 
 		System::set_block_number(5);
-		<Treasury as OnInitialize<u64>>::on_initialize(5);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(5);
 
 		assert_ok!(Balances::transfer(Origin::signed(0), Bounties::bounty_account_id(0), 10));
 
@@ -711,7 +711,7 @@ fn claim_handles_high_fee() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 4, 49));
 		assert_ok!(Bounties::accept_curator(Origin::signed(4), 0));
@@ -719,7 +719,7 @@ fn claim_handles_high_fee() {
 		assert_ok!(Bounties::award_bounty(Origin::signed(4), 0, 3));
 
 		System::set_block_number(5);
-		<Treasury as OnInitialize<u64>>::on_initialize(5);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(5);
 
 		// make fee > balance
 		let res = Balances::slash(&Bounties::bounty_account_id(0), 10);
@@ -753,7 +753,7 @@ fn cancel_and_refund() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Balances::transfer(Origin::signed(0), Bounties::bounty_account_id(0), 10));
 
@@ -790,7 +790,7 @@ fn award_and_cancel() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 0, 10));
 		assert_ok!(Bounties::accept_curator(Origin::signed(0), 0));
@@ -830,7 +830,7 @@ fn expire_and_unassign() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 1, 10));
 		assert_ok!(Bounties::accept_curator(Origin::signed(1), 0));
@@ -839,12 +839,12 @@ fn expire_and_unassign() {
 		assert_eq!(Balances::reserved_balance(1), 5);
 
 		System::set_block_number(22);
-		<Treasury as OnInitialize<u64>>::on_initialize(22);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(22);
 
 		assert_noop!(Bounties::unassign_curator(Origin::signed(0), 0), Error::<Test>::Premature);
 
 		System::set_block_number(23);
-		<Treasury as OnInitialize<u64>>::on_initialize(23);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(23);
 
 		assert_ok!(Bounties::unassign_curator(Origin::signed(0), 0));
 
@@ -881,7 +881,7 @@ fn extend_expiry() {
 		);
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 4, 10));
 		assert_ok!(Bounties::accept_curator(Origin::signed(4), 0));
@@ -890,7 +890,7 @@ fn extend_expiry() {
 		assert_eq!(Balances::reserved_balance(4), 5);
 
 		System::set_block_number(10);
-		<Treasury as OnInitialize<u64>>::on_initialize(10);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(10);
 
 		assert_noop!(
 			Bounties::extend_bounty_expiry(Origin::signed(0), 0, Vec::new()),
@@ -925,7 +925,7 @@ fn extend_expiry() {
 		);
 
 		System::set_block_number(25);
-		<Treasury as OnInitialize<u64>>::on_initialize(25);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(25);
 
 		assert_noop!(Bounties::unassign_curator(Origin::signed(0), 0), Error::<Test>::Premature);
 		assert_ok!(Bounties::unassign_curator(Origin::signed(4), 0));
@@ -1005,7 +1005,7 @@ fn unassign_curator_self() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 1, 10));
 		assert_ok!(Bounties::accept_curator(Origin::signed(1), 0));
@@ -1014,7 +1014,7 @@ fn unassign_curator_self() {
 		assert_eq!(Balances::reserved_balance(1), 5);
 
 		System::set_block_number(8);
-		<Treasury as OnInitialize<u64>>::on_initialize(8);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(8);
 
 		assert_ok!(Bounties::unassign_curator(Origin::signed(1), 0));
 

--- a/frame/child-bounties/src/tests.rs
+++ b/frame/child-bounties/src/tests.rs
@@ -215,7 +215,7 @@ fn add_child_bounty() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 4, 4));
 
@@ -300,7 +300,7 @@ fn child_bounty_assign_curator() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 4, 4));
 
@@ -400,7 +400,7 @@ fn award_claim_child_bounty() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 4, 6));
 		assert_ok!(Bounties::accept_curator(Origin::signed(4), 0));
@@ -484,7 +484,7 @@ fn close_child_bounty_added() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 4, 6));
 
@@ -536,7 +536,7 @@ fn close_child_bounty_active() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 4, 6));
 
@@ -589,7 +589,7 @@ fn close_child_bounty_pending() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 4, 6));
 
@@ -643,7 +643,7 @@ fn child_bounty_added_unassign_curator() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 4, 6));
 
@@ -680,7 +680,7 @@ fn child_bounty_curator_proposed_unassign_curator() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 4, 6));
 
@@ -752,7 +752,7 @@ fn child_bounty_active_unassign_curator() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 4, 6));
 
@@ -763,7 +763,7 @@ fn child_bounty_active_unassign_curator() {
 		assert_eq!(last_event(), ChildBountiesEvent::Added { index: 0, child_index: 0 });
 
 		System::set_block_number(3);
-		<Treasury as OnInitialize<u64>>::on_initialize(3);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(3);
 
 		// Propose and accept curator for child-bounty.
 		assert_ok!(ChildBounties::propose_curator(Origin::signed(4), 0, 0, 8, 2));
@@ -781,7 +781,7 @@ fn child_bounty_active_unassign_curator() {
 		);
 
 		System::set_block_number(4);
-		<Treasury as OnInitialize<u64>>::on_initialize(4);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(4);
 
 		// Unassign curator - from reject origin.
 		assert_ok!(ChildBounties::unassign_curator(Origin::root(), 0, 0));
@@ -818,7 +818,7 @@ fn child_bounty_active_unassign_curator() {
 		);
 
 		System::set_block_number(5);
-		<Treasury as OnInitialize<u64>>::on_initialize(5);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(5);
 
 		// Unassign curator again - from master curator.
 		assert_ok!(ChildBounties::unassign_curator(Origin::signed(4), 0, 0));
@@ -855,7 +855,7 @@ fn child_bounty_active_unassign_curator() {
 		);
 
 		System::set_block_number(6);
-		<Treasury as OnInitialize<u64>>::on_initialize(6);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(6);
 
 		// Unassign curator again - from child-bounty curator.
 		assert_ok!(ChildBounties::unassign_curator(Origin::signed(6), 0, 0));
@@ -892,7 +892,7 @@ fn child_bounty_active_unassign_curator() {
 		);
 
 		System::set_block_number(7);
-		<Treasury as OnInitialize<u64>>::on_initialize(7);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(7);
 
 		// Unassign curator again - from non curator; non reject origin; some random guy.
 		// Bounty update period is not yet complete.
@@ -902,7 +902,7 @@ fn child_bounty_active_unassign_curator() {
 		);
 
 		System::set_block_number(20);
-		<Treasury as OnInitialize<u64>>::on_initialize(20);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(20);
 
 		// Unassign child curator from random account after inactivity.
 		assert_ok!(ChildBounties::unassign_curator(Origin::signed(3), 0, 0));
@@ -947,7 +947,7 @@ fn parent_bounty_inactive_unassign_curator_child_bounty() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 4, 6));
 		assert_ok!(Bounties::accept_curator(Origin::signed(4), 0));
@@ -957,7 +957,7 @@ fn parent_bounty_inactive_unassign_curator_child_bounty() {
 		assert_eq!(last_event(), ChildBountiesEvent::Added { index: 0, child_index: 0 });
 
 		System::set_block_number(3);
-		<Treasury as OnInitialize<u64>>::on_initialize(3);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(3);
 
 		// Propose and accept curator for child-bounty.
 		assert_ok!(ChildBounties::propose_curator(Origin::signed(4), 0, 0, 8, 2));
@@ -975,13 +975,13 @@ fn parent_bounty_inactive_unassign_curator_child_bounty() {
 		);
 
 		System::set_block_number(4);
-		<Treasury as OnInitialize<u64>>::on_initialize(4);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(4);
 
 		// Unassign parent bounty curator.
 		assert_ok!(Bounties::unassign_curator(Origin::root(), 0));
 
 		System::set_block_number(5);
-		<Treasury as OnInitialize<u64>>::on_initialize(5);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(5);
 
 		// Try unassign child-bounty curator - from non curator; non reject
 		// origin; some random guy. Bounty update period is not yet complete.
@@ -1010,14 +1010,14 @@ fn parent_bounty_inactive_unassign_curator_child_bounty() {
 		assert_eq!(Balances::reserved_balance(8), 0); // slashed
 
 		System::set_block_number(6);
-		<Treasury as OnInitialize<u64>>::on_initialize(6);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(6);
 
 		// Propose and accept curator for parent-bounty again.
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 5, 6));
 		assert_ok!(Bounties::accept_curator(Origin::signed(5), 0));
 
 		System::set_block_number(7);
-		<Treasury as OnInitialize<u64>>::on_initialize(7);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(7);
 
 		// Propose and accept curator for child-bounty again.
 		assert_ok!(ChildBounties::propose_curator(Origin::signed(5), 0, 0, 7, 2));
@@ -1035,7 +1035,7 @@ fn parent_bounty_inactive_unassign_curator_child_bounty() {
 		);
 
 		System::set_block_number(8);
-		<Treasury as OnInitialize<u64>>::on_initialize(8);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(8);
 
 		assert_noop!(
 			ChildBounties::unassign_curator(Origin::signed(3), 0, 0),
@@ -1046,7 +1046,7 @@ fn parent_bounty_inactive_unassign_curator_child_bounty() {
 		assert_ok!(Bounties::unassign_curator(Origin::signed(5), 0));
 
 		System::set_block_number(9);
-		<Treasury as OnInitialize<u64>>::on_initialize(9);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(9);
 
 		// Unassign curator again - from master curator.
 		assert_ok!(ChildBounties::unassign_curator(Origin::signed(7), 0, 0));
@@ -1093,7 +1093,7 @@ fn close_parent_with_child_bounty() {
 		);
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 4, 6));
 		assert_ok!(Bounties::accept_curator(Origin::signed(4), 0));
@@ -1103,7 +1103,7 @@ fn close_parent_with_child_bounty() {
 		assert_eq!(last_event(), ChildBountiesEvent::Added { index: 0, child_index: 0 });
 
 		System::set_block_number(4);
-		<Treasury as OnInitialize<u64>>::on_initialize(4);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(4);
 
 		// Try close parent-bounty.
 		// Child bounty active, can't close parent.
@@ -1145,7 +1145,7 @@ fn children_curator_fee_calculation_test() {
 		assert_ok!(Bounties::approve_bounty(Origin::root(), 0));
 
 		System::set_block_number(2);
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 
 		assert_ok!(Bounties::propose_curator(Origin::root(), 0, 4, 6));
 		assert_ok!(Bounties::accept_curator(Origin::signed(4), 0));
@@ -1155,7 +1155,7 @@ fn children_curator_fee_calculation_test() {
 		assert_eq!(last_event(), ChildBountiesEvent::Added { index: 0, child_index: 0 });
 
 		System::set_block_number(4);
-		<Treasury as OnInitialize<u64>>::on_initialize(4);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(4);
 
 		// Propose curator for child-bounty.
 		assert_ok!(ChildBounties::propose_curator(Origin::signed(4), 0, 0, 8, 2));

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -315,7 +315,7 @@ pub mod pallet {
 	pub struct Pallet<T>(PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T>
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T>
 	where
 		T::AccountId: UncheckedFrom<T::Hash>,
 		T::AccountId: AsRef<[u8]>,

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -601,7 +601,7 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		/// Weight: see `begin_block`
 		fn on_initialize(n: T::BlockNumber) -> Weight {
 			Self::begin_block(n)

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -715,7 +715,7 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		fn on_initialize(now: T::BlockNumber) -> Weight {
 			let next_election = T::DataProvider::next_election_prediction(now).max(now);
 

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -254,7 +254,7 @@ pub mod pallet {
 	pub struct Pallet<T>(PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		/// What to do at the end of each block.
 		///
 		/// Checks if an election needs to happen or not.

--- a/frame/examples/basic/src/lib.rs
+++ b/frame/examples/basic/src/lib.rs
@@ -384,7 +384,7 @@ pub mod pallet {
 
 	// Pallet implements [`Hooks`] trait to define some logic to execute in some context.
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		// `on_initialize` is executed at the beginning of the block before any extrinsic are
 		// dispatched.
 		//

--- a/frame/examples/basic/src/tests.rs
+++ b/frame/examples/basic/src/tests.rs
@@ -131,7 +131,7 @@ fn it_works_for_optional_value() {
 		assert_eq!(Example::dummy(), Some(val1 + val2));
 
 		// Check that accumulate works when we Dummy has None in it.
-		<Example as OnInitialize<u64>>::on_initialize(2);
+		<Example as OnInitialize<u64, Weight>>::on_initialize(2);
 		assert_ok!(Example::accumulate_dummy(Origin::signed(1), val1));
 		assert_eq!(Example::dummy(), Some(val1 + val2 + val1));
 	});

--- a/frame/examples/offchain-worker/src/lib.rs
+++ b/frame/examples/offchain-worker/src/lib.rs
@@ -165,7 +165,7 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		/// Offchain Worker entry point.
 		///
 		/// By implementing `fn offchain_worker` you declare a new offchain worker.

--- a/frame/executive/README.md
+++ b/frame/executive/README.md
@@ -52,9 +52,10 @@ the on runtime upgrade logic of all modules is called.
 
 ```rust
 #
+use frame_support::weights::Weight;
 struct CustomOnRuntimeUpgrade;
-impl frame_support::traits::OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
-    fn on_runtime_upgrade() -> frame_support::weights::Weight {
+impl frame_support::traits::OnRuntimeUpgrade<Weight> for CustomOnRuntimeUpgrade {
+    fn on_runtime_upgrade() -> Weight {
         // Do whatever you want.
         0
     }

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -600,7 +600,7 @@ mod tests {
 		pub trait Config: frame_system::Config {}
 
 		#[pallet::hooks]
-		impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 			// module hooks.
 			// one with block number arg and one without
 			fn on_initialize(n: T::BlockNumber) -> Weight {

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -176,7 +176,7 @@ impl<
 		UnsignedValidator,
 		AllPalletsWithSystem: OnRuntimeUpgrade
 			+ OnInitialize<System::BlockNumber, Weight>
-			+ OnIdle<System::BlockNumber>
+			+ OnIdle<System::BlockNumber, Weight>
 			+ OnFinalize<System::BlockNumber>
 			+ OffchainWorker<System::BlockNumber>,
 		COnRuntimeUpgrade: OnRuntimeUpgrade,
@@ -209,7 +209,7 @@ impl<
 		UnsignedValidator,
 		AllPalletsWithSystem: OnRuntimeUpgrade
 			+ OnInitialize<System::BlockNumber, Weight>
-			+ OnIdle<System::BlockNumber>
+			+ OnIdle<System::BlockNumber, Weight>
 			+ OnFinalize<System::BlockNumber>
 			+ OffchainWorker<System::BlockNumber>,
 		COnRuntimeUpgrade: OnRuntimeUpgrade,
@@ -415,10 +415,11 @@ where
 		let remaining_weight = max_weight.saturating_sub(weight.total());
 
 		if remaining_weight > 0 {
-			let used_weight = <AllPalletsWithSystem as OnIdle<System::BlockNumber>>::on_idle(
-				block_number,
-				remaining_weight,
-			);
+			let used_weight =
+				<AllPalletsWithSystem as OnIdle<System::BlockNumber, Weight>>::on_idle(
+					block_number,
+					remaining_weight,
+				);
 			<frame_system::Pallet<System>>::register_extra_weight_unchecked(
 				used_weight,
 				DispatchClass::Mandatory,

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -225,7 +225,8 @@ where
 {
 	/// Execute all `OnRuntimeUpgrade` of this runtime, and return the aggregate weight.
 	pub fn execute_on_runtime_upgrade() -> Weight {
-		<(COnRuntimeUpgrade, AllPalletsWithSystem) as OnRuntimeUpgrade<Weight>>::on_runtime_upgrade()
+		<(COnRuntimeUpgrade, AllPalletsWithSystem) as OnRuntimeUpgrade<Weight>>::on_runtime_upgrade(
+		)
 	}
 
 	/// Execute given block, but don't do any of the `final_checks`.
@@ -264,10 +265,12 @@ where
 	/// This should only be used for testing.
 	#[cfg(feature = "try-runtime")]
 	pub fn try_runtime_upgrade() -> Result<Weight, &'static str> {
-		<(COnRuntimeUpgrade, AllPalletsWithSystem) as OnRuntimeUpgrade<Weight>>::pre_upgrade().unwrap();
+		<(COnRuntimeUpgrade, AllPalletsWithSystem) as OnRuntimeUpgrade<Weight>>::pre_upgrade()
+			.unwrap();
 		let weight = Self::execute_on_runtime_upgrade();
 
-		<(COnRuntimeUpgrade, AllPalletsWithSystem) as OnRuntimeUpgrade<Weight>>::post_upgrade().unwrap();
+		<(COnRuntimeUpgrade, AllPalletsWithSystem) as OnRuntimeUpgrade<Weight>>::post_upgrade()
+			.unwrap();
 
 		Ok(weight)
 	}

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -224,7 +224,7 @@ where
 	UnsignedValidator: ValidateUnsigned<Call = CallOf<Block::Extrinsic, Context>>,
 {
 	/// Execute all `OnRuntimeUpgrade` of this runtime, and return the aggregate weight.
-	pub fn execute_on_runtime_upgrade() -> frame_support::weights::Weight {
+	pub fn execute_on_runtime_upgrade() -> Weight {
 		<(COnRuntimeUpgrade, AllPalletsWithSystem) as OnRuntimeUpgrade<Weight>>::on_runtime_upgrade()
 	}
 
@@ -232,7 +232,7 @@ where
 	///
 	/// Should only be used for testing.
 	#[cfg(feature = "try-runtime")]
-	pub fn execute_block_no_check(block: Block) -> frame_support::weights::Weight {
+	pub fn execute_block_no_check(block: Block) -> Weight {
 		Self::initialize_block(block.header());
 		Self::initial_checks(&block);
 
@@ -263,7 +263,7 @@ where
 	///
 	/// This should only be used for testing.
 	#[cfg(feature = "try-runtime")]
-	pub fn try_runtime_upgrade() -> Result<frame_support::weights::Weight, &'static str> {
+	pub fn try_runtime_upgrade() -> Result<Weight, &'static str> {
 		<(COnRuntimeUpgrade, AllPalletsWithSystem) as OnRuntimeUpgrade<Weight>>::pre_upgrade().unwrap();
 		let weight = Self::execute_on_runtime_upgrade();
 

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -123,7 +123,7 @@ use frame_support::{
 		EnsureInherentsAreFirst, ExecuteBlock, OffchainWorker, OnFinalize, OnIdle, OnInitialize,
 		OnRuntimeUpgrade,
 	},
-	weights::{DispatchClass, DispatchInfo, GetDispatchInfo},
+	weights::{DispatchClass, DispatchInfo, GetDispatchInfo, Weight},
 };
 use sp_runtime::{
 	generic::Digest,
@@ -175,7 +175,7 @@ impl<
 		Context: Default,
 		UnsignedValidator,
 		AllPalletsWithSystem: OnRuntimeUpgrade
-			+ OnInitialize<System::BlockNumber>
+			+ OnInitialize<System::BlockNumber, Weight>
 			+ OnIdle<System::BlockNumber>
 			+ OnFinalize<System::BlockNumber>
 			+ OffchainWorker<System::BlockNumber>,
@@ -208,7 +208,7 @@ impl<
 		Context: Default,
 		UnsignedValidator,
 		AllPalletsWithSystem: OnRuntimeUpgrade
-			+ OnInitialize<System::BlockNumber>
+			+ OnInitialize<System::BlockNumber, Weight>
 			+ OnIdle<System::BlockNumber>
 			+ OnFinalize<System::BlockNumber>
 			+ OffchainWorker<System::BlockNumber>,
@@ -306,6 +306,7 @@ where
 		<frame_system::Pallet<System>>::initialize(block_number, parent_hash, digest);
 		weight = weight.saturating_add(<AllPalletsWithSystem as OnInitialize<
 			System::BlockNumber,
+			Weight,
 		>>::on_initialize(*block_number));
 		weight = weight.saturating_add(
 			<System::BlockWeights as frame_support::traits::Get<_>>::get().base_block,
@@ -1388,7 +1389,7 @@ mod tests {
 			let runtime_upgrade_weight =
 				<AllPalletsWithSystem as OnRuntimeUpgrade>::on_runtime_upgrade();
 			let on_initialize_weight =
-				<AllPalletsWithSystem as OnInitialize<u64>>::on_initialize(block_number);
+				<AllPalletsWithSystem as OnInitialize<u64, Weight>>::on_initialize(block_number);
 			let base_block_weight =
 				<Runtime as frame_system::Config>::BlockWeights::get().base_block;
 

--- a/frame/gilt/src/lib.rs
+++ b/frame/gilt/src/lib.rs
@@ -330,7 +330,7 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		fn on_initialize(n: T::BlockNumber) -> Weight {
 			if (n % T::IntakePeriod::get()).is_zero() {
 				Self::pursue_target(T::MaxIntakeBids::get())

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -128,7 +128,7 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		fn on_finalize(block_number: T::BlockNumber) {
 			// check for scheduled pending authority set changes
 			if let Some(pending_change) = <PendingChange<T>>::get() {

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -516,7 +516,7 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		fn offchain_worker(now: BlockNumberFor<T>) {
 			// Only send messages if we are a potential validator.
 			if sp_io::offchain::is_validator() {

--- a/frame/lottery/src/lib.rs
+++ b/frame/lottery/src/lib.rs
@@ -239,7 +239,7 @@ pub mod pallet {
 		StorageValue<_, BoundedVec<CallIndex, T::MaxCalls>, ValueQuery>;
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		fn on_initialize(n: T::BlockNumber) -> Weight {
 			Lottery::<T>::mutate(|mut lottery| -> Weight {
 				if let Some(config) = &mut lottery {

--- a/frame/merkle-mountain-range/src/lib.rs
+++ b/frame/merkle-mountain-range/src/lib.rs
@@ -173,7 +173,7 @@ pub mod pallet {
 		StorageMap<_, Identity, NodeIndex, <T as Config<I>>::Hash, OptionQuery>;
 
 	#[pallet::hooks]
-	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {
+	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>, Weight> for Pallet<T, I> {
 		fn on_initialize(_n: T::BlockNumber) -> Weight {
 			use primitives::LeafDataProvider;
 			let leaves = Self::mmr_leaves();

--- a/frame/multisig/src/lib.rs
+++ b/frame/multisig/src/lib.rs
@@ -233,7 +233,7 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {

--- a/frame/node-authorization/src/lib.rs
+++ b/frame/node-authorization/src/lib.rs
@@ -170,7 +170,7 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		/// Set reserved node every block. It may not be enabled depends on the offchain
 		/// worker settings when starting the node.
 		fn offchain_worker(now: T::BlockNumber) {

--- a/frame/randomness-collective-flip/src/lib.rs
+++ b/frame/randomness-collective-flip/src/lib.rs
@@ -97,7 +97,7 @@ pub mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		fn on_initialize(block_number: T::BlockNumber) -> Weight {
 			let parent_hash = <frame_system::Pallet<T>>::parent_hash();
 

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -291,7 +291,7 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		/// Execute the scheduled calls
 		fn on_initialize(now: T::BlockNumber) -> Weight {
 			let limit = T::MaximumWeight::get();

--- a/frame/scheduler/src/mock.rs
+++ b/frame/scheduler/src/mock.rs
@@ -55,7 +55,7 @@ pub mod logger {
 	pub struct Pallet<T>(PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {

--- a/frame/scored-pool/src/lib.rs
+++ b/frame/scored-pool/src/lib.rs
@@ -272,7 +272,7 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {
+	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>, Weight> for Pallet<T, I> {
 		/// Every `Period` blocks the `Members` set is refreshed from the
 		/// highest scoring members in the pool.
 		fn on_initialize(n: T::BlockNumber) -> Weight {

--- a/frame/session/benchmarking/src/lib.rs
+++ b/frame/session/benchmarking/src/lib.rs
@@ -29,6 +29,7 @@ use frame_benchmarking::benchmarks;
 use frame_support::{
 	codec::Decode,
 	traits::{Get, KeyOwnerProofSystem, OnInitialize},
+	weights::Weight,
 };
 use frame_system::RawOrigin;
 use pallet_session::{historical::Pallet as Historical, Pallet as Session, *};
@@ -45,7 +46,7 @@ pub trait Config:
 {
 }
 
-impl<T: Config> OnInitialize<T::BlockNumber> for Pallet<T> {
+impl<T: Config> OnInitialize<T::BlockNumber, Weight> for Pallet<T> {
 	fn on_initialize(n: T::BlockNumber) -> frame_support::weights::Weight {
 		pallet_session::Pallet::<T>::on_initialize(n)
 	}

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -567,7 +567,7 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		/// Called when a block is initialized. Will rotate session if it is the last
 		/// block of the current session.
 		fn on_initialize(n: T::BlockNumber) -> Weight {

--- a/frame/society/src/lib.rs
+++ b/frame/society/src/lib.rs
@@ -613,7 +613,7 @@ pub mod pallet {
 	pub(super) type MaxMembers<T: Config<I>, I: 'static = ()> = StorageValue<_, u32, ValueQuery>;
 
 	#[pallet::hooks]
-	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {
+	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>, Weight> for Pallet<T, I> {
 		fn on_initialize(n: T::BlockNumber) -> Weight {
 			let mut members = vec![];
 

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -513,7 +513,7 @@ impl ExtBuilder {
 			ext.execute_with(|| {
 				System::set_block_number(1);
 				Session::on_initialize(1);
-				<Staking as Hooks<u64>>::on_initialize(1);
+				<Staking as Hooks<u64, Weight>>::on_initialize(1);
 				Timestamp::set_timestamp(INIT_TIMESTAMP);
 			});
 		}
@@ -667,7 +667,7 @@ pub(crate) fn run_to_block(n: BlockNumber) {
 	for b in (System::block_number() + 1)..=n {
 		System::set_block_number(b);
 		Session::on_initialize(b);
-		<Staking as Hooks<u64>>::on_initialize(b);
+		<Staking as Hooks<u64, Weight>>::on_initialize(b);
 		Timestamp::set_timestamp(System::block_number() * BLOCK_TIME + INIT_TIMESTAMP);
 		if b != n {
 			Staking::on_finalize(System::block_number());

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -673,7 +673,7 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		fn on_initialize(_now: BlockNumberFor<T>) -> Weight {
 			// just return the weight of the on_finalize.
 			T::DbWeight::get().reads(1)

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -3961,7 +3961,7 @@ fn do_not_die_when_active_is_ed() {
 fn on_finalize_weight_is_nonzero() {
 	ExtBuilder::default().build_and_execute(|| {
 		let on_finalize_weight = <Test as frame_system::Config>::DbWeight::get().reads(1);
-		assert!(<Staking as Hooks<u64>>::on_initialize(1) >= on_finalize_weight);
+		assert!(<Staking as Hooks<u64, Weight>>::on_initialize(1) >= on_finalize_weight);
 	})
 }
 

--- a/frame/support/procedural/src/pallet/expand/hooks.rs
+++ b/frame/support/procedural/src/pallet/expand/hooks.rs
@@ -63,7 +63,7 @@ pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 		let frame_system = &def.frame_system;
 		quote::quote! {
 			impl<#type_impl_gen>
-				#frame_support::traits::Hooks<<T as #frame_system::Config>::BlockNumber>
+				#frame_support::traits::Hooks<<T as #frame_system::Config>::BlockNumber, #frame_support::weights::Weight>
 				for Pallet<#type_use_gen> {}
 		}
 	} else {
@@ -83,7 +83,8 @@ pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 				);
 				<
 					Self as #frame_support::traits::Hooks<
-						<T as #frame_system::Config>::BlockNumber
+						<T as #frame_system::Config>::BlockNumber,
+						#frame_support::weights::Weight,
 					>
 				>::on_finalize(n)
 			}
@@ -99,7 +100,8 @@ pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 			) -> #frame_support::weights::Weight {
 				<
 					Self as #frame_support::traits::Hooks<
-						<T as #frame_system::Config>::BlockNumber
+						<T as #frame_system::Config>::BlockNumber,
+						#frame_support::weights::Weight,
 					>
 				>::on_idle(n, remaining_weight)
 			}
@@ -117,7 +119,8 @@ pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 				);
 				<
 					Self as #frame_support::traits::Hooks<
-						<T as #frame_system::Config>::BlockNumber
+						<T as #frame_system::Config>::BlockNumber,
+						#frame_support::weights::Weight,
 					>
 				>::on_initialize(n)
 			}
@@ -142,7 +145,8 @@ pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 
 				<
 					Self as #frame_support::traits::Hooks<
-						<T as #frame_system::Config>::BlockNumber
+						<T as #frame_system::Config>::BlockNumber,
+						#frame_support::weights::Weight,
 					>
 				>::on_runtime_upgrade()
 			}
@@ -152,7 +156,7 @@ pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 				<
 					Self
 					as
-					#frame_support::traits::Hooks<<T as #frame_system::Config>::BlockNumber>
+					#frame_support::traits::Hooks<<T as #frame_system::Config>::BlockNumber, #frame_support::weights::Weight>
 				>::pre_upgrade()
 			}
 
@@ -161,7 +165,7 @@ pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 				<
 					Self
 					as
-					#frame_support::traits::Hooks<<T as #frame_system::Config>::BlockNumber>
+					#frame_support::traits::Hooks<<T as #frame_system::Config>::BlockNumber, #frame_support::weights::Weight>
 				>::post_upgrade()
 			}
 		}
@@ -173,7 +177,8 @@ pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 			fn offchain_worker(n: <T as #frame_system::Config>::BlockNumber) {
 				<
 					Self as #frame_support::traits::Hooks<
-						<T as #frame_system::Config>::BlockNumber
+						<T as #frame_system::Config>::BlockNumber,
+						#frame_support::weights::Weight,
 					>
 				>::offchain_worker(n)
 			}
@@ -186,7 +191,8 @@ pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 			fn integrity_test() {
 				<
 					Self as #frame_support::traits::Hooks<
-						<T as #frame_system::Config>::BlockNumber
+						<T as #frame_system::Config>::BlockNumber,
+						#frame_support::weights::Weight,
 					>
 				>::integrity_test()
 			}

--- a/frame/support/procedural/src/pallet/expand/hooks.rs
+++ b/frame/support/procedural/src/pallet/expand/hooks.rs
@@ -124,7 +124,7 @@ pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 		}
 
 		impl<#type_impl_gen>
-			#frame_support::traits::OnRuntimeUpgrade
+			#frame_support::traits::OnRuntimeUpgrade<#frame_support::weights::Weight>
 			for #pallet_ident<#type_use_gen> #where_clause
 		{
 			fn on_runtime_upgrade() -> #frame_support::weights::Weight {

--- a/frame/support/procedural/src/pallet/expand/hooks.rs
+++ b/frame/support/procedural/src/pallet/expand/hooks.rs
@@ -106,7 +106,7 @@ pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 		}
 
 		impl<#type_impl_gen>
-			#frame_support::traits::OnInitialize<<T as #frame_system::Config>::BlockNumber>
+			#frame_support::traits::OnInitialize<<T as #frame_system::Config>::BlockNumber, #frame_support::weights::Weight>
 			for #pallet_ident<#type_use_gen> #where_clause
 		{
 			fn on_initialize(

--- a/frame/support/procedural/src/pallet/expand/hooks.rs
+++ b/frame/support/procedural/src/pallet/expand/hooks.rs
@@ -90,7 +90,7 @@ pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 		}
 
 		impl<#type_impl_gen>
-			#frame_support::traits::OnIdle<<T as #frame_system::Config>::BlockNumber>
+			#frame_support::traits::OnIdle<<T as #frame_system::Config>::BlockNumber, #frame_support::weights::Weight>
 			for #pallet_ident<#type_use_gen> #where_clause
 		{
 			fn on_idle(

--- a/frame/support/procedural/src/storage/print_pallet_upgrade.rs
+++ b/frame/support/procedural/src/storage/print_pallet_upgrade.rs
@@ -328,7 +328,7 @@ pub mod pallet {{
 	pub struct Pallet{decl_gen}(PhantomData{use_gen_tuple});
 
 	#[pallet::hooks]
-	impl{impl_gen} Hooks<BlockNumberFor<T>> for Pallet{use_gen}
+	impl{impl_gen} Hooks<BlockNumberFor<T>, Weight> for Pallet{use_gen}
 		// TODO_MAYBE_WHERE_CLAUSE
 	{{
 		// TODO_ON_FINALIZE

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -1504,7 +1504,7 @@ macro_rules! decl_module {
 		fn on_initialize() -> $return:ty { $( $impl:tt )* }
 	) => {
 		impl<$trait_instance: $system::Config + $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::traits::OnInitialize<<$trait_instance as $system::Config>::BlockNumber>
+			$crate::traits::OnInitialize<<$trait_instance as $system::Config>::BlockNumber, $crate::weights::Weight>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 			fn on_initialize(_block_number_not_used: <$trait_instance as $system::Config>::BlockNumber) -> $return {
@@ -1521,7 +1521,7 @@ macro_rules! decl_module {
 		fn on_initialize($param:ident : $param_ty:ty) -> $return:ty { $( $impl:tt )* }
 	) => {
 		impl<$trait_instance: $system::Config + $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::traits::OnInitialize<<$trait_instance as $system::Config>::BlockNumber>
+			$crate::traits::OnInitialize<<$trait_instance as $system::Config>::BlockNumber, $crate::weights::Weight>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 			fn on_initialize($param: $param_ty) -> $return {
@@ -1537,7 +1537,7 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 	) => {
 		impl<$trait_instance: $system::Config + $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::traits::OnInitialize<<$trait_instance as $system::Config>::BlockNumber>
+			$crate::traits::OnInitialize<<$trait_instance as $system::Config>::BlockNumber, $crate::weights::Weight>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{}
 	};
@@ -2789,12 +2789,12 @@ mod tests {
 	#[test]
 	#[should_panic(expected = "on_initialize")]
 	fn on_initialize_should_work_1() {
-		<Module<TraitImpl> as OnInitialize<u32>>::on_initialize(42);
+		<Module<TraitImpl> as OnInitialize<u32, Weight>>::on_initialize(42);
 	}
 
 	#[test]
 	fn on_initialize_should_work_2() {
-		assert_eq!(<Module<TraitImpl> as OnInitialize<u32>>::on_initialize(10), 7);
+		assert_eq!(<Module<TraitImpl> as OnInitialize<u32, Weight>>::on_initialize(10), 7);
 	}
 
 	#[test]

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -1549,7 +1549,7 @@ macro_rules! decl_module {
 		fn on_runtime_upgrade() -> $return:ty { $( $impl:tt )* }
 	) => {
 		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::traits::OnRuntimeUpgrade
+			$crate::traits::OnRuntimeUpgrade<$crate::weights::Weight>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 			fn on_runtime_upgrade() -> $return {
@@ -1590,7 +1590,7 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 	) => {
 		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::traits::OnRuntimeUpgrade
+			$crate::traits::OnRuntimeUpgrade<$crate::weights::Weight>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 			fn on_runtime_upgrade() -> $crate::dispatch::Weight {
@@ -2823,7 +2823,7 @@ mod tests {
 	#[test]
 	fn on_runtime_upgrade_should_work() {
 		sp_io::TestExternalities::default().execute_with(|| {
-			assert_eq!(<Module<TraitImpl> as OnRuntimeUpgrade>::on_runtime_upgrade(), 10)
+			assert_eq!(<Module<TraitImpl> as OnRuntimeUpgrade<Weight>>::on_runtime_upgrade(), 10)
 		});
 	}
 

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -1704,7 +1704,7 @@ macro_rules! decl_module {
 		fn on_idle($param1:ident : $param1_ty:ty, $param2:ident: $param2_ty:ty) -> $return:ty { $( $impl:tt )* }
 	) => {
 		impl<$trait_instance: $system::Config + $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::traits::OnIdle<<$trait_instance as $system::Config>::BlockNumber>
+			$crate::traits::OnIdle<<$trait_instance as $system::Config>::BlockNumber, $crate::weights::Weight>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 			fn on_idle($param1: $param1_ty, $param2: $param2_ty) -> $return {
@@ -1720,7 +1720,7 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 	) => {
 		impl<$trait_instance: $system::Config + $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::traits::OnIdle<<$trait_instance as $system::Config>::BlockNumber>
+			$crate::traits::OnIdle<<$trait_instance as $system::Config>::BlockNumber, $crate::weights::Weight>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 		}
@@ -2800,18 +2800,18 @@ mod tests {
 	#[test]
 	#[should_panic(expected = "on_idle")]
 	fn on_idle_should_work_1() {
-		<Module<TraitImpl> as OnIdle<u32>>::on_idle(42, 9);
+		<Module<TraitImpl> as OnIdle<u32, Weight>>::on_idle(42, 9);
 	}
 
 	#[test]
 	#[should_panic(expected = "on_idle")]
 	fn on_idle_should_work_2() {
-		<Module<TraitImpl> as OnIdle<u32>>::on_idle(9, 42);
+		<Module<TraitImpl> as OnIdle<u32, Weight>>::on_idle(9, 42);
 	}
 
 	#[test]
 	fn on_idle_should_work_3() {
-		assert_eq!(<Module<TraitImpl> as OnIdle<u32>>::on_idle(10, 11), 7);
+		assert_eq!(<Module<TraitImpl> as OnIdle<u32, Weight>>::on_idle(10, 11), 7);
 	}
 
 	#[test]

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -1527,18 +1527,18 @@ pub mod pallet_prelude {
 /// Item must be defined as
 /// ```ignore
 /// #[pallet::hooks]
-/// impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> $optional_where_clause {
+/// impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> $optional_where_clause {
 /// }
 /// ```
 /// I.e. a regular trait implementation with generic bound: `T: Config`, for the trait
-/// `Hooks<BlockNumberFor<T>>` (they are defined in preludes), for the type `Pallet<T>`
+/// `Hooks<BlockNumberFor<T>, Weight>` (they are defined in preludes), for the type `Pallet<T>`
 /// and with an optional where clause.
 ///
 /// If no `#[pallet::hooks]` exists, then a default implementation corresponding to the
 /// following code is automatically generated:
 /// ```ignore
 /// #[pallet::hooks]
-/// impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+/// impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 /// ```
 ///
 /// ### Macro expansion:
@@ -2008,7 +2008,7 @@ pub mod pallet_prelude {
 ///
 /// 	// Implement the pallet hooks.
 /// 	#[pallet::hooks]
-/// 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+/// 	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 /// 		fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
 /// 			unimplemented!();
 /// 		}
@@ -2194,7 +2194,7 @@ pub mod pallet_prelude {
 /// 	pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
 ///
 /// 	#[pallet::hooks]
-/// 	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {
+/// 	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>, Weight> for Pallet<T, I> {
 /// 	}
 ///
 /// 	#[pallet::call]

--- a/frame/support/src/traits/hooks.rs
+++ b/frame/support/src/traits/hooks.rs
@@ -159,7 +159,7 @@ impl<U: OnRuntimeUpgrade> OnRuntimeUpgradeHelpersExt for U {}
 ///
 /// Implementing this lets you express what should happen when the runtime upgrades,
 /// and changes may need to occur to your module.
-pub trait OnRuntimeUpgrade {
+pub trait OnRuntimeUpgrade<Weight: Zero> {
 	/// Perform a module upgrade.
 	///
 	/// # Warning
@@ -169,8 +169,8 @@ pub trait OnRuntimeUpgrade {
 	/// block local data are not accessible.
 	///
 	/// Return the non-negotiable weight consumed for runtime upgrade.
-	fn on_runtime_upgrade() -> crate::weights::Weight {
-		0
+	fn on_runtime_upgrade() -> Weight {
+		Zero::zero()
 	}
 
 	/// Execute some pre-checks prior to a runtime upgrade.
@@ -191,9 +191,12 @@ pub trait OnRuntimeUpgrade {
 }
 
 #[impl_for_tuples(30)]
-impl OnRuntimeUpgrade for Tuple {
-	fn on_runtime_upgrade() -> crate::weights::Weight {
-		let mut weight = 0;
+impl<Weight> OnRuntimeUpgrade<Weight> for Tuple
+where
+	Weight: Zero + Saturating,
+{
+	fn on_runtime_upgrade() -> Weight {
+		let mut weight = Weight::zero();
 		for_tuples!( #( weight = weight.saturating_add(Tuple::on_runtime_upgrade()); )* );
 		weight
 	}
@@ -343,7 +346,7 @@ mod tests {
 				10
 			}
 		}
-		impl OnRuntimeUpgrade for Test {
+		impl OnRuntimeUpgrade<Weight> for Test {
 			fn on_runtime_upgrade() -> Weight {
 				20
 			}

--- a/frame/support/src/traits/hooks.rs
+++ b/frame/support/src/traits/hooks.rs
@@ -226,10 +226,7 @@ pub trait Hooks<BlockNumber, Weight: Zero> {
 	/// Will not fire if the remaining weight is 0.
 	/// Return the weight used, the hook will subtract it from current weight used
 	/// and pass the result to the next `on_idle` hook if it exists.
-	fn on_idle(
-		_n: BlockNumber,
-		_remaining_weight: Weight,
-	) -> Weight {
+	fn on_idle(_n: BlockNumber, _remaining_weight: Weight) -> Weight {
 		Weight::zero()
 	}
 

--- a/frame/support/src/traits/hooks.rs
+++ b/frame/support/src/traits/hooks.rs
@@ -153,7 +153,7 @@ pub trait OnRuntimeUpgradeHelpersExt {
 }
 
 #[cfg(feature = "try-runtime")]
-impl<U: OnRuntimeUpgrade> OnRuntimeUpgradeHelpersExt for U {}
+impl<U> OnRuntimeUpgradeHelpersExt for U {}
 
 /// The runtime upgrade trait.
 ///

--- a/frame/support/src/traits/hooks.rs
+++ b/frame/support/src/traits/hooks.rs
@@ -118,9 +118,9 @@ pub trait OnGenesis {
 #[cfg(feature = "try-runtime")]
 pub const ON_RUNTIME_UPGRADE_PREFIX: &[u8] = b"__ON_RUNTIME_UPGRADE__";
 
-/// Some helper functions for [`OnRuntimeUpgrade`] during `try-runtime` testing.
+/// Some helper functions for [`OnRuntimeUpgrade<Weight>`] during `try-runtime` testing.
 #[cfg(feature = "try-runtime")]
-pub trait OnRuntimeUpgradeHelpersExt {
+pub trait OnRuntimeUpgradeHelpersExt<Weight> {
 	/// Generate a storage key unique to this runtime upgrade.
 	///
 	/// This can be used to communicate data from pre-upgrade to post-upgrade state and check
@@ -153,7 +153,7 @@ pub trait OnRuntimeUpgradeHelpersExt {
 }
 
 #[cfg(feature = "try-runtime")]
-impl<U> OnRuntimeUpgradeHelpersExt for U {}
+impl<Weight: Zero, U: OnRuntimeUpgrade<Weight>> OnRuntimeUpgradeHelpersExt<Weight> for U {}
 
 /// The runtime upgrade trait.
 ///

--- a/frame/support/src/traits/hooks.rs
+++ b/frame/support/src/traits/hooks.rs
@@ -217,7 +217,7 @@ where
 }
 
 /// The pallet hooks trait. Implementing this lets you express some logic to execute.
-pub trait Hooks<BlockNumber> {
+pub trait Hooks<BlockNumber, Weight: Zero> {
 	/// The block is being finalized. Implement to have something happen.
 	fn on_finalize(_n: BlockNumber) {}
 
@@ -228,16 +228,16 @@ pub trait Hooks<BlockNumber> {
 	/// and pass the result to the next `on_idle` hook if it exists.
 	fn on_idle(
 		_n: BlockNumber,
-		_remaining_weight: crate::weights::Weight,
-	) -> crate::weights::Weight {
-		0
+		_remaining_weight: Weight,
+	) -> Weight {
+		Weight::zero()
 	}
 
 	/// The block is being initialized. Implement to have something happen.
 	///
 	/// Return the non-negotiable weight consumed in the block.
-	fn on_initialize(_n: BlockNumber) -> crate::weights::Weight {
-		0
+	fn on_initialize(_n: BlockNumber) -> Weight {
+		Weight::zero()
 	}
 
 	/// Perform a module upgrade.
@@ -259,8 +259,8 @@ pub trait Hooks<BlockNumber> {
 	/// pallet is discouraged and might get deprecated in the future. Alternatively, export the same
 	/// logic as a free-function from your pallet, and pass it to `type Executive` from the
 	/// top-level runtime.
-	fn on_runtime_upgrade() -> crate::weights::Weight {
-		0
+	fn on_runtime_upgrade() -> Weight {
+		Weight::zero()
 	}
 
 	/// Execute some pre-checks prior to a runtime upgrade.
@@ -365,7 +365,7 @@ mod tests {
 		struct Test3;
 		type TestTuple = (Test1, Test2, Test3);
 		impl OnIdle<u32, Weight> for Test1 {
-			fn on_idle(_n: u32, _weight: crate::weights::Weight) -> crate::weights::Weight {
+			fn on_idle(_n: u32, _weight: Weight) -> Weight {
 				unsafe {
 					ON_IDLE_INVOCATION_ORDER.push("Test1");
 				}
@@ -373,7 +373,7 @@ mod tests {
 			}
 		}
 		impl OnIdle<u32, Weight> for Test2 {
-			fn on_idle(_n: u32, _weight: crate::weights::Weight) -> crate::weights::Weight {
+			fn on_idle(_n: u32, _weight: Weight) -> Weight {
 				unsafe {
 					ON_IDLE_INVOCATION_ORDER.push("Test2");
 				}
@@ -381,7 +381,7 @@ mod tests {
 			}
 		}
 		impl OnIdle<u32, Weight> for Test3 {
-			fn on_idle(_n: u32, _weight: crate::weights::Weight) -> crate::weights::Weight {
+			fn on_idle(_n: u32, _weight: Weight) -> Weight {
 				unsafe {
 					ON_IDLE_INVOCATION_ORDER.push("Test3");
 				}

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -160,7 +160,7 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T>
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T>
 	where
 		T::AccountId: From<SomeType2> + From<SomeType1> + SomeAssociation1,
 	{
@@ -453,7 +453,7 @@ pub mod pallet2 {
 	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T>
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T>
 	where
 		T::AccountId: From<SomeType1> + SomeAssociation1,
 	{

--- a/frame/support/test/tests/pallet_compatibility.rs
+++ b/frame/support/test/tests/pallet_compatibility.rs
@@ -128,7 +128,7 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {
+	impl<T: Config> Hooks<T::BlockNumber, Weight> for Pallet<T> {
 		fn on_initialize(_n: T::BlockNumber) -> Weight {
 			<Dummy<T>>::put(T::Balance::from(10));
 			10

--- a/frame/support/test/tests/pallet_compatibility_instance.rs
+++ b/frame/support/test/tests/pallet_compatibility_instance.rs
@@ -113,7 +113,7 @@ pub mod pallet {
 	pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
 
 	#[pallet::hooks]
-	impl<T: Config<I>, I: 'static> Hooks<T::BlockNumber> for Pallet<T, I> {
+	impl<T: Config<I>, I: 'static> Hooks<T::BlockNumber, Weight> for Pallet<T, I> {
 		fn on_initialize(_n: T::BlockNumber) -> Weight {
 			<Dummy<T, I>>::put(T::Balance::from(10));
 			10

--- a/frame/support/test/tests/pallet_instance.rs
+++ b/frame/support/test/tests/pallet_instance.rs
@@ -48,7 +48,7 @@ pub mod pallet {
 	pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
 
 	#[pallet::hooks]
-	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {
+	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>, Weight> for Pallet<T, I> {
 		fn on_initialize(_: BlockNumberFor<T>) -> Weight {
 			if TypeId::of::<I>() == TypeId::of::<()>() {
 				Self::deposit_event(Event::Something(10));

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.rs
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.rs
@@ -12,7 +12,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.rs
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, DispatchResultWithPostInfo};
+	use frame_support::pallet_prelude::{Hooks, DispatchResultWithPostInfo, Weight};
 	use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.rs
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.rs
@@ -12,7 +12,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.rs
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, DispatchResultWithPostInfo};
+	use frame_support::pallet_prelude::{Hooks, DispatchResultWithPostInfo, Weight};
 	use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
@@ -40,7 +40,7 @@ error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeEncode` is
     |  _in this procedural macro expansion
     | |
 2   | | mod pallet {
-3   | |     use frame_support::pallet_prelude::{Hooks, DispatchResultWithPostInfo};
+3   | |     use frame_support::pallet_prelude::{Hooks, DispatchResultWithPostInfo, Weight};
 4   | |     use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
 ...   |
 16  | |

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.rs
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.rs
@@ -1,7 +1,7 @@
 #[frame_support::pallet]
 mod pallet {
 	use codec::{Decode, Encode};
-	use frame_support::pallet_prelude::{DispatchResultWithPostInfo, Hooks};
+	use frame_support::pallet_prelude::{DispatchResultWithPostInfo, Hooks, Weight};
 	use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.rs
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.rs
@@ -11,7 +11,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[derive(Encode, Decode, scale_info::TypeInfo, PartialEq, Clone)]
 	struct Bar;

--- a/frame/support/test/tests/pallet_ui/call_invalid_const.rs
+++ b/frame/support/test/tests/pallet_ui/call_invalid_const.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/call_invalid_const.rs
+++ b/frame/support/test/tests/pallet_ui/call_invalid_const.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {

--- a/frame/support/test/tests/pallet_ui/call_invalid_origin_type.rs
+++ b/frame/support/test/tests/pallet_ui/call_invalid_origin_type.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/call_invalid_origin_type.rs
+++ b/frame/support/test/tests/pallet_ui/call_invalid_origin_type.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {

--- a/frame/support/test/tests/pallet_ui/call_invalid_return.rs
+++ b/frame/support/test/tests/pallet_ui/call_invalid_return.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/call_invalid_return.rs
+++ b/frame/support/test/tests/pallet_ui/call_invalid_return.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {

--- a/frame/support/test/tests/pallet_ui/call_invalid_vis.rs
+++ b/frame/support/test/tests/pallet_ui/call_invalid_vis.rs
@@ -12,7 +12,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {

--- a/frame/support/test/tests/pallet_ui/call_invalid_vis.rs
+++ b/frame/support/test/tests/pallet_ui/call_invalid_vis.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, DispatchResultWithPostInfo};
+	use frame_support::pallet_prelude::{Hooks, DispatchResultWithPostInfo, Weight};
 	use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/call_invalid_vis_2.rs
+++ b/frame/support/test/tests/pallet_ui/call_invalid_vis_2.rs
@@ -12,7 +12,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {

--- a/frame/support/test/tests/pallet_ui/call_invalid_vis_2.rs
+++ b/frame/support/test/tests/pallet_ui/call_invalid_vis_2.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, DispatchResultWithPostInfo};
+	use frame_support::pallet_prelude::{Hooks, DispatchResultWithPostInfo, Weight};
 	use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/call_missing_weight.rs
+++ b/frame/support/test/tests/pallet_ui/call_missing_weight.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, DispatchResultWithPostInfo};
+	use frame_support::pallet_prelude::{Hooks, DispatchResultWithPostInfo, Weight};
 	use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/call_missing_weight.rs
+++ b/frame/support/test/tests/pallet_ui/call_missing_weight.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {

--- a/frame/support/test/tests/pallet_ui/call_no_origin.rs
+++ b/frame/support/test/tests/pallet_ui/call_no_origin.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/call_no_origin.rs
+++ b/frame/support/test/tests/pallet_ui/call_no_origin.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {

--- a/frame/support/test/tests/pallet_ui/call_no_return.rs
+++ b/frame/support/test/tests/pallet_ui/call_no_return.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/call_no_return.rs
+++ b/frame/support/test/tests/pallet_ui/call_no_return.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {

--- a/frame/support/test/tests/pallet_ui/duplicate_call_attr.rs
+++ b/frame/support/test/tests/pallet_ui/duplicate_call_attr.rs
@@ -1,8 +1,7 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{StorageValue, Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
-	use frame_support::pallet_prelude::StorageValue;
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {}

--- a/frame/support/test/tests/pallet_ui/duplicate_call_attr.rs
+++ b/frame/support/test/tests/pallet_ui/duplicate_call_attr.rs
@@ -12,7 +12,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/duplicate_call_attr.stderr
+++ b/frame/support/test/tests/pallet_ui/duplicate_call_attr.stderr
@@ -1,5 +1,5 @@
 error: Invalid duplicated attribute
-  --> $DIR/duplicate_call_attr.rs:23:12
+  --> $DIR/duplicate_call_attr.rs:22:12
    |
-23 |     #[pallet::call]
+22 |     #[pallet::call]
    |               ^^^^

--- a/frame/support/test/tests/pallet_ui/duplicate_store_attr.rs
+++ b/frame/support/test/tests/pallet_ui/duplicate_store_attr.rs
@@ -1,8 +1,7 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, StorageValue, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
-	use frame_support::pallet_prelude::StorageValue;
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {}

--- a/frame/support/test/tests/pallet_ui/duplicate_store_attr.rs
+++ b/frame/support/test/tests/pallet_ui/duplicate_store_attr.rs
@@ -13,7 +13,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/duplicate_store_attr.stderr
+++ b/frame/support/test/tests/pallet_ui/duplicate_store_attr.stderr
@@ -1,5 +1,5 @@
 error: Unexpected duplicated attribute
-  --> $DIR/duplicate_store_attr.rs:12:12
+  --> $DIR/duplicate_store_attr.rs:11:12
    |
-12 |     #[pallet::generate_store(trait Store)]
+11 |     #[pallet::generate_store(trait Store)]
    |               ^^^^^^^^^^^^^^

--- a/frame/support/test/tests/pallet_ui/error_no_fieldless.rs
+++ b/frame/support/test/tests/pallet_ui/error_no_fieldless.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/error_no_fieldless.rs
+++ b/frame/support/test/tests/pallet_ui/error_no_fieldless.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/error_where_clause.rs
+++ b/frame/support/test/tests/pallet_ui/error_where_clause.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/error_where_clause.rs
+++ b/frame/support/test/tests/pallet_ui/error_where_clause.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/error_wrong_item.rs
+++ b/frame/support/test/tests/pallet_ui/error_wrong_item.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/error_wrong_item.rs
+++ b/frame/support/test/tests/pallet_ui/error_wrong_item.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/error_wrong_item_name.rs
+++ b/frame/support/test/tests/pallet_ui/error_wrong_item_name.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/error_wrong_item_name.rs
+++ b/frame/support/test/tests/pallet_ui/error_wrong_item_name.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/event_field_not_member.rs
+++ b/frame/support/test/tests/pallet_ui/event_field_not_member.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, IsType};
+	use frame_support::pallet_prelude::{Hooks, IsType, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/event_field_not_member.rs
+++ b/frame/support/test/tests/pallet_ui/event_field_not_member.rs
@@ -13,7 +13,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/event_not_in_trait.rs
+++ b/frame/support/test/tests/pallet_ui/event_not_in_trait.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/event_not_in_trait.rs
+++ b/frame/support/test/tests/pallet_ui/event_not_in_trait.rs
@@ -12,7 +12,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/event_type_invalid_bound.rs
+++ b/frame/support/test/tests/pallet_ui/event_type_invalid_bound.rs
@@ -13,7 +13,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/event_type_invalid_bound.rs
+++ b/frame/support/test/tests/pallet_ui/event_type_invalid_bound.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/event_type_invalid_bound_2.rs
+++ b/frame/support/test/tests/pallet_ui/event_type_invalid_bound_2.rs
@@ -13,7 +13,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/event_wrong_item.rs
+++ b/frame/support/test/tests/pallet_ui/event_wrong_item.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/event_wrong_item.rs
+++ b/frame/support/test/tests/pallet_ui/event_wrong_item.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/event_wrong_item_name.rs
+++ b/frame/support/test/tests/pallet_ui/event_wrong_item_name.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/event_wrong_item_name.rs
+++ b/frame/support/test/tests/pallet_ui/event_wrong_item_name.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/genesis_default_not_satisfied.rs
+++ b/frame/support/test/tests/pallet_ui/genesis_default_not_satisfied.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, GenesisBuild};
+	use frame_support::pallet_prelude::{Hooks, GenesisBuild, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/genesis_default_not_satisfied.rs
+++ b/frame/support/test/tests/pallet_ui/genesis_default_not_satisfied.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/genesis_inconsistent_build_config.rs
+++ b/frame/support/test/tests/pallet_ui/genesis_inconsistent_build_config.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/genesis_inconsistent_build_config.rs
+++ b/frame/support/test/tests/pallet_ui/genesis_inconsistent_build_config.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/genesis_invalid_generic.rs
+++ b/frame/support/test/tests/pallet_ui/genesis_invalid_generic.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/genesis_invalid_generic.rs
+++ b/frame/support/test/tests/pallet_ui/genesis_invalid_generic.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/genesis_wrong_name.rs
+++ b/frame/support/test/tests/pallet_ui/genesis_wrong_name.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/genesis_wrong_name.rs
+++ b/frame/support/test/tests/pallet_ui/genesis_wrong_name.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/hooks_invalid_item.rs
+++ b/frame/support/test/tests/pallet_ui/hooks_invalid_item.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, Weight};
+	use frame_support::pallet_prelude::Hooks;
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {}

--- a/frame/support/test/tests/pallet_ui/hooks_invalid_item.rs
+++ b/frame/support/test/tests/pallet_ui/hooks_invalid_item.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {}

--- a/frame/support/test/tests/pallet_ui/hooks_invalid_item.stderr
+++ b/frame/support/test/tests/pallet_ui/hooks_invalid_item.stderr
@@ -1,5 +1,5 @@
 error[E0107]: missing generics for trait `Hooks`
-   --> $DIR/hooks_invalid_item.rs:12:18
+   --> tests/pallet_ui/hooks_invalid_item.rs:12:18
     |
 12  |     impl<T: Config> Hooks for Pallet<T> {}
     |                     ^^^^^ expected 2 generic arguments

--- a/frame/support/test/tests/pallet_ui/hooks_invalid_item.stderr
+++ b/frame/support/test/tests/pallet_ui/hooks_invalid_item.stderr
@@ -2,14 +2,14 @@ error[E0107]: missing generics for trait `Hooks`
    --> $DIR/hooks_invalid_item.rs:12:18
     |
 12  |     impl<T: Config> Hooks for Pallet<T> {}
-    |                     ^^^^^ expected 1 generic argument
+    |                     ^^^^^ expected 2 generic arguments
     |
-note: trait defined here, with 1 generic parameter: `BlockNumber`
-   --> $DIR/hooks.rs:214:11
+note: trait defined here, with 2 generic parameters: `BlockNumber`, `Weight`
+   --> $WORKSPACE/frame/support/src/traits/hooks.rs
     |
-214 | pub trait Hooks<BlockNumber> {
-    |           ^^^^^ -----------
-help: add missing generic argument
+    | pub trait Hooks<BlockNumber, Weight: Zero> {
+    |           ^^^^^ -----------  ------
+help: add missing generic arguments
     |
-12  |     impl<T: Config> Hooks<BlockNumber> for Pallet<T> {}
-    |                     ~~~~~~~~~~~~~~~~~~
+12  |     impl<T: Config> Hooks<BlockNumber, Weight> for Pallet<T> {}
+    |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/frame/support/test/tests/pallet_ui/inconsistent_instance_1.rs
+++ b/frame/support/test/tests/pallet_ui/inconsistent_instance_1.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/inconsistent_instance_1.rs
+++ b/frame/support/test/tests/pallet_ui/inconsistent_instance_1.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/inconsistent_instance_1.stderr
+++ b/frame/support/test/tests/pallet_ui/inconsistent_instance_1.stderr
@@ -17,10 +17,10 @@ error: Invalid generic declaration, trait is defined with instance but generic u
    |                     ^^^^^^
 
 error: Invalid generic declaration, trait is defined with instance but generic use none
-  --> $DIR/inconsistent_instance_1.rs:13:47
+  --> $DIR/inconsistent_instance_1.rs:13:55
    |
 13 |     impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
-   |                                                  ^^^^^^
+   |                                                          ^^^^^^
 
 error: Invalid generic declaration, trait is defined with instance but generic use none
   --> $DIR/inconsistent_instance_1.rs:13:7

--- a/frame/support/test/tests/pallet_ui/inconsistent_instance_1.stderr
+++ b/frame/support/test/tests/pallet_ui/inconsistent_instance_1.stderr
@@ -19,11 +19,11 @@ error: Invalid generic declaration, trait is defined with instance but generic u
 error: Invalid generic declaration, trait is defined with instance but generic use none
   --> $DIR/inconsistent_instance_1.rs:13:47
    |
-13 |     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+13 |     impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
    |                                                  ^^^^^^
 
 error: Invalid generic declaration, trait is defined with instance but generic use none
   --> $DIR/inconsistent_instance_1.rs:13:7
    |
-13 |     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+13 |     impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
    |          ^

--- a/frame/support/test/tests/pallet_ui/inconsistent_instance_2.rs
+++ b/frame/support/test/tests/pallet_ui/inconsistent_instance_2.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T, I = ()>(core::marker::PhantomData<(T, I)>);
 
 	#[pallet::hooks]
-	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {}
+	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>, Weight> for Pallet<T, I> {}
 
 	#[pallet::call]
 	impl<T: Config<I>, I: 'static> Pallet<T, I> {}

--- a/frame/support/test/tests/pallet_ui/inconsistent_instance_2.rs
+++ b/frame/support/test/tests/pallet_ui/inconsistent_instance_2.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/inconsistent_instance_2.stderr
+++ b/frame/support/test/tests/pallet_ui/inconsistent_instance_2.stderr
@@ -19,11 +19,11 @@ error: Invalid generic declaration, trait is defined without instance but generi
 error: Invalid generic declaration, trait is defined without instance but generic use some
   --> $DIR/inconsistent_instance_2.rs:13:62
    |
-13 |     impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {}
+13 |     impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>, Weight> for Pallet<T, I> {}
    |                                                                 ^^^^^^
 
 error: Invalid generic declaration, trait is defined without instance but generic use some
   --> $DIR/inconsistent_instance_2.rs:13:7
    |
-13 |     impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {}
+13 |     impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>, Weight> for Pallet<T, I> {}
    |          ^

--- a/frame/support/test/tests/pallet_ui/inconsistent_instance_2.stderr
+++ b/frame/support/test/tests/pallet_ui/inconsistent_instance_2.stderr
@@ -17,10 +17,10 @@ error: Invalid generic declaration, trait is defined without instance but generi
    |                                    ^^^^^^
 
 error: Invalid generic declaration, trait is defined without instance but generic use some
-  --> $DIR/inconsistent_instance_2.rs:13:62
+  --> $DIR/inconsistent_instance_2.rs:13:70
    |
 13 |     impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>, Weight> for Pallet<T, I> {}
-   |                                                                 ^^^^^^
+   |                                                                         ^^^^^^
 
 error: Invalid generic declaration, trait is defined without instance but generic use some
   --> $DIR/inconsistent_instance_2.rs:13:7

--- a/frame/support/test/tests/pallet_ui/inherent_check_inner_span.rs
+++ b/frame/support/test/tests/pallet_ui/inherent_check_inner_span.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, ProvideInherent};
+	use frame_support::pallet_prelude::{Hooks, ProvideInherent, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/inherent_check_inner_span.rs
+++ b/frame/support/test/tests/pallet_ui/inherent_check_inner_span.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/inherent_invalid_item.rs
+++ b/frame/support/test/tests/pallet_ui/inherent_invalid_item.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/inherent_invalid_item.rs
+++ b/frame/support/test/tests/pallet_ui/inherent_invalid_item.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/pass/trait_constant_valid_bounds.rs
+++ b/frame/support/test/tests/pallet_ui/pass/trait_constant_valid_bounds.rs
@@ -19,7 +19,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs
+++ b/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs
@@ -11,7 +11,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs
+++ b/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, StorageValue};
+	use frame_support::pallet_prelude::{Hooks, StorageValue, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs
+++ b/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs
@@ -11,7 +11,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs
+++ b/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, StorageValue};
+	use frame_support::pallet_prelude::{Hooks, StorageValue, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/storage_incomplete_item.rs
+++ b/frame/support/test/tests/pallet_ui/storage_incomplete_item.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/storage_incomplete_item.rs
+++ b/frame/support/test/tests/pallet_ui/storage_incomplete_item.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/storage_info_unsatisfied.rs
+++ b/frame/support/test/tests/pallet_ui/storage_info_unsatisfied.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/storage_info_unsatisfied.rs
+++ b/frame/support/test/tests/pallet_ui/storage_info_unsatisfied.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, StorageValue};
+	use frame_support::pallet_prelude::{Hooks, StorageValue, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.rs
+++ b/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.rs
@@ -1,7 +1,7 @@
 #[frame_support::pallet]
 mod pallet {
 	use frame_support::{
-		pallet_prelude::{Hooks, Twox64Concat},
+		pallet_prelude::{Hooks, Twox64Concat, Weight},
 		storage::types::{StorageNMap, Key},
 	};
 	use frame_system::pallet_prelude::BlockNumberFor;

--- a/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.rs
+++ b/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.rs
@@ -13,7 +13,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/storage_invalid_attribute.rs
+++ b/frame/support/test/tests/pallet_ui/storage_invalid_attribute.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/storage_invalid_first_generic.rs
+++ b/frame/support/test/tests/pallet_ui/storage_invalid_first_generic.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/storage_invalid_first_generic.rs
+++ b/frame/support/test/tests/pallet_ui/storage_invalid_first_generic.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/storage_invalid_rename_value.rs
+++ b/frame/support/test/tests/pallet_ui/storage_invalid_rename_value.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/storage_multiple_getters.rs
+++ b/frame/support/test/tests/pallet_ui/storage_multiple_getters.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/storage_multiple_getters.rs
+++ b/frame/support/test/tests/pallet_ui/storage_multiple_getters.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/storage_multiple_renames.rs
+++ b/frame/support/test/tests/pallet_ui/storage_multiple_renames.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/storage_multiple_renames.rs
+++ b/frame/support/test/tests/pallet_ui/storage_multiple_renames.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/storage_not_storage_type.rs
+++ b/frame/support/test/tests/pallet_ui/storage_not_storage_type.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/storage_not_storage_type.rs
+++ b/frame/support/test/tests/pallet_ui/storage_not_storage_type.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/storage_value_duplicate_named_generic.rs
+++ b/frame/support/test/tests/pallet_ui/storage_value_duplicate_named_generic.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/storage_value_duplicate_named_generic.rs
+++ b/frame/support/test/tests/pallet_ui/storage_value_duplicate_named_generic.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, StorageValue};
+	use frame_support::pallet_prelude::{Hooks, StorageValue, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/storage_value_generic_named_and_unnamed.rs
+++ b/frame/support/test/tests/pallet_ui/storage_value_generic_named_and_unnamed.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, StorageValue, OptionQuery};
+	use frame_support::pallet_prelude::{Hooks, OptionQuery, StorageValue, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/storage_value_generic_named_and_unnamed.rs
+++ b/frame/support/test/tests/pallet_ui/storage_value_generic_named_and_unnamed.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/storage_value_no_generic.rs
+++ b/frame/support/test/tests/pallet_ui/storage_value_no_generic.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/storage_value_no_generic.rs
+++ b/frame/support/test/tests/pallet_ui/storage_value_no_generic.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/storage_value_unexpected_named_generic.rs
+++ b/frame/support/test/tests/pallet_ui/storage_value_unexpected_named_generic.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/storage_value_unexpected_named_generic.rs
+++ b/frame/support/test/tests/pallet_ui/storage_value_unexpected_named_generic.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, StorageValue};
+	use frame_support::pallet_prelude::{Hooks, StorageValue, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/storage_wrong_item.rs
+++ b/frame/support/test/tests/pallet_ui/storage_wrong_item.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/storage_wrong_item.rs
+++ b/frame/support/test/tests/pallet_ui/storage_wrong_item.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/store_trait_leak_private.rs
+++ b/frame/support/test/tests/pallet_ui/store_trait_leak_private.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 	use frame_support::pallet_prelude::StorageValue;
 

--- a/frame/support/test/tests/pallet_ui/store_trait_leak_private.rs
+++ b/frame/support/test/tests/pallet_ui/store_trait_leak_private.rs
@@ -12,7 +12,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/trait_constant_invalid_bound.rs
+++ b/frame/support/test/tests/pallet_ui/trait_constant_invalid_bound.rs
@@ -13,7 +13,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/trait_constant_invalid_bound.rs
+++ b/frame/support/test/tests/pallet_ui/trait_constant_invalid_bound.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/trait_constant_invalid_bound_lifetime.rs
+++ b/frame/support/test/tests/pallet_ui/trait_constant_invalid_bound_lifetime.rs
@@ -13,7 +13,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/trait_constant_invalid_bound_lifetime.rs
+++ b/frame/support/test/tests/pallet_ui/trait_constant_invalid_bound_lifetime.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/trait_invalid_item.rs
+++ b/frame/support/test/tests/pallet_ui/trait_invalid_item.rs
@@ -13,7 +13,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/trait_invalid_item.rs
+++ b/frame/support/test/tests/pallet_ui/trait_invalid_item.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/trait_no_supertrait.rs
+++ b/frame/support/test/tests/pallet_ui/trait_no_supertrait.rs
@@ -11,7 +11,7 @@ mod pallet {
 	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/trait_no_supertrait.rs
+++ b/frame/support/test/tests/pallet_ui/trait_no_supertrait.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/type_value_error_in_block.rs
+++ b/frame/support/test/tests/pallet_ui/type_value_error_in_block.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/type_value_error_in_block.rs
+++ b/frame/support/test/tests/pallet_ui/type_value_error_in_block.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/type_value_forgotten_where_clause.rs
+++ b/frame/support/test/tests/pallet_ui/type_value_forgotten_where_clause.rs
@@ -12,7 +12,7 @@ mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T>
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T>
 	where <T as frame_system::Config>::AccountId: From<u32>
 	{}
 

--- a/frame/support/test/tests/pallet_ui/type_value_forgotten_where_clause.rs
+++ b/frame/support/test/tests/pallet_ui/type_value_forgotten_where_clause.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::Hooks;
+	use frame_support::pallet_prelude::{Hooks, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/type_value_invalid_item.rs
+++ b/frame/support/test/tests/pallet_ui/type_value_invalid_item.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/type_value_invalid_item.rs
+++ b/frame/support/test/tests/pallet_ui/type_value_invalid_item.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, PhantomData};
+	use frame_support::pallet_prelude::{Hooks, PhantomData, Weight};
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]

--- a/frame/support/test/tests/pallet_ui/type_value_no_return.rs
+++ b/frame/support/test/tests/pallet_ui/type_value_no_return.rs
@@ -10,7 +10,7 @@ mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -356,7 +356,7 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		fn integrity_test() {
 			T::BlockWeights::get().validate().expect("The weights are invalid.");
 		}

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -160,7 +160,7 @@ pub mod pallet {
 	pub(super) type DidUpdate<T: Config> = StorageValue<_, bool, ValueQuery>;
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		/// dummy `on_initialize` to return the weight used in `on_finalize`.
 		fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
 			// weight of `on_finalize`

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -335,7 +335,7 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		fn on_finalize(_: T::BlockNumber) {
 			<NextFeeMultiplier<T>>::mutate(|fm| {
 				*fm = T::FeeMultiplierUpdate::convert(*fm);

--- a/frame/transaction-storage/src/lib.rs
+++ b/frame/transaction-storage/src/lib.rs
@@ -133,7 +133,7 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		fn on_initialize(n: T::BlockNumber) -> Weight {
 			// Drop obsolete roots. The proof for `obsolete` will be checked later
 			// in this block, so we drop `obsolete` - 1.

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -292,7 +292,7 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {
+	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>, Weight> for Pallet<T, I> {
 		/// # <weight>
 		/// - Complexity: `O(A)` where `A` is the number of approvals
 		/// - Db reads and writes: `Approvals`, `pot account data`

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -189,7 +189,7 @@ fn accepted_spend_proposal_ignored_outside_spend_period() {
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
 		assert_ok!(Treasury::approve_proposal(Origin::root(), 0));
 
-		<Treasury as OnInitialize<u64>>::on_initialize(1);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(1);
 		assert_eq!(Balances::free_balance(3), 0);
 		assert_eq!(Treasury::pot(), 100);
 	});
@@ -202,7 +202,7 @@ fn unused_pot_should_diminish() {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 		assert_eq!(Balances::total_issuance(), init_total_issuance + 100);
 
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 50);
 		assert_eq!(Balances::total_issuance(), init_total_issuance + 50);
 	});
@@ -216,7 +216,7 @@ fn rejected_spend_proposal_ignored_on_spend_period() {
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
 		assert_ok!(Treasury::reject_proposal(Origin::root(), 0));
 
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 		assert_eq!(Balances::free_balance(3), 0);
 		assert_eq!(Treasury::pot(), 50);
 	});
@@ -267,7 +267,7 @@ fn accepted_spend_proposal_enacted_on_spend_period() {
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
 		assert_ok!(Treasury::approve_proposal(Origin::root(), 0));
 
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 		assert_eq!(Balances::free_balance(3), 100);
 		assert_eq!(Treasury::pot(), 0);
 	});
@@ -282,11 +282,11 @@ fn pot_underflow_should_not_diminish() {
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 150, 3));
 		assert_ok!(Treasury::approve_proposal(Origin::root(), 0));
 
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 100); // Pot hasn't changed
 
 		let _ = Balances::deposit_into_existing(&Treasury::account_id(), 100).unwrap();
-		<Treasury as OnInitialize<u64>>::on_initialize(4);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(4);
 		assert_eq!(Balances::free_balance(3), 150); // Fund has been spent
 		assert_eq!(Treasury::pot(), 25); // Pot has finally changed
 	});
@@ -304,13 +304,13 @@ fn treasury_account_doesnt_get_deleted() {
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), treasury_balance, 3));
 		assert_ok!(Treasury::approve_proposal(Origin::root(), 0));
 
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 100); // Pot hasn't changed
 
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), Treasury::pot(), 3));
 		assert_ok!(Treasury::approve_proposal(Origin::root(), 1));
 
-		<Treasury as OnInitialize<u64>>::on_initialize(4);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(4);
 		assert_eq!(Treasury::pot(), 0); // Pot is emptied
 		assert_eq!(Balances::free_balance(Treasury::account_id()), 1); // but the account is still there
 	});
@@ -335,7 +335,7 @@ fn inexistent_account_works() {
 		assert_ok!(Treasury::approve_proposal(Origin::root(), 0));
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 1, 3));
 		assert_ok!(Treasury::approve_proposal(Origin::root(), 1));
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 0); // Pot hasn't changed
 		assert_eq!(Balances::free_balance(3), 0); // Balance of `3` hasn't changed
 
@@ -343,7 +343,7 @@ fn inexistent_account_works() {
 		assert_eq!(Treasury::pot(), 99); // Pot now contains funds
 		assert_eq!(Balances::free_balance(Treasury::account_id()), 100); // Account does exist
 
-		<Treasury as OnInitialize<u64>>::on_initialize(4);
+		<Treasury as OnInitialize<u64, Weight>>::on_initialize(4);
 
 		assert_eq!(Treasury::pot(), 0); // Pot has changed
 		assert_eq!(Balances::free_balance(3), 99); // Balance of `3` has changed

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -140,7 +140,7 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		fn integrity_test() {
 			// If you hit this error, you need to try to `Box` big dispatchable parameters.
 			assert!(

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -178,7 +178,7 @@ pub mod pallet {
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config> Hooks<BlockNumberFor<T>, Weight> for Pallet<T> {
 		fn integrity_test() {
 			assert!(T::MAX_VESTING_SCHEDULES > 0, "`MaxVestingSchedules` must ge greater than 0");
 		}


### PR DESCRIPTION
This PR makes no logical changes, but abstracts the `Weight` return type of many of the core FRAME traits to be generic.

This could be helpful if we were to ever change the `Weight` type... 🙄 

polkadot companion: https://github.com/paritytech/polkadot/pull/5027

cumulus companion: https://github.com/paritytech/cumulus/pull/1068