### PR TITLE
Prevent div by zero in native babe code

### DIFF
--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -24,6 +24,7 @@
 use codec::{Decode, Encode};
 use frame_support::{
 	dispatch::DispatchResultWithPostInfo,
+	ensure,
 	traits::{
 		ConstU32, DisabledValidators, FindAuthor, Get, KeyOwnerProofSystem, OnTimestampSet,
 		OneSessionHandler,
@@ -185,6 +186,8 @@ pub mod pallet {
 		InvalidKeyOwnershipProof,
 		/// A given equivocation report is valid but already previously reported.
 		DuplicateOffenceReport,
+		/// Submitted configuration is invalid.
+		InvalidConfiguration,
 	}
 
 	/// Current epoch index.
@@ -447,6 +450,11 @@ pub mod pallet {
 			config: NextConfigDescriptor,
 		) -> DispatchResult {
 			ensure_root(origin)?;
+			match config {
+				NextConfigDescriptor::V1 { c, allowed_slots: _ } => {
+					ensure!(c.1 != 0, Error::<T>::InvalidConfiguration);
+				},
+			}
 			PendingEpochConfigChange::<T>::put(config);
 			Ok(())
 		}


### PR DESCRIPTION
This PR introduces a sanity check on Babe's config `c` denominator before on-chain write.

---

Currently we allow to set `c` denominator of Babe configuration to zero.

This value is then stored on-chain and will be enacted on next epoch change.

Once this new value has been enacted, it will be used by the client native authoring code to compute the "primary threshold"

https://github.com/paritytech/substrate/blob/e0ccd008fe8bfaf29357ea87561e60f3baaae08c/client/consensus/babe/src/authorship.rs#L44

A div by zero exception is triggered and the node crashes.

Because the `c` value is stored on-chain, it will be reused on node restart and thus it will then crash again obliterating the ability to author new blocks and thus the ability to easily fix the situation.

---

Even though changing Babe's config params is a Sudo/Governance action, better to be defensive over bad settings 
