### PR TITLE
Add an optional `delta_changes` to `execution_proof`

### DIFF
--- a/client/api/src/call_executor.rs
+++ b/client/api/src/call_executor.rs
@@ -22,7 +22,10 @@ use codec::{Decode, Encode};
 use sc_executor::{RuntimeVersion, RuntimeVersionOf};
 use sp_core::NativeOrEncoded;
 use sp_externalities::Extensions;
-use sp_runtime::{generic::BlockId, traits::Block as BlockT};
+use sp_runtime::{
+	generic::BlockId,
+	traits::{Block as BlockT, HashFor},
+};
 use sp_state_machine::{ExecutionManager, ExecutionStrategy, OverlayedChanges, StorageProof};
 use std::{cell::RefCell, panic::UnwindSafe, result};
 
@@ -105,5 +108,6 @@ pub trait CallExecutor<B: BlockT>: RuntimeVersionOf {
 		at: &BlockId<B>,
 		method: &str,
 		call_data: &[u8],
+		delta_changes: Option<(sp_trie::PrefixedMemoryDB<HashFor<B>>, B::Hash)>,
 	) -> Result<(Vec<u8>, StorageProof), sp_blockchain::Error>;
 }

--- a/client/api/src/proof_provider.rs
+++ b/client/api/src/proof_provider.rs
@@ -18,7 +18,10 @@
 
 //! Proof utilities
 use crate::{CompactProof, StorageProof};
-use sp_runtime::{generic::BlockId, traits::Block as BlockT};
+use sp_runtime::{
+	generic::BlockId,
+	traits::{Block as BlockT, HashFor},
+};
 use sp_state_machine::{KeyValueStates, KeyValueStorageLevel};
 use sp_storage::ChildInfo;
 
@@ -49,6 +52,7 @@ pub trait ProofProvider<Block: BlockT> {
 		id: &BlockId<Block>,
 		method: &str,
 		call_data: &[u8],
+		delta_changes: Option<(sp_trie::PrefixedMemoryDB<HashFor<Block>>, Block::Hash)>,
 	) -> sp_blockchain::Result<(Vec<u8>, StorageProof)>;
 
 	/// Given a `BlockId` iterate over all storage values starting at `start_keys`.

--- a/client/network/src/light_client_requests/handler.rs
+++ b/client/network/src/light_client_requests/handler.rs
@@ -159,23 +159,24 @@ impl<B: Block> LightClientRequestHandler<B> {
 
 		let block = Decode::decode(&mut request.block.as_ref())?;
 
-		let proof =
-			match self
-				.client
-				.execution_proof(&BlockId::Hash(block), &request.method, &request.data)
-			{
-				Ok((_, proof)) => proof,
-				Err(e) => {
-					trace!(
-						"remote call request from {} ({} at {:?}) failed with: {}",
-						peer,
-						request.method,
-						request.block,
-						e,
-					);
-					StorageProof::empty()
-				},
-			};
+		let proof = match self.client.execution_proof(
+			&BlockId::Hash(block),
+			&request.method,
+			&request.data,
+			None,
+		) {
+			Ok((_, proof)) => proof,
+			Err(e) => {
+				trace!(
+					"remote call request from {} ({} at {:?}) failed with: {}",
+					peer,
+					request.method,
+					request.block,
+					e,
+				);
+				StorageProof::empty()
+			},
+		};
 
 		let response = {
 			let r = schema::v1::light::RemoteCallResponse { proof: proof.encode() };

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -1189,8 +1189,9 @@ where
 		id: &BlockId<Block>,
 		method: &str,
 		call_data: &[u8],
+		delta_changes: Option<(sp_trie::PrefixedMemoryDB<HashFor<Block>>, Block::Hash)>,
 	) -> sp_blockchain::Result<(Vec<u8>, StorageProof)> {
-		self.executor.prove_execution(id, method, call_data)
+		self.executor.prove_execution(id, method, call_data, delta_changes)
 	}
 
 	fn read_proof_collection(

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -145,7 +145,8 @@ mod std_reexport {
 		error::{Error, ExecutionError},
 		in_memory_backend::new_in_mem,
 		proving_backend::{
-			create_proof_check_backend, ProofRecorder, ProvingBackend, ProvingBackendRecorder,
+			create_delta_backend, create_proof_check_backend, DeltaBackend, ProofRecorder,
+			ProvingBackend, ProvingBackendRecorder,
 		},
 		read_only::{InspectState, ReadOnlyExternalities},
 		testing::TestExternalities,


### PR DESCRIPTION
This is the first step of #10922. A new trie backend with delta changes is introduced to create a
state during the entire block execution, e.g., a true state after applying some extrinsic. With this
PR, creating execution proof for any stage(initialize_block, extrinsic, finalize_block) during the
block execution can be supported.