### PR TITLE
CI: rename ambiguous jobs

### DIFF
--- a/.github/workflows/pr-custom-review.yml
+++ b/.github/workflows/pr-custom-review.yml
@@ -1,4 +1,4 @@
-name: Check reviews
+name: Assign reviewers
 
 on:
   pull_request:


### PR DESCRIPTION
Even though these jobs are not solely assigning the reviewers, their names were a bit ambiguous due to the fact that by design they are evergreen. There's another job `Check reviews` that compares their outputs and results in a veritable action status.