### PR TITLE
remove the default features of codec in sp-version-proc-macro

### DIFF
--- a/primitives/version/proc-macro/Cargo.toml
+++ b/primitives/version/proc-macro/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro = true
 quote = "1.0.10"
 syn = { version = "1.0.82", features = ["full", "fold", "extra-traits", "visit"] }
 proc-macro2 = "1.0.36"
-codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "derive" ] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive", "full" ] }
 
 [dev-dependencies]
 sp-version = { version = "5.0.0", path = ".." }


### PR DESCRIPTION
Remove the default features in codec of sp-version-proc-macro, otherwise it will introduce the std features and it's not no_std even if we remove the default-features when including the sp-version-proc-macro package.