### PR TITLE
Enforce `MaxEncodedLen` impl for `NposSolution`

### DIFF
--- a/frame/election-provider-multi-phase/src/mock.rs
+++ b/frame/election-provider-multi-phase/src/mock.rs
@@ -74,7 +74,7 @@ frame_election_provider_support::generate_solution_type!(
 		VoterIndex = VoterIndex,
 		TargetIndex = TargetIndex,
 		Accuracy = PerU16,
-		MaxVoters = ConstU32::<20>
+		MaxVoters = ConstU32::<2_000>
 	>(16)
 );
 

--- a/frame/election-provider-support/solution-type/src/single_page.rs
+++ b/frame/election-provider-support/solution-type/src/single_page.rs
@@ -124,6 +124,11 @@ pub(crate) fn generate(def: crate::SolutionDef) -> Result<TokenStream2> {
 					for<'r> FV: Fn(&'r A) -> Option<Self::VoterIndex>,
 					for<'r> FT: Fn(&'r A) -> Option<Self::TargetIndex>,
 			{
+				// Make sure that the voter bound is binding.
+				// `assignments.len()` actually represents the number of voters
+				if assignments.len() as u32 > <#max_voters as _feps::Get<u32>>::get() {
+					return Err(_feps::Error::TooManyVoters);
+				}
 				let mut #struct_name: #ident = Default::default();
 				for _feps::Assignment { who, distribution } in assignments {
 					match distribution.len() {
@@ -135,11 +140,6 @@ pub(crate) fn generate(def: crate::SolutionDef) -> Result<TokenStream2> {
 					}
 				};
 
-				// Make sure that the voter bound is binding.
-				// `assignments.len()` actually represents the number of voters
-				if assignments.len() as u32 > <#max_voters as _feps::Get<u32>>::get() {
-					return Err(_feps::Error::TooManyVoters);
-				}
 				Ok(#struct_name)
 			}
 

--- a/frame/election-provider-support/solution-type/src/single_page.rs
+++ b/frame/election-provider-support/solution-type/src/single_page.rs
@@ -134,6 +134,12 @@ pub(crate) fn generate(def: crate::SolutionDef) -> Result<TokenStream2> {
 						}
 					}
 				};
+
+				// Make sure that the voter bound is binding.
+				use frame_support::traits::Get;
+				if #struct_name.voter_count() as u32 > #max_voters::get() {
+					return Err(_feps::Error::SolutionVotersOverflow);
+				}
 				Ok(#struct_name)
 			}
 

--- a/frame/election-provider-support/solution-type/src/single_page.rs
+++ b/frame/election-provider-support/solution-type/src/single_page.rs
@@ -130,7 +130,7 @@ pub(crate) fn generate(def: crate::SolutionDef) -> Result<TokenStream2> {
 						0 => continue,
 						#from_impl
 						_ => {
-							return Err(_feps::Error::TooManyVoters);
+							return Err(_feps::Error::SolutionTargetOverflow);
 						}
 					}
 				};

--- a/frame/election-provider-support/solution-type/src/single_page.rs
+++ b/frame/election-provider-support/solution-type/src/single_page.rs
@@ -130,7 +130,7 @@ pub(crate) fn generate(def: crate::SolutionDef) -> Result<TokenStream2> {
 						0 => continue,
 						#from_impl
 						_ => {
-							return Err(_feps::Error::SolutionTargetOverflow);
+							return Err(_feps::Error::TooManyVoters);
 						}
 					}
 				};
@@ -138,7 +138,7 @@ pub(crate) fn generate(def: crate::SolutionDef) -> Result<TokenStream2> {
 				// Make sure that the voter bound is binding.
 				use frame_support::traits::Get;
 				if #struct_name.voter_count() as u32 > #max_voters::get() {
-					return Err(_feps::Error::SolutionVotersOverflow);
+					return Err(_feps::Error::TooManyVoters);
 				}
 				Ok(#struct_name)
 			}

--- a/frame/election-provider-support/solution-type/src/single_page.rs
+++ b/frame/election-provider-support/solution-type/src/single_page.rs
@@ -136,8 +136,8 @@ pub(crate) fn generate(def: crate::SolutionDef) -> Result<TokenStream2> {
 				};
 
 				// Make sure that the voter bound is binding.
