### PR TITLE
Move weight constants to own mod

### DIFF
--- a/frame/support/src/weights.rs
+++ b/frame/support/src/weights.rs
@@ -158,7 +158,6 @@ pub type Weight = u64;
 /// For example: FRAME System, FRAME Executive, our FRAME support libraries, etc...
 pub mod constants {
 	use super::Weight;
-	use crate::parameter_types;
 
 	pub const WEIGHT_PER_SECOND: Weight = 1_000_000_000_000;
 	pub const WEIGHT_PER_MILLIS: Weight = WEIGHT_PER_SECOND / 1000; // 1_000_000_000

--- a/frame/support/src/weights.rs
+++ b/frame/support/src/weights.rs
@@ -127,6 +127,8 @@
 //! - Ubuntu 19.10 (GNU/Linux 5.3.0-18-generic x86_64)
 //! - rustc 1.42.0 (b8cedc004 2020-03-09)
 
+mod block_weights;
+mod extrinsic_weights;
 mod paritydb_weights;
 mod rocksdb_weights;
 
@@ -163,12 +165,11 @@ pub mod constants {
 	pub const WEIGHT_PER_MICROS: Weight = WEIGHT_PER_MILLIS / 1000; // 1_000_000
 	pub const WEIGHT_PER_NANOS: Weight = WEIGHT_PER_MICROS / 1000; // 1_000
 
-	parameter_types! {
-		/// Importing a block with 0 txs takes ~5 ms
-		pub const BlockExecutionWeight: Weight = 5 * WEIGHT_PER_MILLIS;
-		/// Executing 10,000 System remarks (no-op) txs takes ~1.26 seconds -> ~125 µs per tx
-		pub const ExtrinsicBaseWeight: Weight = 125 * WEIGHT_PER_MICROS;
-	}
+	// Expose the Block and Extrinsic base weights.
+	pub use super::{
+		block_weights::constants::BlockExecutionWeight,
+		extrinsic_weights::constants::ExtrinsicBaseWeight,
+	};
 
 	// Expose the DB weights.
 	pub use super::{

--- a/frame/support/src/weights/block_weights.rs
+++ b/frame/support/src/weights/block_weights.rs
@@ -1,0 +1,46 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod constants {
+	use frame_support::{
+		parameter_types,
+		weights::{constants, Weight},
+	};
+
+	parameter_types! {
+		/// Importing a block with 0 Extrinsics.
+		pub const BlockExecutionWeight: Weight = 5_000_000 * constants::WEIGHT_PER_NANOS;
+	}
+
+	#[cfg(test)]
+	mod test_weights {
+		use frame_support::weights::constants;
+
+		/// Checks that the weight exists and is sane.
+		// NOTE: If this test fails but you are sure that the generated values are fine,
+		// you can delete it.
+		#[test]
+		fn sane() {
+			let w = super::constants::BlockExecutionWeight::get();
+
+			// At least 100 µs.
+			assert!(w >= 100 * constants::WEIGHT_PER_MICROS, "Weight should be at least 100 µs.");
+			// At most 50 ms.
+			assert!(w <= 50 * constants::WEIGHT_PER_MILLIS, "Weight should be at most 50 ms.");
+		}
+	}
+}

--- a/frame/support/src/weights/extrinsic_weights.rs
+++ b/frame/support/src/weights/extrinsic_weights.rs
@@ -1,0 +1,46 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod constants {
+	use frame_support::{
+		parameter_types,
+		weights::{constants, Weight},
+	};
+
+	parameter_types! {
+		/// Executing a NO-OP `System::remarks` Extrinsic.
+		pub const ExtrinsicBaseWeight: Weight = 125_000 * constants::WEIGHT_PER_NANOS;
+	}
+
+	#[cfg(test)]
+	mod test_weights {
+		use frame_support::weights::constants;
+
+		/// Checks that the weight exists and is sane.
+		// NOTE: If this test fails but you are sure that the generated values are fine,
+		// you can delete it.
+		#[test]
+		fn sane() {
+			let w = super::constants::ExtrinsicBaseWeight::get();
+
+			// At least 10 µs.
+			assert!(w >= 10 * constants::WEIGHT_PER_MICROS, "Weight should be at least 10 µs.");
+			// At most 1 ms.
+			assert!(w <= constants::WEIGHT_PER_MILLIS, "Weight should be at most 1 ms.");
+		}
+	}
+}


### PR DESCRIPTION
No logic change:  
- Move the block and extrinsic weights into their own module to allow for easier automatic generation in the future. 

Preparation for https://github.com/paritytech/substrate/issues/10921