### PR TITLE
contracts: Stabilize `seal_delegate_call`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2196,7 +2196,7 @@ dependencies = [
 name = "frame-election-solution-type-fuzzer"
 version = "2.0.0-alpha.5"
 dependencies = [
- "clap 3.0.7",
+ "clap 3.1.6",
  "frame-election-provider-solution-type",
  "honggfuzz",
  "parity-scale-codec",

--- a/frame/contracts/fixtures/delegate_call.wat
+++ b/frame/contracts/fixtures/delegate_call.wat
@@ -2,7 +2,7 @@
 	(import "seal0" "seal_input" (func $seal_input (param i32 i32)))
 	(import "seal0" "seal_get_storage" (func $seal_get_storage (param i32 i32 i32) (result i32)))
 	(import "seal0" "seal_set_storage" (func $seal_set_storage (param i32 i32 i32)))
-	(import "__unstable__" "seal_delegate_call" (func $seal_delegate_call (param i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_delegate_call" (func $seal_delegate_call (param i32 i32 i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 3 3))
 
 	;; [0, 32) storage key

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -1492,7 +1492,7 @@ benchmarks! {
 		let code = WasmModule::<T>::from(ModuleDefinition {
 			memory: Some(ImportedMemory::max::<T>()),
 			imported_functions: vec![ImportedFunction {
-				module: "__unstable__",
+				module: "seal0",
 				name: "seal_delegate_call",
 				params: vec![
 					ValueType::I32,

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -762,7 +762,6 @@ fn deploy_and_call_other_contract() {
 }
 
 #[test]
-#[cfg(feature = "unstable-interface")]
 fn delegate_call() {
 	let (caller_wasm, caller_code_hash) = compile_module::<Test>("delegate_call").unwrap();
 	let (callee_wasm, callee_code_hash) = compile_module::<Test>("delegate_call_lib").unwrap();

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -618,7 +618,7 @@ mod tests {
 	;;    output_ptr: u32,
 	;;    output_len_ptr: u32
 	;;) -> u32
-	(import "__unstable__" "seal_delegate_call" (func $seal_delegate_call (param i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_delegate_call" (func $seal_delegate_call (param i32 i32 i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 	(func (export "call")
 		(drop

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -191,7 +191,6 @@ pub enum RuntimeCosts {
 	/// Base weight of calling `seal_call`.
 	CallBase,
 	/// Weight of calling `seal_delegate_call` for the given input size.
-	#[cfg(feature = "unstable-interface")]
 	DelegateCallBase,
 	/// Weight of the transfer performed during a call.
 	CallSurchargeTransfer,
@@ -272,7 +271,6 @@ impl RuntimeCosts {
 				.saturating_add(s.take_storage_per_byte.saturating_mul(len.into())),
 			Transfer => s.transfer,
 			CallBase => s.call,
-			#[cfg(feature = "unstable-interface")]
 			DelegateCallBase => s.delegate_call,
 			CallSurchargeTransfer => s.call_transfer_surcharge,
 			CallInputCloned(len) => s.call_per_cloned_byte.saturating_mul(len.into()),
@@ -389,7 +387,6 @@ bitflags! {
 enum CallType {
 	/// Execute another instantiated contract
 	Call { callee_ptr: u32, value_ptr: u32, gas: u64 },
-	#[cfg(feature = "unstable-interface")]
 	/// Execute deployed code in the context (storage, account ID, value) of the caller contract
 	DelegateCall { code_hash_ptr: u32 },
 }
@@ -398,7 +395,6 @@ impl CallType {
 	fn cost(&self) -> RuntimeCosts {
 		match self {
 			CallType::Call { .. } => RuntimeCosts::CallBase,
-			#[cfg(feature = "unstable-interface")]
 			CallType::DelegateCall { .. } => RuntimeCosts::DelegateCallBase,
 		}
 	}
@@ -763,7 +759,6 @@ where
 					flags.contains(CallFlags::ALLOW_REENTRY),
 				)
 			},
-			#[cfg(feature = "unstable-interface")]
 			CallType::DelegateCall { code_hash_ptr } => {
 				if flags.contains(CallFlags::ALLOW_REENTRY) {
 					return Err(Error::<E::T>::InvalidCallFlags.into())
@@ -1129,7 +1124,7 @@ define_env!(Env, <E: Ext>,
 	// `ReturnCode::CalleeReverted`: Output buffer is returned.
 	// `ReturnCode::CalleeTrapped`
 	// `ReturnCode::CodeNotFound`
-	[__unstable__] seal_delegate_call(
+	[seal0] seal_delegate_call(
 		ctx,
 		flags: u32,
 		code_hash_ptr: u32,


### PR DESCRIPTION
There is a working ink waterfall test. We can stabilize.