### PR TITLE
pallet-whitelist: add sp-api/std to std feature to fix compile error

### DIFF
--- a/frame/whitelist/Cargo.toml
+++ b/frame/whitelist/Cargo.toml
@@ -17,25 +17,26 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../primitives/api" }
 sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "6.0.0", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "6.0.0", default-features = false, path = "../../primitives/runtime" }
+
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
 sp-core = { version = "6.0.0", path = "../../primitives/core" }
-pallet-preimage = { version = "4.0.0-dev", path = "../preimage/" }
-pallet-balances = { version = "4.0.0-dev", path = "../balances/" }
+sp-io = { version = "6.0.0", path = "../../primitives/io" }
+pallet-balances = { version = "4.0.0-dev", path = "../balances" }
+pallet-preimage = { version = "4.0.0-dev", path = "../preimage" }
 
 [features]
 default = ["std"]
 std = [
 	"codec/std",
 	"scale-info/std",
-	"sp-std/std",
-	"sp-io/std",
+	"sp-api/std",
 	"sp-runtime/std",
+	"sp-std/std",
 	"frame-support/std",
 	"frame-system/std",
 ]

--- a/frame/whitelist/src/benchmarking.rs
+++ b/frame/whitelist/src/benchmarking.rs
@@ -20,10 +20,11 @@
 #![cfg(feature = "runtime-benchmarks")]
 
 use super::*;
-use core::convert::TryInto;
 use frame_benchmarking::benchmarks;
-use frame_support::{ensure, traits::PreimageRecipient};
-use sp_runtime::traits::Hash;
+use frame_support::{
+	ensure,
+	traits::{EnsureOrigin, Get, PreimageRecipient},
+};
 
 #[cfg(test)]
 use crate::Pallet as Whitelist;

--- a/frame/whitelist/src/lib.rs
+++ b/frame/whitelist/src/lib.rs
@@ -39,21 +39,15 @@ mod mock;
 mod tests;
 pub mod weights;
 
-use sp_runtime::traits::Dispatchable;
-use sp_std::prelude::*;
-
 use codec::{Decode, DecodeLimit, Encode, FullCodec, MaxEncodedLen};
 use frame_support::{
 	ensure,
 	traits::{PreimageProvider, PreimageRecipient},
-	weights::{GetDispatchInfo, PostDispatchInfo},
+	weights::{GetDispatchInfo, PostDispatchInfo, Weight},
 };
 use scale_info::TypeInfo;
-use sp_api::HashT;
-use weights::WeightInfo;
-
-use frame_support::pallet_prelude::*;
-use frame_system::pallet_prelude::*;
+use sp_runtime::traits::{Dispatchable, Hash};
+use sp_std::prelude::*;
 
 pub use pallet::*;
 
@@ -66,6 +60,9 @@ pub struct Preimage<BoundedVec, Balance, AccountId> {
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
+	use crate::weights::WeightInfo;
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
@@ -92,7 +89,7 @@ pub mod pallet {
 		type PreimageProvider: PreimageProvider<Self::Hash> + PreimageRecipient<Self::Hash>;
 
 		/// The weight information for this pallet.
-		type WeightInfo: weights::WeightInfo;
+		type WeightInfo: WeightInfo;
 	}
 
 	#[pallet::pallet]


### PR DESCRIPTION
compilation error when compiling `pallet-whitelist` alone:
```
error[E0432]: unresolved import `sp_core::to_substrate_wasm_fn_return_value`
  --> primitives/api/src/lib.rs:80:9
   |
80 | pub use sp_core::to_substrate_wasm_fn_return_value;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `to_substrate_wasm_fn_return_value` in the root

For more information about this error, try `rustc --explain E0432`.
error: could not compile `sp-api` due to previous error
```

Also adjusted some import ordering