### PR TITLE
Normalization of CLI options format (CamelCase => kebab-case)

### DIFF
--- a/client/cli/src/arg_enums.rs
+++ b/client/cli/src/arg_enums.rs
@@ -165,18 +165,6 @@ impl Into<sc_client_api::ExecutionStrategy> for ExecutionStrategy {
 	}
 }
 
-impl ExecutionStrategy {
-	/// Returns the variant as `'&static str`.
-	pub fn as_str(&self) -> &'static str {
-		match self {
-			Self::Native => "Native",
-			Self::Wasm => "Wasm",
-			Self::Both => "Both",
-			Self::NativeElseWasm => "NativeElseWasm",
-		}
-	}
-}
-
 /// Available RPC methods.
 #[allow(missing_docs)]
 #[derive(Debug, Copy, Clone, PartialEq, ArgEnum)]

--- a/client/cli/src/arg_enums.rs
+++ b/client/cli/src/arg_enums.rs
@@ -88,7 +88,7 @@ impl Into<sc_service::config::WasmExecutionMethod> for WasmExecutionMethod {
 
 /// The default [`WasmExecutionMethod`].
 #[cfg(feature = "wasmtime")]
-pub const DEFAULT_WASM_EXECUTION_METHOD: &str = "Compiled";
+pub const DEFAULT_WASM_EXECUTION_METHOD: &str = "compiled";
 
 /// The default [`WasmExecutionMethod`].
 #[cfg(not(feature = "wasmtime"))]
@@ -96,7 +96,7 @@ pub const DEFAULT_WASM_EXECUTION_METHOD: &str = "interpreted-i-know-what-i-do";
 
 #[allow(missing_docs)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ArgEnum)]
-#[clap(rename_all = "PascalCase")]
+#[clap(rename_all = "kebab-case")]
 pub enum TracingReceiver {
 	/// Output the tracing records using the log.
 	Log,
@@ -112,7 +112,7 @@ impl Into<sc_tracing::TracingReceiver> for TracingReceiver {
 
 /// The type of the node key.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ArgEnum)]
-#[clap(rename_all = "PascalCase")]
+#[clap(rename_all = "kebab-case")]
 pub enum NodeKeyType {
 	/// Use ed25519.
 	Ed25519,
@@ -120,7 +120,7 @@ pub enum NodeKeyType {
 
 /// The crypto scheme to use.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ArgEnum)]
-#[clap(rename_all = "PascalCase")]
+#[clap(rename_all = "kebab-case")]
 pub enum CryptoScheme {
 	/// Use ed25519.
 	Ed25519,
@@ -132,7 +132,7 @@ pub enum CryptoScheme {
 
 /// The type of the output format.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ArgEnum)]
-#[clap(rename_all = "PascalCase")]
+#[clap(rename_all = "kebab-case")]
 pub enum OutputType {
 	/// Output as json.
 	Json,
@@ -142,7 +142,7 @@ pub enum OutputType {
 
 /// How to execute blocks
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ArgEnum)]
-#[clap(rename_all = "PascalCase")]
+#[clap(rename_all = "kebab-case")]
 pub enum ExecutionStrategy {
 	/// Execute with native build (if available, WebAssembly otherwise).
 	Native,
@@ -180,7 +180,7 @@ impl ExecutionStrategy {
 /// Available RPC methods.
 #[allow(missing_docs)]
 #[derive(Debug, Copy, Clone, PartialEq, ArgEnum)]
-#[clap(rename_all = "PascalCase")]
+#[clap(rename_all = "kebab-case")]
 pub enum RpcMethods {
 	/// Expose every RPC method only when RPC is listening on `localhost`,
 	/// otherwise serve only safe RPC methods.
@@ -243,7 +243,7 @@ impl Database {
 /// Whether off-chain workers are enabled.
 #[allow(missing_docs)]
 #[derive(Debug, Clone, ArgEnum)]
-#[clap(rename_all = "PascalCase")]
+#[clap(rename_all = "kebab-case")]
 pub enum OffchainWorkerEnabled {
 	/// Always have offchain worker enabled.
 	Always,
@@ -255,7 +255,7 @@ pub enum OffchainWorkerEnabled {
 
 /// Syncing mode.
 #[derive(Debug, Clone, Copy, ArgEnum, PartialEq)]
-#[clap(rename_all = "PascalCase")]
+#[clap(rename_all = "kebab-case")]
 pub enum SyncMode {
 	/// Full sync. Download end verify all blocks.
 	Full,

--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -71,16 +71,16 @@ pub struct RunCmd {
 
 	/// RPC methods to expose.
 	///
-	/// - `Unsafe`: Exposes every RPC method.
-	/// - `Safe`: Exposes only a safe subset of RPC methods, denying unsafe RPC methods.
-	/// - `Auto`: Acts as `Safe` if RPC is served externally, e.g. when `--{rpc,ws}-external` is
-	///   passed, otherwise acts as `Unsafe`.
+	/// - `unsafe`: Exposes every RPC method.
+	/// - `safe`: Exposes only a safe subset of RPC methods, denying unsafe RPC methods.
+	/// - `auto`: Acts as `safe` if RPC is served externally, e.g. when `--{rpc,ws}-external` is
+	///   passed, otherwise acts as `unsafe`.
 	#[clap(
 		long,
 		value_name = "METHOD SET",
 		arg_enum,
 		ignore_case = true,
-		default_value = "Auto",
+		default_value = "auto",
 		verbatim_doc_comment
 	)]
 	pub rpc_methods: RpcMethods,

--- a/client/cli/src/params/mod.rs
+++ b/client/cli/src/params/mod.rs
@@ -118,7 +118,7 @@ impl BlockNumberOrHash {
 #[derive(Debug, Clone, Args)]
 pub struct CryptoSchemeFlag {
 	/// cryptography scheme
-	#[clap(long, value_name = "SCHEME", arg_enum, ignore_case = true, default_value = "Sr25519")]
+	#[clap(long, value_name = "SCHEME", arg_enum, ignore_case = true, default_value = "sr25519")]
 	pub scheme: CryptoScheme,
 }
 
@@ -126,7 +126,7 @@ pub struct CryptoSchemeFlag {
 #[derive(Debug, Clone, Args)]
 pub struct OutputTypeFlag {
 	/// output format
-	#[clap(long, value_name = "FORMAT", arg_enum, ignore_case = true, default_value = "Text")]
+	#[clap(long, value_name = "FORMAT", arg_enum, ignore_case = true, default_value = "text")]
 	pub output_type: OutputType,
 }
 

--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -132,12 +132,18 @@ pub struct NetworkParams {
 
 	/// Blockchain syncing mode.
 	///
-	/// - `Full`: Download and validate full blockchain history.
-	///
-	/// - `Fast`: Download blocks and the latest state only.
-	///
-	/// - `FastUnsafe`: Same as `Fast`, but skip downloading state proofs.
-	#[clap(long, arg_enum, value_name = "SYNC_MODE", default_value = "Full", ignore_case(true))]
+	/// - `full`: Download and validate full blockchain history.
+	/// - `fast`: Download blocks and the latest state only.
+	/// - `fast-unsafe`: Same as `fast`, but skip downloading state proofs.
+	/// - `warp`: Download the latest state and proof.
+	#[clap(
+		long,
+		arg_enum,
+		value_name = "SYNC_MODE",
+		default_value = "full",
+		ignore_case = true,
+		verbatim_doc_comment
+	)]
 	pub sync: SyncMode,
 }
 

--- a/client/cli/src/params/node_key_params.rs
+++ b/client/cli/src/params/node_key_params.rs
@@ -66,7 +66,7 @@ pub struct NodeKeyParams {
 	///
 	/// The node's secret key determines the corresponding public key and hence the
 	/// node's peer ID in the context of libp2p.
-	#[clap(long, value_name = "TYPE", arg_enum, ignore_case = true, default_value = "Ed25519")]
+	#[clap(long, value_name = "TYPE", arg_enum, ignore_case = true, default_value = "ed25519")]
 	pub node_key_type: NodeKeyType,
 
 	/// The file from which to read the node's secret key to use for libp2p networking.

--- a/client/cli/src/params/offchain_worker_params.rs
+++ b/client/cli/src/params/offchain_worker_params.rs
@@ -40,7 +40,7 @@ pub struct OffchainWorkerParams {
 		value_name = "ENABLED",
 		arg_enum,
 		ignore_case = true,
-		default_value = "WhenValidating"
+		default_value = "when-validating"
 	)]
 	pub enabled: OffchainWorkerEnabled,
 

--- a/client/cli/src/params/shared_params.rs
+++ b/client/cli/src/params/shared_params.rs
@@ -76,7 +76,7 @@ pub struct SharedParams {
 	pub tracing_targets: Option<String>,
 
 	/// Receiver to process tracing messages.
-	#[clap(long, value_name = "RECEIVER", arg_enum, ignore_case = true, default_value = "Log")]
+	#[clap(long, value_name = "RECEIVER", arg_enum, ignore_case = true, default_value = "log")]
 	pub tracing_receiver: TracingReceiver,
 }
 

--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -387,7 +387,7 @@ pub struct SharedParams {
 	pub shared_params: sc_cli::SharedParams,
 
 	/// The execution strategy that should be used.
-	#[clap(long, value_name = "STRATEGY", arg_enum, ignore_case = true, default_value = "Wasm")]
+	#[clap(long, value_name = "STRATEGY", arg_enum, ignore_case = true, default_value = "wasm")]
 	pub execution: ExecutionStrategy,
 
 	/// Type of wasm execution used.


### PR DESCRIPTION
Even though options values are internally converted to lowercase before being parsed, currently some CLI commands are shown in *CamelCase* while others in *kebab-case*.

This PR normalizes the format to (lower) *kebab-case* (e.g. "HelloWorld" => "hello-world").

Main motivations:
- project-wide coherence
- inline with how options are normally specified on other programs/tools found on Unix-like OSs
- faster to type (opinionated) :-)

---

## Some Examples

### Execution strategy

Before
```
--execution <STRATEGY>
    ...
    [possible values: Native, Wasm, Both, NativeElseWasm]
```

Now:
```
--execution <STRATEGY>
    ...
    [possible values: native, wasm, both, native-else-wasm]
```

### Key generation

Before:
```
--scheme <SCHEME>
    ...
    [possible values: Ed25510, Sr25519, Ecdsa]
```

Now:
```
--scheme <SCHEME>
    ...
    [possible values: ed25510, sr25519, ecdsa]
```

### Database

Before and Now:
```
--database <DB>
    ...
    [possible values: rocksdb, paritydb, paritydb-experimental, auto]
```

### Wasm Execution

Before and Now:
```
--wasm-execution <METHOD>
    ...
    [possible values: interpreted-i-know-what-i-do, compiled]
```

---

## Drawback

Because the option's arguments are internally converted to lowercase, this modification is **almost** fully backward compatible.

The only exceptions are **THREE** "*multiword*" arguments that were previously shown as *CamelCase* strings. With this modification their words are split by the `-` character (i.e. conversion to lowercase doesn't provide backward compatibility).

These are the three non backward compatible values:
- (--execution) "NativeElseWasm" => "native-else-wasm"
- (--offchain-worker) "WhenValidating" => "when-validating"
- (--sync) "FastUnsafe" => "fast-unsafe"
