### PR TITLE
pallet-macro: Ensure that building with `missing_docs` works

### DIFF
--- a/frame/support/procedural/src/pallet/expand/call.rs
+++ b/frame/support/procedural/src/pallet/expand/call.rs
@@ -178,7 +178,10 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 			#(
 				#( #[doc = #fn_doc] )*
 				#fn_name {
-					#( #args_compact_attr #args_name_stripped: #args_type ),*
+					#(
+						#[allow(missing_docs)]
+						#args_compact_attr #args_name_stripped: #args_type
+					),*
 				},
 			)*
 		}

--- a/frame/support/procedural/src/pallet/expand/error.rs
+++ b/frame/support/procedural/src/pallet/expand/error.rs
@@ -90,6 +90,7 @@ pub fn expand_error(def: &mut Def) -> proc_macro2::TokenStream {
 		}
 
 		impl<#type_impl_gen> #error_ident<#type_use_gen> #config_where_clause {
+			#[doc(hidden)]
 			pub fn as_u8(&self) -> u8 {
 				match &self {
 					Self::__Ignore(_, _) => unreachable!("`__Ignore` can never be constructed"),
@@ -97,6 +98,7 @@ pub fn expand_error(def: &mut Def) -> proc_macro2::TokenStream {
 				}
 			}
 
+			#[doc(hidden)]
 			pub fn as_str(&self) -> &'static str {
 				match &self {
 					Self::__Ignore(_, _) => unreachable!("`__Ignore` can never be constructed"),

--- a/frame/support/procedural/src/pallet/expand/pallet_struct.rs
+++ b/frame/support/procedural/src/pallet/expand/pallet_struct.rs
@@ -81,6 +81,7 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 		let error_ident = &error_def.error;
 		quote::quote_spanned!(def.pallet_struct.attr_span =>
 			impl<#type_impl_gen> #pallet_ident<#type_use_gen> #config_where_clause {
+				#[doc(hidden)]
 				pub fn error_metadata() -> Option<#frame_support::metadata::PalletErrorMetadata> {
 					Some(#frame_support::metadata::PalletErrorMetadata {
 						ty: #frame_support::scale_info::meta_type::<#error_ident<#type_use_gen>>()
@@ -91,6 +92,7 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 	} else {
 		quote::quote_spanned!(def.pallet_struct.attr_span =>
 			impl<#type_impl_gen> #pallet_ident<#type_use_gen> #config_where_clause {
+				#[doc(hidden)]
 				pub fn error_metadata() -> Option<#frame_support::metadata::PalletErrorMetadata> {
 					None
 				}

--- a/frame/support/procedural/src/pallet/expand/storage.rs
+++ b/frame/support/procedural/src/pallet/expand/storage.rs
@@ -406,6 +406,7 @@ pub fn expand_storages(def: &mut Def) -> proc_macro2::TokenStream {
 
 			quote::quote_spanned!(storage_def.attr_span =>
 				#(#cfg_attrs)*
+				#[doc(hidden)]
 				#prefix_struct_vis struct #counter_prefix_struct_ident<#type_use_gen>(
 					core::marker::PhantomData<(#type_use_gen,)>
 				);
@@ -439,6 +440,7 @@ pub fn expand_storages(def: &mut Def) -> proc_macro2::TokenStream {
 			#maybe_counter
 
 			#(#cfg_attrs)*
+			#[doc(hidden)]
 			#prefix_struct_vis struct #prefix_struct_ident<#type_use_gen>(
 				core::marker::PhantomData<(#type_use_gen,)>
 			);

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -23,7 +23,7 @@ sp-runtime = { version = "6.0.0", default-features = false, path = "../../../pri
 sp-core = { version = "6.0.0", default-features = false, path = "../../../primitives/core" }
 sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-version = { version = "5.0.0", default-features = false, path = "../../../primitives/version" }
-trybuild = "1.0.53"
+trybuild = { version = "1.0.53", features = [ "diff" ] }
 pretty_assertions = "1.0.0"
 rustversion = "1.0.6"
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system" }

--- a/frame/support/test/pallet/src/lib.rs
+++ b/frame/support/test/pallet/src/lib.rs
@@ -14,6 +14,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+//! Testing pallet macro
+
+// Ensure docs are propagated properly by the macros.
+#![warn(missing_docs)]
+
 pub use pallet::*;
 
 #[frame_support::pallet]
@@ -29,6 +35,10 @@ pub mod pallet {
 	#[pallet::config]
 	pub trait Config: frame_system::Config {}
 
+	/// I'm the documentation
+	#[pallet::storage]
+	pub type Value<T> = StorageValue<Value = u32>;
+
 	#[pallet::genesis_config]
 	#[cfg_attr(feature = "std", derive(Default))]
 	pub struct GenesisConfig {}
@@ -36,5 +46,11 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig {
 		fn build(&self) {}
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// Something failed
+		Test,
 	}
 }

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
@@ -56,10 +56,10 @@ note: required by a bound in `encode_to`
     = note: this error originates in the derive macro `frame_support::codec::Encode` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeDecode` is not satisfied
-   --> tests/pallet_ui/call_argument_invalid_bound_2.rs:20:36
+   --> tests/pallet_ui/call_argument_invalid_bound_2.rs:17:12
     |
-20  |         pub fn foo(origin: OriginFor<T>, bar: T::Bar) -> DispatchResultWithPostInfo {
-    |                                          ^^^ the trait `WrapperTypeDecode` is not implemented for `<T as pallet::Config>::Bar`
+17  |     #[pallet::call]
+    |               ^^^^ the trait `WrapperTypeDecode` is not implemented for `<T as pallet::Config>::Bar`
     |
     = note: required because of the requirements on the impl of `Decode` for `<T as pallet::Config>::Bar`
 note: required by a bound in `parity_scale_codec::Decode::decode`


### PR DESCRIPTION
Before this pr it was failing when compiling with `missing_docs`, because the macro was generating
functions etc without the appropriate docs. In the case of this pr it is mainly about hiding these
functions in the docs as they are internal api anyway.

