### PR TITLE
Spellcheck HBS templates and add test

### DIFF
--- a/bin/node/cli/tests/benchmark_storage_works.rs
+++ b/bin/node/cli/tests/benchmark_storage_works.rs
@@ -1,0 +1,49 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use assert_cmd::cargo::cargo_bin;
+use std::{path::Path, process::{ExitStatus, Command}};
+use tempfile::tempdir;
+
+/// Tests that the `benchmark-storage` command works for the dev runtime.
+#[test]
+fn benchmark_storage_works() {
+	let tmp_dir = tempdir().expect("could not create a temp dir");
+	let base_path = tmp_dir.path();
+
+	// Benchmarking the storage works and creates the correct weight file.
+	assert!(benchmark_storage("rocksdb", base_path).success());
+	assert!(base_path.join("rocksdb_weights.rs").exists());
+
+	assert!(benchmark_storage("paritydb", base_path).success());
+	assert!(base_path.join("paritydb_weights.rs").exists());
+}
+
+fn benchmark_storage(db: &'static str, base_path: &Path) -> ExitStatus {
+	Command::new(cargo_bin("substrate"))
+		.args(&["benchmark-storage", "--dev"])
+		.arg("--db")
+		.arg(db)
+		.arg("--weight-path")
+		.arg(base_path)
+		.args(["--state-version", "1"])
+		.args(["--warmups", "0"])
+		.args(["--add", "100", "--mul", "1.2", "--metric", "p75"])
+		.status()
+		.unwrap()
+}

--- a/bin/node/cli/tests/benchmark_storage_works.rs
+++ b/bin/node/cli/tests/benchmark_storage_works.rs
@@ -37,7 +37,7 @@ fn benchmark_storage_works() {
 	assert!(base_path.join("paritydb_weights.rs").exists());
 }
 
