### PR TITLE
Add extra WASM heap pages when precompiling the runtime blob

### DIFF
--- a/client/executor/benches/bench.rs
+++ b/client/executor/benches/bench.rs
@@ -55,11 +55,11 @@ fn initialize(runtime: &[u8], method: Method) -> Arc<dyn WasmModule> {
 			sc_executor_wasmtime::create_runtime::<sp_io::SubstrateHostFunctions>(
 				blob,
 				sc_executor_wasmtime::Config {
-					heap_pages,
 					max_memory_size: None,
 					allow_missing_func_imports,
 					cache_path: None,
 					semantics: sc_executor_wasmtime::Semantics {
+						extra_heap_pages: heap_pages,
 						fast_instance_reuse,
 						deterministic_stack_limit: None,
 						canonicalize_nans: false,

--- a/client/executor/src/wasm_runtime.rs
+++ b/client/executor/src/wasm_runtime.rs
@@ -317,11 +317,11 @@ where
 		WasmExecutionMethod::Compiled => sc_executor_wasmtime::create_runtime::<H>(
 			blob,
 			sc_executor_wasmtime::Config {
-				heap_pages,
 				max_memory_size: None,
 				allow_missing_func_imports,
 				cache_path: cache_path.map(ToOwned::to_owned),
 				semantics: sc_executor_wasmtime::Semantics {
+					extra_heap_pages: heap_pages,
 					fast_instance_reuse: true,
 					deterministic_stack_limit: None,
 					canonicalize_nans: false,

--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -424,11 +424,12 @@ pub struct Config {
 	/// The total amount of memory in bytes an instance can request.
 	///
 	/// If specified, the runtime will be able to allocate only that much of wasm memory.
-	/// This is the total number and therefore the [`Config::extra_heap_pages`] is accounted for.
+	/// This is the total number and therefore the [`Semantics::extra_heap_pages`] is accounted
+	/// for.
 	///
 	/// That means that the initial number of pages of a linear memory plus the
-	/// [`Config::extra_heap_pages`] multiplied by the wasm page size (64KiB) should be less than
-	/// or equal to `max_memory_size`, otherwise the instance won't be created.
+	/// [`Semantics::extra_heap_pages`] multiplied by the wasm page size (64KiB) should be less
+	/// than or equal to `max_memory_size`, otherwise the instance won't be created.
 	///
 	/// Moreover, `memory.grow` will fail (return -1) if the sum of sizes of currently mounted
 	/// and additional pages exceeds `max_memory_size`.

--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -414,12 +414,13 @@ pub struct Semantics {
 
 	/// Configures wasmtime to use multiple threads for compiling.
 	pub parallel_compilation: bool,
+
+	/// The number of extra WASM pages which will be allocated
+	/// on top of what is requested by the WASM blob itself.
+	pub extra_heap_pages: u64,
 }
 
 pub struct Config {
-	/// The number of wasm pages to be mounted after instantiation.
-	pub heap_pages: u64,
-
 	/// The total amount of memory in bytes an instance can request.
 	///
 	/// If specified, the runtime will be able to allocate only that much of wasm memory.
@@ -534,21 +535,7 @@ where
 
 	let (module, snapshot_data) = match code_supply_mode {
 		CodeSupplyMode::Verbatim { blob } => {
-			let mut blob = instrument(blob, &config.semantics)?;
-
-			// We don't actually need the memory to be imported so we can just convert any memory
-			// import into an export with impunity. This simplifies our code since `wasmtime` will
-			// now automatically take care of creating the memory for us, and it also allows us
-			// to potentially enable `wasmtime`'s instance pooling at a later date. (Imported
-			// memories are ineligible for pooling.)
-			blob.convert_memory_import_into_export()?;
-			blob.add_extra_heap_pages_to_memory_section(
-				config
-					.heap_pages
-					.try_into()
-					.map_err(|e| WasmError::Other(format!("invalid `heap_pages`: {}", e)))?,
-			)?;
-
+			let blob = prepare_blob_for_compilation(blob, &config.semantics)?;
 			let serialized_blob = blob.clone().serialize();
 
 			let module = wasmtime::Module::new(&engine, &serialized_blob)
@@ -587,7 +574,7 @@ where
 	Ok(WasmtimeRuntime { engine, instance_pre: Arc::new(instance_pre), snapshot_data, config })
 }
 
-fn instrument(
+fn prepare_blob_for_compilation(
 	mut blob: RuntimeBlob,
 	semantics: &Semantics,
 ) -> std::result::Result<RuntimeBlob, WasmError> {
@@ -600,6 +587,19 @@ fn instrument(
 		blob.expose_mutable_globals();
 	}
 
+	// We don't actually need the memory to be imported so we can just convert any memory
+	// import into an export with impunity. This simplifies our code since `wasmtime` will
+	// now automatically take care of creating the memory for us, and it also allows us
+	// to potentially enable `wasmtime`'s instance pooling at a later date. (Imported
+	// memories are ineligible for pooling.)
+	blob.convert_memory_import_into_export()?;
+	blob.add_extra_heap_pages_to_memory_section(
+		semantics
+			.extra_heap_pages
+			.try_into()
+			.map_err(|e| WasmError::Other(format!("invalid `extra_heap_pages`: {}", e)))?,
+	)?;
+
 	Ok(blob)
 }
 
@@ -609,7 +609,7 @@ pub fn prepare_runtime_artifact(
 	blob: RuntimeBlob,
 	semantics: &Semantics,
 ) -> std::result::Result<Vec<u8>, WasmError> {
-	let blob = instrument(blob, semantics)?;
+	let blob = prepare_blob_for_compilation(blob, semantics)?;
 
 	let engine = Engine::new(&common_config(semantics)?)
 		.map_err(|e| WasmError::Other(format!("cannot create the engine: {}", e)))?;

--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -424,11 +424,11 @@ pub struct Config {
 	/// The total amount of memory in bytes an instance can request.
 	///
 	/// If specified, the runtime will be able to allocate only that much of wasm memory.
-	/// This is the total number and therefore the [`Config::heap_pages`] is accounted for.
+	/// This is the total number and therefore the [`Config::extra_heap_pages`] is accounted for.
 	///
 	/// That means that the initial number of pages of a linear memory plus the
-	/// [`Config::heap_pages`] multiplied by the wasm page size (64KiB) should be less than or
-	/// equal to `max_memory_size`, otherwise the instance won't be created.
+	/// [`Config::extra_heap_pages`] multiplied by the wasm page size (64KiB) should be less than
+	/// or equal to `max_memory_size`, otherwise the instance won't be created.
 	///
 	/// Moreover, `memory.grow` will fail (return -1) if the sum of sizes of currently mounted
 	/// and additional pages exceeds `max_memory_size`.


### PR DESCRIPTION
polkadot companion: https://github.com/paritytech/polkadot/pull/5197

Fixes https://github.com/paritytech/polkadot/issues/5190