### PR TITLE
Child bounties comments

### DIFF
--- a/frame/bounties/README.md
+++ b/frame/bounties/README.md
@@ -2,28 +2,38 @@
 
 ## Bounty
 
-**Note :: This pallet is tightly coupled with pallet-treasury**
+> NOTE: This pallet is tightly coupled with pallet-treasury.
 
-A Bounty Spending is a reward for a specified body of work - or specified set of objectives - that
-needs to be executed for a predefined Treasury amount to be paid out. A curator is assigned after
-the bounty is approved and funded by Council, to be delegated with the responsibility of assigning a
-payout address once the specified set of objectives is completed.
+A Bounty Spending is a reward for a specified body of work - or specified set of objectives -
+that needs to be executed for a predefined Treasury amount to be paid out. A curator is assigned
+after the bounty is approved and funded by Council, to be delegated with the responsibility of
+assigning a payout address once the specified set of objectives is completed.
 
-After the Council has activated a bounty, it delegates the work that requires expertise to a curator
-in exchange of a deposit. Once the curator accepts the bounty, they get to close the active bounty.
-Closing the active bounty enacts a delayed payout to the payout address, the curator fee and the
-return of the curator deposit. The delay allows for intervention through regular democracy. The
-Council gets to unassign the curator, resulting in a new curator election. The Council also gets to
-cancel the bounty if deemed necessary before assigning a curator or once the bounty is active or
-payout is pending, resulting in the slash of the curator's deposit.
+After the Council has activated a bounty, it delegates the work that requires expertise to a
+curator in exchange of a deposit. Once the curator accepts the bounty, they get to close the
+active bounty. Closing the active bounty enacts a delayed payout to the payout address, the
+curator fee and the return of the curator deposit. The delay allows for intervention through
+regular democracy. The Council gets to unassign the curator, resulting in a new curator
+election. The Council also gets to cancel the bounty if deemed necessary before assigning a
+curator or once the bounty is active or payout is pending, resulting in the slash of the
+curator's deposit.
+
+This pallet may opt into using a [`ChildBountyManager`] that enables bounties to be split into
+sub-bounties, as children of anh established bounty (called the parent in the context of it's
+children).
+
+> NOTE: The parent bounty cannot be closed if it has a non-zero number of it has active child
+> bounties associated with it.
 
 ### Terminology
 
-- **Bounty spending proposal:** A proposal to reward a predefined body of work upon completion by
-  the Treasury.
+Bounty:
+
+- **Bounty spending proposal:** A proposal to reward a predefined body of work upon completion
+  by the Treasury.
 - **Proposer:** An account proposing a bounty spending.
-- **Curator:** An account managing the bounty and assigning a payout address receiving the reward
-  for the completion of work.
+- **Curator:** An account managing the bounty and assigning a payout address receiving the
+  reward for the completion of work.
 - **Deposit:** The amount held on deposit for placing a bounty proposal plus the amount held on
   deposit per byte within the bounty description.
 - **Curator deposit:** The payment from a candidate willing to curate an approved bounty. The
@@ -31,7 +41,8 @@ payout is pending, resulting in the slash of the curator's deposit.
 - **Bounty value:** The total amount that should be paid to the Payout Address if the bounty is
   rewarded.
 - **Payout address:** The account to which the total or part of the bounty is assigned to.
-- **Payout Delay:** The delay period for which a bounty beneficiary needs to wait before claiming.
+- **Payout Delay:** The delay period for which a bounty beneficiary needs to wait before
+  claiming.
 - **Curator fee:** The reserved upfront payment for a curator for work related to the bounty.
 
 ## Interface
@@ -39,6 +50,7 @@ payout is pending, resulting in the slash of the curator's deposit.
 ### Dispatchable Functions
 
 Bounty protocol:
+
 - `propose_bounty` - Propose a specific treasury amount to be earmarked for a predefined set of
   tasks and stake the required deposit.
 - `approve_bounty` - Accept a specific treasury amount to be earmarked for a predefined body of

--- a/frame/bounties/src/lib.rs
+++ b/frame/bounties/src/lib.rs
@@ -35,10 +35,17 @@
 //! curator or once the bounty is active or payout is pending, resulting in the slash of the
 //! curator's deposit.
 //!
+//! This pallet may opt into using a [`ChildBountyManager`] that enables bounties to be split into
+//! sub-bounties, as children of anh established bounty (called the parent in the context of it's
+//! children).
+//!
+//! > NOTE: The parent bounty cannot be closed if it has a non-zero number of it has active child
+//! > bounties associated with it.
 //!
 //! ### Terminology
 //!
 //! Bounty:
+//!
 //! - **Bounty spending proposal:** A proposal to reward a predefined body of work upon completion
 //!   by the Treasury.
 //! - **Proposer:** An account proposing a bounty spending.
@@ -60,6 +67,7 @@
 //! ### Dispatchable Functions
 //!
 //! Bounty protocol:
+//!
 //! - `propose_bounty` - Propose a specific treasury amount to be earmarked for a predefined set of
 //!   tasks and stake the required deposit.
 //! - `approve_bounty` - Accept a specific treasury amount to be earmarked for a predefined body of
@@ -165,9 +173,9 @@ pub enum BountyStatus<AccountId, BlockNumber> {
 	},
 }
 
