### PR TITLE
Rename nomination pools pallet id

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -707,7 +707,7 @@ impl pallet_bags_list::Config for Runtime {
 
 parameter_types! {
 	pub const PostUnbondPoolsWindow: u32 = 4;
-	pub const NominationPoolsPalletId: PalletId = PalletId(*b"py/npols");
+	pub const NominationPoolsPalletId: PalletId = PalletId(*b"py/nopls");
 }
 
 use sp_runtime::traits::Convert;


### PR DESCRIPTION
To make it the same as with westend and all of the other deployments on this pallet. 