### PR TITLE
Fix `generate_storage_alias!`

### DIFF
--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -946,6 +946,20 @@ pub mod tests {
 	}
 
 	#[test]
+	fn generate_storage_alias_works() {
+		new_test_ext().execute_with(|| {
+			generate_storage_alias!(
+				Test,
+				GenericData2<T: Config> => Map<(Blake2_128Concat, T::BlockNumber), T::BlockNumber>
+			);
+
+			assert_eq!(Module::<Test>::generic_data2(5), None);
+			GenericData2::<Test>::insert(5, 5);
+			assert_eq!(Module::<Test>::generic_data2(5), Some(5));
+		});
+	}
+
+	#[test]
 	fn map_issue_3318() {
 		new_test_ext().execute_with(|| {
 			OptionLinkedMap::insert(1, 1);

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -154,8 +154,8 @@ macro_rules! bounded_vec {
 /// // to `Vec<u8>`
 /// generate_storage_alias!(
 /// 	OtherPrefix, OtherStorageName => DoubleMap<
-/// 		(u32, Twox64Concat),
-/// 		(u32, Twox64Concat),
+/// 		(Twox64Concat, u32),
+/// 		(Twox64Concat, u32),
 /// 		Vec<u8>
 /// 	>
 /// );
@@ -165,8 +165,8 @@ macro_rules! bounded_vec {
 /// generate_storage_alias!(Prefix, ValueName => Value<u32, OptionQuery>);
 /// generate_storage_alias!(
 /// 	Prefix, SomeStorageName => DoubleMap<
-/// 		(u32, Twox64Concat),
-/// 		(u32, Twox64Concat),
+/// 		(Twox64Concat, u32),
+/// 		(Twox64Concat, u32),
 /// 		Vec<u8>,
 /// 		ValueQuery
 /// 	>
@@ -175,14 +175,14 @@ macro_rules! bounded_vec {
 /// // generate a map from `Config::AccountId` (with hasher `Twox64Concat`) to `Vec<u8>`
 /// trait Config { type AccountId: codec::FullCodec; }
 /// generate_storage_alias!(
-/// 	Prefix, GenericStorage<T: Config> => Map<(T::AccountId, Twox64Concat), Vec<u8>>
+/// 	Prefix, GenericStorage<T: Config> => Map<(Twox64Concat, T::AccountId), Vec<u8>>
 /// );
 /// # fn main() {}
 /// ```
 #[macro_export]
 macro_rules! generate_storage_alias {
 	// without generic for $name.
-	($pallet:ident, $name:ident => Map<($key:ty, $hasher:ty), $value:ty $(, $querytype:ty)?>) => {
+	($pallet:ident, $name:ident => Map<($hasher:ty, $key:ty), $value:ty $(, $querytype:ty)?>) => {
 		$crate::paste::paste! {
 			$crate::generate_storage_alias!(@GENERATE_INSTANCE_STRUCT $pallet, $name);
 			type $name = $crate::storage::types::StorageMap<
@@ -197,7 +197,7 @@ macro_rules! generate_storage_alias {
 	(
 		$pallet:ident,
 		$name:ident
-		=> DoubleMap<($key1:ty, $hasher1:ty), ($key2:ty, $hasher2:ty), $value:ty $(, $querytype:ty)?>
+		=> DoubleMap<($hasher1:ty, $key1:ty), ($hasher2:ty, $key2:ty), $value:ty $(, $querytype:ty)?>
 	) => {
 		$crate::paste::paste! {
 			$crate::generate_storage_alias!(@GENERATE_INSTANCE_STRUCT $pallet, $name);
@@ -215,7 +215,7 @@ macro_rules! generate_storage_alias {
 	(
 		$pallet:ident,
 		$name:ident
-		=> NMap<Key<$(($key:ty, $hasher:ty)),+>, $value:ty $(, $querytype:ty)?>
+		=> NMap<Key<$(($hasher:ty, $key:ty)),+>, $value:ty $(, $querytype:ty)?>
 	) => {
 		$crate::paste::paste! {
 			$crate::generate_storage_alias!(@GENERATE_INSTANCE_STRUCT $pallet, $name);
@@ -243,15 +243,15 @@ macro_rules! generate_storage_alias {
 	(
 		$pallet:ident,
 		$name:ident<$t:ident : $bounds:tt>
-		=> Map<($key:ty, $hasher:ty), $value:ty $(, $querytype:ty)?>
+		=> Map<($hasher:ty, $key:ty), $value:ty $(, $querytype:ty)?>
 	) => {
 		$crate::paste::paste! {
 			$crate::generate_storage_alias!(@GENERATE_INSTANCE_STRUCT $pallet, $name);
 			#[allow(type_alias_bounds)]
 			type $name<$t : $bounds> = $crate::storage::types::StorageMap<
 				[<$name Instance>],
-				$key,
 				$hasher,
+				$key,
 				$value,
 				$( $querytype )?
 			>;
@@ -260,17 +260,17 @@ macro_rules! generate_storage_alias {
 	(
 		$pallet:ident,
 		$name:ident<$t:ident : $bounds:tt>
-		=> DoubleMap<($key1:ty, $hasher1:ty), ($key2:ty, $hasher2:ty), $value:ty $(, $querytype:ty)?>
+		=> DoubleMap<($hasher1:ty, $key1:ty), ($hasher2:ty, $key2:ty), $value:ty $(, $querytype:ty)?>
 	) => {
 		$crate::paste::paste! {
 			$crate::generate_storage_alias!(@GENERATE_INSTANCE_STRUCT $pallet, $name);
 			#[allow(type_alias_bounds)]
 			type $name<$t : $bounds> = $crate::storage::types::StorageDoubleMap<
 				[<$name Instance>],
-				$key1,
 				$hasher1,
-				$key2,
+				$key1,
 				$hasher2,
+				$key2,
 				$value,
 				$( $querytype )?
 			>;
@@ -279,7 +279,7 @@ macro_rules! generate_storage_alias {
 	(
 		$pallet:ident,
 		$name:ident<$t:ident : $bounds:tt>
-		=> NMap<$(($key:ty, $hasher:ty),)+ $value:ty $(, $querytype:ty)?>
+		=> NMap<$(($hasher:ty, $key:ty),)+ $value:ty $(, $querytype:ty)?>
 	) => {
 		$crate::paste::paste! {
 			$crate::generate_storage_alias!(@GENERATE_INSTANCE_STRUCT $pallet, $name);

--- a/frame/support/src/storage/bounded_btree_map.rs
+++ b/frame/support/src/storage/bounded_btree_map.rs
@@ -344,10 +344,10 @@ pub mod test {
 	use sp_io::TestExternalities;
 
 	crate::generate_storage_alias! { Prefix, Foo => Value<BoundedBTreeMap<u32, (), ConstU32<7>>> }
-	crate::generate_storage_alias! { Prefix, FooMap => Map<(u32, Twox128), BoundedBTreeMap<u32, (),  ConstU32<7>>> }
+	crate::generate_storage_alias! { Prefix, FooMap => Map<(Twox128, u32), BoundedBTreeMap<u32, (),  ConstU32<7>>> }
 	crate::generate_storage_alias! {
 		Prefix,
-		FooDoubleMap => DoubleMap<(u32, Twox128), (u32, Twox128), BoundedBTreeMap<u32, (),  ConstU32<7>>>
+		FooDoubleMap => DoubleMap<(Twox128, u32), (Twox128, u32), BoundedBTreeMap<u32, (),  ConstU32<7>>>
 	}
 
 	fn map_from_keys<K>(keys: &[K]) -> BTreeMap<K, ()>

--- a/frame/support/src/storage/bounded_btree_set.rs
+++ b/frame/support/src/storage/bounded_btree_set.rs
@@ -327,10 +327,10 @@ pub mod test {
 	use sp_std::convert::TryInto;
 
 	crate::generate_storage_alias! { Prefix, Foo => Value<BoundedBTreeSet<u32, ConstU32<7>>> }
-	crate::generate_storage_alias! { Prefix, FooMap => Map<(u32, Twox128), BoundedBTreeSet<u32, ConstU32<7>>> }
+	crate::generate_storage_alias! { Prefix, FooMap => Map<(Twox128, u32), BoundedBTreeSet<u32, ConstU32<7>>> }
 	crate::generate_storage_alias! {
 		Prefix,
-		FooDoubleMap => DoubleMap<(u32, Twox128), (u32, Twox128), BoundedBTreeSet<u32, ConstU32<7>>>
+		FooDoubleMap => DoubleMap<(Twox128, u32), (Twox128, u32), BoundedBTreeSet<u32, ConstU32<7>>>
 	}
 
 	fn set_from_keys<T>(keys: &[T]) -> BTreeSet<T>

--- a/frame/support/src/storage/bounded_vec.rs
+++ b/frame/support/src/storage/bounded_vec.rs
@@ -589,10 +589,10 @@ pub mod test {
 	use sp_io::TestExternalities;
 
 	crate::generate_storage_alias! { Prefix, Foo => Value<BoundedVec<u32, ConstU32<7>>> }
-	crate::generate_storage_alias! { Prefix, FooMap => Map<(u32, Twox128), BoundedVec<u32, ConstU32<7>>> }
+	crate::generate_storage_alias! { Prefix, FooMap => Map<(Twox128, u32), BoundedVec<u32, ConstU32<7>>> }
 	crate::generate_storage_alias! {
 		Prefix,
-		FooDoubleMap => DoubleMap<(u32, Twox128), (u32, Twox128), BoundedVec<u32, ConstU32<7>>>
+		FooDoubleMap => DoubleMap<(Twox128, u32), (Twox128, u32), BoundedVec<u32, ConstU32<7>>>
 	}
 
 	#[test]

--- a/frame/support/src/storage/generator/double_map.rs
+++ b/frame/support/src/storage/generator/double_map.rs
@@ -527,7 +527,7 @@ mod test_iterators {
 			use crate::hash::Identity;
 			crate::generate_storage_alias!(
 				MyModule,
-				MyDoubleMap => DoubleMap<(u64, Identity), (u64, Identity), u64>
+				MyDoubleMap => DoubleMap<(Identity, u64), (Identity, u64), u64>
 			);
 
 			MyDoubleMap::insert(1, 10, 100);

--- a/frame/support/src/storage/generator/map.rs
+++ b/frame/support/src/storage/generator/map.rs
@@ -384,7 +384,7 @@ mod test_iterators {
 	fn map_iter_from() {
 		sp_io::TestExternalities::default().execute_with(|| {
 			use crate::hash::Identity;
-			crate::generate_storage_alias!(MyModule, MyMap => Map<(u64, Identity), u64>);
+			crate::generate_storage_alias!(MyModule, MyMap => Map<(Identity, u64), u64>);
 
 			MyMap::insert(1, 10);
 			MyMap::insert(2, 20);

--- a/frame/support/src/storage/generator/nmap.rs
+++ b/frame/support/src/storage/generator/nmap.rs
@@ -477,7 +477,7 @@ mod test_iterators {
 			use crate::{hash::Identity, storage::Key as NMapKey};
 			crate::generate_storage_alias!(
 				MyModule,
-				MyNMap => NMap<Key<(u64, Identity), (u64, Identity), (u64, Identity)>, u64>
+				MyNMap => NMap<Key<(Identity, u64), (Identity, u64), (Identity, u64)>, u64>
 			);
 
 			MyNMap::insert((1, 1, 1), 11);
@@ -519,8 +519,8 @@ mod test_iterators {
 
 			{
 				crate::generate_storage_alias!(Test, NMap => DoubleMap<
-					(u16, crate::Blake2_128Concat),
-					(u32, crate::Twox64Concat),
+					(crate::Blake2_128Concat, u16),
+					(crate::Twox64Concat, u32),
 					u64
 				>);
 

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -1618,7 +1618,7 @@ mod test {
 			use crate::{hash::Identity, storage::generator::map::StorageMap};
 			crate::generate_storage_alias! {
 				MyModule,
-				MyStorageMap => Map<(u64, Identity), u64>
+				MyStorageMap => Map<(Identity, u64), u64>
 			}
 
 			MyStorageMap::insert(1, 10);
@@ -1735,10 +1735,10 @@ mod test {
 	}
 
 	crate::generate_storage_alias! { Prefix, Foo => Value<WeakBoundedVec<u32, ConstU32<7>>> }
-	crate::generate_storage_alias! { Prefix, FooMap => Map<(u32, Twox128), BoundedVec<u32, ConstU32<7>>> }
+	crate::generate_storage_alias! { Prefix, FooMap => Map<(Twox128, u32), BoundedVec<u32, ConstU32<7>>> }
 	crate::generate_storage_alias! {
 		Prefix,
-		FooDoubleMap => DoubleMap<(u32, Twox128), (u32, Twox128), BoundedVec<u32, ConstU32<7>>>
+		FooDoubleMap => DoubleMap<(Twox128, u32), (Twox128, u32), BoundedVec<u32, ConstU32<7>>>
 	}
 
 	#[test]

--- a/frame/support/src/storage/types/nmap.rs
+++ b/frame/support/src/storage/types/nmap.rs
@@ -569,7 +569,7 @@ mod test {
 
 			{
 				crate::generate_storage_alias!(test, Foo => NMap<
-					Key<(u16, Blake2_128Concat)>,
+					Key<(Blake2_128Concat, u16)>,
 					u32
 				>);
 

--- a/frame/support/src/storage/weak_bounded_vec.rs
+++ b/frame/support/src/storage/weak_bounded_vec.rs
@@ -323,10 +323,10 @@ pub mod test {
 	use sp_std::convert::TryInto;
 
 	crate::generate_storage_alias! { Prefix, Foo => Value<WeakBoundedVec<u32, ConstU32<7>>> }
-	crate::generate_storage_alias! { Prefix, FooMap => Map<(u32, Twox128), WeakBoundedVec<u32, ConstU32<7>>> }
+	crate::generate_storage_alias! { Prefix, FooMap => Map<(Twox128, u32), WeakBoundedVec<u32, ConstU32<7>>> }
 	crate::generate_storage_alias! {
 		Prefix,
-		FooDoubleMap => DoubleMap<(u32, Twox128), (u32, Twox128), WeakBoundedVec<u32, ConstU32<7>>>
+		FooDoubleMap => DoubleMap<(Twox128, u32), (Twox128, u32), WeakBoundedVec<u32, ConstU32<7>>>
 	}
 
 	#[test]


### PR DESCRIPTION
This PR does 2 things:

1. Fixes a bug with the `generate_storage_alias!` macro, where some of the syntaxes had the `key` and `hasher` in the wrong order in the underlying storage definition.
2. Chooses the more intuitive order of `(hasher, key)` for the macro definition, which lines up with the order of these same types in the underlying storage type definition.

Fortunately, the Rust type system prevents anyone from really messing up here.