### PR TITLE
Keyless proxied account (a.k.a anonymous proxy v2)

### DIFF
--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -536,9 +536,9 @@ pub mod pallet {
 			let call_hash = T::CallHasher::hash_of(&call);
 			let now = system::Pallet::<T>::block_number();
 			Self::edit_announcements(&delegate, |ann| {
-				ann.real != real ||
-					ann.call_hash != call_hash ||
-					now.saturating_sub(ann.height) < def.delay
+				ann.real != real
+					|| ann.call_hash != call_hash
+					|| now.saturating_sub(ann.height) < def.delay
 			})
 			.map_err(|_| Error::<T>::Unannounced)?;
 
@@ -799,8 +799,8 @@ impl<T: Config> Pallet<T> {
 		force_proxy_type: Option<T::ProxyType>,
 	) -> Result<ProxyDefinition<T::AccountId, T::ProxyType, T::BlockNumber>, DispatchError> {
 		let f = |x: &ProxyDefinition<T::AccountId, T::ProxyType, T::BlockNumber>| -> bool {
-			&x.delegate == delegate &&
-				force_proxy_type.as_ref().map_or(true, |y| &x.proxy_type == y)
+			&x.delegate == delegate
+				&& force_proxy_type.as_ref().map_or(true, |y| &x.proxy_type == y)
 		};
 		Ok(Proxies::<T>::get(real).0.into_iter().find(f).ok_or(Error::<T>::NotProxy)?)
 	}
@@ -818,15 +818,19 @@ impl<T: Config> Pallet<T> {
 			match c.is_sub_type() {
 				// Proxy call cannot add or remove a proxy with more permissions than it already
 				// has.
-				Some(Call::add_proxy { ref proxy_type, .. }) |
-				Some(Call::remove_proxy { ref proxy_type, .. })
+				Some(Call::add_proxy { ref proxy_type, .. })
+				| Some(Call::remove_proxy { ref proxy_type, .. })
 					if !def.proxy_type.is_superset(&proxy_type) =>
-					false,
+				{
+					false
+				},
 				// Proxy call cannot remove all proxies or kill anonymous proxies unless it has full
 				// permissions.
 				Some(Call::remove_proxies { .. }) | Some(Call::kill_anonymous { .. })
 					if def.proxy_type != T::ProxyType::default() =>
-					false,
+				{
+					false
+				},
 				_ => def.proxy_type.filter(c),
 			}
 		});

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -537,13 +537,13 @@ fn proxying_works() {
 }
 
 #[test]
