### PR TITLE
allow defensive operations to take a proof

### DIFF
--- a/frame/bags-list/src/list/mod.rs
+++ b/frame/bags-list/src/list/mod.rs
@@ -443,8 +443,7 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 
 		// remove the heavier node from this list. Note that this removes the node from storage and
 		// decrements the node counter.
-		// defensive: both nodes have been checked to exist.
-		let _ = Self::remove(&heavier_id).defensive();
+		let _ = Self::remove(&heavier_id).defensive("both nodes have been checked to exist; qed");
 
 		// re-fetch `lighter_node` from storage since it may have been updated when `heavier_node`
 		// was removed.

--- a/frame/bags-list/src/list/mod.rs
+++ b/frame/bags-list/src/list/mod.rs
@@ -443,7 +443,7 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 
 		// remove the heavier node from this list. Note that this removes the node from storage and
 		// decrements the node counter.
-		let _ = Self::remove(&heavier_id).defensive("both nodes have been checked to exist; qed");
+		let _ = Self::remove(&heavier_id).defensive_proof("both nodes have been checked to exist; qed");
 
 		// re-fetch `lighter_node` from storage since it may have been updated when `heavier_node`
 		// was removed.

--- a/frame/bags-list/src/list/mod.rs
+++ b/frame/bags-list/src/list/mod.rs
@@ -443,7 +443,8 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 
 		// remove the heavier node from this list. Note that this removes the node from storage and
 		// decrements the node counter.
-		let _ = Self::remove(&heavier_id).defensive_proof("both nodes have been checked to exist; qed");
+		let _ =
+			Self::remove(&heavier_id).defensive_proof("both nodes have been checked to exist; qed");
 
 		// re-fetch `lighter_node` from storage since it may have been updated when `heavier_node`
 		// was removed.

--- a/frame/staking/src/slashing.rs
+++ b/frame/staking/src/slashing.rs
@@ -600,8 +600,8 @@ pub fn do_slash<T: Config>(
 	slashed_imbalance: &mut NegativeImbalanceOf<T>,
 	slash_era: EraIndex,
 ) {
-	let controller = match <Pallet<T>>::bonded(stash) {
-		None => return, // defensive: should always exist.
+	let controller = match <Pallet<T>>::bonded(stash).defensive() {
+		None => return,
 		Some(c) => c,
 	};
 

--- a/frame/staking/src/slashing.rs
+++ b/frame/staking/src/slashing.rs
@@ -56,7 +56,7 @@ use crate::{
 use codec::{Decode, Encode};
 use frame_support::{
 	ensure,
-	traits::{Currency, Get, Imbalance, OnUnbalanced},
+	traits::{Currency, Defensive, Get, Imbalance, OnUnbalanced},
 };
 use scale_info::TypeInfo;
 use sp_runtime::{

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -201,7 +201,7 @@ impl<T> Defensive<T> for Option<T> {
 
 	fn defensive_proof(self, proof: &'static str) -> Self {
 		if self.is_none() {
-			defensive!(proof)
+			defensive!(proof);
 		}
 		self
 	}
@@ -252,10 +252,13 @@ impl<T, E: sp_std::fmt::Debug> Defensive<T> for Result<T, E> {
 	}
 
 	fn defensive_proof(self, proof: &'static str) -> Self {
-		if self.is_err() {
-			defensive!(e, proof);
+		match self {
+			Ok(inner) => Ok(inner),
+			Err(e) => {
+				defensive!(e, proof);
+				Err(e)
+			},
 		}
-		self
 	}
 }
 

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -252,13 +252,10 @@ impl<T, E: sp_std::fmt::Debug> Defensive<T> for Result<T, E> {
 	}
 
 	fn defensive_proof(self, proof: &'static str) -> Self {
-		match self {
-			Ok(inner) => Ok(inner),
-			Err(e) => {
-				defensive!(e, proof);
-				Err(e)
-			},
+		if self.is_err() {
+			defensive!(e, proof);
 		}
+		self
 	}
 }
 

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -50,6 +50,16 @@ macro_rules! defensive {
 			$error
 		);
 		debug_assert!(false, "{}: {:?}", $crate::traits::DEFENSIVE_OP_INTERNAL_ERROR, $error);
+	};
+	($error:tt, $proof:tt) => {
+		frame_support::log::error!(
+			target: "runtime",
+			"{}: {:?}: {:?}",
+			$crate::traits::DEFENSIVE_OP_PUBLIC_ERROR,
+			$error,
+			$proof,
+		);
+		debug_assert!(false, "{}: {:?}: {:?}", $crate::traits::DEFENSIVE_OP_INTERNAL_ERROR, $error, $proof);
 	}
 }
 
@@ -102,6 +112,10 @@ pub trait Defensive<T> {
 	/// }
 	/// ```
 	fn defensive(self) -> Self;
+
+	/// Same as [`Defensive::defensive`], but it takes a proof is input, and displays it if the
+	/// defensive operation has been triggered.
+	fn defensive_proof(self, proof: &'static str) -> Self;
 }
 
 /// Subset of methods similar to [`Defensive`] that can only work for a `Result`.
@@ -184,6 +198,16 @@ impl<T> Defensive<T> for Option<T> {
 			},
 		}
 	}
+
+	fn defensive_proof(self, proof: &'static str) -> Self {
+		match self {
+			Some(inner) => Some(inner),
+			None => {
+				defensive!(proof);
+				None
+			},
+		}
+	}
 }
 
 impl<T, E: sp_std::fmt::Debug> Defensive<T> for Result<T, E> {
@@ -225,6 +249,16 @@ impl<T, E: sp_std::fmt::Debug> Defensive<T> for Result<T, E> {
 			Ok(inner) => Ok(inner),
 			Err(e) => {
 				defensive!(e);
+				Err(e)
+			},
+		}
+	}
+
+	fn defensive_proof(self, proof: &'static str) -> Self {
+		match self {
+			Ok(inner) => Ok(inner),
+			Err(e) => {
+				defensive!(e, proof);
 				Err(e)
 			},
 		}

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -200,13 +200,10 @@ impl<T> Defensive<T> for Option<T> {
 	}
 
 	fn defensive_proof(self, proof: &'static str) -> Self {
-		match self {
-			Some(inner) => Some(inner),
-			None => {
-				defensive!(proof);
-				None
-			},
+		if self.is_none() {
+			defensive!(proof)
 		}
+		self
 	}
 }
 

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -113,7 +113,7 @@ pub trait Defensive<T> {
 	/// ```
 	fn defensive(self) -> Self;
 
-	/// Same as [`Defensive::defensive`], but it takes a proof is input, and displays it if the
+	/// Same as [`Defensive::defensive`], but it takes a proof as input, and displays it if the
 	/// defensive operation has been triggered.
 	fn defensive_proof(self, proof: &'static str) -> Self;
 }


### PR DESCRIPTION
I didn't do it quite delicately, but gets the job done for now. 

Open to an more flexible alternative, specially keeping `defensive!` flexible. 

take out of https://github.com/paritytech/substrate/pull/11013/files.

I changed one or two examples to demonstrate how it should be used. 