### PR TITLE
sp-core: `full_crypto` doesn't imply `std`

### DIFF
--- a/client/cli/src/arg_enums.rs
+++ b/client/cli/src/arg_enums.rs
@@ -211,6 +211,7 @@ impl std::str::FromStr for Database {
 	type Err = String;
 
 	fn from_str(s: &str) -> Result<Self, String> {
+		eprintln!("ELSE: {}", s);
 		if s.eq_ignore_ascii_case("rocksdb") {
 			Ok(Self::RocksDb)
 		} else if s.eq_ignore_ascii_case("paritydb-experimental") {

--- a/client/cli/src/arg_enums.rs
+++ b/client/cli/src/arg_enums.rs
@@ -211,7 +211,6 @@ impl std::str::FromStr for Database {
 	type Err = String;
 
 	fn from_str(s: &str) -> Result<Self, String> {
-		eprintln!("ELSE: {}", s);
 		if s.eq_ignore_ascii_case("rocksdb") {
 			Ok(Self::RocksDb)
 		} else if s.eq_ignore_ascii_case("paritydb-experimental") {

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -56,7 +56,7 @@ schnorrkel = { version = "0.9.1", features = [
 hex = { version = "0.4", default-features = false, optional = true }
 libsecp256k1 = { version = "0.7", default-features = false, features = ["static-context"], optional = true }
 merlin = { version = "2.0", default-features = false, optional = true }
-secp256k1 = { version = "0.21.2", default-features = false, features = ["recovery", "global-context"], optional = true }
+secp256k1 = { version = "0.21.2", default-features = false, features = ["recovery", "alloc"], optional = true }
 ss58-registry = { version = "1.11.0", default-features = false }
 sp-core-hashing = { version = "4.0.0", path = "./hashing", default-features = false, optional = true }
 sp-runtime-interface = { version = "6.0.0", default-features = false, path = "../runtime-interface" }
@@ -108,6 +108,7 @@ std = [
 	"regex",
 	"num-traits/std",
 	"secp256k1/std",
+	"secp256k1/global-context",
 	"sp-core-hashing/std",
 	"sp-debug-derive/std",
 	"sp-externalities",


### PR DESCRIPTION
This pr changes the feature set of `secp256k1` to not use `global-context` when only the
`full_crypto` is enabled. It will be slower when the `std` feature is not enabled as the context
always needs to be recreated, but that is fine.

Closes: https://github.com/paritytech/substrate/issues/11005