### PR TITLE
Split `SolutionImprovementThresholds` into two types

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -26,7 +26,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use frame_election_provider_support::{onchain, ExtendedBalance, SequentialPhragmen, VoteWeight};
 use frame_support::{
 	construct_runtime,
-	pallet_prelude::Get,
+	pallet_prelude::{Get, GetDefault},
 	parameter_types,
 	traits::{
 		AsEnsureOriginWithArg, ConstU128, ConstU16, ConstU32, Currency, EnsureOneOf,
@@ -663,7 +663,8 @@ impl pallet_election_provider_multi_phase::Config for Runtime {
 	type EstimateCallFee = TransactionPayment;
 	type SignedPhase = SignedPhase;
 	type UnsignedPhase = UnsignedPhase;
-	type SolutionImprovementThreshold = SolutionImprovementThreshold;
+	type SolutionImprovementThresholdUnsigned = SolutionImprovementThreshold;
+	type SolutionImprovementThresholdSigned = GetDefault;
 	type OffchainRepeat = OffchainRepeat;
 	type MinerMaxWeight = MinerMaxWeight;
 	type MinerMaxLength = MinerMaxLength;

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -26,7 +26,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use frame_election_provider_support::{onchain, ExtendedBalance, SequentialPhragmen, VoteWeight};
 use frame_support::{
 	construct_runtime,
-	pallet_prelude::{Get, GetDefault},
+	pallet_prelude::Get,
 	parameter_types,
 	traits::{
 		AsEnsureOriginWithArg, ConstU128, ConstU16, ConstU32, Currency, EnsureOneOf,
@@ -574,7 +574,7 @@ parameter_types! {
 	pub const SignedDepositBase: Balance = 1 * DOLLARS;
 	pub const SignedDepositByte: Balance = 1 * CENTS;
 
-	pub SolutionImprovementThreshold: Perbill = Perbill::from_rational(1u32, 10_000);
+	pub BetterUnsignedThreshold: Perbill = Perbill::from_rational(1u32, 10_000);
 
 	// miner configs
 	pub const MultiPhaseUnsignedPriority: TransactionPriority = StakingUnsignedPriority::get() - 1u64;
@@ -663,8 +663,8 @@ impl pallet_election_provider_multi_phase::Config for Runtime {
 	type EstimateCallFee = TransactionPayment;
 	type SignedPhase = SignedPhase;
 	type UnsignedPhase = UnsignedPhase;
-	type SolutionImprovementThresholdUnsigned = SolutionImprovementThreshold;
-	type SolutionImprovementThresholdSigned = GetDefault;
+	type BetterUnsignedThreshold = BetterUnsignedThreshold;
+	type BetterSignedThreshold = ();
 	type OffchainRepeat = OffchainRepeat;
 	type MinerMaxWeight = MinerMaxWeight;
 	type MinerMaxLength = MinerMaxLength;

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -102,8 +102,8 @@
 //! valid if propagated, and it acts similar to an inherent.
 //!
 //! Validators will only submit solutions if the one that they have computed is sufficiently better
-//! than the best queued one (see [`pallet::Config::SolutionImprovementThresholdUnsigned`]) and will
-//! limit the weight of the solution to [`pallet::Config::MinerMaxWeight`].
+//! than the best queued one (see [`pallet::Config::BetterUnsignedThreshold`]) and will limit the
+//! weight of the solution to [`pallet::Config::MinerMaxWeight`].
 //!
 //! The unsigned phase can be made passive depending on how the previous signed phase went, by
 //! setting the first inner value of [`Phase`] to `false`. For now, the signed phase is always
@@ -587,12 +587,12 @@ pub mod pallet {
 		/// The minimum amount of improvement to the solution score that defines a solution as
 		/// "better" in the Signed phase.
 		#[pallet::constant]
-		type SolutionImprovementThresholdSigned: Get<Perbill>;
+		type BetterSignedThreshold: Get<Perbill>;
 
 		/// The minimum amount of improvement to the solution score that defines a solution as
 		/// "better" in the Unsigned phase.
 		#[pallet::constant]
-		type SolutionImprovementThresholdUnsigned: Get<Perbill>;
+		type BetterUnsignedThreshold: Get<Perbill>;
 
 		/// The repeat threshold of the offchain worker.
 		///

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -102,8 +102,8 @@
 //! valid if propagated, and it acts similar to an inherent.
 //!
 //! Validators will only submit solutions if the one that they have computed is sufficiently better
-//! than the best queued one (see [`pallet::Config::SolutionImprovementThreshold`]) and will limit
-//! the weight of the solution to [`pallet::Config::MinerMaxWeight`].
+//! than the best queued one (see [`pallet::Config::SolutionImprovementThresholdUnsigned`]) and will
+//! limit the weight of the solution to [`pallet::Config::MinerMaxWeight`].
 //!
 //! The unsigned phase can be made passive depending on how the previous signed phase went, by
 //! setting the first inner value of [`Phase`] to `false`. For now, the signed phase is always
@@ -585,9 +585,14 @@ pub mod pallet {
 		type SignedPhase: Get<Self::BlockNumber>;
 
 		/// The minimum amount of improvement to the solution score that defines a solution as
-		/// "better" (in any phase).
+		/// "better" in the Signed phase.
 		#[pallet::constant]
-		type SolutionImprovementThreshold: Get<Perbill>;
+		type SolutionImprovementThresholdSigned: Get<Perbill>;
+
+		/// The minimum amount of improvement to the solution score that defines a solution as
+		/// "better" in the Unsigned phase.
+		#[pallet::constant]
+		type SolutionImprovementThresholdUnsigned: Get<Perbill>;
 
 		/// The repeat threshold of the offchain worker.
 		///

--- a/frame/election-provider-multi-phase/src/mock.rs
+++ b/frame/election-provider-multi-phase/src/mock.rs
@@ -263,8 +263,8 @@ parameter_types! {
 	pub static SignedRewardBase: Balance = 7;
 	pub static SignedMaxWeight: Weight = BlockWeights::get().max_block;
 	pub static MinerTxPriority: u64 = 100;
-	pub static SolutionImprovementThresholdSigned: Perbill = Perbill::zero();
-	pub static SolutionImprovementThresholdUnsigned: Perbill = Perbill::zero();
+	pub static BetterSignedThreshold: Perbill = Perbill::zero();
+	pub static BetterUnsignedThreshold: Perbill = Perbill::zero();
 	pub static OffchainRepeat: BlockNumber = 5;
 	pub static MinerMaxWeight: Weight = BlockWeights::get().max_block;
 	pub static MinerMaxLength: u32 = 256;
@@ -414,8 +414,8 @@ impl crate::Config for Runtime {
 	type EstimateCallFee = frame_support::traits::ConstU32<8>;
 	type SignedPhase = SignedPhase;
 	type UnsignedPhase = UnsignedPhase;
-	type SolutionImprovementThresholdUnsigned = SolutionImprovementThresholdUnsigned;
-	type SolutionImprovementThresholdSigned = SolutionImprovementThresholdSigned;
+	type BetterUnsignedThreshold = BetterUnsignedThreshold;
+	type BetterSignedThreshold = BetterSignedThreshold;
 	type OffchainRepeat = OffchainRepeat;
 	type MinerMaxWeight = MinerMaxWeight;
 	type MinerMaxLength = MinerMaxLength;
@@ -538,12 +538,12 @@ impl ExtBuilder {
 		<MinerTxPriority>::set(p);
 		self
 	}
-	pub fn solution_improvement_threshold_signed(self, p: Perbill) -> Self {
-		<SolutionImprovementThresholdSigned>::set(p);
+	pub fn better_signed_threshold(self, p: Perbill) -> Self {
+		<BetterSignedThreshold>::set(p);
 		self
 	}
-	pub fn solution_improvement_threshold_unsigned(self, p: Perbill) -> Self {
-		<SolutionImprovementThresholdUnsigned>::set(p);
+	pub fn better_unsigned_threshold(self, p: Perbill) -> Self {
+		<BetterUnsignedThreshold>::set(p);
 		self
 	}
 	pub fn phases(self, signed: BlockNumber, unsigned: BlockNumber) -> Self {

--- a/frame/election-provider-multi-phase/src/mock.rs
+++ b/frame/election-provider-multi-phase/src/mock.rs
@@ -20,7 +20,7 @@ use crate as multi_phase;
 use frame_election_provider_support::{
 	data_provider, onchain, ElectionDataProvider, NposSolution, SequentialPhragmen,
 };
-pub use frame_support::{assert_noop, assert_ok};
+pub use frame_support::{assert_noop, assert_ok, pallet_prelude::GetDefault};
 use frame_support::{
 	bounded_vec, parameter_types,
 	traits::{ConstU32, Hooks},
@@ -413,7 +413,8 @@ impl crate::Config for Runtime {
 	type EstimateCallFee = frame_support::traits::ConstU32<8>;
 	type SignedPhase = SignedPhase;
 	type UnsignedPhase = UnsignedPhase;
-	type SolutionImprovementThreshold = SolutionImprovementThreshold;
+	type SolutionImprovementThresholdUnsigned = SolutionImprovementThreshold;
+	type SolutionImprovementThresholdSigned = GetDefault;
 	type OffchainRepeat = OffchainRepeat;
 	type MinerMaxWeight = MinerMaxWeight;
 	type MinerMaxLength = MinerMaxLength;

--- a/frame/election-provider-multi-phase/src/mock.rs
+++ b/frame/election-provider-multi-phase/src/mock.rs
@@ -263,7 +263,8 @@ parameter_types! {
 	pub static SignedRewardBase: Balance = 7;
 	pub static SignedMaxWeight: Weight = BlockWeights::get().max_block;
 	pub static MinerTxPriority: u64 = 100;
-	pub static SolutionImprovementThreshold: Perbill = Perbill::zero();
+	pub static SolutionImprovementThresholdSigned: Perbill = Perbill::zero();
+	pub static SolutionImprovementThresholdUnsigned: Perbill = Perbill::zero();
 	pub static OffchainRepeat: BlockNumber = 5;
 	pub static MinerMaxWeight: Weight = BlockWeights::get().max_block;
 	pub static MinerMaxLength: u32 = 256;
@@ -413,8 +414,8 @@ impl crate::Config for Runtime {
 	type EstimateCallFee = frame_support::traits::ConstU32<8>;
 	type SignedPhase = SignedPhase;
 	type UnsignedPhase = UnsignedPhase;
-	type SolutionImprovementThresholdUnsigned = SolutionImprovementThreshold;
-	type SolutionImprovementThresholdSigned = GetDefault;
+	type SolutionImprovementThresholdUnsigned = SolutionImprovementThresholdUnsigned;
+	type SolutionImprovementThresholdSigned = SolutionImprovementThresholdSigned;
 	type OffchainRepeat = OffchainRepeat;
 	type MinerMaxWeight = MinerMaxWeight;
 	type MinerMaxLength = MinerMaxLength;
@@ -537,8 +538,12 @@ impl ExtBuilder {
 		<MinerTxPriority>::set(p);
 		self
 	}
-	pub fn solution_improvement_threshold(self, p: Perbill) -> Self {
-		<SolutionImprovementThreshold>::set(p);
+	pub fn solution_improvement_threshold_signed(self, p: Perbill) -> Self {
+		<SolutionImprovementThresholdSigned>::set(p);
+		self
+	}
+	pub fn solution_improvement_threshold_unsigned(self, p: Perbill) -> Self {
+		<SolutionImprovementThresholdUnsigned>::set(p);
 		self
 	}
 	pub fn phases(self, signed: BlockNumber, unsigned: BlockNumber) -> Self {

--- a/frame/election-provider-multi-phase/src/signed.rs
+++ b/frame/election-provider-multi-phase/src/signed.rs
@@ -291,7 +291,7 @@ impl<T: Config> SignedSubmissions<T> {
 					None => return InsertResult::NotInserted,
 					Some((score, _)) => *score,
 				};
-				let threshold = T::SolutionImprovementThresholdSigned::get();
+				let threshold = T::BetterSignedThreshold::get();
 
 				// if we haven't improved on the weakest score, don't change anything.
 				if !insert_score.strict_threshold_better(weakest_score, threshold) {
@@ -633,10 +633,10 @@ mod tests {
 	}
 
 	#[test]
-	fn cannot_submit_worse_with_full_queue_threshold_100() {
+	fn cannot_submit_worse_with_full_queue_depends_on_threshold() {
 		ExtBuilder::default()
 			.signed_max_submission(1)
-			.solution_improvement_threshold_signed(Perbill::from_percent(100))
+			.better_signed_threshold(Perbill::from_percent(20))
 			.build_and_execute(|| {
 				roll_to(15);
 				assert!(MultiPhase::current_phase().is_signed());
@@ -651,8 +651,7 @@ mod tests {
 				};
 				assert_ok!(MultiPhase::submit(Origin::signed(99), Box::new(solution)));
 
-				// With threshold at 100%, the below is not considered a better solution, and is
-				// therefore rejected.
+				// This is 10% better, so does not meet the 20% threshold and is therefore rejected.
 				solution = RawSolution {
 					score: ElectionScore {
 						minimal_stake: 5u128,
@@ -666,40 +665,18 @@ mod tests {
 					MultiPhase::submit(Origin::signed(99), Box::new(solution)),
 					Error::<Runtime>::SignedQueueFull,
 				);
-			})
-	}
 
-	#[test]
-	fn can_submit_better_with_full_queue_threshold_0() {
-		ExtBuilder::default()
-			.signed_max_submission(1)
-			.solution_improvement_threshold_signed(Perbill::from_percent(0))
-			.build_and_execute(|| {
-				roll_to(15);
-				assert!(MultiPhase::current_phase().is_signed());
-
-				let mut solution = RawSolution {
-					score: ElectionScore {
-						minimal_stake: 5u128,
-						sum_stake: 0u128,
-						sum_stake_squared: 10u128,
-					},
-					..Default::default()
-				};
-				assert_ok!(MultiPhase::submit(Origin::signed(99), Box::new(solution)));
-
-				// With threshold at 0% the below is a better solution because of the lower
-				// `sum_stake_squared`.
+				// This is however 30% better and should therefore be accepted.
 				solution = RawSolution {
 					score: ElectionScore {
 						minimal_stake: 5u128,
 						sum_stake: 0u128,
-						sum_stake_squared: 9u128,
+						sum_stake_squared: 7u128,
 					},
 					..Default::default()
 				};
 
-				assert_ok!(MultiPhase::submit(Origin::signed(99), Box::new(solution)),);
+				assert_ok!(MultiPhase::submit(Origin::signed(99), Box::new(solution)));
 			})
 	}
 

--- a/frame/election-provider-multi-phase/src/signed.rs
+++ b/frame/election-provider-multi-phase/src/signed.rs
@@ -291,7 +291,7 @@ impl<T: Config> SignedSubmissions<T> {
 					None => return InsertResult::NotInserted,
 					Some((score, _)) => *score,
 				};
-				let threshold = T::SolutionImprovementThreshold::get();
+				let threshold = T::SolutionImprovementThresholdSigned::get();
 
 				// if we haven't improved on the weakest score, don't change anything.
 				if !insert_score.strict_threshold_better(weakest_score, threshold) {

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -1066,7 +1066,7 @@ mod tests {
 			.desired_targets(1)
 			.add_voter(7, 2, bounded_vec![10])
 			.add_voter(8, 5, bounded_vec![10])
-			.solution_improvement_threshold(Perbill::from_percent(50))
+			.solution_improvement_threshold_unsigned(Perbill::from_percent(50))
 			.build_and_execute(|| {
 				roll_to(25);
 				assert!(MultiPhase::current_phase().is_unsigned());

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -624,7 +624,7 @@ impl<T: Config> Pallet<T> {
 		ensure!(
 			Self::queued_solution().map_or(true, |q: ReadySolution<_>| raw_solution
 				.score
-				.strict_threshold_better(q.score, T::SolutionImprovementThreshold::get())),
+				.strict_threshold_better(q.score, T::SolutionImprovementThresholdUnsigned::get())),
 			Error::<T>::PreDispatchWeakSubmission,
 		);
 

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -624,7 +624,7 @@ impl<T: Config> Pallet<T> {
 		ensure!(
 			Self::queued_solution().map_or(true, |q: ReadySolution<_>| raw_solution
 				.score
-				.strict_threshold_better(q.score, T::SolutionImprovementThresholdUnsigned::get())),
+				.strict_threshold_better(q.score, T::BetterUnsignedThreshold::get())),
 			Error::<T>::PreDispatchWeakSubmission,
 		);
 
@@ -1066,7 +1066,7 @@ mod tests {
 			.desired_targets(1)
 			.add_voter(7, 2, bounded_vec![10])
 			.add_voter(8, 5, bounded_vec![10])
-			.solution_improvement_threshold_unsigned(Perbill::from_percent(50))
+			.better_unsigned_threshold(Perbill::from_percent(50))
 			.build_and_execute(|| {
 				roll_to(25);
 				assert!(MultiPhase::current_phase().is_unsigned());


### PR DESCRIPTION
Fixes #11204 

As the issue describes, splitting `SolutionImprovementThresholds` into `BetterSignedThreshold` and `BetterUnsignedThreshold`.

Adding some tests to show case the difference.

@kianenigma 

##
Polkadot companion: paritytech/polkadot#5324

##

Polkadot address: 131dPecTmpTC1p1ofemufqFBJo9vNbV7dkgN7vWwKnaSMkC4