### PR TITLE
Updated docs for method `set_payee` & `set_controller`

### DIFF
--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -1109,7 +1109,7 @@ pub mod pallet {
 
 		/// (Re-)set the payment target for a controller.
 		///
-		/// Effects will be felt at the beginning of the next era.
+		/// Effects will be felt instantly (as soon as this function is completed successfully).
 		///
 		/// The dispatch origin for this call must be _Signed_ by the controller, not the stash.
 		///

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -1137,7 +1137,7 @@ pub mod pallet {
 
 		/// (Re-)set the controller of a stash.
 		///
-		/// Effects will be felt at the beginning of the next era.
+		/// Effects will be felt instantly (as soon as this function is completed successfully).
 		///
 		/// The dispatch origin for this call must be _Signed_ by the stash, not the controller.
 		///


### PR DESCRIPTION
### Description
This PR is related to this [issue](https://github.com/paritytech/substrate/issues/11188). It updates the docs for the method [set_payee](https://github.com/paritytech/substrate/blob/994bb57b77b2845e9e1b48d8eb77c9160366d525/frame/staking/src/pallet/mod.rs#L1127) so that they reflect correctly when the changes from this function start to apply.


### Further Notes
The same comment can also be found in the following methods : 
[validate](https://github.com/paritytech/substrate/blob/994bb57b77b2845e9e1b48d8eb77c9160366d525/frame/staking/src/pallet/mod.rs#L990) 
[nominate](https://github.com/paritytech/substrate/blob/994bb57b77b2845e9e1b48d8eb77c9160366d525/frame/staking/src/pallet/mod.rs#L1025) 
[chill](https://github.com/paritytech/substrate/blob/994bb57b77b2845e9e1b48d8eb77c9160366d525/frame/staking/src/pallet/mod.rs#L1093) 
[set_controller](https://github.com/paritytech/substrate/blob/994bb57b77b2845e9e1b48d8eb77c9160366d525/frame/staking/src/pallet/mod.rs#L1140) 
[kick](https://github.com/paritytech/substrate/blob/994bb57b77b2845e9e1b48d8eb77c9160366d525/frame/staking/src/pallet/mod.rs#L1492) 
[chill_other](https://github.com/paritytech/substrate/blob/994bb57b77b2845e9e1b48d8eb77c9160366d525/frame/staking/src/pallet/mod.rs#L1587) 

I was wondering if we need to update these comments too since I do not see an `era` check in these functions either but maybe I am wrong. 

Thank you so much for your feedback.
