### PR TITLE
Use Lowercase

### DIFF
--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -619,7 +619,7 @@ pub(crate) async fn ensure_matching_spec<Block: BlockT + serde::de::DeserializeO
 	{
 		Ok((name, version)) => {
 			// first, deal with spec name
-			if expected_spec_name == name {
+			if expected_spec_name.to_lowercase() == name {
 				log::info!(target: LOG_TARGET, "found matching spec name: {:?}", name);
 			} else {
 				let msg = format!(


### PR DESCRIPTION
```rust
	.map(|(spec_name, spec_version)| (spec_name.to_lowercase(), spec_version))
{
	Ok((name, version)) => {
		// first, deal with spec name
		if expected_spec_name == name {
		if expected_spec_name.to_lowercase() == name {
```

If we turn the `spec_name` into lowercase. We should also make `expected_spec_name` lowercase. 
Our network's `spec_name` is uppercase. So the try runtime always fails here.

cc @kianenigma 