### PR TITLE
Do not upgrade db_version on metadata reading failure.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6697,9 +6697,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865edee5b792f537356d9e55cbc138e7f4718dc881a7ea45a18b37bf61c21e3d"
+checksum = "3d121a9af17a43efd0a38c6afa508b927ba07785bd4709efb2ac03bf77efef8d"
 dependencies = [
  "blake2-rfc",
  "crc32fast",

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -33,7 +33,7 @@ sc-state-db = { version = "0.10.0-dev", path = "../state-db" }
 sp-trie = { version = "6.0.0", path = "../../primitives/trie" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sp-database = { version = "4.0.0-dev", path = "../../primitives/database" }
-parity-db = { version = "0.3.8", optional = true }
+parity-db = { version = "0.3.9", optional = true }
 
 [dev-dependencies]
 sp-tracing = { version = "5.0.0", path = "../../primitives/tracing" }

--- a/client/db/src/parity_db.rs
+++ b/client/db/src/parity_db.rs
@@ -73,7 +73,7 @@ pub fn open<H: Clone + AsRef<[u8]>>(
 	if upgrade {
 		log::info!("Upgrading database metadata.");
 		if let Some(meta) = parity_db::Options::load_metadata(path)? {
-			config.write_metadata(path, &meta.salt)?;
+			config.write_metadata_with_version(path, &meta.salt, Some(meta.version))?;
 		}
 	}
 

--- a/client/db/src/utils.rs
+++ b/client/db/src/utils.rs
@@ -275,6 +275,7 @@ fn open_parity_db<Block: BlockT>(path: &Path, db_type: DatabaseType, create: boo
 	match crate::parity_db::open(path, db_type, create, false) {
 		Ok(db) => Ok(db),
 		Err(parity_db::Error::InvalidConfiguration(_)) => {
+			log::warn!("Invalid parity db configuration, attempting database metadata update.");
 			// Try to update the database with the new config
 			Ok(crate::parity_db::open(path, db_type, create, true)?)
 		},


### PR DESCRIPTION
This PR changes the way we rewrite metada when paritydb meta mismatch.
Changes to column configuration are written, but salt and db_version are kept the same.

This is a quick fix for https://github.com/paritytech/polkadot/issues/5168 but I guess things should evolve to be more manual in the future.

Polkadot companion: https://github.com/paritytech/polkadot/pull/5175