### PR TITLE
Update docs

### DIFF
--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -873,6 +873,8 @@ pub trait SignedExtension:
 	}
 
 	/// Do any pre-flight stuff for a signed transaction.
+	///
+	/// Make sure to perform the same checks as in [`Self::pre_dispatch`].
 	fn pre_dispatch(
 		self,
 		who: &Self::AccountId,

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -874,7 +874,7 @@ pub trait SignedExtension:
 
 	/// Do any pre-flight stuff for a signed transaction.
 	///
-	/// Make sure to perform the same checks as in [`Self::pre_dispatch`].
+	/// Make sure to perform the same checks as in [`Self::validate`].
 	fn pre_dispatch(
 		self,
 		who: &Self::AccountId,

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -873,13 +873,6 @@ pub trait SignedExtension:
 	}
 
 	/// Do any pre-flight stuff for a signed transaction.
-	///
-	/// Note this function by default delegates to `validate`, so that
-	/// all checks performed for the transaction queue are also performed during
-	/// the dispatch phase (applying the extrinsic).
-	///
-	/// If you ever override this function, you need to make sure to always
-	/// perform the same validation as in `validate`.
 	fn pre_dispatch(
 		self,
 		who: &Self::AccountId,


### PR DESCRIPTION
Since: https://github.com/paritytech/substrate/pull/10403/files#diff-514e38151fb6c7e95145e3cc8bf65af2d7e48fc0b7a7325fe5b0be8f714c896bL894

The `pre_dispatch` function no longer executes `validate` by default, and instead must be manually implemented each time.