### PR TITLE
Remove Misleading Sentence About `StorageDoubleMap`

### DIFF
--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -517,9 +517,6 @@ pub trait IterableStorageNMap<K: ReversibleKeyGenerator, V: FullCodec>: StorageN
 
 /// An implementation of a map with a two keys.
 ///
-/// It provides an important ability to efficiently remove all entries
-/// that have a common first key.
-///
 /// Details on implementation can be found at [`generator::StorageDoubleMap`].
 pub trait StorageDoubleMap<K1: FullEncode, K2: FullEncode, V: FullCodec> {
 	/// The type that get/take returns.


### PR DESCRIPTION
`StorageDoubleMap` has no magically efficient storage removal operation compared to an iterator which will remove all the storage items in the double map.

Users are getting confused like here: https://substrate.stackexchange.com/questions/1280/complexity-of-storagedoublemapremove-prefix/1285#1285