### PR TITLE
FIX: paramaterize substrate grafana dashboard network prefix to support polkadot grafana dashboard at the wiki

### DIFF
--- a/scripts/ci/monitoring/grafana-dashboards/substrate-networking.json
+++ b/scripts/ci/monitoring/grafana-dashboards/substrate-networking.json
@@ -1,12 +1,5 @@
 {
   "__inputs": [
-    {
-      "name": "VAR_METRIC_NAMESPACE",
-      "type": "constant",
-      "label": "Prefix of the metrics",
-      "value": "substrate",
-      "description": ""
-    }
   ],
   "__requires": [
     {
@@ -2655,6 +2648,37 @@
     "list": [
       {
         "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "substrate",
+          "value": "substrate"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Chain Metrics",
+        "multi": false,
+        "name": "metric_namespace",
+        "options": [
+          {
+            "selected": true,
+            "text": "substrate",
+            "value": "substrate"
+          },
+          {
+            "selected": false,
+            "text": "polkadot",
+            "value": "polkadot"
+          }
+        ],
+        "query": "substrate, polkadot",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": null,
         "current": {},
         "datasource": "$data_source",
         "definition": "${metric_namespace}_process_start_time_seconds",
@@ -2741,27 +2765,6 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
-      },
-      {
-        "current": {
-          "value": "${VAR_METRIC_NAMESPACE}",
-          "text": "${VAR_METRIC_NAMESPACE}",
-          "selected": false
-        },
-        "error": null,
-        "hide": 2,
-        "label": "Prefix of the metrics",
-        "name": "metric_namespace",
-        "options": [
-          {
-            "value": "${VAR_METRIC_NAMESPACE}",
-            "text": "${VAR_METRIC_NAMESPACE}",
-            "selected": false
-          }
-        ],
-        "query": "${VAR_METRIC_NAMESPACE}",
-        "skipUrlSync": false,
-        "type": "constant"
       },
       {
         "allValue": null,

--- a/scripts/ci/monitoring/grafana-dashboards/substrate-networking.json
+++ b/scripts/ci/monitoring/grafana-dashboards/substrate-networking.json
@@ -2670,9 +2670,14 @@
             "selected": false,
             "text": "polkadot",
             "value": "polkadot"
+          },
+          {
+            "selected": false,
+            "text": "kusama",
+            "value": "kusama"
           }
         ],
-        "query": "substrate, polkadot",
+        "query": "substrate, polkadot, kusama",
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"

--- a/scripts/ci/monitoring/grafana-dashboards/substrate-service-tasks.json
+++ b/scripts/ci/monitoring/grafana-dashboards/substrate-service-tasks.json
@@ -992,9 +992,14 @@
             "selected": false,
             "text": "polkadot",
             "value": "polkadot"
+          },
+          {
+            "selected": false,
+            "text": "kusama",
+            "value": "kusama"
           }
         ],
-        "query": "substrate, polkadot",
+        "query": "substrate, polkadot, kusama",
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"

--- a/scripts/ci/monitoring/grafana-dashboards/substrate-service-tasks.json
+++ b/scripts/ci/monitoring/grafana-dashboards/substrate-service-tasks.json
@@ -1,12 +1,6 @@
 {
   "__inputs": [
-    {
-      "name": "VAR_METRIC_NAMESPACE",
-      "type": "constant",
-      "label": "Prefix of the metrics",
-      "value": "substrate",
-      "description": ""
-    }
+  
   ],
   "__requires": [
     {
@@ -976,6 +970,37 @@
     "list": [
       {
         "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "substrate",
+          "value": "substrate"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Chain Metrics",
+        "multi": false,
+        "name": "metric_namespace",
+        "options": [
+          {
+            "selected": true,
+            "text": "substrate",
+            "value": "substrate"
+          },
+          {
+            "selected": false,
+            "text": "polkadot",
+            "value": "polkadot"
+          }
+        ],
+        "query": "substrate, polkadot",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": null,
         "current": {},
         "datasource": "$data_source",
         "definition": "${metric_namespace}_process_start_time_seconds",
@@ -997,27 +1022,7 @@
         "type": "query",
         "useTags": false
       },
-      {
-        "current": {
-          "value": "${VAR_METRIC_NAMESPACE}",
-          "text": "${VAR_METRIC_NAMESPACE}",
-          "selected": false
-        },
-        "error": null,
-        "hide": 2,
-        "label": "Prefix of the metrics",
-        "name": "metric_namespace",
-        "options": [
-          {
-            "value": "${VAR_METRIC_NAMESPACE}",
-            "text": "${VAR_METRIC_NAMESPACE}",
-            "selected": false
-          }
-        ],
-        "query": "${VAR_METRIC_NAMESPACE}",
-        "skipUrlSync": false,
-        "type": "constant"
-      },
+  
       {
         "current": {
           "selected": false,


### PR DESCRIPTION
Hi Anwesh here 👋  I am participating at [1K Contributor's program](https://github.com/w3f/1KC) and my task was to update the outdated grafana dashboard mentioned at the [monitoring section of polkadot wiki](https://wiki.polkadot.network/docs/maintain-guides-how-to-monitor-your-node).

1K Contributor task : https://github.com/w3f/polkadot-wiki/issues/2192
Original Issue raised : https://github.com/w3f/polkadot-wiki/issues/1652

The latest grafana dashboards were available in this substrate repo, some tweaks were required in the grafana dashboard json file to support polkadot,kusama as a network parameter. I have done in this commit so as to use the same resource at the [monitoring section of polkadot wiki](https://wiki.polkadot.network/docs/maintain-guides-how-to-monitor-your-node)
Im currently running a polkadot node with --dev flag.

I have added the dropdown at the left bottom corner as "Chain Metrics" which supports substrate and polkadot as values. 

![Screenshot 2022-04-04 at 7 38 36 PM](https://user-images.githubusercontent.com/8139783/161562038-6c7dfc99-b7ce-42f4-9677-b575dc47ebce.png)

![Screenshot 2022-04-04 at 7 38 23 PM](https://user-images.githubusercontent.com/8139783/161562020-4d85e045-a38d-47de-82c1-06f9af7a090b.png)
