### PR TITLE
sc-consensus-slots: rename `client` -> `select_chain`

### DIFF
--- a/client/consensus/slots/src/slots.rs
+++ b/client/consensus/slots/src/slots.rs
@@ -102,7 +102,11 @@ pub(crate) struct Slots<Block, SC, IDP> {
 
 impl<Block, SC, IDP> Slots<Block, SC, IDP> {
 	/// Create a new `Slots` stream.
-	pub fn new(slot_duration: Duration, create_inherent_data_providers: IDP, select_chain: SC) -> Self {
+	pub fn new(
+		slot_duration: Duration,
+		create_inherent_data_providers: IDP,
+		select_chain: SC,
+	) -> Self {
 		Slots {
 			last_slot: 0.into(),
 			slot_duration,

--- a/client/consensus/slots/src/slots.rs
+++ b/client/consensus/slots/src/slots.rs
@@ -100,7 +100,7 @@ pub(crate) struct Slots<Block, SC, IDP> {
 	_phantom: std::marker::PhantomData<Block>,
 }
 
-impl<Block, C, IDP> Slots<Block, SC, IDP> {
+impl<Block, SC, IDP> Slots<Block, SC, IDP> {
 	/// Create a new `Slots` stream.
 	pub fn new(slot_duration: Duration, create_inherent_data_providers: IDP, select_chain: SC) -> Self {
 		Slots {

--- a/client/consensus/slots/src/slots.rs
+++ b/client/consensus/slots/src/slots.rs
@@ -118,10 +118,10 @@ impl<Block, SC, IDP> Slots<Block, SC, IDP> {
 	}
 }
 
-impl<Block, C, IDP> Slots<Block, C, IDP>
+impl<Block, SC, IDP> Slots<Block, SC, IDP>
 where
 	Block: BlockT,
-	C: SelectChain<Block>,
+	SC: SelectChain<Block>,
 	IDP: CreateInherentDataProviders<Block, ()>,
 	IDP::InherentDataProviders: crate::InherentDataProviderExt,
 {

--- a/client/consensus/slots/src/slots.rs
+++ b/client/consensus/slots/src/slots.rs
@@ -102,11 +102,7 @@ pub(crate) struct Slots<Block, SC, IDP> {
 
 impl<Block, SC, IDP> Slots<Block, SC, IDP> {
 	/// Create a new `Slots` stream.
-	pub fn new(
-		slot_duration: Duration,
-		create_inherent_data_providers: IDP,
-		select_chain: SC,
-	) -> Self {
+	pub fn new(slot_duration: Duration, create_inherent_data_providers: IDP, select_chain: SC) -> Self {
 		Slots {
 			last_slot: 0.into(),
 			slot_duration,
@@ -133,7 +129,7 @@ where
 					// schedule wait.
 					let wait_dur = time_until_next_slot(self.slot_duration);
 					Some(Delay::new(wait_dur))
-				}
+				},
 				Some(d) => Some(d),
 			};
 
@@ -159,8 +155,8 @@ where
 					);
 					// Let's try at the next slot..
 					self.inner_delay.take();
-					continue;
-				}
+					continue
+				},
 			};
 
 			let inherent_data_providers = self
@@ -190,7 +186,7 @@ where
 					self.slot_duration,
 					chain_head,
 					None,
-				));
+				))
 			}
 		}
 	}

--- a/client/consensus/slots/src/slots.rs
+++ b/client/consensus/slots/src/slots.rs
@@ -102,7 +102,11 @@ pub(crate) struct Slots<Block, SC, IDP> {
 
 impl<Block, SC, IDP> Slots<Block, SC, IDP> {
 	/// Create a new `Slots` stream.
-	pub fn new(slot_duration: Duration, create_inherent_data_providers: IDP, select_chain: SC) -> Self {
+	pub fn new(
+		slot_duration: Duration,
+		create_inherent_data_providers: IDP,
+		select_chain: SC,
+	) -> Self {
 		Slots {
 			last_slot: 0.into(),
 			slot_duration,
@@ -129,7 +133,7 @@ where
 					// schedule wait.
 					let wait_dur = time_until_next_slot(self.slot_duration);
 					Some(Delay::new(wait_dur))
-				},
+				}
 				Some(d) => Some(d),
 			};
 
@@ -155,8 +159,8 @@ where
 					);
 					// Let's try at the next slot..
 					self.inner_delay.take();
-					continue
-				},
+					continue;
+				}
 			};
 
 			let inherent_data_providers = self
@@ -186,7 +190,7 @@ where
 					self.slot_duration,
 					chain_head,
 					None,
-				))
+				));
 			}
 		}
 	}

--- a/client/consensus/slots/src/slots.rs
+++ b/client/consensus/slots/src/slots.rs
@@ -91,24 +91,24 @@ impl<B: BlockT> SlotInfo<B> {
 }
 
 /// A stream that returns every time there is a new slot.
-pub(crate) struct Slots<Block, C, IDP> {
+pub(crate) struct Slots<Block, SC, IDP> {
 	last_slot: Slot,
 	slot_duration: Duration,
 	inner_delay: Option<Delay>,
 	create_inherent_data_providers: IDP,
-	client: C,
+	select_chain: SC,
 	_phantom: std::marker::PhantomData<Block>,
 }
 
-impl<Block, C, IDP> Slots<Block, C, IDP> {
+impl<Block, C, IDP> Slots<Block, SC, IDP> {
 	/// Create a new `Slots` stream.
-	pub fn new(slot_duration: Duration, create_inherent_data_providers: IDP, client: C) -> Self {
+	pub fn new(slot_duration: Duration, create_inherent_data_providers: IDP, select_chain: SC) -> Self {
 		Slots {
 			last_slot: 0.into(),
 			slot_duration,
 			inner_delay: None,
 			create_inherent_data_providers,
-			client,
+			select_chain,
 			_phantom: Default::default(),
 		}
 	}
@@ -145,7 +145,7 @@ where
 
 			let ends_at = Instant::now() + ends_in;
 
-			let chain_head = match self.client.best_chain().await {
+			let chain_head = match self.select_chain.best_chain().await {
 				Ok(x) => x,
 				Err(e) => {
 					log::warn!(


### PR DESCRIPTION
This PR renames several related variables in `sc-consensus-slots` from `client` to `select_chain`, and the corresponding type parameter from `C` to `SC`.

This does not make any behavioral changes, it just corrects a bad name to prevent others from the confusion I faced today.

The trait bound applied was already `SelectChain` and only methods from this trait were used. So I'm pretty confident this is a correct rename. I don't know how the name `client` was originally chosen, but maybe it predates the introduction of the `SelectChain` trait?