### PR TITLE
More efficient identity and multiplier weight to fee

### DIFF
--- a/frame/support/src/weights.rs
+++ b/frame/support/src/weights.rs
@@ -710,6 +710,10 @@ where
 			degree: 1,
 		})
 	}
+
+	fn calc(weight: &Weight) -> Self::Balance {
+		Self::Balance::saturated_from(*weight)
+	}
 }
 
 /// Implementor of [`WeightToFeePolynomial`] that uses a constant multiplier.
@@ -737,6 +741,10 @@ where
 			negative: false,
 			degree: 1,
 		})
+	}
+
+	fn calc(weight: &Weight) -> Self::Balance {
+		Self::Balance::saturated_from(*weight).saturating_mul(M::get())
 	}
 }
 


### PR DESCRIPTION
#10785 left me with impression that `ConstantMultiplier` implementation is too heavy for what is needed in that particular case, so I decided to apply small optimization to it and to `IdentityFee` to avoid going polynomial route since it is not necessary for those cases.