### PR TITLE
Prep to release sp-version-proc-macro with codec 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10372,7 +10372,7 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10388,7 +10388,7 @@ dependencies = [
 
 [[package]]
 name = "sp-version-proc-macro"
-version = "4.0.0-dev"
+version = "5.0.0"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",

--- a/primitives/version/Cargo.toml
+++ b/primitives/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-version"
-version = "5.0.0"
+version = "5.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
 sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 sp-runtime = { version = "6.0.0", default-features = false, path = "../runtime" }
-sp-version-proc-macro = { version = "4.0.0-dev", default-features = false, path = "proc-macro" }
+sp-version-proc-macro = { version = "5.0.0", default-features = false, path = "proc-macro" }
 parity-wasm = { version = "0.42.2", optional = true }
 sp-core-hashing-proc-macro = { version = "5.0.0", path = "../core/hashing/proc-macro" }
 thiserror = { version = "1.0.30", optional = true }

--- a/primitives/version/proc-macro/Cargo.toml
+++ b/primitives/version/proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-version-proc-macro"
-version = "4.0.0-dev"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
This was missed when releasing other crates for subxt using parity-scale-codec 3.0.0 (see https://github.com/paritytech/substrate/pull/10937), so we patch bump sp-version so that things "just work" (given that 5.0.0 was released with the intention of having this change) and major bump sp-version-proc-macro which already has the codec 3.0.0 update we want in.