### PR TITLE
Fix a spelling error.

### DIFF
--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -386,7 +386,7 @@ pub struct Semantics {
 	// I.e. if [`CodeSupplyMode::Verbatim`] is used.
 	pub fast_instance_reuse: bool,
 
-	/// Specifiying `Some` will enable deterministic stack height. That is, all executor
+	/// Specifying `Some` will enable deterministic stack height. That is, all executor
 	/// invocations will reach stack overflow at the exactly same point across different wasmtime
 	/// versions and architectures.
 	///


### PR DESCRIPTION
There is a spelling error in `substrate/client/executor/wasmtime/src/runtime.rs` file.