-fn benchmark_storage(db: &'static str, base_path: &Path) -> ExitStatus {
+fn benchmark_storage(db: &str, base_path: &Path) -> ExitStatus {
 	Command::new(cargo_bin("substrate"))
 		.args(&["benchmark-storage", "--dev"])
 		.arg("--db")

--- a/bin/node/cli/tests/benchmark_storage_works.rs
+++ b/bin/node/cli/tests/benchmark_storage_works.rs
@@ -17,7 +17,10 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use assert_cmd::cargo::cargo_bin;
-use std::{path::Path, process::{ExitStatus, Command}};
+use std::{
+	path::Path,
+	process::{Command, ExitStatus},
+};
 use tempfile::tempdir;
 
 /// Tests that the `benchmark-storage` command works for the dev runtime.

--- a/utils/frame/benchmarking-cli/src/overhead/weights.hbs
+++ b/utils/frame/benchmarking-cli/src/overhead/weights.hbs
@@ -37,17 +37,17 @@ parameter_types! {
 	{{#if (eq short_name "block")}}
 	/// Time to execute an empty block.
 	{{else}}
-	/// Time to execute a NO-OP extrinsic eg. `System::remark`.
+	/// Time to execute a NO-OP extrinsic, for example `System::remark`.
 	{{/if}}
 	/// Calculated by multiplying the *{{params.weight.weight_metric}}* with `{{params.weight.weight_mul}}` and adding `{{params.weight.weight_add}}`.
 	///
-	/// Stats [ns]:
+	/// Stats [NS]:
 	///   Min, Max: {{underscore stats.min}}, {{underscore stats.max}}
 	///   Average:  {{underscore stats.avg}}
 	///   Median:   {{underscore stats.median}}
-	///   StdDev:   {{stats.stddev}}
+	///   Std-Dev:  {{stats.stddev}}
 	///
-	/// Percentiles [ns]:
+	/// Percentiles [NS]:
 	///   99th: {{underscore stats.p99}}
 	///   95th: {{underscore stats.p95}}
 	///   75th: {{underscore stats.p75}}
@@ -67,26 +67,14 @@ mod test_weights {
 
 		{{#if (eq short_name "block")}}			
 		// At least 100 µs.
-		assert!(
-			w >= 100 * constants::WEIGHT_PER_MICROS,
-			"Weight should be at least 100 µs."
-		);
+		assert!(w >= 100 * constants::WEIGHT_PER_MICROS, "Weight should be at least 100 µs.");
 		// At most 50 ms.
-		assert!(
-			w <= 50 * constants::WEIGHT_PER_MILLIS,
-			"Weight should be at most 50 ms."
-		);
+		assert!(w <= 50 * constants::WEIGHT_PER_MILLIS,	"Weight should be at most 50 ms.");
 		{{else}}
 		// At least 10 µs.
-		assert!(
-			w >= 10 * constants::WEIGHT_PER_MICROS,
-			"Weight should be at least 10 µs."
-		);
+		assert!(w >= 10 * constants::WEIGHT_PER_MICROS, "Weight should be at least 10 µs.");
 		// At most 1 ms.
-		assert!(
-			w <= constants::WEIGHT_PER_MILLIS,
-			"Weight should be at most 1 ms."
-		);
+		assert!(w <= constants::WEIGHT_PER_MILLIS, "Weight should be at most 1 ms."		);
 		{{/if}}
 	}
 }

--- a/utils/frame/benchmarking-cli/src/overhead/weights.hbs
+++ b/utils/frame/benchmarking-cli/src/overhead/weights.hbs
@@ -69,12 +69,12 @@ mod test_weights {
 		// At least 100 µs.
 		assert!(w >= 100 * constants::WEIGHT_PER_MICROS, "Weight should be at least 100 µs.");
 		// At most 50 ms.
-		assert!(w <= 50 * constants::WEIGHT_PER_MILLIS,	"Weight should be at most 50 ms.");
+		assert!(w <= 50 * constants::WEIGHT_PER_MILLIS, "Weight should be at most 50 ms.");
 		{{else}}
 		// At least 10 µs.
 		assert!(w >= 10 * constants::WEIGHT_PER_MICROS, "Weight should be at least 10 µs.");
 		// At most 1 ms.
-		assert!(w <= constants::WEIGHT_PER_MILLIS, "Weight should be at most 1 ms."		);
+		assert!(w <= constants::WEIGHT_PER_MILLIS, "Weight should be at most 1 ms.");
 		{{/if}}
 	}
 }

--- a/utils/frame/benchmarking-cli/src/storage/weights.hbs
+++ b/utils/frame/benchmarking-cli/src/storage/weights.hbs
@@ -32,7 +32,10 @@
 
 /// Storage DB weights for the `{{runtime_name}}` runtime and `{{db_name}}`.
 pub mod constants {
-	use frame_support::{parameter_types, weights::{RuntimeDbWeight, constants}};
+	use frame_support::{
+		parameter_types,
+		weights::{constants, RuntimeDbWeight},
+	};
 
 	parameter_types! {
 		{{#if (eq db_name "ParityDb")}}

--- a/utils/frame/benchmarking-cli/src/storage/weights.hbs
+++ b/utils/frame/benchmarking-cli/src/storage/weights.hbs
@@ -22,52 +22,52 @@
 //! BLOCK-NUM: `{{block_number}}`
 //! SKIP-WRITE: `{{params.skip_write}}`, SKIP-READ: `{{params.skip_read}}`, WARMUPS: `{{params.warmups}}`
 //! STATE-VERSION: `V{{params.state_version}}`, STATE-CACHE-SIZE: `{{params.state_cache_size}}`
-//! WEIGHT-PATH: `{{params.weight_path}}`
-//! METRIC: `{{params.weight_metric}}`, WEIGHT-MUL: `{{params.weight_mul}}`, WEIGHT-ADD: `{{params.weight_add}}`
+//! WEIGHT-PATH: `{{params.weight_params.weight_path}}`
+//! METRIC: `{{params.weight_params.weight_metric}}`, WEIGHT-MUL: `{{params.weight_params.weight_mul}}`, WEIGHT-ADD: `{{params.weight_params.weight_add}}`
 
 // Executed Command:
 {{#each args as |arg|}}
 //   {{arg}}
 {{/each}}
 
-/// Storage DB weights for the {{runtime_name}} runtime and {{db_name}}.
+/// Storage DB weights for the `{{runtime_name}}` runtime and `{{db_name}}`.
 pub mod constants {
 	use frame_support::{parameter_types, weights::{RuntimeDbWeight, constants}};
 
 	parameter_types! {
 		{{#if (eq db_name "ParityDb")}}
-		/// ParityDB can be enabled with a feature flag, but is still experimental. These weights
+		/// `ParityDB` can be enabled with a feature flag, but is still experimental. These weights
 		/// are available for brave runtime engineers who may want to try this out as default.
 		{{else}}
-		/// By default, Substrate uses RocksDB, so this will be the weight used throughout
+		/// By default, Substrate uses `RocksDB`, so this will be the weight used throughout
 		/// the runtime.
 		{{/if}}
 		pub const {{db_name}}Weight: RuntimeDbWeight = RuntimeDbWeight {
 			/// Time to read one storage item.
-			/// Calculated by multiplying the *{{params.weight_metric}}* of all values with `{{params.weight_mul}}` and adding `{{params.weight_add}}`.
+			/// Calculated by multiplying the *{{params.weight_params.weight_metric}}* of all values with `{{params.weight_params.weight_mul}}` and adding `{{params.weight_params.weight_add}}`.
 			///
-			/// Stats [ns]:
+			/// Stats [NS]:
 			///   Min, Max: {{underscore read.0.min}}, {{underscore read.0.max}}
 			///   Average:  {{underscore read.0.avg}}
 			///   Median:   {{underscore read.0.median}}
-			///   StdDev:   {{read.0.stddev}}
+			///   Std-Dev:  {{read.0.stddev}}
 			///
-			/// Percentiles [ns]:
+			/// Percentiles [NS]:
 			///   99th: {{underscore read.0.p99}}
 			///   95th: {{underscore read.0.p95}}
 			///   75th: {{underscore read.0.p75}}
 			read: {{underscore read_weight}} * constants::WEIGHT_PER_NANOS,
 
 			/// Time to write one storage item.
-			/// Calculated by multiplying the *{{params.weight_metric}}* of all values with `{{params.weight_mul}}` and adding `{{params.weight_add}}`.
+			/// Calculated by multiplying the *{{params.weight_params.weight_metric}}* of all values with `{{params.weight_params.weight_mul}}` and adding `{{params.weight_params.weight_add}}`.
 			///
-			/// Stats [ns]:
+			/// Stats [NS]:
 			///   Min, Max: {{underscore write.0.min}}, {{underscore write.0.max}}
 			///   Average:  {{underscore write.0.avg}}
 			///   Median:   {{underscore write.0.median}}
-			///   StdDev:   {{write.0.stddev}}
+			///   Std-Dev:  {{write.0.stddev}}
 			///
-			/// Percentiles [ns]:
+			/// Percentiles [NS]:
 			///   99th: {{underscore write.0.p99}}
 			///   95th: {{underscore write.0.p95}}
 			///   75th: {{underscore write.0.p75}}


### PR DESCRIPTION
- The Polkadot spellcheck and fmt CI rejected my filled out templates, this should fix it.  
- Test that `benchmark-storage` works with the `--dev` runtime