### PR TITLE
Remove not required DigestItem conversion

### DIFF
--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -153,7 +153,7 @@ impl<T: Config> Pallet<T> {
 			AURA_ENGINE_ID,
 			ConsensusLog::AuthoritiesChange(new.into_inner()).encode(),
 		);
-		<frame_system::Pallet<T>>::deposit_log(log.into());
+		<frame_system::Pallet<T>>::deposit_log(log);
 	}
 
 	fn initialize_authorities(authorities: &[T::AuthorityId]) {
@@ -225,7 +225,7 @@ impl<T: Config> OneSessionHandler<T::AccountId> for Pallet<T> {
 			ConsensusLog::<T::AuthorityId>::OnDisabled(i as AuthorityIndex).encode(),
 		);
 
-		<frame_system::Pallet<T>>::deposit_log(log.into());
+		<frame_system::Pallet<T>>::deposit_log(log);
 	}
 }
 

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -627,7 +627,7 @@ impl<T: Config> Pallet<T> {
 
 	fn deposit_consensus<U: Encode>(new: U) {
 		let log = DigestItem::Consensus(BABE_ENGINE_ID, new.encode());
-		<frame_system::Pallet<T>>::deposit_log(log.into())
+		<frame_system::Pallet<T>>::deposit_log(log)
 	}
 
 	fn deposit_randomness(randomness: &schnorrkel::Randomness) {

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -498,7 +498,7 @@ impl<T: Config> Pallet<T> {
 	/// Deposit one of this module's logs.
 	fn deposit_log(log: ConsensusLog<T::BlockNumber>) {
 		let log = DigestItem::Consensus(GRANDPA_ENGINE_ID, log.encode());
-		<frame_system::Pallet<T>>::deposit_log(log.into());
+		<frame_system::Pallet<T>>::deposit_log(log);
 	}
 
 	// Perform module initialization, abstracted so that it can be called either through genesis


### PR DESCRIPTION
FRAME system `deposit_log` takes a `DigestItem`, i.e. exactly the type we are passing in