### PR TITLE
Remove useless trait bound and `move` instructions

### DIFF
--- a/bin/node-template/node/src/command.rs
+++ b/bin/node-template/node/src/command.rs
@@ -98,7 +98,7 @@ pub fn run() -> sc_cli::Result<()> {
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, backend, .. } =
 					service::new_partial(&config)?;
-				let aux_revert = Box::new(move |client, _, blocks| {
+				let aux_revert = Box::new(|client, _, blocks| {
 					sc_finality_grandpa::revert(client, blocks)?;
 					Ok(())
 				});

--- a/bin/node/cli/src/command.rs
+++ b/bin/node/cli/src/command.rs
@@ -175,7 +175,7 @@ pub fn run() -> Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, backend, .. } = new_partial(&config)?;
-				let aux_revert = Box::new(move |client: Arc<FullClient>, backend, blocks| {
+				let aux_revert = Box::new(|client: Arc<FullClient>, backend, blocks| {
 					sc_consensus_babe::revert(client.clone(), backend, blocks)?;
 					grandpa::revert(client, blocks)?;
 					Ok(())

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -1173,7 +1173,6 @@ where
 	Client: AuxStore
 		+ HeaderMetadata<Block, Error = sp_blockchain::Error>
 		+ HeaderBackend<Block>
-		+ ProvideRuntimeApi<Block>,
 {
 	let best_number = client.info().best_number;
 	let finalized = client.info().finalized_number;

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -1170,9 +1170,7 @@ fn local_authority_id(
 pub fn revert<Block, Client>(client: Arc<Client>, blocks: NumberFor<Block>) -> ClientResult<()>
 where
 	Block: BlockT,
-	Client: AuxStore
-		+ HeaderMetadata<Block, Error = sp_blockchain::Error>
-		+ HeaderBackend<Block>
+	Client: AuxStore + HeaderMetadata<Block, Error = sp_blockchain::Error> + HeaderBackend<Block>,
 {
 	let best_number = client.info().best_number;
 	let finalized = client.info().finalized_number;


### PR DESCRIPTION
Remove a couple of useless move instructions and a not required trait bound 