### PR TITLE
[ci] update approval rules

### DIFF
--- a/.github/pr-custom-review.yml
+++ b/.github/pr-custom-review.yml
@@ -6,10 +6,21 @@ action-review-team: ci
 rules:
   - name: Core developers
     check_type: changed_files
-    condition: .*
+    condition:
+      include: .*
+      # excluding files from 'CI team' rules
+      exclude: ^\.gitlab-ci\.yml|^scripts/ci/.*|^\.github/.*
     min_approvals: 2
     teams:
       - core-devs
+
+  - name: CI team
+    check_type: changed_files
+    condition:
+      include: ^\.gitlab-ci\.yml|^scripts/ci/.*|^\.github/.*
+    min_approvals: 2
+    teams:
+      - ci
 
 prevent-review-request:
   teams:


### PR DESCRIPTION
This PR update `pr-custom-review` rules according to https://github.com/paritytech/ci_cd/issues/405

* removes mandatory approval by the @paritytech/core-devs team of CI files `.gitlab-ci.yml`, `.github/.*`, `scripts/ci/.*`
* introduces new approval rule for the CI related stuff  `.gitlab-ci.yml`, `.github/.*`, `scripts/ci/.*` by @paritytech/ci team