### PR TITLE
Turn on the logger's interest cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11402,12 +11402,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
+ "ahash",
  "lazy_static",
  "log 0.4.16",
+ "lru 0.7.5",
  "tracing-core",
 ]
 

--- a/client/tracing/Cargo.toml
+++ b/client/tracing/Cargo.toml
@@ -26,7 +26,7 @@ rustc-hash = "1.1.0"
 serde = "1.0.136"
 thiserror = "1.0.30"
 tracing = "0.1.29"
-tracing-log = "0.1.2"
+tracing-log = { version = "0.1.3", features = ["interest-cache"] }
 tracing-subscriber = { version = "0.2.25", features = ["parking_lot"] }
 sp-tracing = { version = "5.0.0", path = "../../primitives/tracing" }
 sp-rpc = { version = "6.0.0", path = "../../primitives/rpc" }

--- a/client/tracing/src/logging/mod.rs
+++ b/client/tracing/src/logging/mod.rs
@@ -155,7 +155,10 @@ where
 	let max_level_hint = Layer::<FmtSubscriber>::max_level_hint(&env_filter);
 	let max_level = to_log_level_filter(max_level_hint);
 
-	tracing_log::LogTracer::builder().with_max_level(max_level).init()?;
+	tracing_log::LogTracer::builder()
+		.with_max_level(max_level)
+		.with_interest_cache(tracing_log::InterestCacheConfig::default())
+		.init()?;
 
 	// If we're only logging `INFO` entries then we'll use a simplified logging format.
 	let detailed_output = match max_level_hint {


### PR DESCRIPTION
polkadot companion: https://github.com/paritytech/polkadot/pull/5393

This lowers the CPU overhead of our logging machinery when *any* `trace` log is enabled down to ~3% of what it is without any `trace` logs enabled.

### Background

The `tracing-log` crate has a bunch of relatively expensive filtering machinery which decides whether a given log should be printed out or not. This machinery has a fast path: if the current most verbose logging level is set to X then the logger can just reject every log which uses a more verbose level and skip the expensive checks.

For example, if we have set `RUST_LOG` to `foo=info,bar=warn` then the most verbose log level is `info`, so any `trace` logs can be quickly rejected because we know that a log *must* be at least `info` to be printable. Now, if we have set `RUST_LOG` to `foo=info,bar=trace` then the most verbose log level is `trace`, so now for *any* `trace` log the logger must actually check whether that log came from `foo` or from `bar` to decide whether it should be printed out, and this is expensive when you're generating thousands of `trace` logs every second (even if they're not printed out!).

So this PR enables a built-in interest cache which I've previously added to `tracing-log`. This cache allows the logger to essentially skip the heavyweight filtering machinery by just doing the work once, and then just querying the cache on any subsequent call. According to the measurements I've done a long time ago this should cut down the CPU usage of the logger to ~3% when you have any `trace` log enabled (even if it's for a target which doesn't actually exist and will never actually match anything).

(This is the second time I'm making this PR; the [previous PR](https://github.com/paritytech/substrate/pull/10072) couldn't be merged since the `tracing-log` crate was not released on crates.io; but that finally changed today with the release of `tracing-log` 0.1.3.)