### PR TITLE
Don't ban peers for small duplicate requests

### DIFF
--- a/client/network/src/block_request_handler.rs
+++ b/client/network/src/block_request_handler.rs
@@ -54,6 +54,10 @@ mod rep {
 
 	/// Reputation change when a peer sent us the same request multiple times.
 	pub const SAME_REQUEST: Rep = Rep::new_fatal("Same block request multiple times");
+
+	/// Reputation change when a peer sent us the same "small" request multiple times.
+	pub const SAME_SMALL_REQUEST: Rep =
+		Rep::new(-(1 << 10), "same small block request multiple times");
 }
 
 /// Generates a [`ProtocolConfig`] for the block request protocol, refusing incoming requests.
@@ -200,8 +204,15 @@ impl<B: BlockT> BlockRequestHandler<B> {
 			Some(SeenRequestsValue::Fulfilled(ref mut requests)) => {
 				*requests = requests.saturating_add(1);
 
+				let small_request =
+					attributes == BlockAttributes::HEADER | BlockAttributes::JUSTIFICATION;
+
 				if *requests > MAX_NUMBER_OF_SAME_REQUESTS_PER_PEER {
-					reputation_change = Some(rep::SAME_REQUEST);
+					reputation_change = Some(if small_request {
+						rep::SAME_SMALL_REQUEST
+					} else {
+						rep::SAME_REQUEST
+					});
 				}
 			},
 			None => {

--- a/client/network/src/block_request_handler.rs
+++ b/client/network/src/block_request_handler.rs
@@ -204,8 +204,9 @@ impl<B: BlockT> BlockRequestHandler<B> {
 			Some(SeenRequestsValue::Fulfilled(ref mut requests)) => {
 				*requests = requests.saturating_add(1);
 
-				let small_request =
-					attributes == BlockAttributes::HEADER | BlockAttributes::JUSTIFICATION;
+				let small_request = attributes
+					.difference(BlockAttributes::HEADER | BlockAttributes::JUSTIFICATION)
+					.is_empty();
 
 				if *requests > MAX_NUMBER_OF_SAME_REQUESTS_PER_PEER {
 					reputation_change = Some(if small_request {


### PR DESCRIPTION
This PR permits duplicate block requests from peers if the request is "small", defined as when only the block header and justification are requested. A separate, milder reputation penalty is issued for those duplicates. This prevents peers from being banned for (e.g.) duplicate ancestor search requests, which can occur if a peer has disconnected and reconnected. This is one of the solutions discussed in #10794.

Should resolve #10794.