-				use frame_support::traits::Get;
-				if #struct_name.voter_count() as u32 > #max_voters::get() {
+				// `assignments.len()` actually represents the number of voters
+				if assignments.len() as u32 > <#max_voters as _feps::Get<u32>>::get() {
 					return Err(_feps::Error::TooManyVoters);
 				}
 				Ok(#struct_name)

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -169,12 +169,13 @@
 pub mod onchain;
 pub mod traits;
 use codec::{Decode, Encode};
-use frame_support::{traits::Get, BoundedVec, RuntimeDebug};
+use frame_support::{BoundedVec, RuntimeDebug};
 use sp_runtime::traits::Bounded;
 use sp_std::{fmt::Debug, prelude::*};
 
 /// Re-export the solution generation macro.
 pub use frame_election_provider_solution_type::generate_solution_type;
+pub use frame_support::traits::Get;
 /// Re-export some type as they are used in the interface.
 pub use sp_arithmetic::PerThing;
 pub use sp_npos_elections::{

--- a/frame/election-provider-support/src/mock.rs
+++ b/frame/election-provider-support/src/mock.rs
@@ -47,7 +47,7 @@ crate::generate_solution_type! {
 		VoterIndex = u32,
 		TargetIndex = u16,
 		Accuracy = TestAccuracy,
-		MaxVoters = frame_support::traits::ConstU32::<20>,
+		MaxVoters = frame_support::traits::ConstU32::<2_500>,
 	>(16)
 }
 

--- a/frame/election-provider-support/src/tests.rs
+++ b/frame/election-provider-support/src/tests.rs
@@ -114,7 +114,7 @@ mod solution_type {
 		assert_eq!(
 			InnerTestSolution::from_assignment(&assignments, &voter_index, &target_index)
 				.unwrap_err(),
-			NposError::SolutionVotersOverflow,
+			NposError::TooManyVoters,
 		);
 	}
 

--- a/frame/election-provider-support/src/tests.rs
+++ b/frame/election-provider-support/src/tests.rs
@@ -92,6 +92,33 @@ mod solution_type {
 	}
 
 	#[test]
+	fn from_assignment_fail_too_many_voters() {
+		let rng = rand::rngs::SmallRng::seed_from_u64(0);
+
+		// This will produce 24 voters..
+		let (voters, assignments, candidates) = generate_random_votes(10, 25, rng);
+		let voter_index = make_voter_fn(&voters);
+		let target_index = make_target_fn(&candidates);
+
+		// Limit the voters to 20..
+		generate_solution_type!(
+			pub struct InnerTestSolution::<
+				VoterIndex = u32,
+				TargetIndex = u16,
+				Accuracy = TestAccuracy,
+				MaxVoters = frame_support::traits::ConstU32::<20>,
+			>(16)
+		);
+
+		// 24 > 20, so this should fail.
+		assert_eq!(
+			InnerTestSolution::from_assignment(&assignments, &voter_index, &target_index)
+				.unwrap_err(),
+			NposError::SolutionVotersOverflow,
+		);
+	}
+
+	#[test]
 	fn max_encoded_len_too_small() {
 		generate_solution_type!(
 			pub struct InnerTestSolution::<

--- a/primitives/npos-elections/src/lib.rs
+++ b/primitives/npos-elections/src/lib.rs
@@ -126,7 +126,7 @@ pub enum Error {
 	/// The data provided to create support map was invalid.
 	InvalidSupportEdge,
 	/// The number of voters is bigger than the `MaxVoters` bound.
-	SolutionVotersOverflow,
+	TooManyVoters,
 }
 
 /// A type which is used in the API of this crate as a numeric weight of a vote, most often the

--- a/primitives/npos-elections/src/lib.rs
+++ b/primitives/npos-elections/src/lib.rs
@@ -119,12 +119,14 @@ pub enum Error {
 	SolutionTargetOverflow,
 	/// One of the index functions returned none.
 	SolutionInvalidIndex,
-	/// One of the page indices was invalid
+	/// One of the page indices was invalid.
 	SolutionInvalidPageIndex,
 	/// An error occurred in some arithmetic operation.
 	ArithmeticError(&'static str),
 	/// The data provided to create support map was invalid.
 	InvalidSupportEdge,
+	/// The number of voters is bigger than the `MaxVoters` bound.
+	SolutionVotersOverflow,
 }
 
 /// A type which is used in the API of this crate as a numeric weight of a vote, most often the


### PR DESCRIPTION
Fixes #11092 

when constructing `NposSolution` via `from_assignment`, check that the number of voters is less than the bound `MaxVoters` provided for the implementation of `MaxEncodedLen`.

@kianenigma 

Polkadot address: 131dPecTmpTC1p1ofemufqFBJo9vNbV7dkgN7vWwKnaSMkC4