### PR TITLE
Reduce penalty for sending duplicate block requests

### DIFF
--- a/client/network/src/block_request_handler.rs
+++ b/client/network/src/block_request_handler.rs
@@ -53,7 +53,7 @@ mod rep {
 	use super::ReputationChange as Rep;
 
 	/// Reputation change when a peer sent us the same request multiple times.
-	pub const SAME_REQUEST: Rep = Rep::new_fatal("Same block request multiple times");
+	pub const SAME_REQUEST: Rep = Rep::new(-(1 << 29), "Same block request multiple times");
 }
 
 /// Generates a [`ProtocolConfig`] for the block request protocol, refusing incoming requests.


### PR DESCRIPTION
This PR reduces the penalty for a peer sending a duplicate block request. Currently, a duplicate block request results in an instant ban. With this PR the penalty is changed to just a large reduction in reputation. This helps to avoid the situation where honest peers are banned for having (e.g.) poor networking. The actual reputation change is sort of arbitrary, I just aimed for a large penalty that allows a few offenses (4, if starting from a neutral reputation) before a peer is banned.

This fixes an issue we've encountered in test networks where honest peers are banned for duplicate requests (which are sent due to e.g. a network interruption) which causes them to fork and struggle to rejoin the network.

This should resolve #10794 as well, I believe.
