### PR TITLE
[ci] fix cargo-check-nixos for nightly pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -268,8 +268,9 @@ cargo-check-nixos:
   <<:                              *docker-env
   <<:                              *test-refs
   before_script:                   []
+  # Don't use CI_IMAGE here because it breaks nightly checks of paritytech/ci-linux image
+  image:                           nixos/nix
   variables:
-    CI_IMAGE:                      "nixos/nix"
     SNAP:                          "DUMMY"
     WS_API:                        "DUMMY"
   script:


### PR DESCRIPTION
Nightly pipelines use `paritytech/ci-linux:staging` image for ci in all jobs where the `CI_IMAGE` variable is used. In this PR I hardcoded `image:` for `cargo-check-nixos`