### PR TITLE
Expose more modules as public

### DIFF
--- a/client/network/src/lib.rs
+++ b/client/network/src/lib.rs
@@ -247,12 +247,12 @@
 mod behaviour;
 mod discovery;
 mod peer_info;
-mod protocol;
+pub mod protocol;
 mod request_responses;
 mod schema;
-mod service;
+pub mod service;
 mod transport;
-mod utils;
+pub mod utils;
 
 pub mod bitswap;
 pub mod config;


### PR DESCRIPTION
We are looking to add our own networking/gossip implementations for external networking programs and need these exposed.
