### PR TITLE
Fix bags-list bench

### DIFF
--- a/frame/bags-list/src/benchmarks.rs
+++ b/frame/bags-list/src/benchmarks.rs
@@ -144,6 +144,10 @@ frame_benchmarking::benchmarks! {
 		// - both heavier's `prev` and `next` are nodes that will need to be read and written.
 		// - `lighter` is the bag's `head`, so the bag will need to be read and written.
 
+		// clear any pre-existing storage.
+		// NOTE: safe to call outside block production
+		List::<T>::unsafe_clear();
+
 		let bag_thresh = T::BagThresholds::get()[0];
 
 		// insert the nodes in order


### PR DESCRIPTION
The benchmarks of bags list currently fail, this fixes it as preparation for https://github.com/paritytech/polkadot/pull/5188  

You can verify it with:  
```sh
cargo run --features=runtime-benchmarks -- benchmark --chain=dev --steps=1 --repeat=1 --pallet="pallet-bags-list" --extrinsic='*' --execution=wasm --wasm-execution compiled
```