-fn anonymous_works() {
+fn keyless_works() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(Proxy::anonymous(Origin::signed(1), ProxyType::Any, 0, 0));
-		let anon = Proxy::anonymous_account(&1, &ProxyType::Any, 0, None);
+		assert_ok!(Proxy::proxied_keyless(Origin::signed(1), ProxyType::Any, 0, 0));
+		let anon = Proxy::keyless_account(&1, &ProxyType::Any, 0, None);
 		System::assert_last_event(
-			ProxyEvent::AnonymousCreated {
-				anonymous: anon.clone(),
+			ProxyEvent::KeylessCreated {
+				keyless: anon.clone(),
 				who: 1,
 				proxy_type: ProxyType::Any,
 				disambiguation_index: 0,
@@ -551,20 +551,20 @@ fn anonymous_works() {
 			.into(),
 		);
 
-		// other calls to anonymous allowed as long as they're not exactly the same.
-		assert_ok!(Proxy::anonymous(Origin::signed(1), ProxyType::JustTransfer, 0, 0));
-		assert_ok!(Proxy::anonymous(Origin::signed(1), ProxyType::Any, 0, 1));
-		let anon2 = Proxy::anonymous_account(&2, &ProxyType::Any, 0, None);
-		assert_ok!(Proxy::anonymous(Origin::signed(2), ProxyType::Any, 0, 0));
+		// other calls to keyless allowed as long as they're not exactly the same.
+		assert_ok!(Proxy::proxied_keyless(Origin::signed(1), ProxyType::JustTransfer, 0, 0));
+		assert_ok!(Proxy::proxied_keyless(Origin::signed(1), ProxyType::Any, 0, 1));
+		let anon2 = Proxy::keyless_account(&2, &ProxyType::Any, 0, None);
+		assert_ok!(Proxy::proxied_keyless(Origin::signed(2), ProxyType::Any, 0, 0));
 		assert_noop!(
-			Proxy::anonymous(Origin::signed(1), ProxyType::Any, 0, 0),
+			Proxy::proxied_keyless(Origin::signed(1), ProxyType::Any, 0, 0),
 			Error::<Test>::Duplicate
 		);
 		System::set_extrinsic_index(1);
-		assert_ok!(Proxy::anonymous(Origin::signed(1), ProxyType::Any, 0, 0));
+		assert_ok!(Proxy::proxied_keyless(Origin::signed(1), ProxyType::Any, 0, 0));
 		System::set_extrinsic_index(0);
 		System::set_block_number(2);
-		assert_ok!(Proxy::anonymous(Origin::signed(1), ProxyType::Any, 0, 0));
+		assert_ok!(Proxy::proxied_keyless(Origin::signed(1), ProxyType::Any, 0, 0));
 
 		let call = Box::new(call_transfer(6, 1));
 		assert_ok!(Balances::transfer(Origin::signed(3), anon, 5));
@@ -572,7 +572,7 @@ fn anonymous_works() {
 		System::assert_last_event(ProxyEvent::ProxyExecuted { result: Ok(()) }.into());
 		assert_eq!(Balances::free_balance(6), 1);
 
-		let call = Box::new(Call::Proxy(ProxyCall::new_call_variant_kill_anonymous(
+		let call = Box::new(Call::Proxy(ProxyCall::new_call_variant_kill_keyless(
 			1,
 			ProxyType::Any,
 			0,
@@ -583,7 +583,7 @@ fn anonymous_works() {
 		let de = DispatchError::from(Error::<Test>::NoPermission).stripped();
 		System::assert_last_event(ProxyEvent::ProxyExecuted { result: Err(de) }.into());
 		assert_noop!(
-			Proxy::kill_anonymous(Origin::signed(1), 1, ProxyType::Any, 0, 1, 0),
+			Proxy::kill_keyless(Origin::signed(1), 1, ProxyType::Any, 0, 1, 0),
 			Error::<Test>::NoPermission
 		);
 		assert_eq!(Balances::free_balance(1), 0);

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -27,7 +27,7 @@ use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::DispatchError,
 	parameter_types,
-	traits::{ConstU32, ConstU64, Contains},
+	traits::{ConstU32, ConstU64, ConstU8, Contains},
 	RuntimeDebug,
 };
 use sp_core::H256;
@@ -160,6 +160,7 @@ impl Config for Test {
 	type WeightInfo = ();
 	type CallHasher = BlakeTwo256;
 	type MaxPending = ConstU32<2>;
+	type MaxVanity = ConstU8<10>;
 	type AnnouncementDepositBase = ConstU64<1>;
 	type AnnouncementDepositFactor = ConstU64<1>;
 }

--- a/frame/proxy/src/weights.rs
+++ b/frame/proxy/src/weights.rs
@@ -54,8 +54,8 @@ pub trait WeightInfo {
 	fn add_proxy(p: u32, ) -> Weight;
 	fn remove_proxy(p: u32, ) -> Weight;
 	fn remove_proxies(p: u32, ) -> Weight;
-	fn anonymous(p: u32, ) -> Weight;
-	fn kill_anonymous(p: u32, ) -> Weight;
+	fn proxied_keyless(p: u32, ) -> Weight;
+	fn kill_keyless(p: u32, ) -> Weight;
 }
 
 /// Weights for pallet_proxy using the Substrate node and recommended hardware.
@@ -140,7 +140,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	// Storage: unknown [0x3a65787472696e7369635f696e646578] (r:1 w:0)
 	// Storage: Proxy Proxies (r:1 w:1)
-	fn anonymous(p: u32, ) -> Weight {
+	fn proxied_keyless(p: u32, ) -> Weight {
 		(25_743_000 as Weight)
 			// Standard Error: 2_000
 			.saturating_add((25_000 as Weight).saturating_mul(p as Weight))
@@ -148,7 +148,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: Proxy Proxies (r:1 w:1)
-	fn kill_anonymous(p: u32, ) -> Weight {
+	fn kill_keyless(p: u32, ) -> Weight {
 		(20_484_000 as Weight)
 			// Standard Error: 2_000
 			.saturating_add((105_000 as Weight).saturating_mul(p as Weight))
@@ -238,7 +238,7 @@ impl WeightInfo for () {
 	}
 	// Storage: unknown [0x3a65787472696e7369635f696e646578] (r:1 w:0)
 	// Storage: Proxy Proxies (r:1 w:1)
-	fn anonymous(p: u32, ) -> Weight {
+	fn proxied_keyless(p: u32, ) -> Weight {
 		(25_743_000 as Weight)
 			// Standard Error: 2_000
 			.saturating_add((25_000 as Weight).saturating_mul(p as Weight))
@@ -246,7 +246,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 	// Storage: Proxy Proxies (r:1 w:1)
-	fn kill_anonymous(p: u32, ) -> Weight {
+	fn kill_keyless(p: u32, ) -> Weight {
 		(20_484_000 as Weight)
 			// Standard Error: 2_000
 			.saturating_add((105_000 as Weight).saturating_mul(p as Weight))

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -275,6 +275,7 @@ pub mod pallet {
 			+ Debug
 			+ MaybeDisplay
 			+ Ord
+			+ AsRef<[u8]>
 			+ MaxEncodedLen;
 
 		/// Converting trait to take a source type and convert to `AccountId`.
@@ -1193,7 +1194,7 @@ impl<T: Config> Pallet<T> {
 		let block_number = Self::block_number();
 		// Don't populate events on genesis.
 		if block_number.is_zero() {
-			return
+			return;
 		}
 
 		let phase = ExecutionPhase::<T>::get().unwrap_or_default();
@@ -1615,7 +1616,7 @@ impl<T: Config> StoredMap<T::AccountId, T::AccountData> for Pallet<T> {
 				},
 			}
 		} else if !was_providing && !is_providing {
-			return Ok(result)
+			return Ok(result);
 		}
 		Account::<T>::mutate(k, |a| a.data = some_data.unwrap_or_default());
 		Ok(result)


### PR DESCRIPTION
Anonymous proxies are a powerful feature that might just need a few tweaks to improve their usability and become the go to primitive for wallets when creating secure user friendly accounts, in Virto for example with our main audience being the crypto-clueless and usability our main priority, anonymous proxies will be a great tool to have, likely the default kind of account for most users so its in our interest to make it better ;)

My main initial goal with this PR was to allow creating anonymous proxies that have a vanity addresses, however I see an opportunity here to tackle some extra issues that haven't received enough attention and I suppose "just going for it" can help bring attention to them and push ourselves to make decisions.

Topic to consider:

- [x] https://github.com/paritytech/substrate/issues/7735 renaming anonymous proxy to **proxied keyless account**. It has been a big source of confusion and most people seem to agree the name should change. 
- [ ] **Keyless account with vanity addresses**. Based on my assumption that "very vain" vanity addresses can be guaranteed to not have a known private key I think it's viable to let the user provide their desired account and judge on-chain whether it's likely to be keyless or not. Initially I wanted to make it more automatic and provide just the desired pattern but maybe due to my lack of understanding of how base58 encoding works I couldn't create a reliable [address generator](https://github.com/olanod/keyless-vanity-substrate/blob/main/src/lib.rs) but for Polkadot addresses at least it works fine and its kind of fun([demo](https://olanod.github.io/keyless-vanity-substrate/demo/)) so it can be left to the client to find their account that can be judged based on some criteria like how much a character repeats in the encoded address or as seen in the [test](https://github.com/olanod/keyless-vanity-substrate/blob/main/src/lib.rs#L118) measure the entropy or something. Also accounts with vanity in the binary representation are easy to evaluate(e.g. make sure everything is 0s after the pattern).  
- [ ] https://github.com/paritytech/substrate/issues/7054 
  > Alternative way is allow account to approve another account to use it as the funding source of tx fee. This can also increase provider count for the spending account. So it will be just one more storage read to fetch funding source. If we bake this into system AccountData, there won't be any additional storage access.
- [ ] https://github.com/paritytech/substrate/issues/8550
- [ ] https://github.com/paritytech/substrate/issues/7894

