### PR TITLE
ci: unbreak CI by updating Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11096,7 +11096,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "matchers",
- "parking_lot 0.9.0",
+ "parking_lot 0.11.2",
  "regex",
  "serde",
  "serde_json",


### PR DESCRIPTION
Slipped through after #8783 
