### PR TITLE
Update kvdb-rocksdb to 0.15.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3616,9 +3616,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e72a631a32527fafe22d0751c002e67d28173c49dcaecf79d1aaa323c520e9"
+checksum = "ca7fbdfd71cd663dceb0faf3367a99f8cf724514933e9867cec4995b6027cbc1"
 dependencies = [
  "fs-swap",
  "kvdb",

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 parking_lot = "0.12.0"
 log = "0.4.8"
 kvdb = "0.11.0"
-kvdb-rocksdb = { version = "0.15.1", optional = true }
+kvdb-rocksdb = { version = "0.15.2", optional = true }
 kvdb-memorydb = "0.11.0"
 linked-hash-map = "0.5.4"
 hash-db = "0.15.2"


### PR DESCRIPTION
Trivial update on the kvdb-rocksdb side, which is essentially just a build fix on openbsd/msvc targets.

