### PR TITLE
Make bags-list generic over node value and instantiable

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -690,10 +690,10 @@ parameter_types! {
 
 impl pallet_bags_list::Config for Runtime {
 	type Event = Event;
-	type ValueProvider = Staking;
+	type ScoreProvider = Staking;
 	type WeightInfo = pallet_bags_list::weights::SubstrateWeight<Runtime>;
 	type BagThresholds = BagThresholds;
-	type Value = sp_npos_elections::VoteWeight;
+	type Score = sp_npos_elections::VoteWeight;
 }
 
 parameter_types! {

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -690,9 +690,10 @@ parameter_types! {
 
 impl pallet_bags_list::Config for Runtime {
 	type Event = Event;
-	type VoteWeightProvider = Staking;
+	type ValueProvider = Staking;
 	type WeightInfo = pallet_bags_list::weights::SubstrateWeight<Runtime>;
 	type BagThresholds = BagThresholds;
+	type Value = sp_npos_elections::VoteWeight;
 }
 
 parameter_types! {

--- a/frame/bags-list/remote-tests/src/lib.rs
+++ b/frame/bags-list/remote-tests/src/lib.rs
@@ -17,6 +17,7 @@
 
 //! Utilities for remote-testing pallet-bags-list.
 
+use frame_election_provider_support::ScoreProvider;
 use sp_std::prelude::*;
 
 /// A common log target to use.
@@ -55,8 +56,12 @@ pub fn display_and_check_bags<Runtime: RuntimeT>(currency_unit: u64, currency_na
 	let mut rebaggable = 0;
 	let mut active_bags = 0;
 	for vote_weight_thresh in <Runtime as pallet_bags_list::Config>::BagThresholds::get() {
+		let vote_weight_thresh_u64: u64 = (*vote_weight_thresh)
+			.try_into()
+			.map_err(|_| "runtime must configure score to at most u64 to use this test")
+			.unwrap();
 		// threshold in terms of UNITS (e.g. KSM, DOT etc)
-		let vote_weight_thresh_as_unit = *vote_weight_thresh as f64 / currency_unit as f64;
+		let vote_weight_thresh_as_unit = vote_weight_thresh_u64 as f64 / currency_unit as f64;
 		let pretty_thresh = format!("Threshold: {}. {}", vote_weight_thresh_as_unit, currency_name);
 
 		let bag = match pallet_bags_list::Pallet::<Runtime>::list_bags_get(*vote_weight_thresh) {
@@ -70,9 +75,13 @@ pub fn display_and_check_bags<Runtime: RuntimeT>(currency_unit: u64, currency_na
 		active_bags += 1;
 
 		for id in bag.std_iter().map(|node| node.std_id().clone()) {
-			let vote_weight = pallet_staking::Pallet::<Runtime>::weight_of(&id);
+			let vote_weight = <Runtime as pallet_bags_list::Config>::ScoreProvider::score(&id);
+			let vote_weight_thresh_u64: u64 = (*vote_weight_thresh)
+				.try_into()
+				.map_err(|_| "runtime must configure score to at most u64 to use this test")
+				.unwrap();
 			let vote_weight_as_balance: pallet_staking::BalanceOf<Runtime> =
-				vote_weight.try_into().map_err(|_| "can't convert").unwrap();
+				vote_weight_thresh_u64.try_into().map_err(|_| "can't convert").unwrap();
 
 			if vote_weight_as_balance < min_nominator_bond {
 				log::trace!(
@@ -87,13 +96,17 @@ pub fn display_and_check_bags<Runtime: RuntimeT>(currency_unit: u64, currency_na
 				pallet_bags_list::Node::<Runtime>::get(&id).expect("node in bag must exist.");
 			if node.is_misplaced(vote_weight) {
 				rebaggable += 1;
+				let notional_bag = pallet_bags_list::notional_bag_for::<Runtime, _>(vote_weight);
+				let notional_bag_as_u64: u64 = notional_bag
+					.try_into()
+					.map_err(|_| "runtime must configure score to at most u64 to use this test")
+					.unwrap();
 				log::trace!(
 					target: LOG_TARGET,
 					"Account {:?} can be rebagged from {:?} to {:?}",
 					id,
 					vote_weight_thresh_as_unit,
-					pallet_bags_list::notional_bag_for::<Runtime, _>(vote_weight) as f64 /
-						currency_unit as f64
+					notional_bag_as_u64 as f64 / currency_unit as f64
 				);
 			}
 		}

--- a/frame/bags-list/remote-tests/src/lib.rs
+++ b/frame/bags-list/remote-tests/src/lib.rs
@@ -92,7 +92,7 @@ pub fn display_and_check_bags<Runtime: RuntimeT>(currency_unit: u64, currency_na
 					"Account {:?} can be rebagged from {:?} to {:?}",
 					id,
 					vote_weight_thresh_as_unit,
-					pallet_bags_list::notional_bag_for::<Runtime>(vote_weight) as f64 /
+					pallet_bags_list::notional_bag_for::<Runtime, _>(vote_weight) as f64 /
 						currency_unit as f64
 				);
 			}

--- a/frame/bags-list/src/benchmarks.rs
+++ b/frame/bags-list/src/benchmarks.rs
@@ -20,7 +20,7 @@
 use super::*;
 use crate::list::List;
 use frame_benchmarking::{account, whitelist_account, whitelisted_caller};
-use frame_election_provider_support::ValueProvider;
+use frame_election_provider_support::ScoreProvider;
 use frame_support::{assert_ok, traits::Get};
 use frame_system::RawOrigin as SystemOrigin;
 use sp_runtime::traits::One;
@@ -68,7 +68,7 @@ frame_benchmarking::benchmarks! {
 
 		let caller = whitelisted_caller();
 		// update the weight of `origin_middle` to guarantee it will be rebagged into the destination.
-		T::ValueProvider::set_value_of(&origin_middle, dest_bag_thresh);
+		T::ScoreProvider::set_score_of(&origin_middle, dest_bag_thresh);
 	}: rebag(SystemOrigin::Signed(caller), origin_middle.clone())
 	verify {
 		// check the bags have updated as expected.
@@ -125,7 +125,7 @@ frame_benchmarking::benchmarks! {
 
 		let caller = whitelisted_caller();
 		// update the weight of `origin_tail` to guarantee it will be rebagged into the destination.
-		T::ValueProvider::set_value_of(&origin_tail, dest_bag_thresh);
+		T::ScoreProvider::set_score_of(&origin_tail, dest_bag_thresh);
 	}: rebag(SystemOrigin::Signed(caller), origin_tail.clone())
 	verify {
 		// check the bags have updated as expected.
@@ -159,8 +159,8 @@ frame_benchmarking::benchmarks! {
 		let heavier_next: T::AccountId = account("heavier_next", 0, 0);
 		assert_ok!(List::<T, _>::insert(heavier_next.clone(), bag_thresh));
 
-		T::ValueProvider::set_value_of(&lighter, bag_thresh - One::one());
-		T::ValueProvider::set_value_of(&heavier, bag_thresh);
+		T::ScoreProvider::set_score_of(&lighter, bag_thresh - One::one());
+		T::ScoreProvider::set_score_of(&heavier, bag_thresh);
 
 		assert_eq!(
 			List::<T, _>::iter().map(|n| n.id().clone()).collect::<Vec<_>>(),

--- a/frame/bags-list/src/benchmarks.rs
+++ b/frame/bags-list/src/benchmarks.rs
@@ -36,7 +36,7 @@ frame_benchmarking::benchmarks! {
 
 		// clear any pre-existing storage.
 		// NOTE: safe to call outside block production
-		List::<T>::unsafe_clear();
+		List::<T, _>::unsafe_clear();
 
 		// define our origin and destination thresholds.
 		let origin_bag_thresh = T::BagThresholds::get()[0];
@@ -44,21 +44,21 @@ frame_benchmarking::benchmarks! {
 
 		// seed items in the origin bag.
 		let origin_head: T::AccountId = account("origin_head", 0, 0);
-		assert_ok!(List::<T>::insert(origin_head.clone(), origin_bag_thresh));
+		assert_ok!(List::<T, _>::insert(origin_head.clone(), origin_bag_thresh));
 
 		let origin_middle: T::AccountId = account("origin_middle", 0, 0); // the node we rebag (_R_)
-		assert_ok!(List::<T>::insert(origin_middle.clone(), origin_bag_thresh));
+		assert_ok!(List::<T, _>::insert(origin_middle.clone(), origin_bag_thresh));
 
 		let origin_tail: T::AccountId  = account("origin_tail", 0, 0);
-		assert_ok!(List::<T>::insert(origin_tail.clone(), origin_bag_thresh));
+		assert_ok!(List::<T, _>::insert(origin_tail.clone(), origin_bag_thresh));
 
 		// seed items in the destination bag.
 		let dest_head: T::AccountId  = account("dest_head", 0, 0);
-		assert_ok!(List::<T>::insert(dest_head.clone(), dest_bag_thresh));
+		assert_ok!(List::<T, _>::insert(dest_head.clone(), dest_bag_thresh));
 
 		// the bags are in the expected state after initial setup.
 		assert_eq!(
-			List::<T>::get_bags(),
+			List::<T, _>::get_bags(),
 			vec![
 				(origin_bag_thresh, vec![origin_head.clone(), origin_middle.clone(), origin_tail.clone()]),
 				(dest_bag_thresh, vec![dest_head.clone()])
@@ -72,7 +72,7 @@ frame_benchmarking::benchmarks! {
 	verify {
 		// check the bags have updated as expected.
 		assert_eq!(
-			List::<T>::get_bags(),
+			List::<T, _>::get_bags(),
 			vec![
 				(
 					origin_bag_thresh,
@@ -104,18 +104,18 @@ frame_benchmarking::benchmarks! {
 
 		// seed items in the origin bag.
 		let origin_head: T::AccountId = account("origin_head", 0, 0);
-		assert_ok!(List::<T>::insert(origin_head.clone(), origin_bag_thresh));
+		assert_ok!(List::<T, _>::insert(origin_head.clone(), origin_bag_thresh));
 
 		let origin_tail: T::AccountId  = account("origin_tail", 0, 0); // the node we rebag (_R_)
-		assert_ok!(List::<T>::insert(origin_tail.clone(), origin_bag_thresh));
+		assert_ok!(List::<T, _>::insert(origin_tail.clone(), origin_bag_thresh));
 
 		// seed items in the destination bag.
 		let dest_head: T::AccountId  = account("dest_head", 0, 0);
-		assert_ok!(List::<T>::insert(dest_head.clone(), dest_bag_thresh));
+		assert_ok!(List::<T, _>::insert(dest_head.clone(), dest_bag_thresh));
 
 		// the bags are in the expected state after initial setup.
 		assert_eq!(
-			List::<T>::get_bags(),
+			List::<T, _>::get_bags(),
 			vec![
 				(origin_bag_thresh, vec![origin_head.clone(), origin_tail.clone()]),
 				(dest_bag_thresh, vec![dest_head.clone()])
@@ -129,7 +129,7 @@ frame_benchmarking::benchmarks! {
 	verify {
 		// check the bags have updated as expected.
 		assert_eq!(
-			List::<T>::get_bags(),
+			List::<T, _>::get_bags(),
 			vec![
 				(origin_bag_thresh, vec![origin_head.clone()]),
 				(dest_bag_thresh, vec![dest_head.clone(), origin_tail.clone()])
@@ -147,22 +147,22 @@ frame_benchmarking::benchmarks! {
 
 		// insert the nodes in order
 		let lighter: T::AccountId = account("lighter", 0, 0);
-		assert_ok!(List::<T>::insert(lighter.clone(), bag_thresh));
+		assert_ok!(List::<T, _>::insert(lighter.clone(), bag_thresh));
 
 		let heavier_prev: T::AccountId = account("heavier_prev", 0, 0);
-		assert_ok!(List::<T>::insert(heavier_prev.clone(), bag_thresh));
+		assert_ok!(List::<T, _>::insert(heavier_prev.clone(), bag_thresh));
 
 		let heavier: T::AccountId = account("heavier", 0, 0);
-		assert_ok!(List::<T>::insert(heavier.clone(), bag_thresh));
+		assert_ok!(List::<T, _>::insert(heavier.clone(), bag_thresh));
 
 		let heavier_next: T::AccountId = account("heavier_next", 0, 0);
-		assert_ok!(List::<T>::insert(heavier_next.clone(), bag_thresh));
+		assert_ok!(List::<T, _>::insert(heavier_next.clone(), bag_thresh));
 
 		T::VoteWeightProvider::set_vote_weight_of(&lighter, bag_thresh - 1);
 		T::VoteWeightProvider::set_vote_weight_of(&heavier, bag_thresh);
 
 		assert_eq!(
-			List::<T>::iter().map(|n| n.id().clone()).collect::<Vec<_>>(),
+			List::<T, _>::iter().map(|n| n.id().clone()).collect::<Vec<_>>(),
 			vec![lighter.clone(), heavier_prev.clone(), heavier.clone(), heavier_next.clone()]
 		);
 
@@ -170,7 +170,7 @@ frame_benchmarking::benchmarks! {
 	}: _(SystemOrigin::Signed(heavier.clone()), lighter.clone())
 	verify {
 		assert_eq!(
-			List::<T>::iter().map(|n| n.id().clone()).collect::<Vec<_>>(),
+			List::<T, _>::iter().map(|n| n.id().clone()).collect::<Vec<_>>(),
 			vec![heavier, lighter, heavier_prev, heavier_next]
 		)
 	}

--- a/frame/bags-list/src/benchmarks.rs
+++ b/frame/bags-list/src/benchmarks.rs
@@ -20,9 +20,10 @@
 use super::*;
 use crate::list::List;
 use frame_benchmarking::{account, whitelist_account, whitelisted_caller};
-use frame_election_provider_support::VoteWeightProvider;
+use frame_election_provider_support::ValueProvider;
 use frame_support::{assert_ok, traits::Get};
 use frame_system::RawOrigin as SystemOrigin;
+use sp_runtime::traits::One;
 
 frame_benchmarking::benchmarks! {
 	rebag_non_terminal {
@@ -67,7 +68,7 @@ frame_benchmarking::benchmarks! {
 
 		let caller = whitelisted_caller();
 		// update the weight of `origin_middle` to guarantee it will be rebagged into the destination.
-		T::VoteWeightProvider::set_vote_weight_of(&origin_middle, dest_bag_thresh);
+		T::ValueProvider::set_value_of(&origin_middle, dest_bag_thresh);
 	}: rebag(SystemOrigin::Signed(caller), origin_middle.clone())
 	verify {
 		// check the bags have updated as expected.
@@ -124,7 +125,7 @@ frame_benchmarking::benchmarks! {
 
 		let caller = whitelisted_caller();
 		// update the weight of `origin_tail` to guarantee it will be rebagged into the destination.
-		T::VoteWeightProvider::set_vote_weight_of(&origin_tail, dest_bag_thresh);
+		T::ValueProvider::set_value_of(&origin_tail, dest_bag_thresh);
 	}: rebag(SystemOrigin::Signed(caller), origin_tail.clone())
 	verify {
 		// check the bags have updated as expected.
@@ -158,8 +159,8 @@ frame_benchmarking::benchmarks! {
 		let heavier_next: T::AccountId = account("heavier_next", 0, 0);
 		assert_ok!(List::<T, _>::insert(heavier_next.clone(), bag_thresh));
 
-		T::VoteWeightProvider::set_vote_weight_of(&lighter, bag_thresh - 1);
-		T::VoteWeightProvider::set_vote_weight_of(&heavier, bag_thresh);
+		T::ValueProvider::set_value_of(&lighter, bag_thresh - One::one());
+		T::ValueProvider::set_value_of(&heavier, bag_thresh);
 
 		assert_eq!(
 			List::<T, _>::iter().map(|n| n.id().clone()).collect::<Vec<_>>(),

--- a/frame/bags-list/src/lib.rs
+++ b/frame/bags-list/src/lib.rs
@@ -53,7 +53,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Codec, FullCodec};
+use codec::FullCodec;
 use frame_election_provider_support::{ScoreProvider, SortedListProvider};
 use frame_system::ensure_signed;
 use sp_runtime::traits::{AtLeast32BitUnsigned, Bounded};
@@ -166,7 +166,6 @@ pub mod pallet {
 			+ AtLeast32BitUnsigned
 			+ Bounded
 			+ TypeInfo
-			+ Codec
 			+ FullCodec
 			+ MaxEncodedLen;
 	}

--- a/frame/bags-list/src/lib.rs
+++ b/frame/bags-list/src/lib.rs
@@ -47,14 +47,14 @@
 //!   it will worsen its position in list iteration; this reduces incentives for some types of spam
 //!   that involve consistently removing and inserting for better position. Further, ordering
 //!   granularity is thus dictated by range between each bag threshold.
-//! - if an item's score changes to a value no longer within the range of its current bag the
-//!   item's position will need to be updated by an external actor with rebag (update), or removal
-//!   and insertion.
+//! - if an item's score changes to a value no longer within the range of its current bag the item's
+//!   position will need to be updated by an external actor with rebag (update), or removal and
+//!   insertion.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Codec, FullCodec};
-use frame_election_provider_support::{SortedListProvider, ScoreProvider};
+use frame_election_provider_support::{ScoreProvider, SortedListProvider};
 use frame_system::ensure_signed;
 use sp_runtime::traits::{AtLeast32BitUnsigned, Bounded};
 use sp_std::prelude::*;

--- a/frame/bags-list/src/lib.rs
+++ b/frame/bags-list/src/lib.rs
@@ -92,12 +92,12 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(crate) trait Store)]
-	pub struct Pallet<T>(_);
+	pub struct Pallet<T, I = ()>(_);
 
 	#[pallet::config]
-	pub trait Config: frame_system::Config {
+	pub trait Config<I: 'static = ()>: frame_system::Config {
 		/// The overarching event type.
-		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+		type Event: From<Event<Self, I>> + IsType<<Self as frame_system::Config>::Event>;
 
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: weights::WeightInfo;
@@ -156,25 +156,26 @@ pub mod pallet {
 	///
 	/// Nodes store links forward and back within their respective bags.
 	#[pallet::storage]
-	pub(crate) type ListNodes<T: Config> =
-		CountedStorageMap<_, Twox64Concat, T::AccountId, list::Node<T>>;
+	pub(crate) type ListNodes<T: Config<I>, I: 'static = ()> =
+		CountedStorageMap<_, Twox64Concat, T::AccountId, list::Node<T, I>>;
 
 	/// A bag stored in storage.
 	///
 	/// Stores a `Bag` struct, which stores head and tail pointers to itself.
 	#[pallet::storage]
-	pub(crate) type ListBags<T: Config> = StorageMap<_, Twox64Concat, VoteWeight, list::Bag<T>>;
+	pub(crate) type ListBags<T: Config<I>, I: 'static = ()> =
+		StorageMap<_, Twox64Concat, VoteWeight, list::Bag<T, I>>;
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
-	pub enum Event<T: Config> {
+	pub enum Event<T: Config<I>, I: 'static = ()> {
 		/// Moved an account from one bag to another.
 		Rebagged { who: T::AccountId, from: VoteWeight, to: VoteWeight },
 	}
 
 	#[pallet::error]
 	#[cfg_attr(test, derive(PartialEq))]
-	pub enum Error<T> {
+	pub enum Error<T, I = ()> {
 		/// Attempted to place node in front of a node in another bag.
 		NotInSameBag,
 		/// Id not found in list.
@@ -184,7 +185,7 @@ pub mod pallet {
 	}
 
 	#[pallet::call]
-	impl<T: Config> Pallet<T> {
+	impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		/// Declare that some `dislocated` account has, through rewards or penalties, sufficiently
 		/// changed its weight that it should properly fall into a different bag than its current
 		/// one.
@@ -197,7 +198,7 @@ pub mod pallet {
 		pub fn rebag(origin: OriginFor<T>, dislocated: T::AccountId) -> DispatchResult {
 			ensure_signed(origin)?;
 			let current_weight = T::VoteWeightProvider::vote_weight(&dislocated);
-			let _ = Pallet::<T>::do_rebag(&dislocated, current_weight);
+			let _ = Pallet::<T, I>::do_rebag(&dislocated, current_weight);
 			Ok(())
 		}
 
@@ -212,12 +213,12 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::put_in_front_of())]
 		pub fn put_in_front_of(origin: OriginFor<T>, lighter: T::AccountId) -> DispatchResult {
 			let heavier = ensure_signed(origin)?;
-			List::<T>::put_in_front_of(&lighter, &heavier).map_err(Into::into)
+			List::<T, I>::put_in_front_of(&lighter, &heavier).map_err(Into::into)
 		}
 	}
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {
 		fn integrity_test() {
 			// ensure they are strictly increasing, this also implies that duplicates are detected.
 			assert!(
@@ -228,7 +229,7 @@ pub mod pallet {
 	}
 }
 
-impl<T: Config> Pallet<T> {
+impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// Move an account from one bag to another, depositing an event on success.
 	///
 	/// If the account changed bags, returns `Some((from, to))`.
@@ -238,46 +239,46 @@ impl<T: Config> Pallet<T> {
 	) -> Option<(VoteWeight, VoteWeight)> {
 		// if no voter at that node, don't do anything.
 		// the caller just wasted the fee to call this.
-		let maybe_movement = list::Node::<T>::get(&account)
+		let maybe_movement = list::Node::<T, I>::get(&account)
 			.and_then(|node| List::update_position_for(node, new_weight));
 		if let Some((from, to)) = maybe_movement {
-			Self::deposit_event(Event::<T>::Rebagged { who: account.clone(), from, to });
+			Self::deposit_event(Event::<T, I>::Rebagged { who: account.clone(), from, to });
 		};
 		maybe_movement
 	}
 
 	/// Equivalent to `ListBags::get`, but public. Useful for tests in outside of this crate.
 	#[cfg(feature = "std")]
-	pub fn list_bags_get(weight: VoteWeight) -> Option<list::Bag<T>> {
+	pub fn list_bags_get(weight: VoteWeight) -> Option<list::Bag<T, I>> {
 		ListBags::get(weight)
 	}
 }
 
-impl<T: Config> SortedListProvider<T::AccountId> for Pallet<T> {
+impl<T: Config<I>, I: 'static> SortedListProvider<T::AccountId> for Pallet<T, I> {
 	type Error = Error;
 
 	fn iter() -> Box<dyn Iterator<Item = T::AccountId>> {
-		Box::new(List::<T>::iter().map(|n| n.id().clone()))
+		Box::new(List::<T, I>::iter().map(|n| n.id().clone()))
 	}
 
 	fn count() -> u32 {
-		ListNodes::<T>::count()
+		ListNodes::<T, I>::count()
 	}
 
 	fn contains(id: &T::AccountId) -> bool {
-		List::<T>::contains(id)
+		List::<T, I>::contains(id)
 	}
 
 	fn on_insert(id: T::AccountId, weight: VoteWeight) -> Result<(), Error> {
-		List::<T>::insert(id, weight)
+		List::<T, I>::insert(id, weight)
 	}
 
 	fn on_update(id: &T::AccountId, new_weight: VoteWeight) {
-		Pallet::<T>::do_rebag(id, new_weight);
+		Pallet::<T, I>::do_rebag(id, new_weight);
 	}
 
 	fn on_remove(id: &T::AccountId) {
-		List::<T>::remove(id)
+		List::<T, I>::remove(id)
 	}
 
 	fn unsafe_regenerate(
@@ -287,12 +288,12 @@ impl<T: Config> SortedListProvider<T::AccountId> for Pallet<T> {
 		// NOTE: This call is unsafe for the same reason as SortedListProvider::unsafe_regenerate.
 		// I.e. because it can lead to many storage accesses.
 		// So it is ok to call it as caller must ensure the conditions.
-		List::<T>::unsafe_regenerate(all, weight_of)
+		List::<T, I>::unsafe_regenerate(all, weight_of)
 	}
 
 	#[cfg(feature = "std")]
 	fn sanity_check() -> Result<(), &'static str> {
-		List::<T>::sanity_check()
+		List::<T, I>::sanity_check()
 	}
 
 	#[cfg(not(feature = "std"))]
@@ -304,14 +305,14 @@ impl<T: Config> SortedListProvider<T::AccountId> for Pallet<T> {
 		// NOTE: This call is unsafe for the same reason as SortedListProvider::unsafe_clear.
 		// I.e. because it can lead to many storage accesses.
 		// So it is ok to call it as caller must ensure the conditions.
-		List::<T>::unsafe_clear()
+		List::<T, I>::unsafe_clear()
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn weight_update_worst_case(who: &T::AccountId, is_increase: bool) -> VoteWeight {
 		use frame_support::traits::Get as _;
 		let thresholds = T::BagThresholds::get();
-		let node = list::Node::<T>::get(who).unwrap();
+		let node = list::Node::<T, I>::get(who).unwrap();
 		let current_bag_idx = thresholds
 			.iter()
 			.chain(sp_std::iter::once(&VoteWeight::MAX))

--- a/frame/bags-list/src/lib.rs
+++ b/frame/bags-list/src/lib.rs
@@ -17,14 +17,14 @@
 
 //! # Bags-List Pallet
 //!
-//! A semi-sorted list, where items hold an `AccountId` based on some `Value`. The
+//! A semi-sorted list, where items hold an `AccountId` based on some `Score`. The
 //! `AccountId` (`id` for short) might be synonym to a `voter` or `nominator` in some context, and
-//! `Value` signifies the chance of each id being included in the final
+//! `Score` signifies the chance of each id being included in the final
 //! [`SortedListProvider::iter`].
 //!
 //! It implements [`frame_election_provider_support::SortedListProvider`] to provide a semi-sorted
 //! list of accounts to another pallet. It needs some other pallet to give it some information about
-//! the weights of accounts via [`frame_election_provider_support::ValueProvider`].
+//! the weights of accounts via [`frame_election_provider_support::ScoreProvider`].
 //!
 //! This pallet is not configurable at genesis. Whoever uses it should call appropriate functions of
 //! the `SortedListProvider` (e.g. `on_insert`, or `unsafe_regenerate`) at their genesis.
@@ -34,12 +34,12 @@
 //! The data structure exposed by this pallet aims to be optimized for:
 //!
 //! - insertions and removals.
-//! - iteration over the top* N items by weight, where the precise ordering of items doesn't
+//! - iteration over the top* N items by score, where the precise ordering of items doesn't
 //!   particularly matter.
 //!
 //! # Details
 //!
-//! - items are kept in bags, which are delineated by their range of weight (See
+//! - items are kept in bags, which are delineated by their range of score (See
 //!   [`Config::BagThresholds`]).
 //! - for iteration, bags are chained together from highest to lowest and elements within the bag
 //!   are iterated from head to tail.
@@ -47,14 +47,14 @@
 //!   it will worsen its position in list iteration; this reduces incentives for some types of spam
 //!   that involve consistently removing and inserting for better position. Further, ordering
 //!   granularity is thus dictated by range between each bag threshold.
-//! - if an item's weight changes to a value no longer within the range of its current bag the
+//! - if an item's score changes to a value no longer within the range of its current bag the
 //!   item's position will need to be updated by an external actor with rebag (update), or removal
 //!   and insertion.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Codec, FullCodec};
-use frame_election_provider_support::{SortedListProvider, ValueProvider};
+use frame_election_provider_support::{SortedListProvider, ScoreProvider};
 use frame_system::ensure_signed;
 use sp_runtime::traits::{AtLeast32BitUnsigned, Bounded};
 use sp_std::prelude::*;
@@ -105,27 +105,27 @@ pub mod pallet {
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: weights::WeightInfo;
 
-		/// Something that provides the weights of ids.
-		type ValueProvider: ValueProvider<Self::AccountId, Value = Self::Value>;
+		/// Something that provides the scores of ids.
+		type ScoreProvider: ScoreProvider<Self::AccountId, Score = Self::Score>;
 
 		/// The list of thresholds separating the various bags.
 		///
-		/// Ids are separated into unsorted bags according to their vote weight. This specifies the
-		/// thresholds separating the bags. An id's bag is the largest bag for which the id's weight
+		/// Ids are separated into unsorted bags according to their score. This specifies the
+		/// thresholds separating the bags. An id's bag is the largest bag for which the id's score
 		/// is less than or equal to its upper threshold.
 		///
 		/// When ids are iterated, higher bags are iterated completely before lower bags. This means
-		/// that iteration is _semi-sorted_: ids of higher weight tend to come before ids of lower
-		/// weight, but peer ids within a particular bag are sorted in insertion order.
+		/// that iteration is _semi-sorted_: ids of higher score tend to come before ids of lower
+		/// score, but peer ids within a particular bag are sorted in insertion order.
 		///
 		/// # Expressing the constant
 		///
 		/// This constant must be sorted in strictly increasing order. Duplicate items are not
 		/// permitted.
 		///
-		/// There is an implied upper limit of `Value::MAX`; that value does not need to be
+		/// There is an implied upper limit of `Score::MAX`; that value does not need to be
 		/// specified within the bag. For any two threshold lists, if one ends with
-		/// `Value::MAX`, the other one does not, and they are otherwise equal, the two
+		/// `Score::MAX`, the other one does not, and they are otherwise equal, the two
 		/// lists will behave identically.
 		///
 		/// # Calculation
@@ -144,18 +144,18 @@ pub mod pallet {
 		///   the procedure given above, then the constant ratio is equal to 2.
 		/// - If `BagThresholds::get().len() == 200`, and the thresholds are determined according to
 		///   the procedure given above, then the constant ratio is approximately equal to 1.248.
-		/// - If the threshold list begins `[1, 2, 3, ...]`, then an id with weight 0 or 1 will fall
-		///   into bag 0, an id with weight 2 will fall into bag 1, etc.
+		/// - If the threshold list begins `[1, 2, 3, ...]`, then an id with score 0 or 1 will fall
+		///   into bag 0, an id with score 2 will fall into bag 1, etc.
 		///
 		/// # Migration
 		///
 		/// In the event that this list ever changes, a copy of the old bags list must be retained.
 		/// With that `List::migrate` can be called, which will perform the appropriate migration.
 		#[pallet::constant]
-		type BagThresholds: Get<&'static [Self::Value]>;
+		type BagThresholds: Get<&'static [Self::Score]>;
 
-		/// The type of value used to dictate a node position relative to other nodes.
-		type Value: Clone
+		/// The type used to dictate a node position relative to other nodes.
+		type Score: Clone
 			+ Default
 			+ PartialEq
 			+ Eq
@@ -183,13 +183,13 @@ pub mod pallet {
 	/// Stores a `Bag` struct, which stores head and tail pointers to itself.
 	#[pallet::storage]
 	pub(crate) type ListBags<T: Config<I>, I: 'static = ()> =
-		StorageMap<_, Twox64Concat, T::Value, list::Bag<T, I>>;
+		StorageMap<_, Twox64Concat, T::Score, list::Bag<T, I>>;
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
 	pub enum Event<T: Config<I>, I: 'static = ()> {
 		/// Moved an account from one bag to another.
-		Rebagged { who: T::AccountId, from: T::Value, to: T::Value },
+		Rebagged { who: T::AccountId, from: T::Score, to: T::Score },
 	}
 
 	#[pallet::error]
@@ -199,14 +199,14 @@ pub mod pallet {
 		NotInSameBag,
 		/// Id not found in list.
 		IdNotFound,
-		/// An Id does not have a greater vote weight than another Id.
+		/// An Id does not have a greater score than another Id.
 		NotHeavier,
 	}
 
 	#[pallet::call]
 	impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		/// Declare that some `dislocated` account has, through rewards or penalties, sufficiently
-		/// changed its weight that it should properly fall into a different bag than its current
+		/// changed its score that it should properly fall into a different bag than its current
 		/// one.
 		///
 		/// Anyone can call this function about any potentially dislocated account.
@@ -216,8 +216,8 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::rebag_non_terminal().max(T::WeightInfo::rebag_terminal()))]
 		pub fn rebag(origin: OriginFor<T>, dislocated: T::AccountId) -> DispatchResult {
 			ensure_signed(origin)?;
-			let current_weight = T::ValueProvider::value(&dislocated);
-			let _ = Pallet::<T, I>::do_rebag(&dislocated, current_weight);
+			let current_score = T::ScoreProvider::score(&dislocated);
+			let _ = Pallet::<T, I>::do_rebag(&dislocated, current_score);
 			Ok(())
 		}
 
@@ -228,7 +228,7 @@ pub mod pallet {
 		///
 		/// Only works if
 		/// - both nodes are within the same bag,
-		/// - and `origin` has a greater `Value` than `lighter`.
+		/// - and `origin` has a greater `Score` than `lighter`.
 		#[pallet::weight(T::WeightInfo::put_in_front_of())]
 		pub fn put_in_front_of(origin: OriginFor<T>, lighter: T::AccountId) -> DispatchResult {
 			let heavier = ensure_signed(origin)?;
@@ -252,7 +252,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// Move an account from one bag to another, depositing an event on success.
 	///
 	/// If the account changed bags, returns `Some((from, to))`.
-	pub fn do_rebag(account: &T::AccountId, new_weight: T::Value) -> Option<(T::Value, T::Value)> {
+	pub fn do_rebag(account: &T::AccountId, new_weight: T::Score) -> Option<(T::Score, T::Score)> {
 		// if no voter at that node, don't do anything.
 		// the caller just wasted the fee to call this.
 		let maybe_movement = list::Node::<T, I>::get(&account)
@@ -265,15 +265,15 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	/// Equivalent to `ListBags::get`, but public. Useful for tests in outside of this crate.
 	#[cfg(feature = "std")]
-	pub fn list_bags_get(weight: T::Value) -> Option<list::Bag<T, I>> {
-		ListBags::get(weight)
+	pub fn list_bags_get(score: T::Score) -> Option<list::Bag<T, I>> {
+		ListBags::get(score)
 	}
 }
 
 impl<T: Config<I>, I: 'static> SortedListProvider<T::AccountId> for Pallet<T, I> {
 	type Error = Error;
 
-	type Value = T::Value;
+	type Score = T::Score;
 
 	fn iter() -> Box<dyn Iterator<Item = T::AccountId>> {
 		Box::new(List::<T, I>::iter().map(|n| n.id().clone()))
@@ -287,12 +287,12 @@ impl<T: Config<I>, I: 'static> SortedListProvider<T::AccountId> for Pallet<T, I>
 		List::<T, I>::contains(id)
 	}
 
-	fn on_insert(id: T::AccountId, weight: T::Value) -> Result<(), Error> {
-		List::<T, I>::insert(id, weight)
+	fn on_insert(id: T::AccountId, score: T::Score) -> Result<(), Error> {
+		List::<T, I>::insert(id, score)
 	}
 
-	fn on_update(id: &T::AccountId, new_weight: T::Value) {
-		Pallet::<T, I>::do_rebag(id, new_weight);
+	fn on_update(id: &T::AccountId, new_score: T::Score) {
+		Pallet::<T, I>::do_rebag(id, new_score);
 	}
 
 	fn on_remove(id: &T::AccountId) {
@@ -301,12 +301,12 @@ impl<T: Config<I>, I: 'static> SortedListProvider<T::AccountId> for Pallet<T, I>
 
 	fn unsafe_regenerate(
 		all: impl IntoIterator<Item = T::AccountId>,
-		weight_of: Box<dyn Fn(&T::AccountId) -> T::Value>,
+		score_of: Box<dyn Fn(&T::AccountId) -> T::Score>,
 	) -> u32 {
 		// NOTE: This call is unsafe for the same reason as SortedListProvider::unsafe_regenerate.
 		// I.e. because it can lead to many storage accesses.
 		// So it is ok to call it as caller must ensure the conditions.
-		List::<T, I>::unsafe_regenerate(all, weight_of)
+		List::<T, I>::unsafe_regenerate(all, score_of)
 	}
 
 	#[cfg(feature = "std")]
@@ -327,13 +327,13 @@ impl<T: Config<I>, I: 'static> SortedListProvider<T::AccountId> for Pallet<T, I>
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	fn weight_update_worst_case(who: &T::AccountId, is_increase: bool) -> Self::Value {
+	fn score_update_worst_case(who: &T::AccountId, is_increase: bool) -> Self::Score {
 		use frame_support::traits::Get as _;
 		let thresholds = T::BagThresholds::get();
 		let node = list::Node::<T, I>::get(who).unwrap();
 		let current_bag_idx = thresholds
 			.iter()
-			.chain(sp_std::iter::once(&T::Value::max_value()))
+			.chain(sp_std::iter::once(&T::Score::max_value()))
 			.position(|w| w == &node.bag_upper())
 			.unwrap();
 

--- a/frame/bags-list/src/list/mod.rs
+++ b/frame/bags-list/src/list/mod.rs
@@ -552,23 +552,23 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 #[scale_info(skip_type_params(T, I))]
 #[cfg_attr(feature = "std", derive(frame_support::DebugNoBound, Clone, PartialEq))]
 pub struct Bag<T: Config<I>, I: 'static = ()> {
-	phantom: PhantomData<I>,
 	head: Option<T::AccountId>,
 	tail: Option<T::AccountId>,
 
 	#[codec(skip)]
 	bag_upper: VoteWeight,
+	#[codec(skip)]
+	phantom: PhantomData<I>,
 }
 
 impl<T: Config<I>, I: 'static> Bag<T, I> {
 	#[cfg(test)]
 	pub(crate) fn new(
-		phantom: PhantomData<I>,
 		head: Option<T::AccountId>,
 		tail: Option<T::AccountId>,
 		bag_upper: VoteWeight,
 	) -> Self {
-		Self { phantom, head, tail, bag_upper }
+		Self { head, tail, bag_upper, phantom: PhantomData, }
 	}
 
 	/// Get a bag by its upper vote weight.
@@ -626,11 +626,11 @@ impl<T: Config<I>, I: 'static> Bag<T, I> {
 		// as this bag is the correct one, we're good. All calls to this must come after getting the
 		// correct [`notional_bag_for`].
 		self.insert_node_unchecked(Node::<T, I> {
-			phantom: Default::default(),
 			id,
 			prev: None,
 			next: None,
 			bag_upper: 0,
+			phantom: PhantomData,
 		});
 	}
 
@@ -763,11 +763,11 @@ impl<T: Config<I>, I: 'static> Bag<T, I> {
 #[scale_info(skip_type_params(T, I))]
 #[cfg_attr(feature = "std", derive(frame_support::DebugNoBound, Clone, PartialEq))]
 pub struct Node<T: Config<I>, I: 'static = ()> {
-	phantom: PhantomData<I>,
 	id: T::AccountId,
 	prev: Option<T::AccountId>,
 	next: Option<T::AccountId>,
 	bag_upper: VoteWeight,
+	phantom: PhantomData<I>,
 }
 
 impl<T: Config<I>, I: 'static> Node<T, I> {

--- a/frame/bags-list/src/list/mod.rs
+++ b/frame/bags-list/src/list/mod.rs
@@ -564,7 +564,7 @@ pub struct Bag<T: Config<I>, I: 'static = ()> {
 	#[codec(skip)]
 	bag_upper: T::Value,
 	#[codec(skip)]
-	phantom: PhantomData<I>,
+	_phantom: PhantomData<I>,
 }
 
 impl<T: Config<I>, I: 'static> Bag<T, I> {
@@ -574,7 +574,7 @@ impl<T: Config<I>, I: 'static> Bag<T, I> {
 		tail: Option<T::AccountId>,
 		bag_upper: T::Value,
 	) -> Self {
-		Self { head, tail, bag_upper, phantom: PhantomData }
+		Self { head, tail, bag_upper, _phantom: PhantomData }
 	}
 
 	/// Get a bag by its upper value.
@@ -636,7 +636,7 @@ impl<T: Config<I>, I: 'static> Bag<T, I> {
 			prev: None,
 			next: None,
 			bag_upper: Zero::zero(),
-			phantom: PhantomData,
+			_phantom: PhantomData,
 		});
 	}
 
@@ -773,7 +773,8 @@ pub struct Node<T: Config<I>, I: 'static = ()> {
 	prev: Option<T::AccountId>,
 	next: Option<T::AccountId>,
 	bag_upper: T::Value,
-	phantom: PhantomData<I>,
+	#[codec(skip)]
+	_phantom: PhantomData<I>,
 }
 
 impl<T: Config<I>, I: 'static> Node<T, I> {

--- a/frame/bags-list/src/list/mod.rs
+++ b/frame/bags-list/src/list/mod.rs
@@ -26,7 +26,7 @@
 
 use crate::Config;
 use codec::{Decode, Encode, MaxEncodedLen};
-use frame_election_provider_support::ValueProvider;
+use frame_election_provider_support::ScoreProvider;
 use frame_support::{traits::Get, DefaultNoBound};
 use scale_info::TypeInfo;
 use sp_runtime::traits::{Bounded, Zero};
@@ -47,31 +47,31 @@ pub enum Error {
 #[cfg(test)]
 mod tests;
 
-/// Given a certain value, to which bag does it belong to?
+/// Given a certain score, to which bag does it belong to?
 ///
 /// Bags are identified by their upper threshold; the value returned by this function is guaranteed
 /// to be a member of `T::BagThresholds`.
 ///
-/// Note that even if the thresholds list does not have `T::Value::max_value()` as its final member,
+/// Note that even if the thresholds list does not have `T::Score::max_value()` as its final member,
 /// this function behaves as if it does.
-pub fn notional_bag_for<T: Config<I>, I: 'static>(weight: T::Value) -> T::Value {
+pub fn notional_bag_for<T: Config<I>, I: 'static>(score: T::Score) -> T::Score {
 	let thresholds = T::BagThresholds::get();
-	let idx = thresholds.partition_point(|&threshold| weight > threshold);
-	thresholds.get(idx).copied().unwrap_or(T::Value::max_value())
+	let idx = thresholds.partition_point(|&threshold| score > threshold);
+	thresholds.get(idx).copied().unwrap_or(T::Score::max_value())
 }
 
 /// The **ONLY** entry point of this module. All operations to the bags-list should happen through
 /// this interface. It is forbidden to access other module members directly.
 //
-// Data structure providing efficient mostly-accurate selection of the top N id by `Value`.
+// Data structure providing efficient mostly-accurate selection of the top N id by `Score`.
 //
 // It's implemented as a set of linked lists. Each linked list comprises a bag of ids of
-// arbitrary and unbounded length, all having a value within a particular constant range.
+// arbitrary and unbounded length, all having a score within a particular constant range.
 // This structure means that ids can be added and removed in `O(1)` time.
 //
 // Iteration is accomplished by chaining the iteration of each bag, from greatest to least. While
-// the users within any particular bag are sorted in an entirely arbitrary order, the overall vote
-// weight decreases as successive bags are reached. This means that it is valid to truncate
+// the users within any particular bag are sorted in an entirely arbitrary order, the overall score
+// decreases as successive bags are reached. This means that it is valid to truncate
 // iteration at any desired point; only those ids in the lowest bag can be excluded. This
 // satisfies both the desire for fairness and the requirement for efficiency.
 pub struct List<T: Config<I>, I: 'static = ()>(PhantomData<(T, I)>);
@@ -99,13 +99,13 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 	/// Returns the number of ids migrated.
 	pub fn unsafe_regenerate(
 		all: impl IntoIterator<Item = T::AccountId>,
-		weight_of: Box<dyn Fn(&T::AccountId) -> T::Value>,
+		score_of: Box<dyn Fn(&T::AccountId) -> T::Score>,
 	) -> u32 {
 		// NOTE: This call is unsafe for the same reason as SortedListProvider::unsafe_regenerate.
 		// I.e. because it can lead to many storage accesses.
 		// So it is ok to call it as caller must ensure the conditions.
 		Self::unsafe_clear();
-		Self::insert_many(all, weight_of)
+		Self::insert_many(all, score_of)
 	}
 
 	/// Migrate the list from one set of thresholds to another.
@@ -128,7 +128,7 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 	/// - ids whose bags change at all are implicitly rebagged into the appropriate bag in the new
 	///   threshold set.
 	#[allow(dead_code)]
-	pub fn migrate(old_thresholds: &[T::Value]) -> u32 {
+	pub fn migrate(old_thresholds: &[T::Score]) -> u32 {
 		let new_thresholds = T::BagThresholds::get();
 		if new_thresholds == old_thresholds {
 			return 0
@@ -161,7 +161,7 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 			let affected_bag = {
 				// this recreates `notional_bag_for` logic, but with the old thresholds.
 				let idx = old_thresholds.partition_point(|&threshold| inserted_bag > threshold);
-				old_thresholds.get(idx).copied().unwrap_or(T::Value::max_value())
+				old_thresholds.get(idx).copied().unwrap_or(T::Score::max_value())
 			};
 			if !affected_old_bags.insert(affected_bag) {
 				// If the previous threshold list was [10, 20], and we insert [3, 5], then there's
@@ -188,10 +188,10 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 
 		// migrate the voters whose bag has changed
 		let num_affected = affected_accounts.len() as u32;
-		let weight_of = T::ValueProvider::value;
+		let score_of = T::ScoreProvider::score;
 		let _removed = Self::remove_many(&affected_accounts);
 		debug_assert_eq!(_removed, num_affected);
-		let _inserted = Self::insert_many(affected_accounts.into_iter(), weight_of);
+		let _inserted = Self::insert_many(affected_accounts.into_iter(), score_of);
 		debug_assert_eq!(_inserted, num_affected);
 
 		// we couldn't previously remove the old bags because both insertion and removal assume that
@@ -231,14 +231,14 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 		// easier; they can just configure `type BagThresholds = ()`.
 		let thresholds = T::BagThresholds::get();
 		let iter = thresholds.iter().copied();
-		let iter: Box<dyn Iterator<Item = T::Value>> = if thresholds.last() ==
-			Some(&T::Value::max_value())
+		let iter: Box<dyn Iterator<Item = T::Score>> = if thresholds.last() ==
+			Some(&T::Score::max_value())
 		{
 			// in the event that they included it, we can just pass the iterator through unchanged.
 			Box::new(iter.rev())
 		} else {
 			// otherwise, insert it here.
-			Box::new(iter.chain(iter::once(T::Value::max_value())).rev())
+			Box::new(iter.chain(iter::once(T::Score::max_value())).rev())
 		};
 
 		iter.filter_map(Bag::get).flat_map(|bag| bag.iter())
@@ -250,12 +250,12 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 	/// Returns the final count of number of ids inserted.
 	fn insert_many(
 		ids: impl IntoIterator<Item = T::AccountId>,
-		weight_of: impl Fn(&T::AccountId) -> T::Value,
+		score_of: impl Fn(&T::AccountId) -> T::Score,
 	) -> u32 {
 		let mut count = 0;
 		ids.into_iter().for_each(|v| {
-			let weight = weight_of(&v);
-			if Self::insert(v, weight).is_ok() {
+			let score = score_of(&v);
+			if Self::insert(v, score).is_ok() {
 				count += 1;
 			}
 		});
@@ -266,13 +266,13 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 	/// Insert a new id into the appropriate bag in the list.
 	///
 	/// Returns an error if the list already contains `id`.
-	pub(crate) fn insert(id: T::AccountId, weight: T::Value) -> Result<(), Error> {
+	pub(crate) fn insert(id: T::AccountId, score: T::Score) -> Result<(), Error> {
 		if Self::contains(&id) {
 			return Err(Error::Duplicate)
 		}
 
-		let bag_weight = notional_bag_for::<T, I>(weight);
-		let mut bag = Bag::<T, I>::get_or_make(bag_weight);
+		let bag_score = notional_bag_for::<T, I>(score);
+		let mut bag = Bag::<T, I>::get_or_make(bag_score);
 		// unchecked insertion is okay; we just got the correct `notional_bag_for`.
 		bag.insert_unchecked(id.clone());
 
@@ -281,11 +281,11 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 
 		crate::log!(
 			debug,
-			"inserted {:?} with weight {:?
+			"inserted {:?} with score {:?
 			} into bag {:?}, new count is {}",
 			id,
-			weight,
-			bag_weight,
+			score,
+			bag_score,
 			crate::ListNodes::<T, I>::count(),
 		);
 
@@ -348,9 +348,9 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 	/// to call [`self.remove_many`] followed by [`self.insert_many`].
 	pub(crate) fn update_position_for(
 		node: Node<T, I>,
-		new_weight: T::Value,
-	) -> Option<(T::Value, T::Value)> {
-		node.is_misplaced(new_weight).then(move || {
+		new_score: T::Score,
+	) -> Option<(T::Score, T::Score)> {
+		node.is_misplaced(new_score).then(move || {
 			let old_bag_upper = node.bag_upper;
 
 			if !node.is_terminal() {
@@ -371,7 +371,7 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 			}
 
 			// put the node into the appropriate new bag.
-			let new_bag_upper = notional_bag_for::<T, I>(new_weight);
+			let new_bag_upper = notional_bag_for::<T, I>(new_score);
 			let mut bag = Bag::<T, I>::get_or_make(new_bag_upper);
 			// prev, next, and bag_upper of the node are updated inside `insert_node`, also
 			// `node.put` is in there.
@@ -383,7 +383,7 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 	}
 
 	/// Put `heavier_id` to the position directly in front of `lighter_id`. Both ids must be in the
-	/// same bag and the `weight_of` `lighter_id` must be less than that of `heavier_id`.
+	/// same bag and the `score_of` `lighter_id` must be less than that of `heavier_id`.
 	pub(crate) fn put_in_front_of(
 		lighter_id: &T::AccountId,
 		heavier_id: &T::AccountId,
@@ -398,7 +398,7 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 
 		// this is the most expensive check, so we do it last.
 		ensure!(
-			T::ValueProvider::value(&heavier_id) > T::ValueProvider::value(&lighter_id),
+			T::ScoreProvider::score(&heavier_id) > T::ScoreProvider::score(&lighter_id),
 			pallet::Error::NotHeavier
 		);
 
@@ -487,13 +487,13 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 
 		let active_bags = {
 			let thresholds = T::BagThresholds::get().iter().copied();
-			let thresholds: Vec<T::Value> =
-				if thresholds.clone().last() == Some(T::Value::max_value()) {
+			let thresholds: Vec<T::Score> =
+				if thresholds.clone().last() == Some(T::Score::max_value()) {
 					// in the event that they included it, we don't need to make any changes
 					thresholds.collect()
 				} else {
 					// otherwise, insert it here.
-					thresholds.chain(iter::once(T::Value::max_value())).collect()
+					thresholds.chain(iter::once(T::Score::max_value())).collect()
 				};
 			thresholds.into_iter().filter_map(|t| Bag::<T, I>::get(t))
 		};
@@ -523,19 +523,19 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 	/// Returns the nodes of all non-empty bags. For testing and benchmarks.
 	#[cfg(any(feature = "std", feature = "runtime-benchmarks"))]
 	#[allow(dead_code)]
-	pub(crate) fn get_bags() -> Vec<(T::Value, Vec<T::AccountId>)> {
+	pub(crate) fn get_bags() -> Vec<(T::Score, Vec<T::AccountId>)> {
 		use frame_support::traits::Get as _;
 
 		let thresholds = T::BagThresholds::get();
 		let iter = thresholds.iter().copied();
-		let iter: Box<dyn Iterator<Item = T::Value>> = if thresholds.last() ==
-			Some(&T::Value::max_value())
+		let iter: Box<dyn Iterator<Item = T::Score>> = if thresholds.last() ==
+			Some(&T::Score::max_value())
 		{
 			// in the event that they included it, we can just pass the iterator through unchanged.
 			Box::new(iter)
 		} else {
 			// otherwise, insert it here.
-			Box::new(iter.chain(sp_std::iter::once(T::Value::max_value())))
+			Box::new(iter.chain(sp_std::iter::once(T::Score::max_value())))
 		};
 
 		iter.filter_map(|t| {
@@ -562,7 +562,7 @@ pub struct Bag<T: Config<I>, I: 'static = ()> {
 	tail: Option<T::AccountId>,
 
 	#[codec(skip)]
-	bag_upper: T::Value,
+	bag_upper: T::Score,
 	#[codec(skip)]
 	_phantom: PhantomData<I>,
 }
@@ -572,22 +572,22 @@ impl<T: Config<I>, I: 'static> Bag<T, I> {
 	pub(crate) fn new(
 		head: Option<T::AccountId>,
 		tail: Option<T::AccountId>,
-		bag_upper: T::Value,
+		bag_upper: T::Score,
 	) -> Self {
 		Self { head, tail, bag_upper, _phantom: PhantomData }
 	}
 
-	/// Get a bag by its upper value.
-	pub(crate) fn get(bag_upper: T::Value) -> Option<Bag<T, I>> {
+	/// Get a bag by its upper score.
+	pub(crate) fn get(bag_upper: T::Score) -> Option<Bag<T, I>> {
 		crate::ListBags::<T, I>::try_get(bag_upper).ok().map(|mut bag| {
 			bag.bag_upper = bag_upper;
 			bag
 		})
 	}
 
-	/// Get a bag by its upper value or make it, appropriately initialized. Does not check if
+	/// Get a bag by its upper score or make it, appropriately initialized. Does not check if
 	/// if `bag_upper` is a valid threshold.
-	fn get_or_make(bag_upper: T::Value) -> Bag<T, I> {
+	fn get_or_make(bag_upper: T::Score) -> Bag<T, I> {
 		Self::get(bag_upper).unwrap_or(Bag { bag_upper, ..Default::default() })
 	}
 
@@ -772,7 +772,7 @@ pub struct Node<T: Config<I>, I: 'static = ()> {
 	id: T::AccountId,
 	prev: Option<T::AccountId>,
 	next: Option<T::AccountId>,
-	bag_upper: T::Value,
+	bag_upper: T::Score,
 	#[codec(skip)]
 	_phantom: PhantomData<I>,
 }
@@ -823,8 +823,8 @@ impl<T: Config<I>, I: 'static> Node<T, I> {
 	}
 
 	/// `true` when this voter is in the wrong bag.
-	pub fn is_misplaced(&self, current_weight: T::Value) -> bool {
-		notional_bag_for::<T, I>(current_weight) != self.bag_upper
+	pub fn is_misplaced(&self, current_score: T::Score) -> bool {
+		notional_bag_for::<T, I>(current_score) != self.bag_upper
 	}
 
 	/// `true` when this voter is a bag head or tail.
@@ -847,7 +847,7 @@ impl<T: Config<I>, I: 'static> Node<T, I> {
 	/// The bag this nodes belongs to (public for benchmarks).
 	#[cfg(feature = "runtime-benchmarks")]
 	#[allow(dead_code)]
-	pub fn bag_upper(&self) -> T::Value {
+	pub fn bag_upper(&self) -> T::Score {
 		self.bag_upper
 	}
 

--- a/frame/bags-list/src/list/mod.rs
+++ b/frame/bags-list/src/list/mod.rs
@@ -53,7 +53,7 @@ mod tests;
 ///
 /// Note that even if the thresholds list does not have `VoteWeight::MAX` as its final member, this
 /// function behaves as if it does.
-pub fn notional_bag_for<T: Config>(weight: VoteWeight) -> VoteWeight {
+pub fn notional_bag_for<T: Config<I>, I: 'static>(weight: VoteWeight) -> VoteWeight {
 	let thresholds = T::BagThresholds::get();
 	let idx = thresholds.partition_point(|&threshold| weight > threshold);
 	thresholds.get(idx).copied().unwrap_or(VoteWeight::MAX)
@@ -73,9 +73,9 @@ pub fn notional_bag_for<T: Config>(weight: VoteWeight) -> VoteWeight {
 // weight decreases as successive bags are reached. This means that it is valid to truncate
 // iteration at any desired point; only those ids in the lowest bag can be excluded. This
 // satisfies both the desire for fairness and the requirement for efficiency.
-pub struct List<T: Config>(PhantomData<T>);
+pub struct List<T: Config<I>, I: 'static = ()>(PhantomData<(T, I)>);
 
-impl<T: Config> List<T> {
+impl<T: Config<I>, I: 'static> List<T, I> {
 	/// Remove all data associated with the list from storage.
 	///
 	/// ## WARNING
@@ -83,8 +83,8 @@ impl<T: Config> List<T> {
 	/// this function should generally not be used in production as it could lead to a very large
 	/// number of storage accesses.
 	pub(crate) fn unsafe_clear() {
-		crate::ListBags::<T>::remove_all(None);
-		crate::ListNodes::<T>::remove_all();
+		crate::ListBags::<T, I>::remove_all(None);
+		crate::ListNodes::<T, I>::remove_all();
 	}
 
 	/// Regenerate all of the data from the given ids.
@@ -135,11 +135,13 @@ impl<T: Config> List<T> {
 
 		// we can't check all preconditions, but we can check one
 		debug_assert!(
-			crate::ListBags::<T>::iter().all(|(threshold, _)| old_thresholds.contains(&threshold)),
+			crate::ListBags::<T, I>::iter()
+				.all(|(threshold, _)| old_thresholds.contains(&threshold)),
 			"not all `bag_upper` currently in storage are members of `old_thresholds`",
 		);
 		debug_assert!(
-			crate::ListNodes::<T>::iter().all(|(_, node)| old_thresholds.contains(&node.bag_upper)),
+			crate::ListNodes::<T, I>::iter()
+				.all(|(_, node)| old_thresholds.contains(&node.bag_upper)),
 			"not all `node.bag_upper` currently in storage are members of `old_thresholds`",
 		);
 
@@ -166,7 +168,7 @@ impl<T: Config> List<T> {
 				continue
 			}
 
-			if let Some(bag) = Bag::<T>::get(affected_bag) {
+			if let Some(bag) = Bag::<T, I>::get(affected_bag) {
 				affected_accounts.extend(bag.iter().map(|node| node.id));
 			}
 		}
@@ -178,7 +180,7 @@ impl<T: Config> List<T> {
 				continue
 			}
 
-			if let Some(bag) = Bag::<T>::get(removed_bag) {
+			if let Some(bag) = Bag::<T, I>::get(removed_bag) {
 				affected_accounts.extend(bag.iter().map(|node| node.id));
 			}
 		}
@@ -199,10 +201,10 @@ impl<T: Config> List<T> {
 		// lookups.
 		for removed_bag in removed_bags {
 			debug_assert!(
-				!crate::ListNodes::<T>::iter().any(|(_, node)| node.bag_upper == removed_bag),
+				!crate::ListNodes::<T, I>::iter().any(|(_, node)| node.bag_upper == removed_bag),
 				"no id should be present in a removed bag",
 			);
-			crate::ListBags::<T>::remove(removed_bag);
+			crate::ListBags::<T, I>::remove(removed_bag);
 		}
 
 		debug_assert_eq!(Self::sanity_check(), Ok(()));
@@ -212,14 +214,14 @@ impl<T: Config> List<T> {
 
 	/// Returns `true` if the list contains `id`, otherwise returns `false`.
 	pub(crate) fn contains(id: &T::AccountId) -> bool {
-		crate::ListNodes::<T>::contains_key(id)
+		crate::ListNodes::<T, I>::contains_key(id)
 	}
 
 	/// Iterate over all nodes in all bags in the list.
 	///
 	/// Full iteration can be expensive; it's recommended to limit the number of items with
 	/// `.take(n)`.
-	pub(crate) fn iter() -> impl Iterator<Item = Node<T>> {
+	pub(crate) fn iter() -> impl Iterator<Item = Node<T, I>> {
 		// We need a touch of special handling here: because we permit `T::BagThresholds` to
 		// omit the final bound, we need to ensure that we explicitly include that threshold in the
 		// list.
@@ -266,8 +268,8 @@ impl<T: Config> List<T> {
 			return Err(Error::Duplicate)
 		}
 
-		let bag_weight = notional_bag_for::<T>(weight);
-		let mut bag = Bag::<T>::get_or_make(bag_weight);
+		let bag_weight = notional_bag_for::<T, I>(weight);
+		let mut bag = Bag::<T, I>::get_or_make(bag_weight);
 		// unchecked insertion is okay; we just got the correct `notional_bag_for`.
 		bag.insert_unchecked(id.clone());
 
@@ -280,7 +282,7 @@ impl<T: Config> List<T> {
 			id,
 			weight,
 			bag_weight,
-			crate::ListNodes::<T>::count(),
+			crate::ListNodes::<T, I>::count(),
 		);
 
 		Ok(())
@@ -301,7 +303,7 @@ impl<T: Config> List<T> {
 		let mut count = 0;
 
 		for id in ids.into_iter() {
-			let node = match Node::<T>::get(id) {
+			let node = match Node::<T, I>::get(id) {
 				Some(node) => node,
 				None => continue,
 			};
@@ -314,7 +316,7 @@ impl<T: Config> List<T> {
 				// this node is a head or tail, so the bag needs to be updated
 				let bag = bags
 					.entry(node.bag_upper)
-					.or_insert_with(|| Bag::<T>::get_or_make(node.bag_upper));
+					.or_insert_with(|| Bag::<T, I>::get_or_make(node.bag_upper));
 				// node.bag_upper must be correct, therefore this bag will contain this node.
 				bag.remove_node_unchecked(&node);
 			}
@@ -341,7 +343,7 @@ impl<T: Config> List<T> {
 	/// [`self.insert`]. However, given large quantities of nodes to move, it may be more efficient
 	/// to call [`self.remove_many`] followed by [`self.insert_many`].
 	pub(crate) fn update_position_for(
-		node: Node<T>,
+		node: Node<T, I>,
 		new_weight: VoteWeight,
 	) -> Option<(VoteWeight, VoteWeight)> {
 		node.is_misplaced(new_weight).then(move || {
@@ -351,7 +353,7 @@ impl<T: Config> List<T> {
 				// this node is not a head or a tail, so we can just cut it out of the list. update
 				// and put the prev and next of this node, we do `node.put` inside `insert_note`.
 				node.excise();
-			} else if let Some(mut bag) = Bag::<T>::get(node.bag_upper) {
+			} else if let Some(mut bag) = Bag::<T, I>::get(node.bag_upper) {
 				// this is a head or tail, so the bag must be updated.
 				bag.remove_node_unchecked(&node);
 				bag.put();
@@ -365,8 +367,8 @@ impl<T: Config> List<T> {
 			}
 
 			// put the node into the appropriate new bag.
-			let new_bag_upper = notional_bag_for::<T>(new_weight);
-			let mut bag = Bag::<T>::get_or_make(new_bag_upper);
+			let new_bag_upper = notional_bag_for::<T, I>(new_weight);
+			let mut bag = Bag::<T, I>::get_or_make(new_bag_upper);
 			// prev, next, and bag_upper of the node are updated inside `insert_node`, also
 			// `node.put` is in there.
 			bag.insert_node_unchecked(node);
@@ -381,12 +383,12 @@ impl<T: Config> List<T> {
 	pub(crate) fn put_in_front_of(
 		lighter_id: &T::AccountId,
 		heavier_id: &T::AccountId,
-	) -> Result<(), crate::pallet::Error<T>> {
+	) -> Result<(), crate::pallet::Error<T, I>> {
 		use crate::pallet;
 		use frame_support::ensure;
 
-		let lighter_node = Node::<T>::get(&lighter_id).ok_or(pallet::Error::IdNotFound)?;
-		let heavier_node = Node::<T>::get(&heavier_id).ok_or(pallet::Error::IdNotFound)?;
+		let lighter_node = Node::<T, I>::get(&lighter_id).ok_or(pallet::Error::IdNotFound)?;
+		let heavier_node = Node::<T, I>::get(&heavier_id).ok_or(pallet::Error::IdNotFound)?;
 
 		ensure!(lighter_node.bag_upper == heavier_node.bag_upper, pallet::Error::NotInSameBag);
 
@@ -403,7 +405,7 @@ impl<T: Config> List<T> {
 
 		// re-fetch `lighter_node` from storage since it may have been updated when `heavier_node`
 		// was removed.
-		let lighter_node = Node::<T>::get(&lighter_id).ok_or_else(|| {
+		let lighter_node = Node::<T, I>::get(&lighter_id).ok_or_else(|| {
 			debug_assert!(false, "id that should exist cannot be found");
 			crate::log!(warn, "id that should exist cannot be found");
 			pallet::Error::IdNotFound
@@ -422,7 +424,7 @@ impl<T: Config> List<T> {
 	/// - this is a naive function in that it does not check if `node` belongs to the same bag as
 	/// `at`. It is expected that the call site will check preconditions.
 	/// - this will panic if `at.bag_upper` is not a bag that already exists in storage.
-	fn insert_at_unchecked(mut at: Node<T>, mut node: Node<T>) {
+	fn insert_at_unchecked(mut at: Node<T, I>, mut node: Node<T, I>) {
 		// connect `node` to its new `prev`.
 		node.prev = at.prev.clone();
 		if let Some(mut prev) = at.prev() {
@@ -439,7 +441,7 @@ impl<T: Config> List<T> {
 			// since `node` is always in front of `at` we know that 1) there is always at least 2
 			// nodes in the bag, and 2) only `node` could be the head and only `at` could be the
 			// tail.
-			let mut bag = Bag::<T>::get(at.bag_upper)
+			let mut bag = Bag::<T, I>::get(at.bag_upper)
 				.expect("given nodes must always have a valid bag. qed.");
 
 			if node.prev == None {
@@ -473,8 +475,8 @@ impl<T: Config> List<T> {
 		);
 
 		let iter_count = Self::iter().count() as u32;
-		let stored_count = crate::ListNodes::<T>::count();
-		let nodes_count = crate::ListNodes::<T>::iter().count() as u32;
+		let stored_count = crate::ListNodes::<T, I>::count();
+		let nodes_count = crate::ListNodes::<T, I>::iter().count() as u32;
 		ensure!(iter_count == stored_count, "iter_count != stored_count");
 		ensure!(stored_count == nodes_count, "stored_count != nodes_count");
 
@@ -489,7 +491,7 @@ impl<T: Config> List<T> {
 				// otherwise, insert it here.
 				thresholds.chain(iter::once(VoteWeight::MAX)).collect()
 			};
-			thresholds.into_iter().filter_map(|t| Bag::<T>::get(t))
+			thresholds.into_iter().filter_map(|t| Bag::<T, I>::get(t))
 		};
 
 		let _ = active_bags.clone().map(|b| b.sanity_check()).collect::<Result<_, _>>()?;
@@ -502,7 +504,7 @@ impl<T: Config> List<T> {
 
 		// check that all nodes are sane. We check the `ListNodes` storage item directly in case we
 		// have some "stale" nodes that are not in a bag.
-		for (_id, node) in crate::ListNodes::<T>::iter() {
+		for (_id, node) in crate::ListNodes::<T, I>::iter() {
 			node.sanity_check()?
 		}
 
@@ -531,7 +533,8 @@ impl<T: Config> List<T> {
 		};
 
 		iter.filter_map(|t| {
-			Bag::<T>::get(t).map(|bag| (t, bag.iter().map(|n| n.id().clone()).collect::<Vec<_>>()))
+			Bag::<T, I>::get(t)
+				.map(|bag| (t, bag.iter().map(|n| n.id().clone()).collect::<Vec<_>>()))
 		})
 		.collect::<Vec<_>>()
 	}
@@ -546,9 +549,10 @@ impl<T: Config> List<T> {
 /// appearing within the ids set.
 #[derive(DefaultNoBound, Encode, Decode, MaxEncodedLen, TypeInfo)]
 #[codec(mel_bound())]
-#[scale_info(skip_type_params(T))]
+#[scale_info(skip_type_params(T, I))]
 #[cfg_attr(feature = "std", derive(frame_support::DebugNoBound, Clone, PartialEq))]
-pub struct Bag<T: Config> {
+pub struct Bag<T: Config<I>, I: 'static = ()> {
+	phantom: PhantomData<I>,
 	head: Option<T::AccountId>,
 	tail: Option<T::AccountId>,
 
@@ -556,19 +560,20 @@ pub struct Bag<T: Config> {
 	bag_upper: VoteWeight,
 }
 
-impl<T: Config> Bag<T> {
+impl<T: Config<I>, I: 'static> Bag<T, I> {
 	#[cfg(test)]
 	pub(crate) fn new(
+		phantom: PhantomData<I>,
 		head: Option<T::AccountId>,
 		tail: Option<T::AccountId>,
 		bag_upper: VoteWeight,
 	) -> Self {
-		Self { head, tail, bag_upper }
+		Self { phantom, head, tail, bag_upper }
 	}
 
 	/// Get a bag by its upper vote weight.
-	pub(crate) fn get(bag_upper: VoteWeight) -> Option<Bag<T>> {
-		crate::ListBags::<T>::try_get(bag_upper).ok().map(|mut bag| {
+	pub(crate) fn get(bag_upper: VoteWeight) -> Option<Bag<T, I>> {
+		crate::ListBags::<T, I>::try_get(bag_upper).ok().map(|mut bag| {
 			bag.bag_upper = bag_upper;
 			bag
 		})
@@ -576,7 +581,7 @@ impl<T: Config> Bag<T> {
 
 	/// Get a bag by its upper vote weight or make it, appropriately initialized. Does not check if
 	/// if `bag_upper` is a valid threshold.
-	fn get_or_make(bag_upper: VoteWeight) -> Bag<T> {
+	fn get_or_make(bag_upper: VoteWeight) -> Bag<T, I> {
 		Self::get(bag_upper).unwrap_or(Bag { bag_upper, ..Default::default() })
 	}
 
@@ -588,24 +593,24 @@ impl<T: Config> Bag<T> {
 	/// Put the bag back into storage.
 	fn put(self) {
 		if self.is_empty() {
-			crate::ListBags::<T>::remove(self.bag_upper);
+			crate::ListBags::<T, I>::remove(self.bag_upper);
 		} else {
-			crate::ListBags::<T>::insert(self.bag_upper, self);
+			crate::ListBags::<T, I>::insert(self.bag_upper, self);
 		}
 	}
 
 	/// Get the head node in this bag.
-	fn head(&self) -> Option<Node<T>> {
+	fn head(&self) -> Option<Node<T, I>> {
 		self.head.as_ref().and_then(|id| Node::get(id))
 	}
 
 	/// Get the tail node in this bag.
-	fn tail(&self) -> Option<Node<T>> {
+	fn tail(&self) -> Option<Node<T, I>> {
 		self.tail.as_ref().and_then(|id| Node::get(id))
 	}
 
 	/// Iterate over the nodes in this bag.
-	pub(crate) fn iter(&self) -> impl Iterator<Item = Node<T>> {
+	pub(crate) fn iter(&self) -> impl Iterator<Item = Node<T, I>> {
 		sp_std::iter::successors(self.head(), |prev| prev.next())
 	}
 
@@ -620,7 +625,13 @@ impl<T: Config> Bag<T> {
 		// insert_node will overwrite `prev`, `next` and `bag_upper` to the proper values. As long
 		// as this bag is the correct one, we're good. All calls to this must come after getting the
 		// correct [`notional_bag_for`].
-		self.insert_node_unchecked(Node::<T> { id, prev: None, next: None, bag_upper: 0 });
+		self.insert_node_unchecked(Node::<T, I> {
+			phantom: Default::default(),
+			id,
+			prev: None,
+			next: None,
+			bag_upper: 0,
+		});
 	}
 
 	/// Insert a node into this bag.
@@ -630,7 +641,7 @@ impl<T: Config> Bag<T> {
 	///
 	/// Storage note: this modifies storage, but only for the node. You still need to call
 	/// `self.put()` after use.
-	fn insert_node_unchecked(&mut self, mut node: Node<T>) {
+	fn insert_node_unchecked(&mut self, mut node: Node<T, I>) {
 		if let Some(tail) = &self.tail {
 			if *tail == node.id {
 				// this should never happen, but this check prevents one path to a worst case
@@ -674,7 +685,7 @@ impl<T: Config> Bag<T> {
 	///
 	/// Storage note: this modifies storage, but only for adjacent nodes. You still need to call
 	/// `self.put()` and `ListNodes::remove(id)` to update storage for the bag and `node`.
-	fn remove_node_unchecked(&mut self, node: &Node<T>) {
+	fn remove_node_unchecked(&mut self, node: &Node<T, I>) {
 		// reassign neighboring nodes.
 		node.excise();
 
@@ -735,7 +746,7 @@ impl<T: Config> Bag<T> {
 	/// Iterate over the nodes in this bag (public for tests).
 	#[cfg(feature = "std")]
 	#[allow(dead_code)]
-	pub fn std_iter(&self) -> impl Iterator<Item = Node<T>> {
+	pub fn std_iter(&self) -> impl Iterator<Item = Node<T, I>> {
 		sp_std::iter::successors(self.head(), |prev| prev.next())
 	}
 
@@ -749,24 +760,25 @@ impl<T: Config> Bag<T> {
 /// A Node is the fundamental element comprising the doubly-linked list described by `Bag`.
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo)]
 #[codec(mel_bound())]
-#[scale_info(skip_type_params(T))]
+#[scale_info(skip_type_params(T, I))]
 #[cfg_attr(feature = "std", derive(frame_support::DebugNoBound, Clone, PartialEq))]
-pub struct Node<T: Config> {
+pub struct Node<T: Config<I>, I: 'static = ()> {
+	phantom: PhantomData<I>,
 	id: T::AccountId,
 	prev: Option<T::AccountId>,
 	next: Option<T::AccountId>,
 	bag_upper: VoteWeight,
 }
 
-impl<T: Config> Node<T> {
+impl<T: Config<I>, I: 'static> Node<T, I> {
 	/// Get a node by id.
-	pub fn get(id: &T::AccountId) -> Option<Node<T>> {
-		crate::ListNodes::<T>::try_get(id).ok()
+	pub fn get(id: &T::AccountId) -> Option<Node<T, I>> {
+		crate::ListNodes::<T, I>::try_get(id).ok()
 	}
 
 	/// Put the node back into storage.
 	fn put(self) {
-		crate::ListNodes::<T>::insert(self.id.clone(), self);
+		crate::ListNodes::<T, I>::insert(self.id.clone(), self);
 	}
 
 	/// Update neighboring nodes to point to reach other.
@@ -790,22 +802,22 @@ impl<T: Config> Node<T> {
 	///
 	/// It is naive because it does not check if the node has first been removed from its bag.
 	fn remove_from_storage_unchecked(&self) {
-		crate::ListNodes::<T>::remove(&self.id)
+		crate::ListNodes::<T, I>::remove(&self.id)
 	}
 
 	/// Get the previous node in the bag.
-	fn prev(&self) -> Option<Node<T>> {
+	fn prev(&self) -> Option<Node<T, I>> {
 		self.prev.as_ref().and_then(|id| Node::get(id))
 	}
 
 	/// Get the next node in the bag.
-	fn next(&self) -> Option<Node<T>> {
+	fn next(&self) -> Option<Node<T, I>> {
 		self.next.as_ref().and_then(|id| Node::get(id))
 	}
 
 	/// `true` when this voter is in the wrong bag.
 	pub fn is_misplaced(&self, current_weight: VoteWeight) -> bool {
-		notional_bag_for::<T>(current_weight) != self.bag_upper
+		notional_bag_for::<T, I>(current_weight) != self.bag_upper
 	}
 
 	/// `true` when this voter is a bag head or tail.
@@ -834,7 +846,7 @@ impl<T: Config> Node<T> {
 
 	#[cfg(feature = "std")]
 	fn sanity_check(&self) -> Result<(), &'static str> {
-		let expected_bag = Bag::<T>::get(self.bag_upper).ok_or("bag not found for node")?;
+		let expected_bag = Bag::<T, I>::get(self.bag_upper).ok_or("bag not found for node")?;
 
 		let id = self.id();
 

--- a/frame/bags-list/src/list/tests.rs
+++ b/frame/bags-list/src/list/tests.rs
@@ -22,6 +22,7 @@ use crate::{
 };
 use frame_election_provider_support::SortedListProvider;
 use frame_support::{assert_ok, assert_storage_noop};
+use frame_election_provider_support::VoteWeight;
 
 #[test]
 fn basic_setup_works() {
@@ -84,11 +85,11 @@ fn notional_bag_for_works() {
 	assert_eq!(max_explicit_threshold, 10_000);
 
 	// if the max explicit threshold is less than T::Value::max_value(),
-	assert!(u64::MAX > max_explicit_threshold);
+	assert!(VoteWeight::MAX > max_explicit_threshold);
 
 	// then anything above it will belong to the T::Value::max_value() bag.
 	assert_eq!(notional_bag_for::<Runtime, _>(max_explicit_threshold), max_explicit_threshold);
-	assert_eq!(notional_bag_for::<Runtime, _>(max_explicit_threshold + 1), u64::MAX);
+	assert_eq!(notional_bag_for::<Runtime, _>(max_explicit_threshold + 1), VoteWeight::MAX);
 }
 
 #[test]
@@ -132,7 +133,7 @@ fn migrate_works() {
 			assert_eq!(old_thresholds, vec![10, 20, 30, 40, 50, 60, 1_000, 2_000, 10_000]);
 
 			// when the new thresholds adds `15` and removes `2_000`
-			const NEW_THRESHOLDS: &'static [u64] = &[10, 15, 20, 30, 40, 50, 60, 1_000, 10_000];
+			const NEW_THRESHOLDS: &'static [VoteWeight] = &[10, 15, 20, 30, 40, 50, 60, 1_000, 10_000];
 			BagThresholds::set(NEW_THRESHOLDS);
 			// and we call
 			List::<Runtime>::migrate(old_thresholds);
@@ -564,7 +565,7 @@ mod bags {
 			// and all other bag thresholds don't get bags.
 			<Runtime as Config>::BagThresholds::get()
 				.iter()
-				.chain(iter::once(&u64::MAX))
+				.chain(iter::once(&VoteWeight::MAX))
 				.filter(|bag_upper| !vec![10, 1_000].contains(bag_upper))
 				.for_each(|bag_upper| {
 					assert_storage_noop!(assert_eq!(Bag::<Runtime>::get(*bag_upper), None));

--- a/frame/bags-list/src/list/tests.rs
+++ b/frame/bags-list/src/list/tests.rs
@@ -411,8 +411,8 @@ mod list {
 			// given
 			ListNodes::<Runtime>::insert(10, node_10_no_bag);
 			ListNodes::<Runtime>::insert(11, node_11_no_bag);
-			StakingMock::set_value_of(&10, 14);
-			StakingMock::set_value_of(&11, 15);
+			StakingMock::set_score_of(&10, 14);
+			StakingMock::set_score_of(&11, 15);
 			assert!(!ListBags::<Runtime>::contains_key(15));
 			assert_eq!(List::<Runtime>::get_bags(), vec![]);
 

--- a/frame/bags-list/src/list/tests.rs
+++ b/frame/bags-list/src/list/tests.rs
@@ -32,7 +32,7 @@ fn basic_setup_works() {
 			prev,
 			next,
 			bag_upper,
-			phantom: PhantomData,
+			_phantom: PhantomData,
 		};
 
 		assert_eq!(ListNodes::<Runtime>::count(), 4);
@@ -44,11 +44,11 @@ fn basic_setup_works() {
 		// the state of the bags is as expected
 		assert_eq!(
 			ListBags::<Runtime>::get(10).unwrap(),
-			Bag::<Runtime> { head: Some(1), tail: Some(1), bag_upper: 0, phantom: PhantomData }
+			Bag::<Runtime> { head: Some(1), tail: Some(1), bag_upper: 0, _phantom: PhantomData }
 		);
 		assert_eq!(
 			ListBags::<Runtime>::get(1_000).unwrap(),
-			Bag::<Runtime> { head: Some(2), tail: Some(4), bag_upper: 0, phantom: PhantomData }
+			Bag::<Runtime> { head: Some(2), tail: Some(4), bag_upper: 0, _phantom: PhantomData }
 		);
 
 		assert_eq!(ListNodes::<Runtime>::get(2).unwrap(), node(2, None, Some(3), 1_000));
@@ -398,14 +398,14 @@ mod list {
 				prev: None,
 				next: None,
 				bag_upper: 15,
-				phantom: PhantomData,
+				_phantom: PhantomData,
 			};
 			let node_11_no_bag = Node::<Runtime> {
 				id: 11,
 				prev: None,
 				next: None,
 				bag_upper: 15,
-				phantom: PhantomData,
+				_phantom: PhantomData,
 			};
 
 			// given
@@ -436,7 +436,7 @@ mod list {
 				prev: Some(1),
 				next: Some(2),
 				bag_upper: 1_000,
-				phantom: PhantomData,
+				_phantom: PhantomData,
 			};
 			assert!(!crate::ListNodes::<Runtime>::contains_key(42));
 
@@ -465,7 +465,7 @@ mod list {
 				prev: Some(4),
 				next: None,
 				bag_upper: 1_000,
-				phantom: PhantomData,
+				_phantom: PhantomData,
 			};
 			assert!(!crate::ListNodes::<Runtime>::contains_key(42));
 
@@ -494,7 +494,7 @@ mod list {
 				prev: None,
 				next: Some(2),
 				bag_upper: 1_000,
-				phantom: PhantomData,
+				_phantom: PhantomData,
 			};
 			assert!(!crate::ListNodes::<Runtime>::contains_key(42));
 
@@ -523,7 +523,7 @@ mod list {
 				prev: Some(42),
 				next: Some(42),
 				bag_upper: 1_000,
-				phantom: PhantomData,
+				_phantom: PhantomData,
 			};
 			assert!(!crate::ListNodes::<Runtime>::contains_key(42));
 
@@ -551,7 +551,7 @@ mod bags {
 				let bag = Bag::<Runtime>::get(bag_upper).unwrap();
 				let bag_ids = bag.iter().map(|n| *n.id()).collect::<Vec<_>>();
 
-				assert_eq!(bag, Bag::<Runtime> { head, tail, bag_upper, phantom: PhantomData });
+				assert_eq!(bag, Bag::<Runtime> { head, tail, bag_upper, _phantom: PhantomData });
 				assert_eq!(bag_ids, ids);
 			};
 
@@ -587,7 +587,7 @@ mod bags {
 				prev: None,
 				next: None,
 				bag_upper,
-				phantom: PhantomData,
+				_phantom: PhantomData,
 			};
 
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])]);
@@ -597,7 +597,7 @@ mod bags {
 
 			assert_eq!(
 				ListNodes::<Runtime>::get(&42).unwrap(),
-				Node { bag_upper: 10, prev: Some(1), next: None, id: 42, phantom: PhantomData }
+				Node { bag_upper: 10, prev: Some(1), next: None, id: 42, _phantom: PhantomData }
 			);
 		});
 	}
@@ -610,7 +610,7 @@ mod bags {
 				prev: None,
 				next: None,
 				bag_upper,
-				phantom: PhantomData,
+				_phantom: PhantomData,
 			};
 
 			// when inserting into a bag with 1 node
@@ -637,7 +637,7 @@ mod bags {
 				prev: Some(21),
 				next: Some(101),
 				bag_upper: 20,
-				phantom: PhantomData,
+				_phantom: PhantomData,
 			};
 			bag_20.insert_node_unchecked(node_61);
 			// then ids are in order
@@ -650,7 +650,7 @@ mod bags {
 					prev: Some(62),
 					next: None,
 					bag_upper: 20,
-					phantom: PhantomData,
+					_phantom: PhantomData,
 				}
 			);
 
@@ -671,7 +671,7 @@ mod bags {
 			prev,
 			next,
 			bag_upper,
-			phantom: PhantomData,
+			_phantom: PhantomData,
 		};
 		ExtBuilder::default().build_and_execute_no_post_check(|| {
 			// when inserting a node with both prev & next pointing at an account in an incorrect
@@ -727,7 +727,7 @@ mod bags {
 
 			assert_eq!(
 				bag_1000,
-				Bag { head: Some(2), tail: Some(2), bag_upper: 1_000, phantom: PhantomData }
+				Bag { head: Some(2), tail: Some(2), bag_upper: 1_000, _phantom: PhantomData }
 			)
 		});
 	}
@@ -745,7 +745,7 @@ mod bags {
 				prev,
 				next,
 				bag_upper,
-				phantom: PhantomData,
+				_phantom: PhantomData,
 			};
 
 			// given
@@ -878,7 +878,7 @@ mod bags {
 				prev: None,
 				next: Some(3),
 				bag_upper: 10, // should be 1_000
-				phantom: PhantomData,
+				_phantom: PhantomData,
 			};
 			let mut bag_1000 = Bag::<Runtime>::get(1_000).unwrap();
 

--- a/frame/bags-list/src/list/tests.rs
+++ b/frame/bags-list/src/list/tests.rs
@@ -27,12 +27,12 @@ use frame_support::{assert_ok, assert_storage_noop};
 fn basic_setup_works() {
 	ExtBuilder::default().build_and_execute(|| {
 		// syntactic sugar to create a raw node
-		let node = |phantom, id, prev, next, bag_upper| Node::<Runtime> {
-			phantom,
+		let node = |id, prev, next, bag_upper| Node::<Runtime> {
 			id,
 			prev,
 			next,
 			bag_upper,
+			phantom: PhantomData,
 		};
 
 		assert_eq!(ListNodes::<Runtime>::count(), 4);
@@ -44,26 +44,26 @@ fn basic_setup_works() {
 		// the state of the bags is as expected
 		assert_eq!(
 			ListBags::<Runtime>::get(10).unwrap(),
-			Bag::<Runtime> { phantom: PhantomData, head: Some(1), tail: Some(1), bag_upper: 0 }
+			Bag::<Runtime> { head: Some(1), tail: Some(1), bag_upper: 0, phantom: PhantomData }
 		);
 		assert_eq!(
 			ListBags::<Runtime>::get(1_000).unwrap(),
-			Bag::<Runtime> { phantom: PhantomData, head: Some(2), tail: Some(4), bag_upper: 0 }
+			Bag::<Runtime> { head: Some(2), tail: Some(4), bag_upper: 0, phantom: PhantomData }
 		);
 
 		assert_eq!(
 			ListNodes::<Runtime>::get(2).unwrap(),
-			node(PhantomData, 2, None, Some(3), 1_000)
+			node(2, None, Some(3), 1_000)
 		);
 		assert_eq!(
 			ListNodes::<Runtime>::get(3).unwrap(),
-			node(PhantomData, 3, Some(2), Some(4), 1_000)
+			node(3, Some(2), Some(4), 1_000)
 		);
 		assert_eq!(
 			ListNodes::<Runtime>::get(4).unwrap(),
-			node(PhantomData, 4, Some(3), None, 1_000)
+			node(4, Some(3), None, 1_000)
 		);
-		assert_eq!(ListNodes::<Runtime>::get(1).unwrap(), node(PhantomData, 1, None, None, 10));
+		assert_eq!(ListNodes::<Runtime>::get(1).unwrap(), node(1, None, None, 10));
 
 		// non-existent id does not have a storage footprint
 		assert_eq!(ListNodes::<Runtime>::get(42), None);
@@ -404,18 +404,18 @@ mod list {
 	fn put_in_front_of_panics_if_bag_not_found() {
 		ExtBuilder::default().skip_genesis_ids().build_and_execute_no_post_check(|| {
 			let node_10_no_bag = Node::<Runtime> {
-				phantom: PhantomData,
 				id: 10,
 				prev: None,
 				next: None,
 				bag_upper: 15,
+				phantom: PhantomData,
 			};
 			let node_11_no_bag = Node::<Runtime> {
-				phantom: PhantomData,
 				id: 11,
 				prev: None,
 				next: None,
 				bag_upper: 15,
+				phantom: PhantomData,
 			};
 
 			// given
@@ -442,11 +442,11 @@ mod list {
 
 			// implicitly also test that `node`'s `prev`/`next` are correctly re-assigned.
 			let node_42 = Node::<Runtime> {
-				phantom: PhantomData,
 				id: 42,
 				prev: Some(1),
 				next: Some(2),
 				bag_upper: 1_000,
+				phantom: PhantomData,
 			};
 			assert!(!crate::ListNodes::<Runtime>::contains_key(42));
 
@@ -471,11 +471,11 @@ mod list {
 
 			// implicitly also test that `node`'s `prev`/`next` are correctly re-assigned.
 			let node_42 = Node::<Runtime> {
-				phantom: PhantomData,
 				id: 42,
 				prev: Some(4),
 				next: None,
 				bag_upper: 1_000,
+				phantom: PhantomData,
 			};
 			assert!(!crate::ListNodes::<Runtime>::contains_key(42));
 
@@ -500,11 +500,11 @@ mod list {
 
 			// implicitly also test that `node`'s `prev`/`next` are correctly re-assigned.
 			let node_42 = Node::<Runtime> {
-				phantom: PhantomData,
 				id: 42,
 				prev: None,
 				next: Some(2),
 				bag_upper: 1_000,
+				phantom: PhantomData,
 			};
 			assert!(!crate::ListNodes::<Runtime>::contains_key(42));
 
@@ -529,11 +529,11 @@ mod list {
 
 			// implicitly also test that `node`'s `prev`/`next` are correctly re-assigned.
 			let node_42 = Node::<Runtime> {
-				phantom: PhantomData,
 				id: 42,
 				prev: Some(42),
 				next: Some(42),
 				bag_upper: 1_000,
+				phantom: PhantomData,
 			};
 			assert!(!crate::ListNodes::<Runtime>::contains_key(42));
 
@@ -561,7 +561,7 @@ mod bags {
 				let bag = Bag::<Runtime>::get(bag_upper).unwrap();
 				let bag_ids = bag.iter().map(|n| *n.id()).collect::<Vec<_>>();
 
-				assert_eq!(bag, Bag::<Runtime> { phantom: PhantomData, head, tail, bag_upper });
+				assert_eq!(bag, Bag::<Runtime> { head, tail, bag_upper, phantom: PhantomData });
 				assert_eq!(bag_ids, ids);
 			};
 
@@ -593,11 +593,11 @@ mod bags {
 	fn insert_node_sets_proper_bag() {
 		ExtBuilder::default().build_and_execute_no_post_check(|| {
 			let node = |id, bag_upper| Node::<Runtime> {
-				phantom: PhantomData,
 				id,
 				prev: None,
 				next: None,
 				bag_upper,
+				phantom: PhantomData,
 			};
 
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])]);
@@ -607,7 +607,7 @@ mod bags {
 
 			assert_eq!(
 				ListNodes::<Runtime>::get(&42).unwrap(),
-				Node { phantom: PhantomData, bag_upper: 10, prev: Some(1), next: None, id: 42 }
+				Node { bag_upper: 10, prev: Some(1), next: None, id: 42, phantom: PhantomData }
 			);
 		});
 	}
@@ -616,11 +616,11 @@ mod bags {
 	fn insert_node_happy_paths_works() {
 		ExtBuilder::default().build_and_execute_no_post_check(|| {
 			let node = |id, bag_upper| Node::<Runtime> {
-				phantom: PhantomData,
 				id,
 				prev: None,
 				next: None,
 				bag_upper,
+				phantom: PhantomData,
 			};
 
 			// when inserting into a bag with 1 node
@@ -643,11 +643,11 @@ mod bags {
 
 			// when inserting a node pointing to the accounts not in the bag
 			let node_61 = Node::<Runtime> {
-				phantom: PhantomData,
 				id: 61,
 				prev: Some(21),
 				next: Some(101),
 				bag_upper: 20,
+				phantom: PhantomData,
 			};
 			bag_20.insert_node_unchecked(node_61);
 			// then ids are in order
@@ -656,11 +656,11 @@ mod bags {
 			assert_eq!(
 				Node::<Runtime>::get(&61).unwrap(),
 				Node::<Runtime> {
-					phantom: PhantomData,
 					id: 61,
 					prev: Some(62),
 					next: None,
-					bag_upper: 20
+					bag_upper: 20,
+					phantom: PhantomData,
 				}
 			);
 
@@ -676,18 +676,18 @@ mod bags {
 	// Document improper ways `insert_node` may be getting used.
 	#[test]
 	fn insert_node_bad_paths_documented() {
-		let node = |phantom, id, prev, next, bag_upper| Node::<Runtime> {
-			phantom,
+		let node = |id, prev, next, bag_upper| Node::<Runtime> {
 			id,
 			prev,
 			next,
 			bag_upper,
+			phantom: PhantomData,
 		};
 		ExtBuilder::default().build_and_execute_no_post_check(|| {
 			// when inserting a node with both prev & next pointing at an account in an incorrect
 			// bag.
 			let mut bag_1000 = Bag::<Runtime>::get(1_000).unwrap();
-			bag_1000.insert_node_unchecked(node(PhantomData, 42, Some(1), Some(1), 500));
+			bag_1000.insert_node_unchecked(node(42, Some(1), Some(1), 500));
 
 			// then the proper prev and next is set.
 			assert_eq!(bag_as_ids(&bag_1000), vec![2, 3, 4, 42]);
@@ -695,7 +695,7 @@ mod bags {
 			// and when the node is re-fetched all the info is correct
 			assert_eq!(
 				Node::<Runtime>::get(&42).unwrap(),
-				node(PhantomData, 42, Some(4), None, bag_1000.bag_upper)
+				node(42, Some(4), None, bag_1000.bag_upper)
 			);
 		});
 
@@ -705,7 +705,7 @@ mod bags {
 			assert_eq!(bag_as_ids(&bag_1000), vec![2, 3, 4]);
 
 			// when inserting a node with duplicate id 3
-			bag_1000.insert_node_unchecked(node(PhantomData, 3, None, None, bag_1000.bag_upper));
+			bag_1000.insert_node_unchecked(node(3, None, None, bag_1000.bag_upper));
 
 			// then all the nodes after the duplicate are lost (because it is set as the tail)
 			assert_eq!(bag_as_ids(&bag_1000), vec![2, 3]);
@@ -715,7 +715,7 @@ mod bags {
 			// and the last accessible node has an **incorrect** prev pointer.
 			assert_eq!(
 				Node::<Runtime>::get(&3).unwrap(),
-				node(PhantomData, 3, Some(4), None, bag_1000.bag_upper)
+				node(3, Some(4), None, bag_1000.bag_upper)
 			);
 		});
 
@@ -723,7 +723,7 @@ mod bags {
 			// when inserting a duplicate id of the head
 			let mut bag_1000 = Bag::<Runtime>::get(1_000).unwrap();
 			assert_eq!(bag_as_ids(&bag_1000), vec![2, 3, 4]);
-			bag_1000.insert_node_unchecked(node(PhantomData, 2, None, None, 0));
+			bag_1000.insert_node_unchecked(node(2, None, None, 0));
 
 			// then all nodes after the head are lost
 			assert_eq!(bag_as_ids(&bag_1000), vec![2]);
@@ -731,13 +731,13 @@ mod bags {
 			// and the re-fetched node has bad pointers
 			assert_eq!(
 				Node::<Runtime>::get(&2).unwrap(),
-				node(PhantomData, 2, Some(4), None, bag_1000.bag_upper)
+				node(2, Some(4), None, bag_1000.bag_upper)
 			);
 			//         ^^^ despite being the bags head, it has a prev
 
 			assert_eq!(
 				bag_1000,
-				Bag { phantom: PhantomData, head: Some(2), tail: Some(2), bag_upper: 1_000 }
+				Bag { head: Some(2), tail: Some(2), bag_upper: 1_000, phantom: PhantomData }
 			)
 		});
 	}
@@ -750,12 +750,12 @@ mod bags {
 	)]
 	fn insert_node_duplicate_tail_panics_with_debug_assert() {
 		ExtBuilder::default().build_and_execute(|| {
-			let node = |phantom, id, prev, next, bag_upper| Node::<Runtime> {
-				phantom,
+			let node = |id, prev, next, bag_upper| Node::<Runtime> {
 				id,
 				prev,
 				next,
 				bag_upper,
+				phantom: PhantomData,
 			};
 
 			// given
@@ -765,7 +765,7 @@ mod bags {
 			// when inserting a duplicate id that is already the tail
 			assert_eq!(bag_1000.tail, Some(4));
 			assert_eq!(bag_1000.iter().count(), 3);
-			bag_1000.insert_node_unchecked(node(PhantomData, 4, None, None, bag_1000.bag_upper)); // panics in debug
+			bag_1000.insert_node_unchecked(node(4, None, None, bag_1000.bag_upper)); // panics in debug
 			assert_eq!(bag_1000.iter().count(), 3); // in release we expect it to silently ignore the request.
 		});
 	}
@@ -884,11 +884,11 @@ mod bags {
 	fn remove_node_bad_paths_documented() {
 		ExtBuilder::default().build_and_execute_no_post_check(|| {
 			let bad_upper_node_2 = Node::<Runtime> {
-				phantom: PhantomData,
 				id: 2,
 				prev: None,
 				next: Some(3),
 				bag_upper: 10, // should be 1_000
+				phantom: PhantomData,
 			};
 			let mut bag_1000 = Bag::<Runtime>::get(1_000).unwrap();
 

--- a/frame/bags-list/src/list/tests.rs
+++ b/frame/bags-list/src/list/tests.rs
@@ -20,9 +20,8 @@ use crate::{
 	mock::{test_utils::*, *},
 	ListBags, ListNodes,
 };
-use frame_election_provider_support::SortedListProvider;
+use frame_election_provider_support::{SortedListProvider, VoteWeight};
 use frame_support::{assert_ok, assert_storage_noop};
-use frame_election_provider_support::VoteWeight;
 
 #[test]
 fn basic_setup_works() {
@@ -133,7 +132,8 @@ fn migrate_works() {
 			assert_eq!(old_thresholds, vec![10, 20, 30, 40, 50, 60, 1_000, 2_000, 10_000]);
 
 			// when the new thresholds adds `15` and removes `2_000`
-			const NEW_THRESHOLDS: &'static [VoteWeight] = &[10, 15, 20, 30, 40, 50, 60, 1_000, 10_000];
+			const NEW_THRESHOLDS: &'static [VoteWeight] =
+				&[10, 15, 20, 30, 40, 50, 60, 1_000, 10_000];
 			BagThresholds::set(NEW_THRESHOLDS);
 			// and we call
 			List::<Runtime>::migrate(old_thresholds);

--- a/frame/bags-list/src/list/tests.rs
+++ b/frame/bags-list/src/list/tests.rs
@@ -27,7 +27,13 @@ use frame_support::{assert_ok, assert_storage_noop};
 fn basic_setup_works() {
 	ExtBuilder::default().build_and_execute(|| {
 		// syntactic sugar to create a raw node
-		let node = |id, prev, next, bag_upper| Node::<Runtime> { id, prev, next, bag_upper };
+		let node = |phantom, id, prev, next, bag_upper| Node::<Runtime> {
+			phantom,
+			id,
+			prev,
+			next,
+			bag_upper,
+		};
 
 		assert_eq!(ListNodes::<Runtime>::count(), 4);
 		assert_eq!(ListNodes::<Runtime>::iter().count(), 4);
@@ -38,17 +44,26 @@ fn basic_setup_works() {
 		// the state of the bags is as expected
 		assert_eq!(
 			ListBags::<Runtime>::get(10).unwrap(),
-			Bag::<Runtime> { head: Some(1), tail: Some(1), bag_upper: 0 }
+			Bag::<Runtime> { phantom: PhantomData, head: Some(1), tail: Some(1), bag_upper: 0 }
 		);
 		assert_eq!(
 			ListBags::<Runtime>::get(1_000).unwrap(),
-			Bag::<Runtime> { head: Some(2), tail: Some(4), bag_upper: 0 }
+			Bag::<Runtime> { phantom: PhantomData, head: Some(2), tail: Some(4), bag_upper: 0 }
 		);
 
-		assert_eq!(ListNodes::<Runtime>::get(2).unwrap(), node(2, None, Some(3), 1_000));
-		assert_eq!(ListNodes::<Runtime>::get(3).unwrap(), node(3, Some(2), Some(4), 1_000));
-		assert_eq!(ListNodes::<Runtime>::get(4).unwrap(), node(4, Some(3), None, 1_000));
-		assert_eq!(ListNodes::<Runtime>::get(1).unwrap(), node(1, None, None, 10));
+		assert_eq!(
+			ListNodes::<Runtime>::get(2).unwrap(),
+			node(PhantomData, 2, None, Some(3), 1_000)
+		);
+		assert_eq!(
+			ListNodes::<Runtime>::get(3).unwrap(),
+			node(PhantomData, 3, Some(2), Some(4), 1_000)
+		);
+		assert_eq!(
+			ListNodes::<Runtime>::get(4).unwrap(),
+			node(PhantomData, 4, Some(3), None, 1_000)
+		);
+		assert_eq!(ListNodes::<Runtime>::get(1).unwrap(), node(PhantomData, 1, None, None, 10));
 
 		// non-existent id does not have a storage footprint
 		assert_eq!(ListNodes::<Runtime>::get(42), None);
@@ -65,14 +80,14 @@ fn basic_setup_works() {
 #[test]
 fn notional_bag_for_works() {
 	// under a threshold gives the next threshold.
-	assert_eq!(notional_bag_for::<Runtime>(0), 10);
-	assert_eq!(notional_bag_for::<Runtime>(9), 10);
+	assert_eq!(notional_bag_for::<Runtime, _>(0), 10);
+	assert_eq!(notional_bag_for::<Runtime, _>(9), 10);
 
 	// at a threshold gives that threshold.
-	assert_eq!(notional_bag_for::<Runtime>(10), 10);
+	assert_eq!(notional_bag_for::<Runtime, _>(10), 10);
 
 	// above the threshold, gives the next threshold.
-	assert_eq!(notional_bag_for::<Runtime>(11), 20);
+	assert_eq!(notional_bag_for::<Runtime, _>(11), 20);
 
 	let max_explicit_threshold = *<Runtime as Config>::BagThresholds::get().last().unwrap();
 	assert_eq!(max_explicit_threshold, 10_000);
@@ -81,8 +96,8 @@ fn notional_bag_for_works() {
 	assert!(VoteWeight::MAX > max_explicit_threshold);
 
 	// then anything above it will belong to the VoteWeight::MAX bag.
-	assert_eq!(notional_bag_for::<Runtime>(max_explicit_threshold), max_explicit_threshold);
-	assert_eq!(notional_bag_for::<Runtime>(max_explicit_threshold + 1), VoteWeight::MAX);
+	assert_eq!(notional_bag_for::<Runtime, _>(max_explicit_threshold), max_explicit_threshold);
+	assert_eq!(notional_bag_for::<Runtime, _>(max_explicit_threshold + 1), VoteWeight::MAX);
 }
 
 #[test]
@@ -388,8 +403,20 @@ mod list {
 	#[should_panic = "given nodes must always have a valid bag. qed."]
 	fn put_in_front_of_panics_if_bag_not_found() {
 		ExtBuilder::default().skip_genesis_ids().build_and_execute_no_post_check(|| {
-			let node_10_no_bag = Node::<Runtime> { id: 10, prev: None, next: None, bag_upper: 15 };
-			let node_11_no_bag = Node::<Runtime> { id: 11, prev: None, next: None, bag_upper: 15 };
+			let node_10_no_bag = Node::<Runtime> {
+				phantom: PhantomData,
+				id: 10,
+				prev: None,
+				next: None,
+				bag_upper: 15,
+			};
+			let node_11_no_bag = Node::<Runtime> {
+				phantom: PhantomData,
+				id: 11,
+				prev: None,
+				next: None,
+				bag_upper: 15,
+			};
 
 			// given
 			ListNodes::<Runtime>::insert(10, node_10_no_bag);
@@ -414,8 +441,13 @@ mod list {
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])]);
 
 			// implicitly also test that `node`'s `prev`/`next` are correctly re-assigned.
-			let node_42 =
-				Node::<Runtime> { id: 42, prev: Some(1), next: Some(2), bag_upper: 1_000 };
+			let node_42 = Node::<Runtime> {
+				phantom: PhantomData,
+				id: 42,
+				prev: Some(1),
+				next: Some(2),
+				bag_upper: 1_000,
+			};
 			assert!(!crate::ListNodes::<Runtime>::contains_key(42));
 
 			let node_1 = crate::ListNodes::<Runtime>::get(&1).unwrap();
@@ -438,7 +470,13 @@ mod list {
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])]);
 
 			// implicitly also test that `node`'s `prev`/`next` are correctly re-assigned.
-			let node_42 = Node::<Runtime> { id: 42, prev: Some(4), next: None, bag_upper: 1_000 };
+			let node_42 = Node::<Runtime> {
+				phantom: PhantomData,
+				id: 42,
+				prev: Some(4),
+				next: None,
+				bag_upper: 1_000,
+			};
 			assert!(!crate::ListNodes::<Runtime>::contains_key(42));
 
 			let node_2 = crate::ListNodes::<Runtime>::get(&2).unwrap();
@@ -461,7 +499,13 @@ mod list {
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])]);
 
 			// implicitly also test that `node`'s `prev`/`next` are correctly re-assigned.
-			let node_42 = Node::<Runtime> { id: 42, prev: None, next: Some(2), bag_upper: 1_000 };
+			let node_42 = Node::<Runtime> {
+				phantom: PhantomData,
+				id: 42,
+				prev: None,
+				next: Some(2),
+				bag_upper: 1_000,
+			};
 			assert!(!crate::ListNodes::<Runtime>::contains_key(42));
 
 			let node_3 = crate::ListNodes::<Runtime>::get(&3).unwrap();
@@ -484,8 +528,13 @@ mod list {
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])]);
 
 			// implicitly also test that `node`'s `prev`/`next` are correctly re-assigned.
-			let node_42 =
-				Node::<Runtime> { id: 42, prev: Some(42), next: Some(42), bag_upper: 1_000 };
+			let node_42 = Node::<Runtime> {
+				phantom: PhantomData,
+				id: 42,
+				prev: Some(42),
+				next: Some(42),
+				bag_upper: 1_000,
+			};
 			assert!(!crate::ListNodes::<Runtime>::contains_key(42));
 
 			let node_4 = crate::ListNodes::<Runtime>::get(&4).unwrap();
@@ -512,7 +561,7 @@ mod bags {
 				let bag = Bag::<Runtime>::get(bag_upper).unwrap();
 				let bag_ids = bag.iter().map(|n| *n.id()).collect::<Vec<_>>();
 
-				assert_eq!(bag, Bag::<Runtime> { head, tail, bag_upper });
+				assert_eq!(bag, Bag::<Runtime> { phantom: PhantomData, head, tail, bag_upper });
 				assert_eq!(bag_ids, ids);
 			};
 
@@ -543,7 +592,13 @@ mod bags {
 	#[test]
 	fn insert_node_sets_proper_bag() {
 		ExtBuilder::default().build_and_execute_no_post_check(|| {
-			let node = |id, bag_upper| Node::<Runtime> { id, prev: None, next: None, bag_upper };
+			let node = |id, bag_upper| Node::<Runtime> {
+				phantom: PhantomData,
+				id,
+				prev: None,
+				next: None,
+				bag_upper,
+			};
 
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])]);
 
@@ -552,7 +607,7 @@ mod bags {
 
 			assert_eq!(
 				ListNodes::<Runtime>::get(&42).unwrap(),
-				Node { bag_upper: 10, prev: Some(1), next: None, id: 42 }
+				Node { phantom: PhantomData, bag_upper: 10, prev: Some(1), next: None, id: 42 }
 			);
 		});
 	}
@@ -560,7 +615,13 @@ mod bags {
 	#[test]
 	fn insert_node_happy_paths_works() {
 		ExtBuilder::default().build_and_execute_no_post_check(|| {
-			let node = |id, bag_upper| Node::<Runtime> { id, prev: None, next: None, bag_upper };
+			let node = |id, bag_upper| Node::<Runtime> {
+				phantom: PhantomData,
+				id,
+				prev: None,
+				next: None,
+				bag_upper,
+			};
 
 			// when inserting into a bag with 1 node
 			let mut bag_10 = Bag::<Runtime>::get(10).unwrap();
@@ -581,15 +642,26 @@ mod bags {
 			assert_eq!(bag_as_ids(&bag_20), vec![62]);
 
 			// when inserting a node pointing to the accounts not in the bag
-			let node_61 =
-				Node::<Runtime> { id: 61, prev: Some(21), next: Some(101), bag_upper: 20 };
+			let node_61 = Node::<Runtime> {
+				phantom: PhantomData,
+				id: 61,
+				prev: Some(21),
+				next: Some(101),
+				bag_upper: 20,
+			};
 			bag_20.insert_node_unchecked(node_61);
 			// then ids are in order
 			assert_eq!(bag_as_ids(&bag_20), vec![62, 61]);
 			// and when the node is re-fetched all the info is correct
 			assert_eq!(
 				Node::<Runtime>::get(&61).unwrap(),
-				Node::<Runtime> { id: 61, prev: Some(62), next: None, bag_upper: 20 }
+				Node::<Runtime> {
+					phantom: PhantomData,
+					id: 61,
+					prev: Some(62),
+					next: None,
+					bag_upper: 20
+				}
 			);
 
 			// state of all bags is as expected
@@ -604,12 +676,18 @@ mod bags {
 	// Document improper ways `insert_node` may be getting used.
 	#[test]
 	fn insert_node_bad_paths_documented() {
-		let node = |id, prev, next, bag_upper| Node::<Runtime> { id, prev, next, bag_upper };
+		let node = |phantom, id, prev, next, bag_upper| Node::<Runtime> {
+			phantom,
+			id,
+			prev,
+			next,
+			bag_upper,
+		};
 		ExtBuilder::default().build_and_execute_no_post_check(|| {
 			// when inserting a node with both prev & next pointing at an account in an incorrect
 			// bag.
 			let mut bag_1000 = Bag::<Runtime>::get(1_000).unwrap();
-			bag_1000.insert_node_unchecked(node(42, Some(1), Some(1), 500));
+			bag_1000.insert_node_unchecked(node(PhantomData, 42, Some(1), Some(1), 500));
 
 			// then the proper prev and next is set.
 			assert_eq!(bag_as_ids(&bag_1000), vec![2, 3, 4, 42]);
@@ -617,7 +695,7 @@ mod bags {
 			// and when the node is re-fetched all the info is correct
 			assert_eq!(
 				Node::<Runtime>::get(&42).unwrap(),
-				node(42, Some(4), None, bag_1000.bag_upper)
+				node(PhantomData, 42, Some(4), None, bag_1000.bag_upper)
 			);
 		});
 
@@ -627,7 +705,7 @@ mod bags {
 			assert_eq!(bag_as_ids(&bag_1000), vec![2, 3, 4]);
 
 			// when inserting a node with duplicate id 3
-			bag_1000.insert_node_unchecked(node(3, None, None, bag_1000.bag_upper));
+			bag_1000.insert_node_unchecked(node(PhantomData, 3, None, None, bag_1000.bag_upper));
 
 			// then all the nodes after the duplicate are lost (because it is set as the tail)
 			assert_eq!(bag_as_ids(&bag_1000), vec![2, 3]);
@@ -637,7 +715,7 @@ mod bags {
 			// and the last accessible node has an **incorrect** prev pointer.
 			assert_eq!(
 				Node::<Runtime>::get(&3).unwrap(),
-				node(3, Some(4), None, bag_1000.bag_upper)
+				node(PhantomData, 3, Some(4), None, bag_1000.bag_upper)
 			);
 		});
 
@@ -645,7 +723,7 @@ mod bags {
 			// when inserting a duplicate id of the head
 			let mut bag_1000 = Bag::<Runtime>::get(1_000).unwrap();
 			assert_eq!(bag_as_ids(&bag_1000), vec![2, 3, 4]);
-			bag_1000.insert_node_unchecked(node(2, None, None, 0));
+			bag_1000.insert_node_unchecked(node(PhantomData, 2, None, None, 0));
 
 			// then all nodes after the head are lost
 			assert_eq!(bag_as_ids(&bag_1000), vec![2]);
@@ -653,11 +731,14 @@ mod bags {
 			// and the re-fetched node has bad pointers
 			assert_eq!(
 				Node::<Runtime>::get(&2).unwrap(),
-				node(2, Some(4), None, bag_1000.bag_upper)
+				node(PhantomData, 2, Some(4), None, bag_1000.bag_upper)
 			);
 			//         ^^^ despite being the bags head, it has a prev
 
-			assert_eq!(bag_1000, Bag { head: Some(2), tail: Some(2), bag_upper: 1_000 })
+			assert_eq!(
+				bag_1000,
+				Bag { phantom: PhantomData, head: Some(2), tail: Some(2), bag_upper: 1_000 }
+			)
 		});
 	}
 
@@ -669,7 +750,13 @@ mod bags {
 	)]
 	fn insert_node_duplicate_tail_panics_with_debug_assert() {
 		ExtBuilder::default().build_and_execute(|| {
-			let node = |id, prev, next, bag_upper| Node::<Runtime> { id, prev, next, bag_upper };
+			let node = |phantom, id, prev, next, bag_upper| Node::<Runtime> {
+				phantom,
+				id,
+				prev,
+				next,
+				bag_upper,
+			};
 
 			// given
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])],);
@@ -678,7 +765,7 @@ mod bags {
 			// when inserting a duplicate id that is already the tail
 			assert_eq!(bag_1000.tail, Some(4));
 			assert_eq!(bag_1000.iter().count(), 3);
-			bag_1000.insert_node_unchecked(node(4, None, None, bag_1000.bag_upper)); // panics in debug
+			bag_1000.insert_node_unchecked(node(PhantomData, 4, None, None, bag_1000.bag_upper)); // panics in debug
 			assert_eq!(bag_1000.iter().count(), 3); // in release we expect it to silently ignore the request.
 		});
 	}
@@ -797,6 +884,7 @@ mod bags {
 	fn remove_node_bad_paths_documented() {
 		ExtBuilder::default().build_and_execute_no_post_check(|| {
 			let bad_upper_node_2 = Node::<Runtime> {
+				phantom: PhantomData,
 				id: 2,
 				prev: None,
 				next: Some(3),

--- a/frame/bags-list/src/mock.rs
+++ b/frame/bags-list/src/mock.rs
@@ -21,19 +21,20 @@ use super::*;
 use crate::{self as bags_list};
 use frame_support::parameter_types;
 use std::collections::HashMap;
+use frame_election_provider_support::VoteWeight;
 
 pub type AccountId = u32;
 pub type Balance = u32;
 
 parameter_types! {
 	// Set the vote weight for any id who's weight has _not_ been set with `set_value_of`.
-	pub static NextVoteWeight: u64 = 0;
-	pub static NextVoteWeightMap: HashMap<AccountId, u64> = Default::default();
+	pub static NextVoteWeight: VoteWeight = 0;
+	pub static NextVoteWeightMap: HashMap<AccountId, VoteWeight> = Default::default();
 }
 
 pub struct StakingMock;
 impl frame_election_provider_support::ValueProvider<AccountId> for StakingMock {
-	type Value = u64;
+	type Value = VoteWeight;
 
 	fn value(id: &AccountId) -> Self::Value {
 		*NextVoteWeightMap::get().get(id).unwrap_or(&NextVoteWeight::get())
@@ -73,7 +74,7 @@ impl frame_system::Config for Runtime {
 }
 
 parameter_types! {
-	pub static BagThresholds: &'static [u64] = &[10, 20, 30, 40, 50, 60, 1_000, 2_000, 10_000];
+	pub static BagThresholds: &'static [VoteWeight] = &[10, 20, 30, 40, 50, 60, 1_000, 2_000, 10_000];
 }
 
 impl bags_list::Config for Runtime {
@@ -81,7 +82,7 @@ impl bags_list::Config for Runtime {
 	type WeightInfo = ();
 	type BagThresholds = BagThresholds;
 	type ValueProvider = StakingMock;
-	type Value = u64;
+	type Value = VoteWeight;
 }
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
@@ -98,11 +99,11 @@ frame_support::construct_runtime!(
 );
 
 /// Default AccountIds and their weights.
-pub(crate) const GENESIS_IDS: [(AccountId, u64); 4] = [(1, 10), (2, 1_000), (3, 1_000), (4, 1_000)];
+pub(crate) const GENESIS_IDS: [(AccountId, VoteWeight); 4] = [(1, 10), (2, 1_000), (3, 1_000), (4, 1_000)];
 
 #[derive(Default)]
 pub struct ExtBuilder {
-	ids: Vec<(AccountId, u64)>,
+	ids: Vec<(AccountId, VoteWeight)>,
 	skip_genesis_ids: bool,
 }
 
@@ -116,7 +117,7 @@ impl ExtBuilder {
 
 	/// Add some AccountIds to insert into `List`.
 	#[cfg(test)]
-	pub(crate) fn add_ids(mut self, ids: Vec<(AccountId, u64)>) -> Self {
+	pub(crate) fn add_ids(mut self, ids: Vec<(AccountId, VoteWeight)>) -> Self {
 		self.ids = ids;
 		self
 	}

--- a/frame/bags-list/src/tests.rs
+++ b/frame/bags-list/src/tests.rs
@@ -18,10 +18,9 @@
 use frame_support::{assert_noop, assert_ok, assert_storage_noop, traits::IntegrityTest};
 
 use super::*;
-use frame_election_provider_support::SortedListProvider;
+use frame_election_provider_support::{SortedListProvider, VoteWeight};
 use list::Bag;
 use mock::{test_utils::*, *};
-use frame_election_provider_support::VoteWeight;
 
 mod pallet {
 	use super::*;
@@ -191,7 +190,10 @@ mod pallet {
 			// any insertion goes there as well.
 			assert_ok!(List::<Runtime>::insert(5, 999));
 			assert_ok!(List::<Runtime>::insert(6, 0));
-			assert_eq!(List::<Runtime>::get_bags(), vec![(VoteWeight::MAX, vec![1, 2, 3, 4, 5, 6])]);
+			assert_eq!(
+				List::<Runtime>::get_bags(),
+				vec![(VoteWeight::MAX, vec![1, 2, 3, 4, 5, 6])]
+			);
 
 			// any rebag is noop.
 			assert_storage_noop!(assert!(BagsList::rebag(Origin::signed(0), 1).is_ok()));

--- a/frame/bags-list/src/tests.rs
+++ b/frame/bags-list/src/tests.rs
@@ -35,7 +35,7 @@ mod pallet {
 			);
 
 			// when increasing vote weight to the level of non-existent bag
-			StakingMock::set_vote_weight_of(&42, 2_000);
+			StakingMock::set_value_of(&42, 2_000);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 42));
 
 			// then a new bag is created and the id moves into it
@@ -45,7 +45,7 @@ mod pallet {
 			);
 
 			// when decreasing weight within the range of the current bag
-			StakingMock::set_vote_weight_of(&42, 1_001);
+			StakingMock::set_value_of(&42, 1_001);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 42));
 
 			// then the id does not move
@@ -55,7 +55,7 @@ mod pallet {
 			);
 
 			// when reducing weight to the level of a non-existent bag
-			StakingMock::set_vote_weight_of(&42, 30);
+			StakingMock::set_value_of(&42, 30);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 42));
 
 			// then a new bag is created and the id moves into it
@@ -65,7 +65,7 @@ mod pallet {
 			);
 
 			// when increasing weight to the level of a pre-existing bag
-			StakingMock::set_vote_weight_of(&42, 500);
+			StakingMock::set_value_of(&42, 500);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 42));
 
 			// then the id moves into that bag
@@ -85,35 +85,26 @@ mod pallet {
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])]);
 
 			// when
-			StakingMock::set_vote_weight_of(&4, 10);
+			StakingMock::set_value_of(&4, 10);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 4));
 
 			// then
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1, 4]), (1_000, vec![2, 3])]);
-			assert_eq!(
-				Bag::<Runtime>::get(1_000).unwrap(),
-				Bag::new(Some(2), Some(3), 1_000)
-			);
+			assert_eq!(Bag::<Runtime>::get(1_000).unwrap(), Bag::new(Some(2), Some(3), 1_000));
 
 			// when
-			StakingMock::set_vote_weight_of(&3, 10);
+			StakingMock::set_value_of(&3, 10);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 3));
 
 			// then
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1, 4, 3]), (1_000, vec![2])]);
 
-			assert_eq!(
-				Bag::<Runtime>::get(10).unwrap(),
-				Bag::new(Some(1), Some(3), 10)
-			);
-			assert_eq!(
-				Bag::<Runtime>::get(1_000).unwrap(),
-				Bag::new(Some(2), Some(2), 1_000)
-			);
+			assert_eq!(Bag::<Runtime>::get(10).unwrap(), Bag::new(Some(1), Some(3), 10));
+			assert_eq!(Bag::<Runtime>::get(1_000).unwrap(), Bag::new(Some(2), Some(2), 1_000));
 			assert_eq!(get_list_as_ids(), vec![2u32, 1, 4, 3]);
 
 			// when
-			StakingMock::set_vote_weight_of(&2, 10);
+			StakingMock::set_value_of(&2, 10);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 2));
 
 			// then
@@ -128,29 +119,23 @@ mod pallet {
 	fn rebag_head_works() {
 		ExtBuilder::default().build_and_execute(|| {
 			// when
-			StakingMock::set_vote_weight_of(&2, 10);
+			StakingMock::set_value_of(&2, 10);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 2));
 
 			// then
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1, 2]), (1_000, vec![3, 4])]);
-			assert_eq!(
-				Bag::<Runtime>::get(1_000).unwrap(),
-				Bag::new(Some(3), Some(4), 1_000)
-			);
+			assert_eq!(Bag::<Runtime>::get(1_000).unwrap(), Bag::new(Some(3), Some(4), 1_000));
 
 			// when
-			StakingMock::set_vote_weight_of(&3, 10);
+			StakingMock::set_value_of(&3, 10);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 3));
 
 			// then
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1, 2, 3]), (1_000, vec![4])]);
-			assert_eq!(
-				Bag::<Runtime>::get(1_000).unwrap(),
-				Bag::new(Some(4), Some(4), 1_000)
-			);
+			assert_eq!(Bag::<Runtime>::get(1_000).unwrap(), Bag::new(Some(4), Some(4), 1_000));
 
 			// when
-			StakingMock::set_vote_weight_of(&4, 10);
+			StakingMock::set_value_of(&4, 10);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 4));
 
 			// then
@@ -181,7 +166,7 @@ mod pallet {
 	#[test]
 	#[should_panic = "thresholds must strictly increase, and have no duplicates"]
 	fn duplicate_in_bags_threshold_panics() {
-		const DUPE_THRESH: &[VoteWeight; 4] = &[10, 20, 30, 30];
+		const DUPE_THRESH: &[u64; 4] = &[10, 20, 30, 30];
 		BagThresholds::set(DUPE_THRESH);
 		BagsList::integrity_test();
 	}
@@ -189,7 +174,7 @@ mod pallet {
 	#[test]
 	#[should_panic = "thresholds must strictly increase, and have no duplicates"]
 	fn decreasing_in_bags_threshold_panics() {
-		const DECREASING_THRESH: &[VoteWeight; 4] = &[10, 30, 20, 40];
+		const DECREASING_THRESH: &[u64; 4] = &[10, 30, 20, 40];
 		BagThresholds::set(DECREASING_THRESH);
 		BagsList::integrity_test();
 	}
@@ -200,15 +185,12 @@ mod pallet {
 
 		ExtBuilder::default().build_and_execute(|| {
 			// everyone in the same bag.
-			assert_eq!(List::<Runtime>::get_bags(), vec![(VoteWeight::MAX, vec![1, 2, 3, 4])]);
+			assert_eq!(List::<Runtime>::get_bags(), vec![(u64::MAX, vec![1, 2, 3, 4])]);
 
 			// any insertion goes there as well.
 			assert_ok!(List::<Runtime>::insert(5, 999));
 			assert_ok!(List::<Runtime>::insert(6, 0));
-			assert_eq!(
-				List::<Runtime>::get_bags(),
-				vec![(VoteWeight::MAX, vec![1, 2, 3, 4, 5, 6])]
-			);
+			assert_eq!(List::<Runtime>::get_bags(), vec![(u64::MAX, vec![1, 2, 3, 4, 5, 6])]);
 
 			// any rebag is noop.
 			assert_storage_noop!(assert!(BagsList::rebag(Origin::signed(0), 1).is_ok()));
@@ -256,7 +238,7 @@ mod pallet {
 			// given
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4, 5])]);
 
-			StakingMock::set_vote_weight_of(&3, 999);
+			StakingMock::set_value_of(&3, 999);
 
 			// when
 			assert_ok!(BagsList::put_in_front_of(Origin::signed(4), 3));
@@ -277,7 +259,7 @@ mod pallet {
 					vec![(10, vec![1]), (1_000, vec![2, 3, 4, 5, 6])]
 				);
 
-				StakingMock::set_vote_weight_of(&5, 999);
+				StakingMock::set_value_of(&5, 999);
 
 				// when
 				assert_ok!(BagsList::put_in_front_of(Origin::signed(3), 5));
@@ -296,7 +278,7 @@ mod pallet {
 			// given
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])]);
 
-			StakingMock::set_vote_weight_of(&2, 999);
+			StakingMock::set_value_of(&2, 999);
 
 			// when
 			assert_ok!(BagsList::put_in_front_of(Origin::signed(3), 2));
@@ -312,7 +294,7 @@ mod pallet {
 			// given
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])]);
 
-			StakingMock::set_vote_weight_of(&3, 999);
+			StakingMock::set_value_of(&3, 999);
 
 			// when
 			assert_ok!(BagsList::put_in_front_of(Origin::signed(4), 3));
@@ -328,7 +310,7 @@ mod pallet {
 			// given
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4, 5])]);
 
-			StakingMock::set_vote_weight_of(&2, 999);
+			StakingMock::set_value_of(&2, 999);
 
 			// when
 			assert_ok!(BagsList::put_in_front_of(Origin::signed(5), 2));
@@ -344,7 +326,7 @@ mod pallet {
 			// given
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4, 5])]);
 
-			StakingMock::set_vote_weight_of(&4, 999);
+			StakingMock::set_value_of(&4, 999);
 
 			// when
 			BagsList::put_in_front_of(Origin::signed(2), 4).unwrap();
@@ -374,7 +356,7 @@ mod pallet {
 			// given
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])]);
 
-			StakingMock::set_vote_weight_of(&4, 999);
+			StakingMock::set_value_of(&4, 999);
 
 			// when
 			BagsList::put_in_front_of(Origin::signed(2), 4).unwrap();
@@ -390,7 +372,7 @@ mod pallet {
 			// given
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])]);
 
-			StakingMock::set_vote_weight_of(&3, 999);
+			StakingMock::set_value_of(&3, 999);
 
 			// then
 			assert_noop!(
@@ -490,7 +472,7 @@ mod sorted_list_provider {
 			assert_eq!(BagsList::count(), 4);
 
 			// when updating
-			BagsList::on_update(&201, VoteWeight::MAX);
+			BagsList::on_update(&201, u64::MAX);
 			// then the count stays the same
 			assert_eq!(BagsList::count(), 4);
 		});
@@ -571,12 +553,12 @@ mod sorted_list_provider {
 			assert_eq!(BagsList::iter().collect::<Vec<_>>(), vec![42, 2, 3, 4, 1]);
 
 			// when increasing weight to the level of a non-existent bag with the max threshold
-			BagsList::on_update(&42, VoteWeight::MAX);
+			BagsList::on_update(&42, u64::MAX);
 
 			// the the new bag is created with the id in it,
 			assert_eq!(
 				List::<Runtime>::get_bags(),
-				vec![(10, vec![1]), (1_000, vec![2, 3, 4]), (VoteWeight::MAX, vec![42])]
+				vec![(10, vec![1]), (1_000, vec![2, 3, 4]), (u64::MAX, vec![42])]
 			);
 			// and the id position is updated in the list.
 			assert_eq!(BagsList::iter().collect::<Vec<_>>(), vec![42, 2, 3, 4, 1]);

--- a/frame/bags-list/src/tests.rs
+++ b/frame/bags-list/src/tests.rs
@@ -35,7 +35,7 @@ mod pallet {
 			);
 
 			// when increasing vote weight to the level of non-existent bag
-			StakingMock::set_value_of(&42, 2_000);
+			StakingMock::set_score_of(&42, 2_000);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 42));
 
 			// then a new bag is created and the id moves into it
@@ -45,7 +45,7 @@ mod pallet {
 			);
 
 			// when decreasing weight within the range of the current bag
-			StakingMock::set_value_of(&42, 1_001);
+			StakingMock::set_score_of(&42, 1_001);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 42));
 
 			// then the id does not move
@@ -55,7 +55,7 @@ mod pallet {
 			);
 
 			// when reducing weight to the level of a non-existent bag
-			StakingMock::set_value_of(&42, 30);
+			StakingMock::set_score_of(&42, 30);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 42));
 
 			// then a new bag is created and the id moves into it
@@ -65,7 +65,7 @@ mod pallet {
 			);
 
 			// when increasing weight to the level of a pre-existing bag
-			StakingMock::set_value_of(&42, 500);
+			StakingMock::set_score_of(&42, 500);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 42));
 
 			// then the id moves into that bag
@@ -85,7 +85,7 @@ mod pallet {
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])]);
 
 			// when
-			StakingMock::set_value_of(&4, 10);
+			StakingMock::set_score_of(&4, 10);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 4));
 
 			// then
@@ -93,7 +93,7 @@ mod pallet {
 			assert_eq!(Bag::<Runtime>::get(1_000).unwrap(), Bag::new(Some(2), Some(3), 1_000));
 
 			// when
-			StakingMock::set_value_of(&3, 10);
+			StakingMock::set_score_of(&3, 10);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 3));
 
 			// then
@@ -104,7 +104,7 @@ mod pallet {
 			assert_eq!(get_list_as_ids(), vec![2u32, 1, 4, 3]);
 
 			// when
-			StakingMock::set_value_of(&2, 10);
+			StakingMock::set_score_of(&2, 10);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 2));
 
 			// then
@@ -119,7 +119,7 @@ mod pallet {
 	fn rebag_head_works() {
 		ExtBuilder::default().build_and_execute(|| {
 			// when
-			StakingMock::set_value_of(&2, 10);
+			StakingMock::set_score_of(&2, 10);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 2));
 
 			// then
@@ -127,7 +127,7 @@ mod pallet {
 			assert_eq!(Bag::<Runtime>::get(1_000).unwrap(), Bag::new(Some(3), Some(4), 1_000));
 
 			// when
-			StakingMock::set_value_of(&3, 10);
+			StakingMock::set_score_of(&3, 10);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 3));
 
 			// then
@@ -135,7 +135,7 @@ mod pallet {
 			assert_eq!(Bag::<Runtime>::get(1_000).unwrap(), Bag::new(Some(4), Some(4), 1_000));
 
 			// when
-			StakingMock::set_value_of(&4, 10);
+			StakingMock::set_score_of(&4, 10);
 			assert_ok!(BagsList::rebag(Origin::signed(0), 4));
 
 			// then
@@ -238,7 +238,7 @@ mod pallet {
 			// given
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4, 5])]);
 
-			StakingMock::set_value_of(&3, 999);
+			StakingMock::set_score_of(&3, 999);
 
 			// when
 			assert_ok!(BagsList::put_in_front_of(Origin::signed(4), 3));
@@ -259,7 +259,7 @@ mod pallet {
 					vec![(10, vec![1]), (1_000, vec![2, 3, 4, 5, 6])]
 				);
 
-				StakingMock::set_value_of(&5, 999);
+				StakingMock::set_score_of(&5, 999);
 
 				// when
 				assert_ok!(BagsList::put_in_front_of(Origin::signed(3), 5));
@@ -278,7 +278,7 @@ mod pallet {
 			// given
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])]);
 
-			StakingMock::set_value_of(&2, 999);
+			StakingMock::set_score_of(&2, 999);
 
 			// when
 			assert_ok!(BagsList::put_in_front_of(Origin::signed(3), 2));
@@ -294,7 +294,7 @@ mod pallet {
 			// given
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])]);
 
-			StakingMock::set_value_of(&3, 999);
+			StakingMock::set_score_of(&3, 999);
 
 			// when
 			assert_ok!(BagsList::put_in_front_of(Origin::signed(4), 3));
@@ -310,7 +310,7 @@ mod pallet {
 			// given
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4, 5])]);
 
-			StakingMock::set_value_of(&2, 999);
+			StakingMock::set_score_of(&2, 999);
 
 			// when
 			assert_ok!(BagsList::put_in_front_of(Origin::signed(5), 2));
@@ -326,7 +326,7 @@ mod pallet {
 			// given
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4, 5])]);
 
-			StakingMock::set_value_of(&4, 999);
+			StakingMock::set_score_of(&4, 999);
 
 			// when
 			BagsList::put_in_front_of(Origin::signed(2), 4).unwrap();
@@ -356,7 +356,7 @@ mod pallet {
 			// given
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])]);
 
-			StakingMock::set_value_of(&4, 999);
+			StakingMock::set_score_of(&4, 999);
 
 			// when
 			BagsList::put_in_front_of(Origin::signed(2), 4).unwrap();
@@ -372,7 +372,7 @@ mod pallet {
 			// given
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1]), (1_000, vec![2, 3, 4])]);
 
-			StakingMock::set_value_of(&3, 999);
+			StakingMock::set_score_of(&3, 999);
 
 			// then
 			assert_noop!(

--- a/frame/bags-list/src/tests.rs
+++ b/frame/bags-list/src/tests.rs
@@ -21,6 +21,7 @@ use super::*;
 use frame_election_provider_support::SortedListProvider;
 use list::Bag;
 use mock::{test_utils::*, *};
+use sp_std::marker::PhantomData;
 
 mod pallet {
 	use super::*;
@@ -90,7 +91,10 @@ mod pallet {
 
 			// then
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1, 4]), (1_000, vec![2, 3])]);
-			assert_eq!(Bag::<Runtime>::get(1_000).unwrap(), Bag::new(Some(2), Some(3), 1_000));
+			assert_eq!(
+				Bag::<Runtime>::get(1_000).unwrap(),
+				Bag::new(PhantomData, Some(2), Some(3), 1_000)
+			);
 
 			// when
 			StakingMock::set_vote_weight_of(&3, 10);
@@ -99,8 +103,14 @@ mod pallet {
 			// then
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1, 4, 3]), (1_000, vec![2])]);
 
-			assert_eq!(Bag::<Runtime>::get(10).unwrap(), Bag::new(Some(1), Some(3), 10));
-			assert_eq!(Bag::<Runtime>::get(1_000).unwrap(), Bag::new(Some(2), Some(2), 1_000));
+			assert_eq!(
+				Bag::<Runtime>::get(10).unwrap(),
+				Bag::new(PhantomData, Some(1), Some(3), 10)
+			);
+			assert_eq!(
+				Bag::<Runtime>::get(1_000).unwrap(),
+				Bag::new(PhantomData, Some(2), Some(2), 1_000)
+			);
 			assert_eq!(get_list_as_ids(), vec![2u32, 1, 4, 3]);
 
 			// when
@@ -124,7 +134,10 @@ mod pallet {
 
 			// then
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1, 2]), (1_000, vec![3, 4])]);
-			assert_eq!(Bag::<Runtime>::get(1_000).unwrap(), Bag::new(Some(3), Some(4), 1_000));
+			assert_eq!(
+				Bag::<Runtime>::get(1_000).unwrap(),
+				Bag::new(PhantomData, Some(3), Some(4), 1_000)
+			);
 
 			// when
 			StakingMock::set_vote_weight_of(&3, 10);
@@ -132,7 +145,10 @@ mod pallet {
 
 			// then
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1, 2, 3]), (1_000, vec![4])]);
-			assert_eq!(Bag::<Runtime>::get(1_000).unwrap(), Bag::new(Some(4), Some(4), 1_000));
+			assert_eq!(
+				Bag::<Runtime>::get(1_000).unwrap(),
+				Bag::new(PhantomData, Some(4), Some(4), 1_000)
+			);
 
 			// when
 			StakingMock::set_vote_weight_of(&4, 10);

--- a/frame/bags-list/src/tests.rs
+++ b/frame/bags-list/src/tests.rs
@@ -21,7 +21,6 @@ use super::*;
 use frame_election_provider_support::SortedListProvider;
 use list::Bag;
 use mock::{test_utils::*, *};
-use sp_std::marker::PhantomData;
 
 mod pallet {
 	use super::*;
@@ -93,7 +92,7 @@ mod pallet {
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1, 4]), (1_000, vec![2, 3])]);
 			assert_eq!(
 				Bag::<Runtime>::get(1_000).unwrap(),
-				Bag::new(PhantomData, Some(2), Some(3), 1_000)
+				Bag::new(Some(2), Some(3), 1_000)
 			);
 
 			// when
@@ -105,11 +104,11 @@ mod pallet {
 
 			assert_eq!(
 				Bag::<Runtime>::get(10).unwrap(),
-				Bag::new(PhantomData, Some(1), Some(3), 10)
+				Bag::new(Some(1), Some(3), 10)
 			);
 			assert_eq!(
 				Bag::<Runtime>::get(1_000).unwrap(),
-				Bag::new(PhantomData, Some(2), Some(2), 1_000)
+				Bag::new(Some(2), Some(2), 1_000)
 			);
 			assert_eq!(get_list_as_ids(), vec![2u32, 1, 4, 3]);
 
@@ -136,7 +135,7 @@ mod pallet {
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1, 2]), (1_000, vec![3, 4])]);
 			assert_eq!(
 				Bag::<Runtime>::get(1_000).unwrap(),
-				Bag::new(PhantomData, Some(3), Some(4), 1_000)
+				Bag::new(Some(3), Some(4), 1_000)
 			);
 
 			// when
@@ -147,7 +146,7 @@ mod pallet {
 			assert_eq!(List::<Runtime>::get_bags(), vec![(10, vec![1, 2, 3]), (1_000, vec![4])]);
 			assert_eq!(
 				Bag::<Runtime>::get(1_000).unwrap(),
-				Bag::new(PhantomData, Some(4), Some(4), 1_000)
+				Bag::new(Some(4), Some(4), 1_000)
 			);
 
 			// when

--- a/frame/bags-list/src/tests.rs
+++ b/frame/bags-list/src/tests.rs
@@ -21,6 +21,7 @@ use super::*;
 use frame_election_provider_support::SortedListProvider;
 use list::Bag;
 use mock::{test_utils::*, *};
+use frame_election_provider_support::VoteWeight;
 
 mod pallet {
 	use super::*;
@@ -166,7 +167,7 @@ mod pallet {
 	#[test]
 	#[should_panic = "thresholds must strictly increase, and have no duplicates"]
 	fn duplicate_in_bags_threshold_panics() {
-		const DUPE_THRESH: &[u64; 4] = &[10, 20, 30, 30];
+		const DUPE_THRESH: &[VoteWeight; 4] = &[10, 20, 30, 30];
 		BagThresholds::set(DUPE_THRESH);
 		BagsList::integrity_test();
 	}
@@ -174,7 +175,7 @@ mod pallet {
 	#[test]
 	#[should_panic = "thresholds must strictly increase, and have no duplicates"]
 	fn decreasing_in_bags_threshold_panics() {
-		const DECREASING_THRESH: &[u64; 4] = &[10, 30, 20, 40];
+		const DECREASING_THRESH: &[VoteWeight; 4] = &[10, 30, 20, 40];
 		BagThresholds::set(DECREASING_THRESH);
 		BagsList::integrity_test();
 	}
@@ -185,12 +186,12 @@ mod pallet {
 
 		ExtBuilder::default().build_and_execute(|| {
 			// everyone in the same bag.
-			assert_eq!(List::<Runtime>::get_bags(), vec![(u64::MAX, vec![1, 2, 3, 4])]);
+			assert_eq!(List::<Runtime>::get_bags(), vec![(VoteWeight::MAX, vec![1, 2, 3, 4])]);
 
 			// any insertion goes there as well.
 			assert_ok!(List::<Runtime>::insert(5, 999));
 			assert_ok!(List::<Runtime>::insert(6, 0));
-			assert_eq!(List::<Runtime>::get_bags(), vec![(u64::MAX, vec![1, 2, 3, 4, 5, 6])]);
+			assert_eq!(List::<Runtime>::get_bags(), vec![(VoteWeight::MAX, vec![1, 2, 3, 4, 5, 6])]);
 
 			// any rebag is noop.
 			assert_storage_noop!(assert!(BagsList::rebag(Origin::signed(0), 1).is_ok()));
@@ -472,7 +473,7 @@ mod sorted_list_provider {
 			assert_eq!(BagsList::count(), 4);
 
 			// when updating
-			BagsList::on_update(&201, u64::MAX);
+			BagsList::on_update(&201, VoteWeight::MAX);
 			// then the count stays the same
 			assert_eq!(BagsList::count(), 4);
 		});
@@ -553,12 +554,12 @@ mod sorted_list_provider {
 			assert_eq!(BagsList::iter().collect::<Vec<_>>(), vec![42, 2, 3, 4, 1]);
 
 			// when increasing weight to the level of a non-existent bag with the max threshold
-			BagsList::on_update(&42, u64::MAX);
+			BagsList::on_update(&42, VoteWeight::MAX);
 
 			// the the new bag is created with the id in it,
 			assert_eq!(
 				List::<Runtime>::get_bags(),
-				vec![(10, vec![1]), (1_000, vec![2, 3, 4]), (u64::MAX, vec![42])]
+				vec![(10, vec![1]), (1_000, vec![2, 3, 4]), (VoteWeight::MAX, vec![42])]
 			);
 			// and the id position is updated in the list.
 			assert_eq!(BagsList::iter().collect::<Vec<_>>(), vec![42, 2, 3, 4, 1]);

--- a/frame/election-provider-support/Cargo.toml
+++ b/frame/election-provider-support/Cargo.toml
@@ -18,12 +18,12 @@ scale-info = { version = "2.0.1", default-features = false, features = ["derive"
 sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
 sp-arithmetic = { version = "5.0.0", default-features = false, path = "../../primitives/arithmetic" }
 sp-npos-elections = { version = "4.0.0-dev", default-features = false, path = "../../primitives/npos-elections" }
+sp-runtime = { version = "6.0.0", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
 sp-npos-elections = { version = "4.0.0-dev", path = "../../primitives/npos-elections" }
-sp-runtime = { version = "6.0.0", path = "../../primitives/runtime" }
 sp-core = { version = "6.0.0", path = "../../primitives/core" }
 sp-io = { version = "6.0.0", path = "../../primitives/io" }
 

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -169,6 +169,7 @@
 pub mod onchain;
 use frame_support::{traits::Get, BoundedVec};
 use sp_std::{fmt::Debug, prelude::*};
+use sp_runtime::traits::Bounded;
 
 /// Re-export some type as they are used in the interface.
 pub use sp_arithmetic::PerThing;
@@ -343,7 +344,7 @@ pub trait SortedListProvider<AccountId> {
 	/// The list's error type.
 	type Error: sp_std::fmt::Debug;
 
-	type Value;
+	type Value: Bounded;
 
 	/// An iterator over the list, which can have `take` called on it.
 	fn iter() -> Box<dyn Iterator<Item = AccountId>>;
@@ -390,7 +391,9 @@ pub trait SortedListProvider<AccountId> {
 	/// If `who` changes by the returned amount they are guaranteed to have a worst case change
 	/// in their list position.
 	#[cfg(feature = "runtime-benchmarks")]
-	fn weight_update_worst_case(_who: &AccountId, _is_increase: bool) -> Self::Value;
+	fn weight_update_worst_case(_who: &AccountId, _is_increase: bool) -> Self::Value {
+		Self::Value::max_value()
+	}
 }
 
 /// Something that can provide the `VoteWeight` of an account. Similar to [`ElectionProvider`] and

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -168,8 +168,8 @@
 
 pub mod onchain;
 use frame_support::{traits::Get, BoundedVec};
-use sp_std::{fmt::Debug, prelude::*};
 use sp_runtime::traits::Bounded;
+use sp_std::{fmt::Debug, prelude::*};
 
 /// Re-export some type as they are used in the interface.
 pub use sp_arithmetic::PerThing;
@@ -334,9 +334,7 @@ where
 /// This is generic over `AccountId` and it can represent a validator, a nominator, or any other
 /// entity.
 ///
-/// To simplify the trait, the `VoteWeight` is hardcoded as the weight of each entity. The weights
-/// are ascending, the higher, the better. In the long term, if this trait ends up having use cases
-/// outside of the election context, it is easy enough to make it generic over the `VoteWeight`.
+/// The scores (see [`Self::Score`]) are ascending, the higher, the better.
 ///
 /// Something that implements this trait will do a best-effort sort over ids, and thus can be
 /// used on the implementing side of [`ElectionDataProvider`].
@@ -344,7 +342,8 @@ pub trait SortedListProvider<AccountId> {
 	/// The list's error type.
 	type Error: sp_std::fmt::Debug;
 
-	type Value: Bounded;
+	/// The type used by the list to compare nodes for ordering.
+	type Score: Bounded;
 
 	/// An iterator over the list, which can have `take` called on it.
 	fn iter() -> Box<dyn Iterator<Item = AccountId>>;
@@ -356,10 +355,10 @@ pub trait SortedListProvider<AccountId> {
 	fn contains(id: &AccountId) -> bool;
 
 	/// Hook for inserting a new id.
-	fn on_insert(id: AccountId, weight: Self::Value) -> Result<(), Self::Error>;
+	fn on_insert(id: AccountId, score: Self::Score) -> Result<(), Self::Error>;
 
 	/// Hook for updating a single id.
-	fn on_update(id: &AccountId, weight: Self::Value);
+	fn on_update(id: &AccountId, score: Self::Score);
 
 	/// Hook for removing am id from the list.
 	fn on_remove(id: &AccountId);
@@ -374,7 +373,7 @@ pub trait SortedListProvider<AccountId> {
 	/// new list, which can lead to too many storage accesses, exhausting the block weight.
 	fn unsafe_regenerate(
 		all: impl IntoIterator<Item = AccountId>,
-		weight_of: Box<dyn Fn(&AccountId) -> Self::Value>,
+		score_of: Box<dyn Fn(&AccountId) -> Self::Score>,
 	) -> u32;
 
 	/// Remove all items from the list.
@@ -391,23 +390,23 @@ pub trait SortedListProvider<AccountId> {
 	/// If `who` changes by the returned amount they are guaranteed to have a worst case change
 	/// in their list position.
 	#[cfg(feature = "runtime-benchmarks")]
-	fn weight_update_worst_case(_who: &AccountId, _is_increase: bool) -> Self::Value {
-		Self::Value::max_value()
+	fn score_update_worst_case(_who: &AccountId, _is_increase: bool) -> Self::Score {
+		Self::Score::max_value()
 	}
 }
 
 /// Something that can provide the `VoteWeight` of an account. Similar to [`ElectionProvider`] and
 /// [`ElectionDataProvider`], this should typically be implementing by whoever is supposed to *use*
 /// `SortedListProvider`.
-pub trait ValueProvider<AccountId> {
-	type Value;
+pub trait ScoreProvider<AccountId> {
+	type Score;
 
-	/// Get the current `VoteWeight` of `who`.
-	fn value(who: &AccountId) -> Self::Value;
+	/// Get the current `Score` of `who`.
+	fn score(who: &AccountId) -> Self::Score;
 
 	/// For tests and benchmarks, set the `VoteWeight`.
 	#[cfg(any(feature = "runtime-benchmarks", test))]
-	fn set_value_of(_: &AccountId, _: Self::Value) {}
+	fn set_score_of(_: &AccountId, _: Self::Score) {}
 }
 
 /// Something that can compute the result to an NPoS solution.

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -343,6 +343,8 @@ pub trait SortedListProvider<AccountId> {
 	/// The list's error type.
 	type Error: sp_std::fmt::Debug;
 
+	type Value;
+
 	/// An iterator over the list, which can have `take` called on it.
 	fn iter() -> Box<dyn Iterator<Item = AccountId>>;
 
@@ -353,10 +355,10 @@ pub trait SortedListProvider<AccountId> {
 	fn contains(id: &AccountId) -> bool;
 
 	/// Hook for inserting a new id.
-	fn on_insert(id: AccountId, weight: VoteWeight) -> Result<(), Self::Error>;
+	fn on_insert(id: AccountId, weight: Self::Value) -> Result<(), Self::Error>;
 
 	/// Hook for updating a single id.
-	fn on_update(id: &AccountId, weight: VoteWeight);
+	fn on_update(id: &AccountId, weight: Self::Value);
 
 	/// Hook for removing am id from the list.
 	fn on_remove(id: &AccountId);
@@ -371,7 +373,7 @@ pub trait SortedListProvider<AccountId> {
 	/// new list, which can lead to too many storage accesses, exhausting the block weight.
 	fn unsafe_regenerate(
 		all: impl IntoIterator<Item = AccountId>,
-		weight_of: Box<dyn Fn(&AccountId) -> VoteWeight>,
+		weight_of: Box<dyn Fn(&AccountId) -> Self::Value>,
 	) -> u32;
 
 	/// Remove all items from the list.
@@ -388,21 +390,21 @@ pub trait SortedListProvider<AccountId> {
 	/// If `who` changes by the returned amount they are guaranteed to have a worst case change
 	/// in their list position.
 	#[cfg(feature = "runtime-benchmarks")]
-	fn weight_update_worst_case(_who: &AccountId, _is_increase: bool) -> VoteWeight {
-		VoteWeight::MAX
-	}
+	fn weight_update_worst_case(_who: &AccountId, _is_increase: bool) -> Self::Value;
 }
 
 /// Something that can provide the `VoteWeight` of an account. Similar to [`ElectionProvider`] and
 /// [`ElectionDataProvider`], this should typically be implementing by whoever is supposed to *use*
 /// `SortedListProvider`.
-pub trait VoteWeightProvider<AccountId> {
+pub trait ValueProvider<AccountId> {
+	type Value;
+
 	/// Get the current `VoteWeight` of `who`.
-	fn vote_weight(who: &AccountId) -> VoteWeight;
+	fn value(who: &AccountId) -> Self::Value;
 
 	/// For tests and benchmarks, set the `VoteWeight`.
 	#[cfg(any(feature = "runtime-benchmarks", test))]
-	fn set_vote_weight_of(_: &AccountId, _: VoteWeight) {}
+	fn set_value_of(_: &AccountId, _: Self::Value) {}
 }
 
 /// Something that can compute the result to an NPoS solution.

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -189,7 +189,7 @@ impl<T: Config> ListScenario<T> {
 
 		// find a destination weight that will trigger the worst case scenario
 		let dest_weight_as_vote =
-			T::SortedListProvider::weight_update_worst_case(&origin_stash1, is_increase);
+			T::SortedListProvider::score_update_worst_case(&origin_stash1, is_increase);
 
 		let total_issuance = T::Currency::total_issuance();
 

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -36,6 +36,7 @@ use sp_runtime::{
 };
 use sp_staking::offence::{DisableStrategy, OffenceDetails, OnOffenceHandler};
 use std::cell::RefCell;
+use frame_election_provider_support::VoteWeight;
 
 pub const INIT_TIMESTAMP: u64 = 30_000;
 pub const BLOCK_TIME: u64 = 1000;
@@ -240,9 +241,9 @@ parameter_types! {
 impl pallet_bags_list::Config for Test {
 	type Event = Event;
 	type WeightInfo = ();
-	type ValueProvider = Staking;
+	type ScoreProvider = Staking;
 	type BagThresholds = BagThresholds;
-	type Value = u64;
+	type Score = VoteWeight;
 }
 
 impl onchain::Config for Test {

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -18,7 +18,7 @@
 //! Test utilities
 
 use crate::{self as pallet_staking, *};
-use frame_election_provider_support::{onchain, SortedListProvider};
+use frame_election_provider_support::{onchain, SortedListProvider, VoteWeight};
 use frame_support::{
 	assert_ok, parameter_types,
 	traits::{
@@ -36,7 +36,6 @@ use sp_runtime::{
 };
 use sp_staking::offence::{DisableStrategy, OffenceDetails, OnOffenceHandler};
 use std::cell::RefCell;
-use frame_election_provider_support::VoteWeight;
 
 pub const INIT_TIMESTAMP: u64 = 30_000;
 pub const BLOCK_TIME: u64 = 1000;

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -240,8 +240,9 @@ parameter_types! {
 impl pallet_bags_list::Config for Test {
 	type Event = Event;
 	type WeightInfo = ();
-	type VoteWeightProvider = Staking;
+	type ValueProvider = Staking;
 	type BagThresholds = BagThresholds;
+	type Value = u64;
 }
 
 impl onchain::Config for Test {

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -1320,9 +1320,4 @@ impl<T: Config> SortedListProvider<T::AccountId> for UseNominatorsMap<T> {
 		// condition of SortedListProvider::unsafe_clear.
 		Nominators::<T>::remove_all();
 	}
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn weight_update_worst_case(_: &T::AccountId, _: bool) -> Self::Value {
-		u64::MAX
-	}
 }

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -18,8 +18,8 @@
 //! Implementations for the Staking FRAME Pallet.
 
 use frame_election_provider_support::{
-	data_provider, ElectionDataProvider, ElectionProvider, SortedListProvider, Supports,
-	ScoreProvider, VoteWeight, VoterOf,
+	data_provider, ElectionDataProvider, ElectionProvider, ScoreProvider, SortedListProvider,
+	Supports, VoteWeight, VoterOf,
 };
 use frame_support::{
 	pallet_prelude::*,

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -1279,7 +1279,6 @@ impl<T: Config> ScoreProvider<T::AccountId> for Pallet<T> {
 /// does not provided nominators in sorted ordered. If you desire nominators in a sorted order take
 /// a look at [`pallet-bags-list].
 pub struct UseNominatorsMap<T>(sp_std::marker::PhantomData<T>);
-
 impl<T: Config> SortedListProvider<T::AccountId> for UseNominatorsMap<T> {
 	type Error = ();
 	type Score = VoteWeight;

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -19,7 +19,7 @@
 
 use frame_election_provider_support::{
 	data_provider, ElectionDataProvider, ElectionProvider, SortedListProvider, Supports,
-	VoteWeight, ValueProvider, VoterOf,
+	ScoreProvider, VoteWeight, VoterOf,
 };
 use frame_support::{
 	pallet_prelude::*,
@@ -1244,15 +1244,15 @@ where
 	}
 }
 
-impl<T: Config> ValueProvider<T::AccountId> for Pallet<T> {
-	type Value = VoteWeight;
+impl<T: Config> ScoreProvider<T::AccountId> for Pallet<T> {
+	type Score = VoteWeight;
 
-	fn value(who: &T::AccountId) -> Self::Value {
+	fn score(who: &T::AccountId) -> Self::Score {
 		Self::weight_of(who)
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	fn set_value_of(who: &T::AccountId, weight: Self::Value) {
+	fn set_score_of(who: &T::AccountId, weight: Self::Score) {
 		// this will clearly results in an inconsistent state, but it should not matter for a
 		// benchmark.
 		let active: BalanceOf<T> = weight.try_into().map_err(|_| ()).unwrap();
@@ -1282,7 +1282,7 @@ pub struct UseNominatorsMap<T>(sp_std::marker::PhantomData<T>);
 
 impl<T: Config> SortedListProvider<T::AccountId> for UseNominatorsMap<T> {
 	type Error = ();
-	type Value = VoteWeight;
+	type Score = VoteWeight;
 
 	/// Returns iterator over voter list, which can have `take` called on it.
 	fn iter() -> Box<dyn Iterator<Item = T::AccountId>> {
@@ -1294,11 +1294,11 @@ impl<T: Config> SortedListProvider<T::AccountId> for UseNominatorsMap<T> {
 	fn contains(id: &T::AccountId) -> bool {
 		Nominators::<T>::contains_key(id)
 	}
-	fn on_insert(_: T::AccountId, _weight: Self::Value) -> Result<(), Self::Error> {
+	fn on_insert(_: T::AccountId, _weight: Self::Score) -> Result<(), Self::Error> {
 		// nothing to do on insert.
 		Ok(())
 	}
-	fn on_update(_: &T::AccountId, _weight: Self::Value) {
+	fn on_update(_: &T::AccountId, _weight: Self::Score) {
 		// nothing to do on update.
 	}
 	fn on_remove(_: &T::AccountId) {
@@ -1306,7 +1306,7 @@ impl<T: Config> SortedListProvider<T::AccountId> for UseNominatorsMap<T> {
 	}
 	fn unsafe_regenerate(
 		_: impl IntoIterator<Item = T::AccountId>,
-		_: Box<dyn Fn(&T::AccountId) -> Self::Value>,
+		_: Box<dyn Fn(&T::AccountId) -> Self::Score>,
 	) -> u32 {
 		// nothing to do upon regenerate.
 		0

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -1321,6 +1321,7 @@ impl<T: Config> SortedListProvider<T::AccountId> for UseNominatorsMap<T> {
 		Nominators::<T>::remove_all();
 	}
 
+	#[cfg(feature = "runtime-benchmarks")]
 	fn weight_update_worst_case(_: &T::AccountId, _: bool) -> Self::Value {
 		u64::MAX
 	}

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -166,7 +166,10 @@ pub mod pallet {
 		/// Something that can provide a sorted list of voters in a somewhat sorted way. The
 		/// original use case for this was designed with `pallet_bags_list::Pallet` in mind. If
 		/// the bags-list is not desired, [`impls::UseNominatorsMap`] is likely the desired option.
-		type SortedListProvider: SortedListProvider<Self::AccountId, Score = frame_election_provider_support::VoteWeight>;
+		type SortedListProvider: SortedListProvider<
+			Self::AccountId,
+			Score = frame_election_provider_support::VoteWeight,
+		>;
 
 		/// The maximum number of `unlocking` chunks a [`StakingLedger`] can have. Effectively
 		/// determines how many unique eras a staker may be unbonding in.

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -166,7 +166,7 @@ pub mod pallet {
 		/// Something that can provide a sorted list of voters in a somewhat sorted way. The
 		/// original use case for this was designed with `pallet_bags_list::Pallet` in mind. If
 		/// the bags-list is not desired, [`impls::UseNominatorsMap`] is likely the desired option.
-		type SortedListProvider: SortedListProvider<Self::AccountId, Value = u64>;
+		type SortedListProvider: SortedListProvider<Self::AccountId, Value = VoteWeight>;
 
 		/// The maximum number of `unlocking` chunks a [`StakingLedger`] can have. Effectively
 		/// determines how many unique eras a staker may be unbonding in.

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -166,7 +166,7 @@ pub mod pallet {
 		/// Something that can provide a sorted list of voters in a somewhat sorted way. The
 		/// original use case for this was designed with `pallet_bags_list::Pallet` in mind. If
 		/// the bags-list is not desired, [`impls::UseNominatorsMap`] is likely the desired option.
-		type SortedListProvider: SortedListProvider<Self::AccountId>;
+		type SortedListProvider: SortedListProvider<Self::AccountId, Value = u64>;
 
 		/// The maximum number of `unlocking` chunks a [`StakingLedger`] can have. Effectively
 		/// determines how many unique eras a staker may be unbonding in.

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -166,7 +166,7 @@ pub mod pallet {
 		/// Something that can provide a sorted list of voters in a somewhat sorted way. The
 		/// original use case for this was designed with `pallet_bags_list::Pallet` in mind. If
 		/// the bags-list is not desired, [`impls::UseNominatorsMap`] is likely the desired option.
-		type SortedListProvider: SortedListProvider<Self::AccountId, Value = VoteWeight>;
+		type SortedListProvider: SortedListProvider<Self::AccountId, Score = frame_election_provider_support::VoteWeight>;
 
 		/// The maximum number of `unlocking` chunks a [`StakingLedger`] can have. Effectively
 		/// determines how many unique eras a staker may be unbonding in.


### PR DESCRIPTION
polkadot companion: https://github.com/paritytech/polkadot/pull/5065

This is a breaking change to some public APIs, but contains zero logic changes.

While this doesn't change any logic, it technically is a breaking change for the `SortedListProvider,` `pallet-bags_list::Config`, and `VoteWeightProvider` which gets renamed too `ScoreProvider`. All through of the aforementioned get a new associated type, `Score`, which replaces the concrete type `VoteWeight`. For those who need to migrate to the new APIs, simply set `Score = VoteWeight`. Check out the polkadot companion for examples