### PR TITLE
Update clap to the latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,7 @@ name = "chain-spec-builder"
 version = "2.0.0"
 dependencies = [
  "ansi_term",
- "clap 3.0.7",
+ "clap 3.1.6",
  "node-cli",
  "rand 0.8.4",
  "sc-chain-spec",
@@ -1006,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.7"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e8611f9ae4e068fa3e56931fded356ff745e70987ff76924a6e0ab1c8ef2e3"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
 dependencies = [
  "atty",
  "bitflags",
@@ -1018,7 +1018,7 @@ dependencies = [
  "os_str_bytes",
  "strsim",
  "termcolor",
- "textwrap 0.14.2",
+ "textwrap 0.15.0",
 ]
 
 [[package]]
@@ -1027,14 +1027,14 @@ version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a394f7ec0715b42a4e52b294984c27c9a61f77c8d82f7774c5198350be143f19"
 dependencies = [
- "clap 3.0.7",
+ "clap 3.1.6",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.5"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a0645a430ec9136d2d701e54a95d557de12649a9dd7109ced3187e648ac824"
+checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -2126,7 +2126,7 @@ version = "4.0.0-dev"
 dependencies = [
  "Inflector",
  "chrono",
- "clap 3.0.7",
+ "clap 3.1.6",
  "frame-benchmarking",
  "frame-support",
  "handlebars",
@@ -4751,7 +4751,7 @@ dependencies = [
 name = "node-bench"
 version = "0.9.0-dev"
 dependencies = [
- "clap 3.0.7",
+ "clap 3.1.6",
  "derive_more",
  "fs_extra",
  "futures 0.3.19",
@@ -4790,7 +4790,7 @@ version = "3.0.0-dev"
 dependencies = [
  "assert_cmd",
  "async-std",
- "clap 3.0.7",
+ "clap 3.1.6",
  "clap_complete",
  "criterion",
  "frame-benchmarking-cli",
@@ -4904,7 +4904,7 @@ dependencies = [
 name = "node-inspect"
 version = "0.9.0-dev"
 dependencies = [
- "clap 3.0.7",
+ "clap 3.1.6",
  "parity-scale-codec",
  "sc-cli",
  "sc-client-api",
@@ -5050,7 +5050,7 @@ dependencies = [
 name = "node-runtime-generate-bags"
 version = "3.0.0"
 dependencies = [
- "clap 3.0.7",
+ "clap 3.1.6",
  "generate-bags",
  "node-runtime",
 ]
@@ -5059,7 +5059,7 @@ dependencies = [
 name = "node-template"
 version = "4.0.0-dev"
 dependencies = [
- "clap 3.0.7",
+ "clap 3.1.6",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "jsonrpc-core",
@@ -8083,7 +8083,7 @@ name = "sc-cli"
 version = "0.10.0-dev"
 dependencies = [
  "chrono",
- "clap 3.0.7",
+ "clap 3.1.6",
  "fdlimit",
  "futures 0.3.19",
  "hex",
@@ -10068,7 +10068,7 @@ dependencies = [
 name = "sp-npos-elections-fuzzer"
 version = "2.0.0-alpha.5"
 dependencies = [
- "clap 3.0.7",
+ "clap 3.1.6",
  "honggfuzz",
  "parity-scale-codec",
  "rand 0.8.4",
@@ -10525,7 +10525,7 @@ dependencies = [
 name = "subkey"
 version = "2.0.1"
 dependencies = [
- "clap 3.0.7",
+ "clap 3.1.6",
  "sc-cli",
 ]
 
@@ -10553,7 +10553,7 @@ dependencies = [
 name = "substrate-frame-cli"
 version = "4.0.0-dev"
 dependencies = [
- "clap 3.0.7",
+ "clap 3.1.6",
  "frame-support",
  "frame-system",
  "sc-cli",
@@ -10843,9 +10843,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -11367,7 +11367,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 name = "try-runtime-cli"
 version = "0.10.0-dev"
 dependencies = [
- "clap 3.0.7",
+ "clap 3.1.6",
  "jsonrpsee 0.4.1",
  "log 0.4.14",
  "parity-scale-codec",

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 name = "node-template"
 
 [dependencies]
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "3.1.6", features = ["derive"] }
 
 sc-cli = { version = "0.10.0-dev", path = "../../../client/cli", features = ["wasmtime"] }
 sp-core = { version = "6.0.0", path = "../../../primitives/core" }

--- a/bin/node/bench/Cargo.toml
+++ b/bin/node/bench/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "3.1.6", features = ["derive"] }
 log = "0.4.8"
 node-primitives = { version = "2.0.0", path = "../primitives" }
 node-testing = { version = "3.0.0-dev", path = "../testing" }

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -34,7 +34,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # third-party dependencies
-clap = { version = "3.0", features = ["derive"], optional = true }
+clap = { version = "3.1.6", features = ["derive"], optional = true }
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 serde = { version = "1.0.136", features = ["derive"] }
 futures = "0.3.19"
@@ -133,7 +133,7 @@ remote-externalities = { path = "../../../utils/frame/remote-externalities" }
 pallet-timestamp = { version = "4.0.0-dev", path = "../../../frame/timestamp" }
 
 [build-dependencies]
-clap = { version = "3.0", optional = true }
+clap = { version = "3.1.6", optional = true }
 clap_complete = { version = "3.0", optional = true }
 node-inspect = { version = "0.9.0-dev", optional = true, path = "../inspect" }
 frame-benchmarking-cli = { version = "4.0.0-dev", optional = true, path = "../../../utils/frame/benchmarking-cli" }

--- a/bin/node/cli/build.rs
+++ b/bin/node/cli/build.rs
@@ -25,7 +25,7 @@ fn main() {
 mod cli {
 	include!("src/cli.rs");
 
-	use clap::{ArgEnum, IntoApp};
+	use clap::{ArgEnum, CommandFactory};
 	use clap_complete::{generate_to, Shell};
 	use std::{env, fs, path::Path};
 	use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
@@ -61,6 +61,6 @@ mod cli {
 
 		fs::create_dir(&path).ok();
 
-		let _ = generate_to(*shell, &mut Cli::into_app(), "substrate-node", &path);
+		let _ = generate_to(*shell, &mut Cli::command(), "substrate-node", &path);
 	}
 }

--- a/bin/node/inspect/Cargo.toml
+++ b/bin/node/inspect/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "3.1.6", features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 thiserror = "1.0"
 sc-cli = { version = "0.10.0-dev", path = "../../../client/cli" }

--- a/bin/utils/chain-spec-builder/Cargo.toml
+++ b/bin/utils/chain-spec-builder/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 ansi_term = "0.12.1"
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "3.1.6", features = ["derive"] }
 rand = "0.8"
 
 sc-keystore = { version = "4.0.0-dev", path = "../../../client/keystore" }

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -17,5 +17,5 @@ path = "src/main.rs"
 name = "subkey"
 
 [dependencies]
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "3.1.6", features = ["derive"] }
 sc-cli = { version = "0.10.0-dev", path = "../../../client/cli" }

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 chrono = "0.4.10"
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "3.1.6", features = ["derive"] }
 fdlimit = "0.2.1"
 futures = "0.3.19"
 hex = "0.4.2"

--- a/client/cli/src/arg_enums.rs
+++ b/client/cli/src/arg_enums.rs
@@ -86,6 +86,14 @@ impl Into<sc_service::config::WasmExecutionMethod> for WasmExecutionMethod {
 	}
 }
 
+/// The default [`WasmExecutionMethod`].
+#[cfg(feature = "wasmtime")]
+pub const DEFAULT_WASM_EXECUTION_METHOD: &str = "Compiled";
+
+/// The default [`WasmExecutionMethod`].
+#[cfg(not(feature = "wasmtime"))]
+pub const DEFAULT_WASM_EXECUTION_METHOD: &str = "interpreted-i-know-what-i-do";
+
 #[allow(missing_docs)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ArgEnum)]
 #[clap(rename_all = "PascalCase")]

--- a/client/cli/src/params/import_params.rs
+++ b/client/cli/src/params/import_params.rs
@@ -21,18 +21,13 @@ use crate::{
 		ExecutionStrategy, WasmExecutionMethod, DEFAULT_EXECUTION_BLOCK_CONSTRUCTION,
 		DEFAULT_EXECUTION_IMPORT_BLOCK, DEFAULT_EXECUTION_IMPORT_BLOCK_VALIDATOR,
 		DEFAULT_EXECUTION_OFFCHAIN_WORKER, DEFAULT_EXECUTION_OTHER, DEFAULT_EXECUTION_SYNCING,
+		DEFAULT_WASM_EXECUTION_METHOD,
 	},
 	params::{DatabaseParams, PruningParams},
 };
 use clap::Args;
 use sc_client_api::execution_extensions::ExecutionStrategies;
 use std::path::PathBuf;
-
-#[cfg(feature = "wasmtime")]
-const WASM_METHOD_DEFAULT: &str = "Compiled";
-
-#[cfg(not(feature = "wasmtime"))]
-const WASM_METHOD_DEFAULT: &str = "interpreted-i-know-what-i-do";
 
 /// Parameters for block import.
 #[derive(Debug, Clone, Args)]
@@ -59,7 +54,7 @@ pub struct ImportParams {
 		value_name = "METHOD",
 		possible_values = WasmExecutionMethod::variants(),
 		ignore_case = true,
-		default_value = WASM_METHOD_DEFAULT
+		default_value = DEFAULT_WASM_EXECUTION_METHOD,
 	)]
 	pub wasm_method: WasmExecutionMethod,
 

--- a/primitives/npos-elections/fuzzer/Cargo.toml
+++ b/primitives/npos-elections/fuzzer/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "3.1.6", features = ["derive"] }
 honggfuzz = "0.5"
 rand = { version = "0.8", features = ["std", "small_rng"] }
 

--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -33,7 +33,7 @@ sp-std = { version = "4.0.0", default-features = false, path = "../../../primiti
 sp-state-machine = { version = "0.12.0", path = "../../../primitives/state-machine" }
 sp-trie = { version = "6.0.0", path = "../../../primitives/trie" }
 codec = { version = "3.0.0", package = "parity-scale-codec" }
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "3.1.6", features = ["derive"] }
 chrono = "0.4"
 serde = "1.0.136"
 serde_json = "1.0.74"

--- a/utils/frame/benchmarking-cli/src/lib.rs
+++ b/utils/frame/benchmarking-cli/src/lib.rs
@@ -19,7 +19,7 @@ mod command;
 mod storage;
 mod writer;
 
-use sc_cli::{ExecutionStrategy, WasmExecutionMethod};
+use sc_cli::{ExecutionStrategy, WasmExecutionMethod, DEFAULT_WASM_EXECUTION_METHOD};
 use std::{fmt::Debug, path::PathBuf};
 
 pub use storage::StorageCmd;
@@ -130,7 +130,7 @@ pub struct BenchmarkCmd {
 		value_name = "METHOD",
 		possible_values = WasmExecutionMethod::variants(),
 		ignore_case = true,
-		default_value = "compiled"
+		default_value = DEFAULT_WASM_EXECUTION_METHOD,
 	)]
 	pub wasm_method: WasmExecutionMethod,
 

--- a/utils/frame/benchmarking-cli/src/lib.rs
+++ b/utils/frame/benchmarking-cli/src/lib.rs
@@ -46,11 +46,11 @@ pub struct BenchmarkCmd {
 	pub steps: u32,
 
 	/// Indicates lowest values for each of the component ranges.
-	#[clap(long = "low", use_delimiter = true)]
+	#[clap(long = "low", use_value_delimiter = true)]
 	pub lowest_range_values: Vec<u32>,
 
 	/// Indicates highest values for each of the component ranges.
-	#[clap(long = "high", use_delimiter = true)]
+	#[clap(long = "high", use_value_delimiter = true)]
 	pub highest_range_values: Vec<u32>,
 
 	/// Select how many repetitions of this benchmark should run from within the wasm.

--- a/utils/frame/frame-utilities-cli/Cargo.toml
+++ b/utils/frame/frame-utilities-cli/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/substrate-frame-cli"
 readme = "README.md"
 
 [dependencies]
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "3.1.6", features = ["derive"] }
 
 sp-core = { version = "6.0.0", path = "../../../primitives/core" }
 sc-cli = { version = "0.10.0-dev", path = "../../../client/cli" }

--- a/utils/frame/generate-bags/node-runtime/Cargo.toml
+++ b/utils/frame/generate-bags/node-runtime/Cargo.toml
@@ -14,4 +14,4 @@ node-runtime = { version = "3.0.0-dev", path = "../../../../bin/node/runtime" }
 generate-bags = { version = "4.0.0-dev", path = "../" }
 
 # third-party
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "3.1.6", features = ["derive"] }

--- a/utils/frame/try-runtime/cli/Cargo.toml
+++ b/utils/frame/try-runtime/cli/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "3.1.6", features = ["derive"] }
 log = "0.4.8"
 parity-scale-codec = "3.0.0"
 serde = "1.0.136"

--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -270,7 +270,9 @@ use remote_externalities::{
 	Builder, Mode, OfflineConfig, OnlineConfig, SnapshotConfig, TestExternalities,
 };
 use sc_chain_spec::ChainSpec;
-use sc_cli::{CliConfiguration, ExecutionStrategy, WasmExecutionMethod};
+use sc_cli::{
+	CliConfiguration, ExecutionStrategy, WasmExecutionMethod, DEFAULT_WASM_EXECUTION_METHOD,
+};
 use sc_executor::NativeElseWasmExecutor;
 use sc_service::{Configuration, NativeExecutionDispatch};
 use sp_core::{
@@ -394,7 +396,7 @@ pub struct SharedParams {
 		value_name = "METHOD",
 		possible_values = WasmExecutionMethod::variants(),
 		ignore_case = true,
-		default_value = "Compiled"
+		default_value = DEFAULT_WASM_EXECUTION_METHOD,
 	)]
 	pub wasm_method: WasmExecutionMethod,
 

--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -458,15 +458,15 @@ pub enum State {
 		snapshot_path: Option<PathBuf>,
 
 		/// The pallets to scrape. If empty, entire chain state will be scraped.
-		#[clap(short, long, require_delimiter = true)]
-		pallets: Option<Vec<String>>,
+		#[clap(short, long, multiple_values = true)]
+		pallets: Vec<String>,
 
 		/// Fetch the child-keys as well.
 		///
-		/// Default is `false`, if specific `pallets` are specified, true otherwise. In other
+		/// Default is `false`, if specific `--pallets` are specified, `true` otherwise. In other
 		/// words, if you scrape the whole state the child tree data is included out of the box.
 		/// Otherwise, it must be enabled explicitly using this flag.
-		#[clap(long, require_delimiter = true)]
+		#[clap(long)]
 		child_tree: bool,
 	},
 }
@@ -492,7 +492,7 @@ impl State {
 					.mode(Mode::Online(OnlineConfig {
 						transport: uri.to_owned().into(),
 						state_snapshot: snapshot_path.as_ref().map(SnapshotConfig::new),
-						pallets: pallets.clone().unwrap_or_default(),
+						pallets: pallets.clone(),
 						scrape_children: true,
 						at,
 					}))


### PR DESCRIPTION
Besides that it also removes some `structopt` leftovers from some docs.


