### PR TITLE
sc-network: Do not return error on peer id only reserved nodes

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -356,13 +356,15 @@ where
 			let mut default_sets_reserved = HashSet::new();
 			for reserved in network_config.default_peers_set.reserved_nodes.iter() {
 				default_sets_reserved.insert(reserved.peer_id);
-				known_addresses.push((reserved.peer_id, reserved.multiaddr.clone()));
+
+				if !reserved.multiaddr.is_empty() {
+					known_addresses.push((reserved.peer_id, reserved.multiaddr.clone()));
+				}
 			}
 
 			let mut bootnodes = Vec::with_capacity(network_config.boot_nodes.len());
 			for bootnode in network_config.boot_nodes.iter() {
 				bootnodes.push(bootnode.peer_id);
-				known_addresses.push((bootnode.peer_id, bootnode.multiaddr.clone()));
 			}
 
 			// Set number 0 is used for block announces.

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -228,12 +228,10 @@ where
 		)?;
 
 		// List of multiaddresses that we know in the network.
-		let mut bootnodes = Vec::new();
 		let mut boot_node_ids = HashSet::new();
 
 		// Process the bootnodes.
 		for bootnode in params.network_config.boot_nodes.iter() {
-			bootnodes.push(bootnode.peer_id);
 			boot_node_ids.insert(bootnode.peer_id);
 			known_addresses.push((bootnode.peer_id, bootnode.multiaddr.clone()));
 		}
@@ -241,12 +239,18 @@ where
 		let boot_node_ids = Arc::new(boot_node_ids);
 
 		// Check for duplicate bootnodes.
-		known_addresses.iter().try_for_each(|(peer_id, addr)| {
-			if let Some(other) = known_addresses.iter().find(|o| o.1 == *addr && o.0 != *peer_id) {
+		params.network_config.boot_nodes.iter().try_for_each(|bootnode| {
+			if let Some(other) = params
+				.network_config
+				.boot_nodes
+				.iter()
+				.filter(|o| o.multiaddr == bootnode.multiaddr)
+				.find(|o| o.peer_id != bootnode.peer_id)
+			{
 				Err(Error::DuplicateBootnode {
-					address: addr.clone(),
-					first_id: *peer_id,
-					second_id: other.0,
+					address: bootnode.multiaddr.clone(),
+					first_id: bootnode.peer_id,
+					second_id: other.peer_id,
 				})
 			} else {
 				Ok(())


### PR DESCRIPTION
When passing reserved nodes only with a peer id it was failing with the `DuplicateBootnode` error.
Besides that there are some clean ups. We for example added the bootnodes twice to the `known_addresses`.


Closes: https://github.com/paritytech/substrate/issues/11345