### PR TITLE
Unignore test

### DIFF
--- a/client/network/src/service/tests.rs
+++ b/client/network/src/service/tests.rs
@@ -186,7 +186,6 @@ fn build_nodes_one_proto() -> (
 	(node1, events_stream1, node2, events_stream2)
 }
 
-#[ignore]
 #[test]
 fn notifications_state_consistent() {
 	// Runs two nodes and ensures that events are propagated out of the API in a consistent
@@ -272,38 +271,38 @@ fn notifications_state_consistent() {
 			match next_event {
 				future::Either::Left(Event::NotificationStreamOpened {
 					remote, protocol, ..
-				}) => {
-					something_happened = true;
-					assert!(!node1_to_node2_open);
-					node1_to_node2_open = true;
-					assert_eq!(remote, *node2.local_peer_id());
-					assert_eq!(protocol, PROTOCOL_NAME);
-				},
+				}) =>
+					if protocol == PROTOCOL_NAME {
+						something_happened = true;
+						assert!(!node1_to_node2_open);
+						node1_to_node2_open = true;
+						assert_eq!(remote, *node2.local_peer_id());
+					},
 				future::Either::Right(Event::NotificationStreamOpened {
 					remote, protocol, ..
-				}) => {
-					something_happened = true;
-					assert!(!node2_to_node1_open);
-					node2_to_node1_open = true;
-					assert_eq!(remote, *node1.local_peer_id());
-					assert_eq!(protocol, PROTOCOL_NAME);
-				},
+				}) =>
+					if protocol == PROTOCOL_NAME {
+						something_happened = true;
+						assert!(!node2_to_node1_open);
+						node2_to_node1_open = true;
+						assert_eq!(remote, *node1.local_peer_id());
+					},
 				future::Either::Left(Event::NotificationStreamClosed {
 					remote, protocol, ..
-				}) => {
-					assert!(node1_to_node2_open);
-					node1_to_node2_open = false;
-					assert_eq!(remote, *node2.local_peer_id());
-					assert_eq!(protocol, PROTOCOL_NAME);
-				},
+				}) =>
+					if protocol == PROTOCOL_NAME {
+						assert!(node1_to_node2_open);
+						node1_to_node2_open = false;
+						assert_eq!(remote, *node2.local_peer_id());
+					},
 				future::Either::Right(Event::NotificationStreamClosed {
 					remote, protocol, ..
-				}) => {
-					assert!(node2_to_node1_open);
-					node2_to_node1_open = false;
-					assert_eq!(remote, *node1.local_peer_id());
-					assert_eq!(protocol, PROTOCOL_NAME);
-				},
+				}) =>
+					if protocol == PROTOCOL_NAME {
+						assert!(node2_to_node1_open);
+						node2_to_node1_open = false;
+						assert_eq!(remote, *node1.local_peer_id());
+					},
 				future::Either::Left(Event::NotificationsReceived { remote, .. }) => {
 					assert!(node1_to_node2_open);
 					assert_eq!(remote, *node2.local_peer_id());


### PR DESCRIPTION
The test broke when the transaction pool synchronization appeared in the instantiated client.

Closes #8681

