### PR TITLE
Add github issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -27,7 +27,7 @@ body:
   - type: textarea
     id: steps
     attributes:
-      label: Steps to Reproduce
+      label: Steps to reproduce
       description: Provide the steps that led to the discovery of the issue.
       # placeholder: Describe what you were doing so we can reproduce the problem.
     validations:

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,34 @@
+name: Bug Report
+description: Let us know about an issue you experienced with this software
+# labels: ["some existing label","another one"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue?
+      description: Please search to see if an issue already exists and leave a comment that you also experienced this issue or add your specifics that are related to an existing issue.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Experiencing problems? Have you tried our Stack Exchange first?
+      description: Please search <https://substrate.stackexchange.com> to see if an post already exists, and ask if not. Please do not file support issues here.
+      options:
+        - label: This is not a support question.
+          required: true
+  - type: textarea
+    id: bug
+    attributes:
+      label: Description of bug
+      # description: What seems to be the problem?
+      # placeholder: Describe the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Provide the steps that led to the discovery of the issue.
+      # placeholder: Describe what you were doing so we can reproduce the problem.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Support & Troubleshooting with the Substrate Stack Exchange Community
+    url: https://substrate.stackexchange.com
+    about: |
+      For general problems with Substrate or related technologies, please search here first
+      for solutions, by keyword and tags. If you discover no solution, please then ask and questions in our community! We highly encourage everyone also share their understanding by answering questions for others.

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,52 @@
+name: Feature Request
+description: Submit your requests and suggestions to improve!
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue?
+      description: Please search to see if an issue already exists and leave a comment that you also experienced this issue or add your specifics that are related to an existing issue.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Experiencing problems? Have you tried our Stack Exchange first?
+      description: Please search <https://substrate.stackexchange.com> to see if an post already exists, and ask if not. Please do not file support issues here.
+      options:
+        - label: This is not a support question.
+          required: true
+  - type: textarea
+    id: content
+    attributes:
+      label: Motivation
+      description: Please give precedence as to what lead you to file this issue.
+      # placeholder: Describe ...
+    validations:
+      required: false
+  - type: textarea
+    id: content
+    attributes:
+      label: Request
+      description: Please describe what is needed.
+      # placeholder: Describe what you would like to see added or changed.
+    validations:
+      required: true
+  - type: textarea
+    id: content
+    attributes:
+      label: Solution
+      description: If possible, please describe what a solution could be.
+      # placeholder: Describe what you would like to see added or changed.
+    validations:
+      required: false
+  - type: dropdown
+    id: help
+    attributes:
+      label: Are you willing to help with this request?
+      multiple: true
+      options:
+        - Yes!
+        - No.
+        - Maybe (please elaborate above)
+    validations:
+      required: true


### PR DESCRIPTION
This introduces [template forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms), with a very strong call to action to use our stack exchange over filing issues for support. This can beset be experienced before a merge at the docs issues:

https://github.com/substrate-developer-hub/substrate-docs/issues/new/choose

![image](https://user-images.githubusercontent.com/35669742/158947406-76fd1bd0-a7ed-48d5-9bc0-76debcf32176.png)

All buttons lead to open a issue that has this to begin with:

![image](https://user-images.githubusercontent.com/35669742/158947183-55383f9c-506a-4160-a5d9-ddd0ffb7c1d3.png)

---

If users want to bypass using the issue forms and get the typical empty text entry area they only need to hit the bottom left "open a blank issue" link (a bit hidden)

![image](https://user-images.githubusercontent.com/35669742/158947514-eab2ee10-9576-4981-8b9c-7b4ab205c949.png)
