### PR TITLE
Additional `benchmark-storage` flags

### DIFF
--- a/utils/frame/benchmarking-cli/src/lib.rs
+++ b/utils/frame/benchmarking-cli/src/lib.rs
@@ -67,7 +67,7 @@ pub struct BenchmarkCmd {
 	#[clap(long = "json")]
 	pub json_output: bool,
 
-	/// Write the raw results in JSON format into the give file.
+	/// Write the raw results in JSON format into the given file.
 	#[clap(long, conflicts_with = "json-output")]
 	pub json_file: Option<PathBuf>,
 

--- a/utils/frame/benchmarking-cli/src/storage/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/storage/cmd.rs
@@ -84,7 +84,7 @@ pub struct StorageParams {
 	#[clap(long)]
 	pub skip_write: bool,
 
-	/// Path to Handlebars template file used for outputting benchmark results. (Optional)
+	/// Specify the Handlebars template to use for outputting benchmark results.
 	#[clap(long)]
 	pub template_path: Option<PathBuf>,
 
@@ -125,16 +125,10 @@ impl StorageCmd {
 		Block: BlockT<Hash = DbHash>,
 		C: UsageProvider<Block> + StorageProvider<Block, BA> + HeaderBackend<Block>,
 	{
-		if let Some(hbs_template) = &self.params.template_path {
-			if !hbs_template.is_file() {
-				return Err("Handlebars template file is invalid!".into())
-			};
-		}
-
 		let mut template = TemplateData::new(&cfg, &self.params);
 
 		let block_id = BlockId::<Block>::Number(client.usage_info().chain.best_number);
-		template.set_block_id(block_id.to_string());
+		template.set_block_number(block_id.to_string());
 
 		if !self.params.skip_read {
 			let record = self.bench_read(client.clone())?;

--- a/utils/frame/benchmarking-cli/src/storage/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/storage/cmd.rs
@@ -59,8 +59,8 @@ pub struct StorageCmd {
 pub struct StorageParams {
 	/// Path to write the *weight* file to. Can be a file or directory.
 	/// For substrate this should be `frame/support/src/weights`.
-	#[clap(long, default_value = ".")]
-	pub weight_path: String,
+	#[clap(long)]
+	pub weight_path: Option<PathBuf>,
 
 	/// Select a specific metric to calculate the final weight output.
 	#[clap(long = "metric", default_value = "average")]

--- a/utils/frame/benchmarking-cli/src/storage/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/storage/cmd.rs
@@ -97,7 +97,6 @@ pub struct StorageParams {
 	pub json_write_path: Option<String>,
 
 	/// Rounds of warmups before measuring.
-	/// Only supported for `read` benchmarks.
 	#[clap(long, default_value = "1")]
 	pub warmups: u32,
 

--- a/utils/frame/benchmarking-cli/src/storage/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/storage/cmd.rs
@@ -29,6 +29,7 @@ use clap::{Args, Parser};
 use log::info;
 use rand::prelude::*;
 use serde::Serialize;
+use sp_runtime::generic::BlockId;
 use std::{fmt::Debug, path::PathBuf, sync::Arc};
 
 use super::{record::StatSelect, template::TemplateData};
@@ -132,6 +133,9 @@ impl StorageCmd {
 		}
 
 		let mut template = TemplateData::new(&cfg, &self.params);
+
+		let block_id = BlockId::<Block>::Number(client.usage_info().chain.best_number);
+		template.set_block_id(block_id.to_string());
 
 		if !self.params.skip_read {
 			let record = self.bench_read(client.clone())?;

--- a/utils/frame/benchmarking-cli/src/storage/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/storage/cmd.rs
@@ -87,16 +87,12 @@ pub struct StorageParams {
 	#[clap(long)]
 	pub template_path: Option<PathBuf>,
 
-	/// Don't write benchmark output to a JSON file.
+	/// Write the raw 'read' results in JSON format to the specified file.
 	#[clap(long)]
-	pub no_json: bool,
-
-	/// Optionally specify the filename where to write the raw 'read' results in JSON format.
-	#[clap(long, conflicts_with = "no-json")]
 	pub json_read_path: Option<String>,
 
-	/// Optionally specify the filename where to write the raw 'write' results in JSON format.
-	#[clap(long, conflicts_with = "no-json")]
+	/// Write the raw 'write' results in JSON format to the specified file.
+	#[clap(long)]
 	pub json_write_path: Option<String>,
 
 	/// Rounds of warmups before measuring.
@@ -139,8 +135,8 @@ impl StorageCmd {
 
 		if !self.params.skip_read {
 			let record = self.bench_read(client.clone())?;
-			if !self.params.no_json {
-				record.save_json(&cfg, &self.params.json_read_path, "read")?;
+			if let Some(path) = &self.params.json_read_path {
+				record.save_json(&cfg, &path, "read")?;
 			}
 			let stats = record.calculate_stats()?;
 			info!("Time summary [ns]:\n{:?}\nValue size summary:\n{:?}", stats.0, stats.1);
@@ -149,8 +145,8 @@ impl StorageCmd {
 
 		if !self.params.skip_write {
 			let record = self.bench_write(client, db, storage)?;
-			if !self.params.no_json {
-				record.save_json(&cfg, &self.params.json_write_path, "write")?;
+			if let Some(path) = &self.params.json_write_path {
+				record.save_json(&cfg, &path, "write")?;
 			}
 			let stats = record.calculate_stats()?;
 			info!("Time summary [ns]:\n{:?}\nValue size summary:\n{:?}", stats.0, stats.1);

--- a/utils/frame/benchmarking-cli/src/storage/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/storage/cmd.rs
@@ -88,13 +88,13 @@ pub struct StorageParams {
 	#[clap(long)]
 	pub template_path: Option<PathBuf>,
 
-	/// Write the raw 'read' results in JSON format to the specified file.
+	/// Path to write the raw 'read' results in JSON format to. Can be a file or directory.
 	#[clap(long)]
-	pub json_read_path: Option<String>,
+	pub json_read_path: Option<PathBuf>,
 
-	/// Write the raw 'write' results in JSON format to the specified file.
+	/// Path to write the raw 'write' results in JSON format to. Can be a file or directory.
 	#[clap(long)]
-	pub json_write_path: Option<String>,
+	pub json_write_path: Option<PathBuf>,
 
 	/// Rounds of warmups before measuring.
 	#[clap(long, default_value = "1")]
@@ -133,7 +133,7 @@ impl StorageCmd {
 		if !self.params.skip_read {
 			let record = self.bench_read(client.clone())?;
 			if let Some(path) = &self.params.json_read_path {
-				record.save_json(&cfg, &path, "read")?;
+				record.save_json(&cfg, path, "read")?;
 			}
 			let stats = record.calculate_stats()?;
 			info!("Time summary [ns]:\n{:?}\nValue size summary:\n{:?}", stats.0, stats.1);
@@ -143,7 +143,7 @@ impl StorageCmd {
 		if !self.params.skip_write {
 			let record = self.bench_write(client, db, storage)?;
 			if let Some(path) = &self.params.json_write_path {
-				record.save_json(&cfg, &path, "write")?;
+				record.save_json(&cfg, path, "write")?;
 			}
 			let stats = record.calculate_stats()?;
 			info!("Time summary [ns]:\n{:?}\nValue size summary:\n{:?}", stats.0, stats.1);

--- a/utils/frame/benchmarking-cli/src/storage/read.rs
+++ b/utils/frame/benchmarking-cli/src/storage/read.rs
@@ -49,17 +49,6 @@ impl StorageCmd {
 		let mut rng = Self::setup_rng();
 		keys.shuffle(&mut rng);
 
-		// Run some rounds of the benchmark as warmup.
-		for i in 0..self.params.warmups {
-			info!("Warmup round {}/{}", i + 1, self.params.warmups);
-			for key in keys.clone() {
-				let _ = client
-					.storage(&block, &key)
-					.expect("Checked above to exist")
-					.ok_or("Value unexpectedly empty")?;
-			}
-		}
-
 		// Interesting part here:
 		// Read all the keys in the database and measure the time it takes to access each.
 		info!("Reading {} keys", keys.len());

--- a/utils/frame/benchmarking-cli/src/storage/record.rs
+++ b/utils/frame/benchmarking-cli/src/storage/record.rs
@@ -97,10 +97,10 @@ impl BenchRecord {
 
 	/// Unless a path is specified, saves the raw results in a json file in the current directory.
 	/// Prefixes it with the DB name and suffixed with `path_suffix`.
-	pub fn save_json(&self, cfg: &Configuration, out_path: &str, path_suffix: &str) -> Result<()> {
+	pub fn save_json(&self, cfg: &Configuration, out_path: &PathBuf, suffix: &str) -> Result<()> {
 		let mut path = PathBuf::from(out_path);
-		if path.is_dir() {
-			path.push(&format!("{}_{}", cfg.database, path_suffix).to_lowercase());
+		if path.is_dir() || path.as_os_str().is_empty() {
+			path.push(&format!("{}_{}", cfg.database, suffix).to_lowercase());
 			path.set_extension("json");
 		}
 

--- a/utils/frame/benchmarking-cli/src/storage/record.rs
+++ b/utils/frame/benchmarking-cli/src/storage/record.rs
@@ -22,7 +22,8 @@ use sc_service::Configuration;
 
 use log::info;
 use serde::Serialize;
-use std::{fmt, fs, result, str::FromStr, time::Duration};
+use sp_runtime::traits::Clear;
+use std::{fmt, fs, path::PathBuf, result, str::FromStr, time::Duration};
 
 /// Raw output of a Storage benchmark.
 #[derive(Debug, Default, Clone, Serialize)]
@@ -95,12 +96,27 @@ impl BenchRecord {
 		Ok((time, size)) // The swap of time/size here is intentional.
 	}
 
-	/// Saves the raw results in a json file in the current directory.
+	/// Unless a path is specified, saves the raw results in a json file in the current directory.
 	/// Prefixes it with the DB name and suffixed with `path_suffix`.
-	pub fn save_json(&self, cfg: &Configuration, path_suffix: &str) -> Result<()> {
-		let path = format!("{}_{}.json", cfg.database, path_suffix).to_lowercase();
+	pub fn save_json(
+		&self,
+		cfg: &Configuration,
+		out_path: &Option<String>,
+		path_suffix: &str,
+	) -> Result<()> {
+		let mut path = PathBuf::new();
+		if let Some(p) = out_path {
+			path = PathBuf::from(p);
+		}
+
+		if path.is_clear() || path.is_dir() {
+			path.push(&format!("{}_{}.json", cfg.database, path_suffix).to_lowercase());
+			path.set_extension("json");
+		}
+
 		let json = serde_json::to_string_pretty(&self)
 			.map_err(|e| format!("Serializing as JSON: {:?}", e))?;
+
 		fs::write(&path, json)?;
 		info!("Raw data written to {:?}", fs::canonicalize(&path)?);
 		Ok(())

--- a/utils/frame/benchmarking-cli/src/storage/record.rs
+++ b/utils/frame/benchmarking-cli/src/storage/record.rs
@@ -100,7 +100,7 @@ impl BenchRecord {
 	pub fn save_json(&self, cfg: &Configuration, out_path: &str, path_suffix: &str) -> Result<()> {
 		let mut path = PathBuf::from(out_path);
 		if path.is_dir() {
-			path.push(&format!("{}_{}.json", cfg.database, path_suffix).to_lowercase());
+			path.push(&format!("{}_{}", cfg.database, path_suffix).to_lowercase());
 			path.set_extension("json");
 		}
 

--- a/utils/frame/benchmarking-cli/src/storage/record.rs
+++ b/utils/frame/benchmarking-cli/src/storage/record.rs
@@ -22,7 +22,6 @@ use sc_service::Configuration;
 
 use log::info;
 use serde::Serialize;
-use sp_runtime::traits::Clear;
 use std::{fmt, fs, path::PathBuf, result, str::FromStr, time::Duration};
 
 /// Raw output of a Storage benchmark.
@@ -98,18 +97,9 @@ impl BenchRecord {
 
 	/// Unless a path is specified, saves the raw results in a json file in the current directory.
 	/// Prefixes it with the DB name and suffixed with `path_suffix`.
-	pub fn save_json(
-		&self,
-		cfg: &Configuration,
-		out_path: &Option<String>,
-		path_suffix: &str,
-	) -> Result<()> {
-		let mut path = PathBuf::new();
-		if let Some(p) = out_path {
-			path = PathBuf::from(p);
-		}
-
-		if path.is_clear() || path.is_dir() {
+	pub fn save_json(&self, cfg: &Configuration, out_path: &str, path_suffix: &str) -> Result<()> {
+		let mut path = PathBuf::from(out_path);
+		if path.is_dir() {
 			path.push(&format!("{}_{}.json", cfg.database, path_suffix).to_lowercase());
 			path.set_extension("json");
 		}

--- a/utils/frame/benchmarking-cli/src/storage/template.rs
+++ b/utils/frame/benchmarking-cli/src/storage/template.rs
@@ -32,6 +32,8 @@ static TEMPLATE: &str = include_str!("./weights.hbs");
 pub(crate) struct TemplateData {
 	/// Name of the database used.
 	db_name: String,
+	/// Block number that was used.
+	block_id: String,
 	/// Name of the runtime. Taken from the chain spec.
 	runtime_name: String,
 	/// Version of the benchmarking CLI used.
@@ -85,6 +87,11 @@ impl TemplateData {
 		Ok(())
 	}
 
+	/// Sets the block id that was used.
+	pub fn set_block_id(&mut self, block_id: String) {
+		self.block_id = block_id
+	}
+
 	/// Fills out the `weights.hbs` or specified HBS template with its own data.
 	/// Writes the result to `path` which can be a directory or file.
 	pub fn write(&self, path: &str, hbs_template_path: &Option<PathBuf>) -> Result<()> {
@@ -100,7 +107,7 @@ impl TemplateData {
 
 		// Use custom template if provided.
 		let template = match hbs_template_path {
-			Some(template)  => fs::read_to_string(template)?,
+			Some(template) => fs::read_to_string(template)?,
 			None => TEMPLATE.to_string(),
 		};
 		handlebars

--- a/utils/frame/benchmarking-cli/src/storage/template.rs
+++ b/utils/frame/benchmarking-cli/src/storage/template.rs
@@ -85,7 +85,7 @@ impl TemplateData {
 		Ok(())
 	}
 
-	/// Filles out the `weights.hbs` HBS template with its own data.
+	/// Fills out the `weights.hbs` HBS template with its own data.
 	/// Writes the result to `path` which can be a directory or file.
 	pub fn write(&self, path: &str) -> Result<()> {
 		let mut handlebars = handlebars::Handlebars::new();

--- a/utils/frame/benchmarking-cli/src/storage/template.rs
+++ b/utils/frame/benchmarking-cli/src/storage/template.rs
@@ -120,7 +120,7 @@ impl TemplateData {
 	fn build_path(&self, weight_out: &str) -> PathBuf {
 		let mut path = PathBuf::from(weight_out);
 		if path.is_dir() {
-			path.push(format!("{}_weights.rs", self.db_name.to_lowercase()));
+			path.push(format!("{}_weights", self.db_name.to_lowercase()));
 			path.set_extension("rs");
 		}
 		path

--- a/utils/frame/benchmarking-cli/src/storage/template.rs
+++ b/utils/frame/benchmarking-cli/src/storage/template.rs
@@ -103,7 +103,7 @@ impl TemplateData {
 		// Use custom template if provided.
 		let template = match hbs_template_path {
 			Some(template) if template.is_file() => fs::read_to_string(template)?,
-			Some(_) => return Err("Handlebars template file is invalid!".into()),
+			Some(_) => return Err("Handlebars template is not a valid file!".into()),
 			None => TEMPLATE.to_string(),
 		};
 

--- a/utils/frame/benchmarking-cli/src/storage/weights.hbs
+++ b/utils/frame/benchmarking-cli/src/storage/weights.hbs
@@ -19,6 +19,7 @@
 //! DATE: {{date}}
 //!
 //! DATABASE: `{{db_name}}`, RUNTIME: `{{runtime_name}}`
+//! BLOCK-ID: `{{block_id}}`
 //! SKIP-WRITE: `{{params.skip_write}}`, SKIP-READ: `{{params.skip_read}}`, WARMUPS: `{{params.warmups}}`
 //! STATE-VERSION: `V{{params.state_version}}`, STATE-CACHE-SIZE: `{{params.state_cache_size}}`
 //! WEIGHT-PATH: `{{params.weight_path}}`

--- a/utils/frame/benchmarking-cli/src/storage/weights.hbs
+++ b/utils/frame/benchmarking-cli/src/storage/weights.hbs
@@ -19,7 +19,7 @@
 //! DATE: {{date}}
 //!
 //! DATABASE: `{{db_name}}`, RUNTIME: `{{runtime_name}}`
-//! BLOCK-ID: `{{block_id}}`
+//! BLOCK-NUM: `{{block_number}}`
 //! SKIP-WRITE: `{{params.skip_write}}`, SKIP-READ: `{{params.skip_read}}`, WARMUPS: `{{params.warmups}}`
 //! STATE-VERSION: `V{{params.state_version}}`, STATE-CACHE-SIZE: `{{params.state_cache_size}}`
 //! WEIGHT-PATH: `{{params.weight_path}}`

--- a/utils/frame/benchmarking-cli/src/storage/write.rs
+++ b/utils/frame/benchmarking-cli/src/storage/write.rs
@@ -62,18 +62,6 @@ impl StorageCmd {
 		let mut rng = Self::setup_rng();
 		kvs.shuffle(&mut rng);
 
-		// Run some rounds of the benchmark as warmup, excluding db transactions.
-		// The code here is derived from the instrumentation run below, look there for comments.
-		for i in 0..self.params.warmups {
-			info!("Warmup round {}/{}", i + 1, self.params.warmups);
-			for (k, original_v) in kvs.clone() {
-				let mut new_v = vec![0; original_v.len()];
-				rng.fill_bytes(&mut new_v[..]);
-				let replace = vec![(k.as_ref(), Some(new_v.as_ref()))];
-				let _ = trie.storage_root(replace.iter().cloned(), self.state_version());
-			}
-		}
-
 		info!("Writing {} keys", kvs.len());
 		// Write each value in one commit.
 		for (k, original_v) in kvs.iter() {

--- a/utils/frame/benchmarking-cli/src/storage/write.rs
+++ b/utils/frame/benchmarking-cli/src/storage/write.rs
@@ -63,6 +63,7 @@ impl StorageCmd {
 		kvs.shuffle(&mut rng);
 
 		// Run some rounds of the benchmark as warmup.
+		// The code here is a copy of the instrumentation run below, look there for comments.
 		for i in 0..self.params.warmups {
 			info!("Warmup round {}/{}", i + 1, self.params.warmups);
 			for (k, original_v) in kvs.clone().iter() {

--- a/utils/frame/benchmarking-cli/src/storage/write.rs
+++ b/utils/frame/benchmarking-cli/src/storage/write.rs
@@ -62,20 +62,15 @@ impl StorageCmd {
 		let mut rng = Self::setup_rng();
 		kvs.shuffle(&mut rng);
 
-		// Run some rounds of the benchmark as warmup.
-		// The code here is a copy of the instrumentation run below, look there for comments.
+		// Run some rounds of the benchmark as warmup, excluding db transactions.
+		// The code here is derived from the instrumentation run below, look there for comments.
 		for i in 0..self.params.warmups {
 			info!("Warmup round {}/{}", i + 1, self.params.warmups);
-			for (k, original_v) in kvs.clone().iter() {
+			for (k, original_v) in kvs.clone() {
 				let mut new_v = vec![0; original_v.len()];
 				rng.fill_bytes(&mut new_v[..]);
-
 				let replace = vec![(k.as_ref(), Some(new_v.as_ref()))];
-				let (_, stx) = trie.storage_root(replace.iter().cloned(), self.state_version());
-				let tx = convert_tx::<Block>(stx.clone(), true, state_col, supports_rc);
-				db.commit(tx).map_err(|e| format!("Writing to the Database: {}", e))?;
-				let tx = convert_tx::<Block>(stx.clone(), false, state_col, supports_rc);
-				db.commit(tx).map_err(|e| format!("Writing to the Database: {}", e))?;
+				let _ = trie.storage_root(replace.iter().cloned(), self.state_version());
 			}
 		}
 


### PR DESCRIPTION
Fixes #10929.

In this PR additional convenience flags are added to `benchmark-storage`.

- `--json-read-path` and `json-write-path`, each of which produces output at the specified location for their respective operations, defaulting to _no_ JSON output if neither are specified. If a directory is specified, default names are used.
- A custom handlebars template can now be specified with `--template-path`

Additionally,
- The block ID is added to the `weights.hbs` handlebars template and produces the following output:
```
...
//! DATABASE: `RocksDb`, RUNTIME: `Development`
//! BLOCK-ID: `BlockId::Number(0)`
//! SKIP-WRITE: `false`, SKIP-READ: `false`, WARMUPS: `1`
...
```

- The warmup rounds are extended to include `write` benchmarks. 
    - I'm not sure how to test this one and just mirrored the related logic from its `read` counterpart. 
    - Assistance would be appreciated.

polkadot address: 13j1pnePj28QqPNnGAs2srzWCiR17dwbJwn3mrNrba4WjFak