### PR TITLE
Catch panics on the FFI boundary between the runtime and the host for `wasmtime`

### DIFF
--- a/client/executor/runtime-test/src/lib.rs
+++ b/client/executor/runtime-test/src/lib.rs
@@ -113,7 +113,9 @@ sp_core::wasm_export_functions! {
 	   }
    }
 
-   fn test_exhaust_heap() -> Vec<u8> { Vec::with_capacity(16777216) }
+	fn test_allocate_vec(size: u32) -> Vec<u8> {
+		Vec::with_capacity(size as usize)
+	}
 
    fn test_fp_f32add(a: [u8; 4], b: [u8; 4]) -> [u8; 4] {
 	   let a = f32::from_le_bytes(a);
@@ -348,10 +350,6 @@ sp_core::wasm_export_functions! {
 
 	fn test_unreachable_intrinsic() {
 		core::arch::wasm32::unreachable()
-	}
-
-	fn test_allocate_too_much_memory() {
-		sp_io::allocator::malloc(1024 * 1024 * 1024);
 	}
 }
 

--- a/client/executor/runtime-test/src/lib.rs
+++ b/client/executor/runtime-test/src/lib.rs
@@ -349,6 +349,10 @@ sp_core::wasm_export_functions! {
 	fn test_unreachable_intrinsic() {
 		core::arch::wasm32::unreachable()
 	}
+
+	fn test_allocate_too_much_memory() {
+		sp_io::allocator::malloc(1024 * 1024 * 1024);
+	}
 }
 
 #[cfg(not(feature = "std"))]


### PR DESCRIPTION
Currently if the runtime calls into the host and the host panics we're left with no backtrace from within the runtime since the panic is only caught [here](https://github.com/paritytech/substrate/blob/78b1ad3c754514135bc0026407f7d2bf3bacae27/client/executor/src/native_executor.rs#L65) *after* the whole execution context is already dropped. (And the host functions [*can* panic](https://github.com/paritytech/substrate/issues/11132).)

This PR makes it so that we catch any panics on the FFI boundary between the runtime and the host, and turn that into a trap. This allows us to extract and print out the backtrace from within the runtime as part of the error message and see what exactly within the runtime called the host function which panicked.

This is done only for `wasmtime` since at this time `wasmi` doesn't support backtraces anyway.