### PR TITLE
Avoid a duplicate block request when syncing from a fork

### DIFF
--- a/client/consensus/common/src/import_queue.rs
+++ b/client/consensus/common/src/import_queue.rs
@@ -160,6 +160,16 @@ pub enum BlockImportStatus<N: std::fmt::Debug + PartialEq> {
 	ImportedUnknown(N, ImportedAux, Option<Origin>),
 }
 
+impl<N: std::fmt::Debug + PartialEq> BlockImportStatus<N> {
+	/// Returns the imported block number.
+	pub fn number(&self) -> &N {
+		match self {
+			BlockImportStatus::ImportedKnown(n, _) |
+			BlockImportStatus::ImportedUnknown(n, _, _) => n,
+		}
+	}
+}
+
 /// Block import error.
 #[derive(Debug, thiserror::Error)]
 pub enum BlockImportError {

--- a/client/network/sync/src/blocks.rs
+++ b/client/network/sync/src/blocks.rs
@@ -215,7 +215,7 @@ impl<B: BlockT> BlockCollection<B> {
 			None => {
 				debug!(target: "sync", "Can't clear unknown queued blocks from {:?}", from_hash);
 			},
-			Some(&(from, to)) => {
+			Some((from, to)) => {
 				let mut block_num = from;
 				while block_num < to {
 					self.blocks.remove(&block_num);

--- a/client/network/sync/src/blocks.rs
+++ b/client/network/sync/src/blocks.rs
@@ -202,6 +202,10 @@ impl<B: BlockT> BlockCollection<B> {
 			*range_data = BlockRangeState::Queued { len };
 		}
 
+		if let Some(BlockData { block, .. }) = ready.first() {
+			self.queued_blocks.insert(block.hash, (from, from + (ready.len() as u32).into()));
+		}
+
 		trace!(target: "sync", "{} blocks ready for import", ready.len());
 		ready
 	}

--- a/client/network/sync/src/blocks.rs
+++ b/client/network/sync/src/blocks.rs
@@ -178,15 +178,18 @@ impl<B: BlockT> BlockCollection<B> {
 
 		let mut prev = from;
 		for (start, range_data) in &mut self.blocks {
+			if *start > prev {
+				break
+			}
 			let len = match range_data {
-				BlockRangeState::Complete(blocks) if *start <= prev => {
+				BlockRangeState::Complete(blocks) => {
 					let len = (blocks.len() as u32).into();
 					prev = *start + len;
 					// Remove all elements from `blocks` and add them to `drained`
 					ready.append(blocks);
 					len
 				},
-				BlockRangeState::Queued { .. } if *start <= prev => continue,
+				BlockRangeState::Queued { .. } => continue,
 				_ => break,
 			};
 			*range_data = BlockRangeState::Queued { len };

--- a/client/network/sync/src/blocks.rs
+++ b/client/network/sync/src/blocks.rs
@@ -211,7 +211,7 @@ impl<B: BlockT> BlockCollection<B> {
 	}
 
 	pub fn clear_queued(&mut self, from_hash: &B::Hash) {
-		match self.queued_blocks.get(from_hash) {
+		match self.queued_blocks.remove(from_hash) {
 			None => {
 				debug!(target: "sync", "Can't clear unknown queued blocks from {:?}", from_hash);
 			},
@@ -221,7 +221,6 @@ impl<B: BlockT> BlockCollection<B> {
 					self.blocks.remove(&block_num);
 					block_num += One::one();
 				}
-				self.queued_blocks.remove(from_hash);
 				trace!(target: "sync", "Cleared blocks from {:?} to {:?}", from, to);
 			},
 		}

--- a/client/network/sync/src/blocks.rs
+++ b/client/network/sync/src/blocks.rs
@@ -203,7 +203,8 @@ impl<B: BlockT> BlockCollection<B> {
 		}
 
 		if let Some(BlockData { block, .. }) = ready.first() {
-			self.queued_blocks.insert(block.hash, (from, from + (ready.len() as u32).into()));
+			self.queued_blocks
+				.insert(block.hash, (from, from + (ready.len() as u32).into()));
 		}
 
 		trace!(target: "sync", "{} blocks ready for import", ready.len());

--- a/client/network/sync/src/blocks.rs
+++ b/client/network/sync/src/blocks.rs
@@ -191,9 +191,6 @@ impl<B: BlockT> BlockCollection<B> {
 			let len = match range_data {
 				BlockRangeState::Complete(blocks) => {
 					let len = (blocks.len() as u32).into();
-					if let Some(BlockData { block, .. }) = blocks.first() {
-						self.queued_blocks.insert(block.hash, (start, start + len));
-					}
 					prev = start + len;
 					// Remove all elements from `blocks` and add them to `ready`
 					ready.append(blocks);

--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -1507,9 +1507,8 @@ where
 		for (_, hash) in &results {
 			self.queue_blocks.remove(hash);
 		}
-		let up_to = results.last().and_then(|(r, _)| Some(r.as_ref().ok()?.number().clone()));
-		if let Some(up_to) = up_to {
-			self.blocks.clear_queued(up_to);
+		if let Some(from_hash) = results.first().map(|(_, h)| h) {
+			self.blocks.clear_queued(from_hash);
 		}
 		for (result, hash) in results {
 			if has_error {

--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -3273,7 +3273,6 @@ mod test {
 			),);
 
 			best_block_num += MAX_BLOCKS_TO_REQUEST as u32;
-			log::info!("best block = {best_block_num}");
 
 			if best_block_num < last_block_num {
 				// make sure we're not getting a duplicate request in the time before the blocks are


### PR DESCRIPTION
Currently, duplicate block requests are sent if a node is on a fork and starts syncing with a peer, where our node's best block number is greater than our common block number. In this case, our `best_queued_number` is greater than the common block number, so when we receive the first block response we:

1. Clear the peer download
2. Insert the downloaded block range as `Complete` in the block collection
3. We `drain_blocks` up to `best_queued_number+1` which removes the just-downloaded set of blocks from the block collection
4. We  queue the blocks for import
5. When we make our next set of block requests, our common block number hasn't changed because the blocks haven't been processed yet, so in `needed_blocks` we find that the block collection is empty, and so we think we still need to download the set of blocks starting at the common block number, though we just downloaded it.
6. We issue a duplicate block request for the set we just finished downloading.

To fix this I separated queueing blocks for import from removing the queued blocks from the collection. Now we wait until our common block number is updated to clear the queued blocks from the block collection, because at this point the removal from the collection won't cause a duplicate block request.

Fixes the final issue described in https://github.com/paritytech/substrate/issues/10794#issuecomment-1072736260.

Polkadot address: 1nTsyyNkN8A4HzfGDLkcNsccYA2kATMVxLFZUZUVSr77EB4

Related to #10794.