### PR TITLE
BEEFY voter bugfixes

### DIFF
--- a/client/beefy/src/tests.rs
+++ b/client/beefy/src/tests.rs
@@ -469,8 +469,8 @@ fn finalize_block_and_wait_for_beefy(
 	}
 
 	if expected_beefy.is_empty() {
-		// run for 1 second then verify no new best beefy block available
-		let timeout = Some(Duration::from_millis(500));
+		// run for quarter second then verify no new best beefy block available
+		let timeout = Some(Duration::from_millis(250));
 		streams_empty_after_timeout(best_blocks, &net, runtime, timeout);
 		streams_empty_after_timeout(signed_commitments, &net, runtime, None);
 	} else {
@@ -535,8 +535,8 @@ fn lagging_validators() {
 	let beefy_peers = peers.iter().enumerate().map(|(id, key)| (id, key, api.clone())).collect();
 	runtime.spawn(initialize_beefy(&mut net, beefy_peers, min_block_delta));
 
-	// push 42 blocks including `AuthorityChange` digests every 30 blocks.
-	net.generate_blocks(42, session_len, &validator_set, true);
+	// push 62 blocks including `AuthorityChange` digests every 30 blocks.
+	net.generate_blocks(62, session_len, &validator_set, true);
 	net.block_until_sync();
 
 	let net = Arc::new(Mutex::new(net));
@@ -550,7 +550,7 @@ fn lagging_validators() {
 	let (best_blocks, signed_commitments) = get_beefy_streams(&mut *net.lock(), peers);
 	net.lock().peer(0).client().as_client().finalize_block(finalize, None).unwrap();
 	// verify nothing gets finalized by BEEFY
-	let timeout = Some(Duration::from_millis(500));
+	let timeout = Some(Duration::from_millis(250));
 	streams_empty_after_timeout(best_blocks, &net, &mut runtime, timeout);
 	streams_empty_after_timeout(signed_commitments, &net, &mut runtime, None);
 
@@ -563,6 +563,26 @@ fn lagging_validators() {
 
 	// Both finalize #30 (mandatory session) and #32 -> BEEFY finalize #30 (mandatory), #31, #32
 	finalize_block_and_wait_for_beefy(&net, peers, &mut runtime, &[30, 32], &[30, 31, 32]);
+
+	// Verify that session-boundary votes get buffered by client and only processed once
+	// session-boundary block is GRANDPA-finalized (this guarantees authenticity for the new session
+	// validator set).
+
+	// Alice finalizes session-boundary mandatory block #60, Bob lags behind
+	let (best_blocks, signed_commitments) = get_beefy_streams(&mut *net.lock(), peers);
+	let finalize = BlockId::number(60);
+	net.lock().peer(0).client().as_client().finalize_block(finalize, None).unwrap();
+	// verify nothing gets finalized by BEEFY
+	let timeout = Some(Duration::from_millis(250));
+	streams_empty_after_timeout(best_blocks, &net, &mut runtime, timeout);
+	streams_empty_after_timeout(signed_commitments, &net, &mut runtime, None);
+
+	// Bob catches up and also finalizes #60 (and should have buffered Alice's vote on #60)
+	let (best_blocks, signed_commitments) = get_beefy_streams(&mut *net.lock(), peers);
+	net.lock().peer(1).client().as_client().finalize_block(finalize, None).unwrap();
+	// verify beefy skips intermediary votes, and successfully finalizes mandatory block #40
+	wait_for_best_beefy_blocks(best_blocks, &net, &mut runtime, &[60]);
+	wait_for_beefy_signed_commitments(signed_commitments, &net, &mut runtime, &[60]);
 }
 
 #[test]
@@ -624,7 +644,7 @@ fn correct_beefy_payload() {
 		.unwrap();
 
 	// verify consensus is _not_ reached
-	let timeout = Some(Duration::from_millis(500));
+	let timeout = Some(Duration::from_millis(250));
 	streams_empty_after_timeout(best_blocks, &net, &mut runtime, timeout);
 	streams_empty_after_timeout(signed_commitments, &net, &mut runtime, None);
 

--- a/client/beefy/src/worker.rs
+++ b/client/beefy/src/worker.rs
@@ -238,7 +238,11 @@ where
 	}
 
 	/// Handle session changes by starting new voting round for mandatory blocks.
-	fn init_session_at(&mut self, active: ValidatorSet<AuthorityId>, session_start: NumberFor<B>) {
+	fn init_session_at(
+		&mut self,
+		active: ValidatorSet<AuthorityId>,
+		new_session_start: NumberFor<B>,
+	) {
 		debug!(target: "beefy", "🥩 New active validator set: {:?}", active);
 		metric_set!(self, beefy_validator_set_id, active.id());
 		// BEEFY should produce a signed commitment for each session
@@ -246,23 +250,22 @@ where
 			active.id() != GENESIS_AUTHORITY_SET_ID &&
 			self.last_signed_id != 0
 		{
+			debug!(
+				target: "beefy", "🥩 Detected skipped session: active-id {:?}, last-signed-id {:?}",
+				active.id(),
+				self.last_signed_id,
+			);
 			metric_inc!(self, beefy_skipped_sessions);
 		}
 
 		if log_enabled!(target: "beefy", log::Level::Debug) {
 			// verify the new validator set - only do it if we're also logging the warning
-			let _ = self.verify_validator_set(&session_start, &active);
+			let _ = self.verify_validator_set(&new_session_start, &active);
 		}
 
-		let prev_validator_set = if let Some(r) = &self.rounds {
-			r.validator_set().clone()
-		} else {
-			// no previous rounds present use new validator set instead (genesis case)
-			active.clone()
-		};
 		let id = active.id();
-		self.rounds = Some(Rounds::new(session_start, active, prev_validator_set));
-		info!(target: "beefy", "🥩 New Rounds for validator set id: {:?} with session_start {:?}", id, session_start);
+		self.rounds = Some(Rounds::new(new_session_start, active));
+		info!(target: "beefy", "🥩 New Rounds for validator set id: {:?} with session_start {:?}", id, new_session_start);
 	}
 
 	fn handle_finality_notification(&mut self, notification: &FinalityNotification<B>) {
@@ -313,7 +316,7 @@ where
 				self.gossip_validator.conclude_round(round.1);
 
 				// id is stored for skipped session metric calculation
-				self.last_signed_id = rounds.validator_set_id_for(round.1);
+				self.last_signed_id = rounds.validator_set_id();
 
 				let block_num = round.1;
 				let commitment = Commitment {
@@ -390,7 +393,7 @@ where
 				debug!(target: "beefy", "🥩 Don't double vote for block number: {:?}", target_number);
 				return
 			}
-			(rounds.validators_for(target_number), rounds.validator_set_id_for(target_number))
+			(rounds.validators(), rounds.validator_set_id())
 		} else {
 			debug!(target: "beefy", "🥩 Missing validator set - can't vote for: {:?}", target_hash);
 			return
@@ -854,8 +857,7 @@ pub(crate) mod tests {
 			worker.best_grandpa_block_header = grandpa_header;
 			worker.best_beefy_block = best_beefy;
 			worker.min_block_delta = min_delta;
-			worker.rounds =
-				Some(Rounds::new(session_start, validator_set.clone(), validator_set.clone()));
+			worker.rounds = Some(Rounds::new(session_start, validator_set.clone()));
 		};
 
 		// under min delta
@@ -970,11 +972,10 @@ pub(crate) mod tests {
 		worker.init_session_at(validator_set.clone(), 1);
 
 		let worker_rounds = worker.rounds.as_ref().unwrap();
-		assert_eq!(worker_rounds.validator_set(), &validator_set);
 		assert_eq!(worker_rounds.session_start(), &1);
 		// in genesis case both current and prev validator sets are the same
-		assert_eq!(worker_rounds.validator_set_id_for(1), validator_set.id());
-		assert_eq!(worker_rounds.validator_set_id_for(2), validator_set.id());
+		assert_eq!(worker_rounds.validators(), validator_set.validators());
+		assert_eq!(worker_rounds.validator_set_id(), validator_set.id());
 
 		// new validator set
 		let keys = &[Keyring::Bob];
@@ -984,11 +985,8 @@ pub(crate) mod tests {
 		worker.init_session_at(new_validator_set.clone(), 11);
 
 		let worker_rounds = worker.rounds.as_ref().unwrap();
-		assert_eq!(worker_rounds.validator_set(), &new_validator_set);
 		assert_eq!(worker_rounds.session_start(), &11);
-		// mandatory block gets prev set, further blocks get new set
-		assert_eq!(worker_rounds.validator_set_id_for(11), validator_set.id());
-		assert_eq!(worker_rounds.validator_set_id_for(12), new_validator_set.id());
-		assert_eq!(worker_rounds.validator_set_id_for(13), new_validator_set.id());
+		assert_eq!(worker_rounds.validators(), new_validator_set.validators());
+		assert_eq!(worker_rounds.validator_set_id(), new_validator_set.id());
 	}
 }


### PR DESCRIPTION
BEEFY gadget should always use current validator set.

The gadget/client-voter was using previous' session validator set to sign the 1st block in the new session (to have chained validator set handoffs).

This is not necessary because:
 1. BEEFY piggy-backs on GRANDPA and only works on canonical chain, so it need not concern itself with the validity of the block header (which contains digest with the new session's validator set). It can safely assume header is valid and simply use new validator set.
 2. The BEEFY payload itself already contains a merkle root for the next validator set keys. So at the BEEFY-payload layer we already have a validated/trusted hand-off of authority.

BEEFY gadget should also buffer votes for blocks not yet finalized by GRANDPA.

Fixes https://github.com/paritytech/grandpa-bridge-gadget/issues/414
Fixes https://github.com/paritytech/grandpa-bridge-gadget/issues/415