-/// The child-bounty manager.
+/// The child bounty manager.
 pub trait ChildBountyManager<Balance> {
-	/// Get the active child-bounties for a parent bounty.
+	/// Get the active child bounties for a parent bounty.
 	fn child_bounties_count(bounty_id: BountyIndex) -> BountyIndex;
 
 	/// Get total curator fees of children-bounty curators.
@@ -221,7 +229,7 @@ pub mod pallet {
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 
-		/// The child-bounty manager.
+		/// The child bounty manager.
 		type ChildBountyManager: ChildBountyManager<BalanceOf<Self>>;
 	}
 
@@ -246,7 +254,7 @@ pub mod pallet {
 		PendingPayout,
 		/// The bounties cannot be claimed/closed because it's still in the countdown period.
 		Premature,
-		/// The bounty cannot be closed because it has active child-bounties.
+		/// The bounty cannot be closed because it has active child bounties.
 		HasActiveChildBounty,
 		/// Too many approvals are already queued.
 		TooManyQueued,
@@ -542,7 +550,7 @@ pub mod pallet {
 			Bounties::<T>::try_mutate_exists(bounty_id, |maybe_bounty| -> DispatchResult {
 				let mut bounty = maybe_bounty.as_mut().ok_or(Error::<T>::InvalidIndex)?;
 
-				// Ensure no active child-bounties before processing the call.
+				// Ensure no active child bounties before processing the call.
 				ensure!(
 					T::ChildBountyManager::child_bounties_count(bounty_id) == 0,
 					Error::<T>::HasActiveChildBounty
@@ -600,8 +608,8 @@ pub mod pallet {
 					let err_amount = T::Currency::unreserve(&curator, bounty.curator_deposit);
 					debug_assert!(err_amount.is_zero());
 
-					// Get total child-bounties curator fees, and subtract it from master curator
-					// fee.
+					// Get total child bounties curator fees, and subtract it from the parent
+					// curator fee (the fee in present referenced bounty, `self`).
 					let children_fee = T::ChildBountyManager::children_curator_fees(bounty_id);
 					debug_assert!(children_fee <= fee);
 
@@ -653,7 +661,7 @@ pub mod pallet {
 				|maybe_bounty| -> DispatchResultWithPostInfo {
 					let bounty = maybe_bounty.as_ref().ok_or(Error::<T>::InvalidIndex)?;
 
-					// Ensure no active child-bounties before processing the call.
+					// Ensure no active child bounties before processing the call.
 					ensure!(
 						T::ChildBountyManager::child_bounties_count(bounty_id) == 0,
 						Error::<T>::HasActiveChildBounty

--- a/frame/child-bounties/README.md
+++ b/frame/child-bounties/README.md
@@ -1,21 +1,29 @@
-# Child Bounties Pallet (pallet-child-bounties)
+# Child Bounties Pallet ( `pallet-child-bounties` )
 
 ## Child Bounty
 
-> NOTE: This pallet is tightly coupled with pallet-treasury and pallet-bounties.
+> NOTE: This pallet is tightly coupled with `pallet-treasury` and `pallet-bounties`.
 
-With child bounties, a large bounty proposal can be divided into smaller chunks, for parallel execution, and for efficient governance and tracking of spent funds.
-
-A child-bounty is a smaller piece of work, extracted from a parent bounty. A curator is assigned after the child-bounty is created by the parent bounty curator, to be delegated with the responsibility of assigning a payout address once the specified set of tasks is completed.
+With child bounties, a large bounty proposal can be divided into smaller chunks,
+for parallel execution, and for efficient governance and tracking of spent funds.
+A child bounty is a smaller piece of work, extracted from a parent bounty.
+A curator is assigned after the child bounty is created by the parent bounty curator,
+to be delegated with the responsibility of assigning a payout address once 
+the specified set of tasks is completed.
 
 ## Interface
 
 ### Dispatchable Functions
 
-- `add_child_bounty` - Add a child-bounty for a parent-bounty to for dividing the work in smaller tasks.
-- `propose_curator` - Assign an account to a child-bounty as candidate curator.
-- `accept_curator` - Accept a child-bounty assignment from the parent-bounty curator, setting a curator deposit.
+Child Bounty protocol:
+
+- `add_child_bounty` - Add a child bounty for a parent bounty to for dividing the work in
+  smaller tasks.
+- `propose_curator` - Assign an account to a child bounty as candidate curator.
+- `accept_curator` - Accept a child bounty assignment from the parent bounty curator,
+  setting a curator deposit.
 - `award_child_bounty` - Close and pay out the specified amount for the completed work.
-- `claim_child_bounty` - Claim a specific child-bounty amount from the payout address.
-- `unassign_curator` - Unassign an accepted curator from a specific child-bounty.
-- `close_child_bounty` - Cancel the child-bounty for a specific treasury amount and close the bounty.
+- `claim_child_bounty` - Claim a specific child bounty amount from the payout address.
+- `unassign_curator` - Unassign an accepted curator from a specific child bounty.
+- `close_child_bounty` - Cancel the child bounty for a specific treasury amount
+  and close the bounty.

--- a/frame/child-bounties/src/lib.rs
+++ b/frame/child-bounties/src/lib.rs
@@ -170,18 +170,18 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// A child-bounty is added.
-		Added { parent_index: BountyIndex, child_index: BountyIndex },
+		Added { index: BountyIndex, child_index: BountyIndex },
 		/// A child-bounty is awarded to a beneficiary.
-		Awarded { parent_index: BountyIndex, child_index: BountyIndex, beneficiary: T::AccountId },
+		Awarded { index: BountyIndex, child_index: BountyIndex, beneficiary: T::AccountId },
 		/// A child-bounty is claimed by beneficiary.
 		Claimed {
-			parent_index: BountyIndex,
+			index: BountyIndex,
 			child_index: BountyIndex,
 			payout: BalanceOf<T>,
 			beneficiary: T::AccountId,
 		},
 		/// A child-bounty is cancelled.
-		Canceled { parent_index: BountyIndex, child_index: BountyIndex },
+		Canceled { index: BountyIndex, child_index: BountyIndex },
 	}
 
 	/// Number of total child bounties.
@@ -614,7 +614,7 @@ pub mod pallet {
 
 			// Trigger the event Awarded.
 			Self::deposit_event(Event::<T>::Awarded {
-				parent_index: parent_bounty_id,
+				index: parent_bounty_id,
 				child_index: child_bounty_id,
 				beneficiary,
 			});
@@ -700,7 +700,7 @@ pub mod pallet {
 
 						// Trigger the Claimed event.
 						Self::deposit_event(Event::<T>::Claimed {
-							parent_index: parent_bounty_id,
+							index: parent_bounty_id,
 							child_index: child_bounty_id,
 							payout,
 							beneficiary: beneficiary.clone(),
@@ -794,7 +794,7 @@ impl<T: Config> Pallet<T> {
 		ChildBounties::<T>::insert(parent_bounty_id, child_bounty_id, &child_bounty);
 		ChildBountyDescriptions::<T>::insert(child_bounty_id, description);
 		Self::deposit_event(Event::Added {
-			parent_index: parent_bounty_id,
+			index: parent_bounty_id,
 			child_index: child_bounty_id,
 		});
 	}
@@ -870,7 +870,7 @@ impl<T: Config> Pallet<T> {
 				*maybe_child_bounty = None;
 
 				Self::deposit_event(Event::<T>::Canceled {
-					parent_index: parent_bounty_id,
+					index: parent_bounty_id,
 					child_index: child_bounty_id,
 				});
 				Ok(())

--- a/frame/child-bounties/src/lib.rs
+++ b/frame/child-bounties/src/lib.rs
@@ -793,10 +793,7 @@ impl<T: Config> Pallet<T> {
 		};
 		ChildBounties::<T>::insert(parent_bounty_id, child_bounty_id, &child_bounty);
 		ChildBountyDescriptions::<T>::insert(child_bounty_id, description);
-		Self::deposit_event(Event::Added {
-			index: parent_bounty_id,
-			child_index: child_bounty_id,
-		});
+		Self::deposit_event(Event::Added { index: parent_bounty_id, child_index: child_bounty_id });
 	}
 
 	fn ensure_bounty_active(

--- a/frame/child-bounties/src/lib.rs
+++ b/frame/child-bounties/src/lib.rs
@@ -170,18 +170,18 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// A child-bounty is added.
-		Added { index: BountyIndex, child_index: BountyIndex },
+		Added { parent_index: BountyIndex, child_index: BountyIndex },
 		/// A child-bounty is awarded to a beneficiary.
-		Awarded { index: BountyIndex, child_index: BountyIndex, beneficiary: T::AccountId },
+		Awarded { parent_index: BountyIndex, child_index: BountyIndex, beneficiary: T::AccountId },
 		/// A child-bounty is claimed by beneficiary.
 		Claimed {
-			index: BountyIndex,
+			parent_index: BountyIndex,
 			child_index: BountyIndex,
 			payout: BalanceOf<T>,
 			beneficiary: T::AccountId,
 		},
 		/// A child-bounty is cancelled.
-		Canceled { index: BountyIndex, child_index: BountyIndex },
+		Canceled { parent_index: BountyIndex, child_index: BountyIndex },
 	}
 
 	/// Number of total child bounties.
@@ -238,13 +238,13 @@ pub mod pallet {
 		/// If the call is success, the status of child-bounty is updated to
 		/// "Added".
 		///
-		/// - `bounty_id`: Index of parent bounty for which child-bounty is being added.
+		/// - `parent_bounty_id`: Index of parent bounty for which child-bounty is being added.
 		/// - `value`: Value for executing the proposal.
 		/// - `description`: Text description for the child-bounty.
 		#[pallet::weight(<T as Config>::WeightInfo::add_child_bounty(description.len() as u32))]
 		pub fn add_child_bounty(
 			origin: OriginFor<T>,
-			#[pallet::compact] bounty_id: BountyIndex,
+			#[pallet::compact] parent_bounty_id: BountyIndex,
 			#[pallet::compact] value: BalanceOf<T>,
 			description: Vec<u8>,
 		) -> DispatchResult {
@@ -255,17 +255,17 @@ pub mod pallet {
 				description.try_into().map_err(|_| BountiesError::<T>::ReasonTooBig)?;
 			ensure!(value >= T::ChildBountyValueMinimum::get(), BountiesError::<T>::InvalidValue);
 			ensure!(
-				Self::parent_child_bounties(bounty_id) <=
+				Self::parent_child_bounties(parent_bounty_id) <=
 					T::MaxActiveChildBountyCount::get() as u32,
 				Error::<T>::TooManyChildBounties,
 			);
 
-			let (curator, _) = Self::ensure_bounty_active(bounty_id)?;
+			let (curator, _) = Self::ensure_bounty_active(parent_bounty_id)?;
 			ensure!(signer == curator, BountiesError::<T>::RequireCurator);
 
 			// Read parent bounty account info.
 			let parent_bounty_account =
-				pallet_bounties::Pallet::<T>::bounty_account_id(bounty_id);
+				pallet_bounties::Pallet::<T>::bounty_account_id(parent_bounty_id);
 
 			// Ensure parent bounty has enough balance after adding child-bounty.
 			let bounty_balance = T::Currency::free_balance(&parent_bounty_account);
@@ -287,12 +287,12 @@ pub mod pallet {
 			T::Currency::transfer(&parent_bounty_account, &child_bounty_account, value, KeepAlive)?;
 
 			// Increment the active child-bounty count.
-			<ParentChildBounties<T>>::mutate(bounty_id, |count| count.saturating_inc());
+			<ParentChildBounties<T>>::mutate(parent_bounty_id, |count| count.saturating_inc());
 			<ChildBountyCount<T>>::put(child_bounty_id.saturating_add(1));
 
 			// Create child-bounty instance.
 			Self::create_child_bounty(
-				bounty_id,
+				parent_bounty_id,
 				child_bounty_id,
 				value,
 				bounded_description,
@@ -311,14 +311,14 @@ pub mod pallet {
 		/// state of child-bounty is moved to "CuratorProposed" on successful
 		/// call completion.
 		///
-		/// - `bounty_id`: Index of parent bounty.
+		/// - `parent_bounty_id`: Index of parent bounty.
 		/// - `child_bounty_id`: Index of child bounty.
 		/// - `curator`: Address of child-bounty curator.
 		/// - `fee`: payment fee to child-bounty curator for execution.
 		#[pallet::weight(<T as Config>::WeightInfo::propose_curator())]
 		pub fn propose_curator(
 			origin: OriginFor<T>,
-			#[pallet::compact] bounty_id: BountyIndex,
+			#[pallet::compact] parent_bounty_id: BountyIndex,
 			#[pallet::compact] child_bounty_id: BountyIndex,
 			curator: <T::Lookup as StaticLookup>::Source,
 			#[pallet::compact] fee: BalanceOf<T>,
@@ -326,12 +326,12 @@ pub mod pallet {
 			let signer = ensure_signed(origin)?;
 			let child_bounty_curator = T::Lookup::lookup(curator)?;
 
-			let (curator, _) = Self::ensure_bounty_active(bounty_id)?;
+			let (curator, _) = Self::ensure_bounty_active(parent_bounty_id)?;
 			ensure!(signer == curator, BountiesError::<T>::RequireCurator);
 
 			// Mutate the child-bounty instance.
 			ChildBounties::<T>::try_mutate_exists(
-				bounty_id,
+				parent_bounty_id,
 				child_bounty_id,
 				|maybe_child_bounty| -> DispatchResult {
 					let mut child_bounty =
@@ -349,7 +349,7 @@ pub mod pallet {
 					// Add child-bounty curator fee to the cumulative sum. To be
 					// subtracted from the parent bounty curator when claiming
 					// bounty.
-					ChildrenCuratorFees::<T>::mutate(bounty_id, |value| {
+					ChildrenCuratorFees::<T>::mutate(parent_bounty_id, |value| {
 						*value = value.saturating_add(fee)
 					});
 
@@ -382,20 +382,20 @@ pub mod pallet {
 		/// call. And state of child-bounty is moved to "Active" on successful
 		/// call completion.
 		///
-		/// - `bounty_id`: Index of parent bounty.
+		/// - `parent_bounty_id`: Index of parent bounty.
 		/// - `child_bounty_id`: Index of child bounty.
 		#[pallet::weight(<T as Config>::WeightInfo::accept_curator())]
 		pub fn accept_curator(
 			origin: OriginFor<T>,
-			#[pallet::compact] bounty_id: BountyIndex,
+			#[pallet::compact] parent_bounty_id: BountyIndex,
 			#[pallet::compact] child_bounty_id: BountyIndex,
 		) -> DispatchResult {
 			let signer = ensure_signed(origin)?;
 
-			let _ = Self::ensure_bounty_active(bounty_id)?;
+			let _ = Self::ensure_bounty_active(parent_bounty_id)?;
 			// Mutate child-bounty.
 			ChildBounties::<T>::try_mutate_exists(
-				bounty_id,
+				parent_bounty_id,
 				child_bounty_id,
 				|maybe_child_bounty| -> DispatchResult {
 					let mut child_bounty =
@@ -456,12 +456,12 @@ pub mod pallet {
 		/// State of child-bounty is moved to Added state on successful call
 		/// completion.
 		///
-		/// - `bounty_id`: Index of parent bounty.
+		/// - `parent_bounty_id`: Index of parent bounty.
 		/// - `child_bounty_id`: Index of child bounty.
 		#[pallet::weight(<T as Config>::WeightInfo::unassign_curator())]
 		pub fn unassign_curator(
 			origin: OriginFor<T>,
-			#[pallet::compact] bounty_id: BountyIndex,
+			#[pallet::compact] parent_bounty_id: BountyIndex,
 			#[pallet::compact] child_bounty_id: BountyIndex,
 		) -> DispatchResult {
 			let maybe_sender = ensure_signed(origin.clone())
@@ -469,7 +469,7 @@ pub mod pallet {
 				.or_else(|_| T::RejectOrigin::ensure_origin(origin).map(|_| None))?;
 
 			ChildBounties::<T>::try_mutate_exists(
-				bounty_id,
+				parent_bounty_id,
 				child_bounty_id,
 				|maybe_child_bounty| -> DispatchResult {
 					let mut child_bounty =
@@ -494,7 +494,7 @@ pub mod pallet {
 							ensure!(
 								maybe_sender.map_or(true, |sender| {
 									sender == *curator ||
-										Self::ensure_bounty_active(bounty_id)
+										Self::ensure_bounty_active(parent_bounty_id)
 											.map_or(false, |(parent_curator, _)| {
 												sender == parent_curator
 											})
@@ -522,7 +522,7 @@ pub mod pallet {
 								},
 								Some(sender) => {
 									let (parent_curator, update_due) =
-										Self::ensure_bounty_active(bounty_id)?;
+										Self::ensure_bounty_active(parent_bounty_id)?;
 									if sender == parent_curator ||
 										update_due < frame_system::Pallet::<T>::block_number()
 									{
@@ -539,7 +539,7 @@ pub mod pallet {
 							}
 						},
 						ChildBountyStatus::PendingPayout { ref curator, .. } => {
-							let (parent_curator, _) = Self::ensure_bounty_active(bounty_id)?;
+							let (parent_curator, _) = Self::ensure_bounty_active(parent_bounty_id)?;
 							ensure!(
 								maybe_sender.map_or(true, |sender| parent_curator == sender),
 								BadOrigin,
@@ -569,13 +569,13 @@ pub mod pallet {
 		/// state of child-bounty is moved to "PendingPayout" on successful call
 		/// completion.
 		///
-		/// - `bounty_id`: Index of parent bounty.
+		/// - `parent_bounty_id`: Index of parent bounty.
 		/// - `child_bounty_id`: Index of child bounty.
 		/// - `beneficiary`: Beneficiary account.
 		#[pallet::weight(<T as Config>::WeightInfo::award_child_bounty())]
 		pub fn award_child_bounty(
 			origin: OriginFor<T>,
-			#[pallet::compact] bounty_id: BountyIndex,
+			#[pallet::compact] parent_bounty_id: BountyIndex,
 			#[pallet::compact] child_bounty_id: BountyIndex,
 			beneficiary: <T::Lookup as StaticLookup>::Source,
 		) -> DispatchResult {
@@ -583,10 +583,10 @@ pub mod pallet {
 			let beneficiary = T::Lookup::lookup(beneficiary)?;
 
 			// Ensure parent bounty exists, and is active.
-			let (parent_curator, _) = Self::ensure_bounty_active(bounty_id)?;
+			let (parent_curator, _) = Self::ensure_bounty_active(parent_bounty_id)?;
 
 			ChildBounties::<T>::try_mutate_exists(
-				bounty_id,
+				parent_bounty_id,
 				child_bounty_id,
 				|maybe_child_bounty| -> DispatchResult {
 					let mut child_bounty =
@@ -614,7 +614,7 @@ pub mod pallet {
 
 			// Trigger the event Awarded.
 			Self::deposit_event(Event::<T>::Awarded {
-				index: bounty_id,
+				parent_index: parent_bounty_id,
 				child_index: child_bounty_id,
 				beneficiary,
 			});
@@ -636,19 +636,19 @@ pub mod pallet {
 		/// call. And instance of child-bounty is removed from the state on
 		/// successful call completion.
 		///
-		/// - `bounty_id`: Index of parent bounty.
+		/// - `parent_bounty_id`: Index of parent bounty.
 		/// - `child_bounty_id`: Index of child bounty.
 		#[pallet::weight(<T as Config>::WeightInfo::claim_child_bounty())]
 		pub fn claim_child_bounty(
 			origin: OriginFor<T>,
-			#[pallet::compact] bounty_id: BountyIndex,
+			#[pallet::compact] parent_bounty_id: BountyIndex,
 			#[pallet::compact] child_bounty_id: BountyIndex,
 		) -> DispatchResult {
 			let _ = ensure_signed(origin)?;
 
 			// Ensure child-bounty is in expected state.
 			ChildBounties::<T>::try_mutate_exists(
-				bounty_id,
+				parent_bounty_id,
 				child_bounty_id,
 				|maybe_child_bounty| -> DispatchResult {
 					let child_bounty =
@@ -700,14 +700,14 @@ pub mod pallet {
 
 						// Trigger the Claimed event.
 						Self::deposit_event(Event::<T>::Claimed {
-							index: bounty_id,
+							parent_index: parent_bounty_id,
 							child_index: child_bounty_id,
 							payout,
 							beneficiary: beneficiary.clone(),
 						});
 
 						// Update the active child-bounty tracking count.
-						<ParentChildBounties<T>>::mutate(bounty_id, |count| {
+						<ParentChildBounties<T>>::mutate(parent_bounty_id, |count| {
 							count.saturating_dec()
 						});
 
@@ -745,13 +745,13 @@ pub mod pallet {
 		/// Instance of child-bounty is removed from the state on successful
 		/// call completion.
 		///
-		/// - `bounty_id`: Index of parent bounty.
+		/// - `parent_bounty_id`: Index of parent bounty.
 		/// - `child_bounty_id`: Index of child bounty.
 		#[pallet::weight(<T as Config>::WeightInfo::close_child_bounty_added()
 			.max(<T as Config>::WeightInfo::close_child_bounty_active()))]
 		pub fn close_child_bounty(
 			origin: OriginFor<T>,
-			#[pallet::compact] bounty_id: BountyIndex,
+			#[pallet::compact] parent_bounty_id: BountyIndex,
 			#[pallet::compact] child_bounty_id: BountyIndex,
 		) -> DispatchResult {
 			let maybe_sender = ensure_signed(origin.clone())
@@ -759,11 +759,11 @@ pub mod pallet {
 				.or_else(|_| T::RejectOrigin::ensure_origin(origin).map(|_| None))?;
 
 			// Ensure parent bounty exist, get parent curator.
-			let (parent_curator, _) = Self::ensure_bounty_active(bounty_id)?;
+			let (parent_curator, _) = Self::ensure_bounty_active(parent_bounty_id)?;
 
 			ensure!(maybe_sender.map_or(true, |sender| parent_curator == sender), BadOrigin);
 
-			Self::impl_close_child_bounty(bounty_id, child_bounty_id)?;
+			Self::impl_close_child_bounty(parent_bounty_id, child_bounty_id)?;
 			Ok(())
 		}
 	}
@@ -779,30 +779,30 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn create_child_bounty(
-		bounty_id: BountyIndex,
+		parent_bounty_id: BountyIndex,
 		child_bounty_id: BountyIndex,
 		child_bounty_value: BalanceOf<T>,
 		description: BoundedVec<u8, T::MaximumReasonLength>,
 	) {
 		let child_bounty = ChildBounty {
-			parent_bounty: bounty_id,
+			parent_bounty: parent_bounty_id,
 			value: child_bounty_value,
 			fee: 0u32.into(),
 			curator_deposit: 0u32.into(),
 			status: ChildBountyStatus::Added,
 		};
-		ChildBounties::<T>::insert(bounty_id, child_bounty_id, &child_bounty);
+		ChildBounties::<T>::insert(parent_bounty_id, child_bounty_id, &child_bounty);
 		ChildBountyDescriptions::<T>::insert(child_bounty_id, description);
 		Self::deposit_event(Event::Added {
-			index: bounty_id,
+			parent_index: parent_bounty_id,
 			child_index: child_bounty_id,
 		});
 	}
 
 	fn ensure_bounty_active(
-		bounty_id: BountyIndex,
+		parent_bounty_id: BountyIndex,
 	) -> Result<(T::AccountId, T::BlockNumber), DispatchError> {
-		let parent_bounty = pallet_bounties::Pallet::<T>::bounties(bounty_id)
+		let parent_bounty = pallet_bounties::Pallet::<T>::bounties(parent_bounty_id)
 			.ok_or(BountiesError::<T>::InvalidIndex)?;
 		if let BountyStatus::Active { curator, update_due } = parent_bounty.get_status() {
 			Ok((curator, update_due))
@@ -812,11 +812,11 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn impl_close_child_bounty(
-		bounty_id: BountyIndex,
+		parent_bounty_id: BountyIndex,
 		child_bounty_id: BountyIndex,
 	) -> DispatchResult {
 		ChildBounties::<T>::try_mutate_exists(
-			bounty_id,
+			parent_bounty_id,
 			child_bounty_id,
 			|maybe_child_bounty| -> DispatchResult {
 				let child_bounty =
@@ -844,16 +844,16 @@ impl<T: Config> Pallet<T> {
 
 				// Revert the curator fee back to parent bounty curator &
 				// reduce the active child-bounty count.
-				ChildrenCuratorFees::<T>::mutate(bounty_id, |value| {
+				ChildrenCuratorFees::<T>::mutate(parent_bounty_id, |value| {
 					*value = value.saturating_sub(child_bounty.fee)
 				});
-				<ParentChildBounties<T>>::mutate(bounty_id, |count| {
+				<ParentChildBounties<T>>::mutate(parent_bounty_id, |count| {
 					*count = count.saturating_sub(1)
 				});
 
 				// Transfer fund from child-bounty to parent bounty.
 				let parent_bounty_account =
-					pallet_bounties::Pallet::<T>::bounty_account_id(bounty_id);
+					pallet_bounties::Pallet::<T>::bounty_account_id(parent_bounty_id);
 				let child_bounty_account = Self::child_bounty_account_id(child_bounty_id);
 				let balance = T::Currency::free_balance(&child_bounty_account);
 				let transfer_result = T::Currency::transfer(
@@ -870,7 +870,7 @@ impl<T: Config> Pallet<T> {
 				*maybe_child_bounty = None;
 
 				Self::deposit_event(Event::<T>::Canceled {
-					index: bounty_id,
+					parent_index: parent_bounty_id,
 					child_index: child_bounty_id,
 				});
 				Ok(())

--- a/frame/child-bounties/src/lib.rs
+++ b/frame/child-bounties/src/lib.rs
@@ -15,16 +15,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! # Child Bounties Pallet ( pallet-child-bounties )
+//! # Child Bounties Pallet ( `pallet-child-bounties` )
 //!
 //! ## Child Bounty
 //!
-//! > NOTE: This pallet is tightly coupled with pallet-treasury and pallet-bounties.
+//! > NOTE: This pallet is tightly coupled with `pallet-treasury` and `pallet-bounties`.
 //!
 //! With child bounties, a large bounty proposal can be divided into smaller chunks,
 //! for parallel execution, and for efficient governance and tracking of spent funds.
-//! A child-bounty is a smaller piece of work, extracted from a parent bounty.
-//! A curator is assigned after the child-bounty is created by the parent bounty curator,
+//! A child bounty is a smaller piece of work, extracted from a parent bounty.
+//! A curator is assigned after the child bounty is created by the parent bounty curator,
 //! to be delegated with the responsibility of assigning a payout address once the specified
 //! set of tasks is completed.
 //!
@@ -33,22 +33,22 @@
 //! ### Dispatchable Functions
 //!
 //! Child Bounty protocol:
-//! - `add_child_bounty` - Add a child-bounty for a parent-bounty to for dividing the work in
+//! - `add_child_bounty` - Add a child bounty for a parent bounty to for dividing the work in
 //!   smaller tasks.
-//! - `propose_curator` - Assign an account to a child-bounty as candidate curator.
-//! - `accept_curator` - Accept a child-bounty assignment from the parent-bounty curator, setting a
+//! - `propose_curator` - Assign an account to a child bounty as candidate curator.
+//! - `accept_curator` - Accept a child bounty assignment from the parent bounty curator, setting a
 //!   curator deposit.
 //! - `award_child_bounty` - Close and pay out the specified amount for the completed work.
-//! - `claim_child_bounty` - Claim a specific child-bounty amount from the payout address.
-//! - `unassign_curator` - Unassign an accepted curator from a specific child-bounty.
-//! - `close_child_bounty` - Cancel the child-bounty for a specific treasury amount and close the
+//! - `claim_child_bounty` - Claim a specific child bounty amount from the payout address.
+//! - `unassign_curator` - Unassign an accepted curator from a specific child bounty.
+//! - `close_child_bounty` - Cancel the child bounty for a specific treasury amount and close the
 //!   bounty.
 
 // Most of the business logic in this pallet has been
 // originally contributed by "https://github.com/shamb0",
 // as part of the PR - https://github.com/paritytech/substrate/pull/7965.
 // The code has been moved here and then refactored in order to
-// extract child-bounties as a separate pallet.
+// extract child bounties as a separate pallet.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -101,7 +101,7 @@ pub struct ChildBounty<AccountId, Balance, BlockNumber> {
 pub enum ChildBountyStatus<AccountId, BlockNumber> {
 	/// The child-bounty is added and waiting for curator assignment.
 	Added,
-	/// A curator has been proposed by the parent-bounty curator. Waiting for
+	/// A curator has been proposed by the parent bounty curator. Waiting for
 	/// acceptance from the child-bounty curator.
 	CuratorProposed {
 		/// The assigned child-bounty curator of this bounty.
@@ -136,7 +136,7 @@ pub mod pallet {
 	pub trait Config:
 		frame_system::Config + pallet_treasury::Config + pallet_bounties::Config
 	{
-		/// Maximum number of child-bounties that can be added to a parent bounty.
+		/// Maximum number of child bounties that can be added to a parent bounty.
 		#[pallet::constant]
 		type MaxActiveChildBountyCount: Get<u32>;
 
@@ -162,7 +162,7 @@ pub mod pallet {
 		ParentBountyNotActive,
 		/// The bounty balance is not enough to add new child-bounty.
 		InsufficientBountyBalance,
-		/// Number of child-bounties exceeds limit `MaxActiveChildBountyCount`.
+		/// Number of child bounties exceeds limit `MaxActiveChildBountyCount`.
 		TooManyChildBounties,
 	}
 
@@ -170,18 +170,18 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// A child-bounty is added.
-		Added { index: BountyIndex, child_index: BountyIndex },
+		Added { parent_index: BountyIndex, child_index: BountyIndex },
 		/// A child-bounty is awarded to a beneficiary.
-		Awarded { index: BountyIndex, child_index: BountyIndex, beneficiary: T::AccountId },
+		Awarded { parent_index: BountyIndex, child_index: BountyIndex, beneficiary: T::AccountId },
 		/// A child-bounty is claimed by beneficiary.
 		Claimed {
-			index: BountyIndex,
+			parent_index: BountyIndex,
 			child_index: BountyIndex,
 			payout: BalanceOf<T>,
 			beneficiary: T::AccountId,
 		},
 		/// A child-bounty is cancelled.
-		Canceled { index: BountyIndex, child_index: BountyIndex },
+		Canceled { parent_index: BountyIndex, child_index: BountyIndex },
 	}
 
 	/// Number of total child bounties.
@@ -189,14 +189,14 @@ pub mod pallet {
 	#[pallet::getter(fn child_bounty_count)]
 	pub type ChildBountyCount<T: Config> = StorageValue<_, BountyIndex, ValueQuery>;
 
-	/// Number of child-bounties per parent bounty.
+	/// Number of child bounties per parent bounty.
 	/// Map of parent bounty index to number of child bounties.
 	#[pallet::storage]
 	#[pallet::getter(fn parent_child_bounties)]
 	pub type ParentChildBounties<T: Config> =
 		StorageMap<_, Twox64Concat, BountyIndex, u32, ValueQuery>;
 
-	/// Child-bounties that have been added.
+	/// child bounties that have been added.
 	#[pallet::storage]
 	#[pallet::getter(fn child_bounties)]
 	pub type ChildBounties<T: Config> = StorageDoubleMap<
@@ -231,7 +231,7 @@ pub mod pallet {
 		/// parent bounty to child-bounty account, if parent bounty has enough
 		/// funds, else the call fails.
 		///
-		/// Upper bound to maximum number of active  child-bounties that can be
+		/// Upper bound to maximum number of active  child bounties that can be
 		/// added are managed via runtime trait config
 		/// [`Config::MaxActiveChildBountyCount`].
 		///
@@ -430,12 +430,12 @@ pub mod pallet {
 		/// the curator of the parent bounty, or any signed origin.
 		///
 		/// For the origin other than T::RejectOrigin and the child-bounty
-		/// curator, parent-bounty must be in active state, for this call to
+		/// curator, parent bounty must be in active state, for this call to
 		/// work. We allow child-bounty curator and T::RejectOrigin to execute
-		/// this call irrespective of the parent-bounty state.
+		/// this call irrespective of the parent bounty state.
 		///
 		/// If this function is called by the `RejectOrigin` or the
-		/// parent-bounty curator, we assume that the child-bounty curator is
+		/// parent bounty curator, we assume that the child-bounty curator is
 		/// malicious or inactive. As a result, child-bounty curator deposit is
 		/// slashed.
 		///
@@ -489,7 +489,7 @@ pub mod pallet {
 						},
 						ChildBountyStatus::CuratorProposed { ref curator } => {
 							// A child-bounty curator has been proposed, but not accepted yet.
-							// Either `RejectOrigin`, parent-bounty curator or the proposed
+							// Either `RejectOrigin`, parent bounty curator or the proposed
 							// child-bounty curator can unassign the child-bounty curator.
 							ensure!(
 								maybe_sender.map_or(true, |sender| {
@@ -527,7 +527,7 @@ pub mod pallet {
 										update_due < frame_system::Pallet::<T>::block_number()
 									{
 										// Slash the child-bounty curator if
-										// + the call is made by the parent-bounty curator.
+										// + the call is made by the parent bounty curator.
 										// + or the curator is inactive.
 										slash_curator(curator, &mut child_bounty.curator_deposit);
 									// Continue to change bounty status below.
@@ -559,7 +559,7 @@ pub mod pallet {
 		///
 		/// The beneficiary will be able to claim the funds after a delay.
 		///
-		/// The dispatch origin for this call must be the master curator or
+		/// The dispatch origin for this call must be the parent curator or
 		/// curator of this child-bounty.
 		///
 		/// Parent bounty must be in active state, for this child-bounty call to
@@ -614,7 +614,7 @@ pub mod pallet {
 
 			// Trigger the event Awarded.
 			Self::deposit_event(Event::<T>::Awarded {
-				index: parent_bounty_id,
+				parent_index: parent_bounty_id,
 				child_index: child_bounty_id,
 				beneficiary,
 			});
@@ -700,7 +700,7 @@ pub mod pallet {
 
 						// Trigger the Claimed event.
 						Self::deposit_event(Event::<T>::Claimed {
-							index: parent_bounty_id,
+							parent_index: parent_bounty_id,
 							child_index: child_bounty_id,
 							payout,
 							beneficiary: beneficiary.clone(),
@@ -793,13 +793,16 @@ impl<T: Config> Pallet<T> {
 		};
 		ChildBounties::<T>::insert(parent_bounty_id, child_bounty_id, &child_bounty);
 		ChildBountyDescriptions::<T>::insert(child_bounty_id, description);
-		Self::deposit_event(Event::Added { index: parent_bounty_id, child_index: child_bounty_id });
+		Self::deposit_event(Event::Added {
+			parent_index: parent_bounty_id,
+			child_index: child_bounty_id,
+		});
 	}
 
 	fn ensure_bounty_active(
-		bounty_id: BountyIndex,
+		parent_bounty_id: BountyIndex,
 	) -> Result<(T::AccountId, T::BlockNumber), DispatchError> {
-		let parent_bounty = pallet_bounties::Pallet::<T>::bounties(bounty_id)
+		let parent_bounty = pallet_bounties::Pallet::<T>::bounties(parent_bounty_id)
 			.ok_or(BountiesError::<T>::InvalidIndex)?;
 		if let BountyStatus::Active { curator, update_due } = parent_bounty.get_status() {
 			Ok((curator, update_due))
@@ -824,7 +827,7 @@ impl<T: Config> Pallet<T> {
 						// Nothing extra to do besides the removal of the child-bounty below.
 					},
 					ChildBountyStatus::Active { curator } => {
-						// Cancelled by master curator or RejectOrigin,
+						// Cancelled by parent curator or RejectOrigin,
 						// refund deposit of the working child-bounty curator.
 						let _ = T::Currency::unreserve(curator, child_bounty.curator_deposit);
 						// Then execute removal of the child-bounty below.
@@ -839,7 +842,7 @@ impl<T: Config> Pallet<T> {
 					},
 				}
 
-				// Revert the curator fee back to parent-bounty curator &
+				// Revert the curator fee back to parent bounty curator &
 				// reduce the active child-bounty count.
 				ChildrenCuratorFees::<T>::mutate(parent_bounty_id, |value| {
 					*value = value.saturating_sub(child_bounty.fee)
@@ -867,7 +870,7 @@ impl<T: Config> Pallet<T> {
 				*maybe_child_bounty = None;
 
 				Self::deposit_event(Event::<T>::Canceled {
-					index: parent_bounty_id,
+					parent_index: parent_bounty_id,
 					child_index: child_bounty_id,
 				});
 				Ok(())
@@ -877,7 +880,7 @@ impl<T: Config> Pallet<T> {
 }
 
 // Implement ChildBountyManager to connect with the bounties pallet. This is
-// where we pass the active child-bounties and child curator fees to the parent
+// where we pass the active child bounties and child curator fees to the parent
 // bounty.
 impl<T: Config> pallet_bounties::ChildBountyManager<BalanceOf<T>> for Pallet<T> {
 	fn child_bounties_count(

--- a/frame/child-bounties/src/lib.rs
+++ b/frame/child-bounties/src/lib.rs
@@ -196,7 +196,7 @@ pub mod pallet {
 	pub type ParentChildBounties<T: Config> =
 		StorageMap<_, Twox64Concat, BountyIndex, u32, ValueQuery>;
 
-	/// child bounties that have been added.
+	/// Child bounties that have been added.
 	#[pallet::storage]
 	#[pallet::getter(fn child_bounties)]
 	pub type ChildBounties<T: Config> = StorageDoubleMap<
@@ -797,9 +797,9 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn ensure_bounty_active(
-		parent_bounty_id: BountyIndex,
+		bounty_id: BountyIndex,
 	) -> Result<(T::AccountId, T::BlockNumber), DispatchError> {
-		let parent_bounty = pallet_bounties::Pallet::<T>::bounties(parent_bounty_id)
+		let parent_bounty = pallet_bounties::Pallet::<T>::bounties(bounty_id)
 			.ok_or(BountiesError::<T>::InvalidIndex)?;
 		if let BountyStatus::Active { curator, update_due } = parent_bounty.get_status() {
 			Ok((curator, update_due))


### PR DESCRIPTION
Only comment changes, no logic impacted.

* Use uniform notion of parent and child, no "master" or "general" entity referenced.
* README updated to match comments.