### PR TITLE
BABE: Fix aux data cleaning (#11263)

### DIFF
--- a/client/api/src/client.rs
+++ b/client/api/src/client.rs
@@ -308,7 +308,7 @@ pub struct FinalityNotification<Block: BlockT> {
 	pub header: Block::Header,
 	/// Path from the old finalized to new finalized parent (implicitly finalized blocks).
 	///
-	/// This maps to the range `(old_finalized, new_finalized]`.
+	/// This maps to the range `(old_finalized, new_finalized)`.
 	pub tree_route: Arc<[Block::Hash]>,
 	/// Stale branches heads.
 	pub stale_heads: Arc<[Block::Hash]>,

--- a/client/consensus/babe/src/tests.rs
+++ b/client/consensus/babe/src/tests.rs
@@ -1043,4 +1043,13 @@ fn obsolete_blocks_aux_data_cleanup() {
 	assert!(aux_data_check(&fork2_hashes, false));
 	// Present C4, C5
 	assert!(aux_data_check(&fork3_hashes, true));
+
+	client.finalize_block(BlockId::Number(4), None, true).unwrap();
+
+	// Wiped: A3
+	assert!(aux_data_check(&fork1_hashes[2..3], false));
+	// Present: A4
+	assert!(aux_data_check(&fork1_hashes[3..], true));
+	// Present C4, C5
+	assert!(aux_data_check(&fork3_hashes, true));
 }


### PR DESCRIPTION
Backport of #11263 into the release branch `polkadot-v0.9.20`

With the latest optimizations of the `FinalityNotification` generation, the aux data pruning started
to print a warning. The problem here was that we printed a warning and stopped the adding of blocks
to prune when we hit the `heigh_limit`. This is now wrong, as we could for example have two 512 long
forks and then we start finalizing one of them. The second fork head would be part of the stale
heads at some point (in the current implementation when we finalize second fork head number + 1),
but then we would actually need to go back into the past than `heigh_limit` (which was actually
last_finalized - 1). We now go back until we reach the canonical chain.

Also fixed some wrong comment that was added by be about the content of the `finalized` blocks in
the `FinalityNotification`.
