### PR TITLE
add `MaxEncodedLen` trait to Time::Moment

### DIFF
--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -510,7 +510,7 @@ pub trait HandleLifetime<T> {
 impl<T> HandleLifetime<T> for () {}
 
 pub trait Time {
-	type Moment: sp_arithmetic::traits::AtLeast32Bit + Parameter + Default + Copy;
+	type Moment: sp_arithmetic::traits::AtLeast32Bit + Parameter + Default + Copy + MaxEncodedLen;
 
 	fn now() -> Self::Moment;
 }


### PR DESCRIPTION
add `MaxEncodedLen` trait to `Time` trait, as in our [migration](https://github.com/open-web3-stack/open-runtime-module-library/blob/fecbe0197ac0c1380424d193a46289d3846cbf1d/oracle/src/lib.rs#L77) to removing `without_storage_info`, the `Time::Moment` need `MaxEncodedLen`.

also currently in pallet_timestamp, `Moment` already has `MaxEncodedLen` trait bound:

https://github.com/paritytech/substrate/blob/6506784c95c2b6ee1db19cdbfc8142e9c7a071dc/frame/timestamp/src/lib.rs#L126-L131