### PR TITLE
cumulus-companion: Fix CI when there is no Polkadot companion

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -474,6 +474,7 @@ cargo-check-macos:
         "$DEPENDENT_REPO"
         "$GITHUB_PR_TOKEN"
         "$CARGO_UPDATE_CRATES"
+        "$EXTRA_DEPENDENCIES"
 
 # Individual jobs are set up for each dependent project so that they can be ran in parallel.
 # Arguably we could generate a job for each companion in the PR's description using Gitlab's
@@ -490,6 +491,7 @@ check-dependent-cumulus:
   variables:
     DEPENDENT_REPO: cumulus
     CARGO_UPDATE_CRATES: "sp-io polkadot-runtime-common"
+    EXTRA_DEPENDENCIES: polkadot
 
 
 build-linux-substrate:


### PR DESCRIPTION
This tries to fix the CI if there is no polkadot companion. Currently we don't update Polkadot
master in Cumulus, which means we may use some old commit that isn't compiling with the latest
Substrate master anymore. This can happen if there was a pr that had a companion in Polkadot, but no
companion was required for Cumulus. Then Cumulus will still point to some old Polkadot commit that
isn't compiling anymore with the latest Substrate commit. So, we need to tell the script to use the
latest master of Polkadot. If there is a companion for Polkadot, it would simply override the extra
dependency patch later on.

