### PR TITLE
Fix pallet_assets no_std compilation

### DIFF
--- a/frame/assets/src/functions.rs
+++ b/frame/assets/src/functions.rs
@@ -19,6 +19,7 @@
 
 use super::*;
 use frame_support::{traits::Get, BoundedVec};
+use sp_std::vec;
 
 #[must_use]
 pub(super) enum DeadConsequence {


### PR DESCRIPTION
Could you port this to polkadot-v0.9.19 as well? thanks