### PR TITLE
Don't return the same block twice in ancestor binary search

### DIFF
--- a/client/network/src/protocol/sync.rs
+++ b/client/network/src/protocol/sync.rs
@@ -3242,4 +3242,9 @@ mod test {
 		sync.on_block_data(&peer_id1, Some(request), response).unwrap();
 		assert_eq!(sync.best_queued_number, 4);
 	}
+	#[test]
+	fn ancestor_search_repeat() {
+		let state = AncestorSearchState::<Block>::BinarySearch(1, 3);
+		assert!(handle_ancestor_search_state(&state, 2, true).is_none());
+	}
 }

--- a/client/network/src/protocol/sync.rs
+++ b/client/network/src/protocol/sync.rs
@@ -2320,7 +2320,11 @@ fn handle_ancestor_search_state<B: BlockT>(
 			}
 			assert!(right >= left);
 			let middle = left + (right - left) / two;
-			Some((AncestorSearchState::BinarySearch(left, right), middle))
+			if middle == curr_block_num {
+				None
+			} else {
+				Some((AncestorSearchState::BinarySearch(left, right), middle))
+			}
 		},
 	}
 }


### PR DESCRIPTION
This PR fixes a bug in ancestor search where we could return the same block to search for two steps in a row. 

During the binary search portion of ancestor search, from the state
```
current = 2, left = 1, right = 3, block_hash_match = true
```
we would return `2` as the next block to search, leading to a duplicate block request.

Related #10794.
