### PR TITLE
chore: remove unused scoped-tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8635,7 +8635,6 @@ dependencies = [
  "parity-scale-codec",
  "sc-allocator",
  "sc-executor-common",
- "scoped-tls",
  "sp-core",
  "sp-runtime-interface",
  "sp-wasm-interface",
@@ -9342,12 +9341,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8636,7 +8636,6 @@ dependencies = [
  "parity-scale-codec",
  "sc-allocator",
  "sc-executor-common",
- "sp-core",
  "sp-runtime-interface",
  "sp-sandbox",
  "sp-wasm-interface",

--- a/client/executor/wasmi/Cargo.toml
+++ b/client/executor/wasmi/Cargo.toml
@@ -22,5 +22,4 @@ sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }
 sc-executor-common = { version = "0.10.0-dev", path = "../common" }
 sp-sandbox = { version = "0.10.0-dev", path = "../../../primitives/sandbox" }
 sp-runtime-interface = { version = "6.0.0", path = "../../../primitives/runtime-interface" }
-sp-core = { version = "6.0.0", path = "../../../primitives/core" }
 sp-wasm-interface = { version = "6.0.0", path = "../../../primitives/wasm-interface" }

--- a/client/executor/wasmi/Cargo.toml
+++ b/client/executor/wasmi/Cargo.toml
@@ -22,4 +22,3 @@ sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }
 sp-wasm-interface = { version = "6.0.0", path = "../../../primitives/wasm-interface" }
 sp-runtime-interface = { version = "6.0.0", path = "../../../primitives/runtime-interface" }
 sp-core = { version = "6.0.0", path = "../../../primitives/core" }
-scoped-tls = "1.0"

--- a/fleet.toml
+++ b/fleet.toml
@@ -1,5 +1,0 @@
-rd_enabled = true
-fleet_id = "346cc67d-2ef2-4abf-8868-3845e12c731a"
-
-[build]
-sccache = "/Users/yjhmelody/.cargo/bin/sccache"


### PR DESCRIPTION
`scoped-tls` is not used now.