### PR TITLE
contracts: Prevent PoV attack vector with minimal viable solution

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1059,8 +1059,11 @@ parameter_types! {
 	pub const DepositPerByte: Balance = deposit(0, 1);
 	pub const MaxValueSize: u32 = 16 * 1024;
 	// The lazy deletion runs inside on_initialize.
-	pub DeletionWeightLimit: Weight = AVERAGE_ON_INITIALIZE_RATIO *
-		RuntimeBlockWeights::get().max_block;
+	pub DeletionWeightLimit: Weight = RuntimeBlockWeights::get()
+		.per_class
+		.get(DispatchClass::Normal)
+		.max_total
+		.unwrap_or(RuntimeBlockWeights::get().max_block);
 	// The weight needed for decoding the queue should be less or equal than a fifth
 	// of the overall weight dedicated to the lazy deletion.
 	pub DeletionQueueDepth: u32 = ((DeletionWeightLimit::get() / (
@@ -1093,6 +1096,7 @@ impl pallet_contracts::Config for Runtime {
 	type DeletionWeightLimit = DeletionWeightLimit;
 	type Schedule = Schedule;
 	type AddressGenerator = pallet_contracts::DefaultAddressGenerator;
+	type ContractAccessWeight = pallet_contracts::DefaultContractAccessWeight<RuntimeBlockWeights>;
 }
 
 impl pallet_sudo::Config for Runtime {

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -115,9 +115,9 @@ use frame_support::{
 	dispatch::Dispatchable,
 	ensure,
 	traits::{Contains, Currency, Get, Randomness, ReservableCurrency, StorageVersion, Time},
-	weights::{GetDispatchInfo, Pays, PostDispatchInfo, Weight},
+	weights::{DispatchClass, GetDispatchInfo, Pays, PostDispatchInfo, Weight},
 };
-use frame_system::Pallet as System;
+use frame_system::{limits::BlockWeights, Pallet as System};
 use pallet_contracts_primitives::{
 	Code, CodeUploadResult, CodeUploadReturnValue, ContractAccessError, ContractExecResult,
 	ContractInstantiateResult, ExecReturnValue, GetStorageResult, InstantiateReturnValue,
@@ -126,7 +126,7 @@ use pallet_contracts_primitives::{
 use scale_info::TypeInfo;
 use sp_core::{crypto::UncheckedFrom, Bytes};
 use sp_runtime::traits::{Convert, Hash, Saturating, StaticLookup};
-use sp_std::{fmt::Debug, prelude::*};
+use sp_std::{fmt::Debug, marker::PhantomData, prelude::*};
 
 type CodeHash<T> = <T as frame_system::Config>::Hash;
 type TrieId = Vec<u8>;
@@ -190,6 +190,29 @@ where
 			.cloned()
 			.collect();
 		UncheckedFrom::unchecked_from(T::Hashing::hash(&buf))
+	}
+}
+
+/// A conservative implementation to be used for [`pallet::Config::ContractAccessWeight`].
+///
+/// This derives the weight from the [`BlockWeights`] passed as `B` and the `maxPovSize` passed
+/// as `P`. The default value for `P` is the `maxPovSize` used by polkadot and kusama.
+///
+/// It simply charges from the weight meter pro rata: If loading the contract code would consume
+/// 50% of the max storage proof then this charges 50% of the max block weight.
+pub struct DefaultContractAccessWeight<B: Get<BlockWeights>, const P: u32 = 5_242_880>(
+	PhantomData<B>,
+);
+
+impl<B: Get<BlockWeights>, const P: u32> Get<Weight> for DefaultContractAccessWeight<B, P> {
+	fn get() -> Weight {
+		let block_weights = B::get();
+		block_weights
+			.per_class
+			.get(DispatchClass::Normal)
+			.max_total
+			.unwrap_or(block_weights.max_block) /
+			Weight::from(P)
 	}
 }
 
@@ -296,6 +319,27 @@ pub mod pallet {
 		/// Changing this value for an existing chain might need a storage migration.
 		#[pallet::constant]
 		type DepositPerByte: Get<BalanceOf<Self>>;
+
+		/// The weight per byte of code that is charged when loading a contract from storage.
+		///
+		/// Currently, FRAME only charged fees for computation incurred but not for PoV
+		/// consumption caused for storage access. This is usually not exploitable because
+		/// accessing storage carries some substantial weight costs, too. However in case
+		/// of contract code very much PoV consumption can be caused while consuming very little
+		/// computation. This could be used to keep the chain busy without paying the
+		/// proper fee for it. Until this is resolved we charge from the weight meter for
+		/// contract access.
+		///
+		/// For more information check out: <https://github.com/paritytech/substrate/issues/10301>
+		///
+		/// [`DefaultContractAccessWeight`] is a safe default to be used for polkadot or kusama
+		/// parachains.
+		///
+		/// # Note
+		///
+		/// This is only relevant for parachains. Set to zero in case of a standalone chain.
+		#[pallet::constant]
+		type ContractAccessWeight: Get<Weight>;
 
 		/// The amount of balance a caller has to pay for each storage item.
 		///

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -24,8 +24,8 @@ use crate::{
 	storage::Storage,
 	wasm::{PrefabWasmModule, ReturnCode as RuntimeReturnCode},
 	weights::WeightInfo,
-	BalanceOf, Code, CodeStorage, Config, ContractInfoOf, DefaultAddressGenerator, Error, Pallet,
-	Schedule,
+	BalanceOf, Code, CodeStorage, Config, ContractInfoOf, DefaultAddressGenerator,
+	DefaultContractAccessWeight, Error, Pallet, Schedule,
 };
 use assert_matches::assert_matches;
 use codec::Encode;
@@ -287,6 +287,7 @@ impl Config for Test {
 	type DepositPerByte = DepositPerByte;
 	type DepositPerItem = DepositPerItem;
 	type AddressGenerator = DefaultAddressGenerator;
+	type ContractAccessWeight = DefaultContractAccessWeight<BlockWeights>;
 }
 
 pub const ALICE: AccountId32 = AccountId32::new([1u8; 32]);


### PR DESCRIPTION
Fixes #11272 #10301

The amount that is charged from the gas meter is configurable via a new `ContractAccessWeight` type in the `Config` trait. A `DefaultContractAccessWeight` is added to help with a sensible implementation. Please note that this could be too conservative. We would need some benchmarking using `smart-bench` (cc @ascjones) to determine the impact on throughput.