### PR TITLE
jsonrpc http server: expose health endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3173,9 +3173,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6f9ff3481f3069c92474b697c104502f7e9191d29b34bfa38ae9a19415f1cd"
+checksum = "eae63f7fdeb51700b35e9b28bf92e8d233951590968c186ed79510b6c12fa3d9"
 dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-http-server",
@@ -3188,9 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4358e100faf43b2f3b7b0ecf0ad4ce3e6275fe12fda8428dedda2979751dd184"
+checksum = "32feb1f2f0b5ce37a03b96a988a6dadccc3f529a2f930356bac93f13c09cf385"
 dependencies = [
  "futures-util",
  "http",
@@ -3209,9 +3209,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d26ab3868749d6f716345a5fbd3334a100c0709fe464bd9189ee9d78adcde"
+checksum = "31e6b13067b615dd050ced7c19517a52cde490eee2c754d5447ce513f2275f7d"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.1",
@@ -3236,9 +3236,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-server"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee87f19a7a01a55248fc4b4861d822331c4fd60151d99e7ac9c6771999132671"
+checksum = "b34f1090bdc8f7f14ad8811fc84501867c23a9046ce79d49c0cd929a256c501e"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -3255,9 +3255,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75da57d54817577801c2f7a1b638610819dfd86f0470c21a2af81b06eb41ba6"
+checksum = "5d8dc7a8b629e371cd5ca9d128883763ae00c5b63158ace4a6a61345726a21b7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3267,9 +3267,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fe5a629443d17a30ff564881ba68881a710fd7eb02a538087b0bc51cb4962c"
+checksum = "44f1835f131e77cd766b4dcb025873944cb1e479cd5debb639e2dc11f90df24a"
 dependencies = [
  "anyhow",
  "beef",
@@ -3281,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba31eb2b9a4b73d8833f53fe55e579516289f8b31adb6104b3dbc629755acf7d"
+checksum = "9d75df866743c9733b3e2f5421e56df2f5b4630f7de39f82c44eaab350604926"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -3292,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-server"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "179fe584af5c0145f922c581770d073c661a514ae6cdfa5b1a0bce41fdfdf646"
+checksum = "099971913436e7f6b1bc80180d4e5f014ec944660636da45d2f372c23d6308c3"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -11264,9 +11264,9 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "digest 0.10.3",
- "rand 0.6.5",
+ "rand 0.8.4",
  "static_assertions",
 ]
 

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -42,7 +42,7 @@ frame-system = { version = "4.0.0-dev", path = "../../../frame/system" }
 pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, path = "../../../frame/transaction-payment" }
 
 # These dependencies are used for the node template's RPCs
-jsonrpsee = { version = "0.12.0", features = ["server"] }
+jsonrpsee = { version = "0.13.0", features = ["server"] }
 sc-rpc = { version = "4.0.0-dev", path = "../../../client/rpc" }
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
 sc-rpc-api = { version = "0.10.0-dev", path = "../../../client/rpc-api" }

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -37,7 +37,7 @@ crate-type = ["cdylib", "rlib"]
 clap = { version = "3.1.6", features = ["derive"], optional = true }
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 serde = { version = "1.0.136", features = ["derive"] }
-jsonrpsee = { version = "0.12.0", features = ["server"] }
+jsonrpsee = { version = "0.13.0", features = ["server"] }
 futures = "0.3.21"
 hex-literal = "0.3.4"
 log = "0.4.16"

--- a/bin/node/rpc/Cargo.toml
+++ b/bin/node/rpc/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-jsonrpsee = { version = "0.12.0", features = ["server"] }
+jsonrpsee = { version = "0.13.0", features = ["server"] }
 node-primitives = { version = "2.0.0", path = "../primitives" }
 pallet-contracts-rpc = { version = "4.0.0-dev", path = "../../../frame/contracts/rpc/" }
 pallet-mmr-rpc = { version = "3.0.0", path = "../../../frame/merkle-mountain-range/rpc/" }

--- a/client/beefy/rpc/Cargo.toml
+++ b/client/beefy/rpc/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://substrate.io"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 futures = "0.3.21"
-jsonrpsee = { version = "0.12.0", features = ["server", "macros"] }
+jsonrpsee = { version = "0.13.0", features = ["server", "macros"] }
 log = "0.4"
 parking_lot = "0.12.0"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/client/consensus/babe/rpc/Cargo.toml
+++ b/client/consensus/babe/rpc/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-jsonrpsee = { version = "0.12.0", features = ["server", "macros"] }
+jsonrpsee = { version = "0.13.0", features = ["server", "macros"] }
 futures = "0.3.21"
 serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0"

--- a/client/consensus/manual-seal/Cargo.toml
+++ b/client/consensus/manual-seal/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-jsonrpsee = { version = "0.12.0", features = ["server", "macros"] }
+jsonrpsee = { version = "0.13.0", features = ["server", "macros"] }
 assert_matches = "1.3.0"
 async-trait = "0.1.50"
 codec = { package = "parity-scale-codec", version = "3.0.0" }

--- a/client/finality-grandpa/rpc/Cargo.toml
+++ b/client/finality-grandpa/rpc/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://substrate.io"
 [dependencies]
 finality-grandpa = { version = "0.15.0", features = ["derive-codec"] }
 futures = "0.3.16"
-jsonrpsee = { version = "0.12.0", features = ["server", "macros"] }
+jsonrpsee = { version = "0.13.0", features = ["server", "macros"] }
 log = "0.4.8"
 parity-scale-codec = { version = "3.0.0", features = ["derive"] }
 serde = { version = "1.0.105", features = ["derive"] }

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -28,4 +28,4 @@ sp-rpc = { version = "6.0.0", path = "../../primitives/rpc" }
 sp-runtime = { version = "6.0.0", path = "../../primitives/runtime" }
 sp-tracing = { version = "5.0.0", path = "../../primitives/tracing" }
 sp-version = { version = "5.0.0", path = "../../primitives/version" }
-jsonrpsee = { version = "0.12.0", features = ["server", "macros"] }
+jsonrpsee = { version = "0.13.0", features = ["server", "macros"] }

--- a/client/rpc-servers/Cargo.toml
+++ b/client/rpc-servers/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 futures = "0.3.21"
-jsonrpsee = { version = "0.12.0", features = ["server"] }
+jsonrpsee = { version = "0.13.0", features = ["server"] }
 log = "0.4.16"
 serde_json = "1.0.79"
 tokio = { version = "1.17.0", features = ["parking_lot"] }

--- a/client/rpc-servers/src/lib.rs
+++ b/client/rpc-servers/src/lib.rs
@@ -103,6 +103,7 @@ pub async fn start_http<M: Send + Sync + 'static>(
 		.max_request_body_size(max_payload_in as u32)
 		.max_response_body_size(max_payload_out as u32)
 		.set_access_control(acl.build())
+		.health_api("/health", "system_health")
 		.custom_tokio_runtime(rt);
 
 	let rpc_api = build_rpc_api(rpc_api);

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 futures = "0.3.21"
 hash-db = { version = "0.15.2", default-features = false }
-jsonrpsee = { version = "0.12.0", features = ["server"] }
+jsonrpsee = { version = "0.13.0", features = ["server"] }
 lazy_static = { version = "1.4.0", optional = true }
 log = "0.4.16"
 parking_lot = "0.12.0"

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -22,7 +22,7 @@ wasmtime = ["sc-executor/wasmtime"]
 test-helpers = []
 
 [dependencies]
-jsonrpsee = { version = "0.12.0", features = ["server"] }
+jsonrpsee = { version = "0.13.0", features = ["server"] }
 thiserror = "1.0.30"
 futures = "0.3.21"
 rand = "0.7.3"

--- a/client/sync-state-rpc/Cargo.toml
+++ b/client/sync-state-rpc/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
-jsonrpsee = { version = "0.12.0", features = ["server", "macros"] }
+jsonrpsee = { version = "0.13.0", features = ["server", "macros"] }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 thiserror = "1.0.30"

--- a/frame/contracts/rpc/Cargo.toml
+++ b/frame/contracts/rpc/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
-jsonrpsee = { version = "0.12.0", features = ["server", "macros"] }
+jsonrpsee = { version = "0.13.0", features = ["server", "macros"] }
 serde = { version = "1", features = ["derive"] }
 
 # Substrate Dependencies

--- a/frame/merkle-mountain-range/rpc/Cargo.toml
+++ b/frame/merkle-mountain-range/rpc/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
-jsonrpsee = { version = "0.12.0", features = ["server", "macros"] }
+jsonrpsee = { version = "0.13.0", features = ["server", "macros"] }
 serde = { version = "1.0.136", features = ["derive"] }
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }

--- a/frame/transaction-payment/rpc/Cargo.toml
+++ b/frame/transaction-payment/rpc/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
-jsonrpsee = { version = "0.12.0", features = ["server", "macros"] }
+jsonrpsee = { version = "0.13.0", features = ["server", "macros"] }
 pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", path = "./runtime-api" }
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }

--- a/utils/frame/remote-externalities/Cargo.toml
+++ b/utils/frame/remote-externalities/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 env_logger = "0.9"
-jsonrpsee = { version = "0.12.0", features = ["ws-client", "macros"] }
+jsonrpsee = { version = "0.13.0", features = ["ws-client", "macros"] }
 log = "0.4.16"
 serde = "1.0.136"
 serde_json = "1.0"

--- a/utils/frame/rpc/state-trie-migration-rpc/Cargo.toml
+++ b/utils/frame/rpc/state-trie-migration-rpc/Cargo.toml
@@ -25,7 +25,7 @@ sp-state-machine = { path = "../../../../primitives/state-machine" }
 sp-trie = { path = "../../../../primitives/trie" }
 trie-db = { version = "0.23.1" }
 
-jsonrpsee = { version = "0.12.0", features = ["server", "macros"] }
+jsonrpsee = { version = "0.13.0", features = ["server", "macros"] }
 
 # Substrate Dependencies
 sc-client-api = { version = "4.0.0-dev", path = "../../../../client/api" }

--- a/utils/frame/rpc/support/Cargo.toml
+++ b/utils/frame/rpc/support/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 futures = "0.3.21"
-jsonrpsee = { version = "0.12.0", features = ["jsonrpsee-types"] }
+jsonrpsee = { version = "0.13.0", features = ["jsonrpsee-types"] }
 serde = "1"
 frame-support = { version = "4.0.0-dev", path = "../../../../frame/support" }
 sc-rpc-api = { version = "0.10.0-dev", path = "../../../../client/rpc-api" }
@@ -25,6 +25,6 @@ sp-storage = { version = "6.0.0", path = "../../../../primitives/storage" }
 
 [dev-dependencies]
 scale-info = "2.0.1"
-jsonrpsee = { version = "0.12.0", features = ["ws-client", "jsonrpsee-types"] }
+jsonrpsee = { version = "0.13.0", features = ["ws-client", "jsonrpsee-types"] }
 tokio = "1.17.0"
 frame-system = { version = "4.0.0-dev", path = "../../../../frame/system" }

--- a/utils/frame/rpc/system/Cargo.toml
+++ b/utils/frame/rpc/system/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde_json = "1"
 codec = { package = "parity-scale-codec", version = "3.0.0" }
-jsonrpsee = { version = "0.12.0", features = ["server"] }
+jsonrpsee = { version = "0.13.0", features = ["server"] }
 futures = "0.3.21"
 log = "0.4.16"
 frame-system-rpc-runtime-api = { version = "4.0.0-dev", path = "../../../../frame/system/rpc/runtime-api" }

--- a/utils/frame/try-runtime/cli/Cargo.toml
+++ b/utils/frame/try-runtime/cli/Cargo.toml
@@ -19,7 +19,7 @@ parity-scale-codec = "3.0.0"
 serde = "1.0.136"
 zstd = { version = "0.10.0", default-features = false }
 remote-externalities = { version = "0.10.0-dev", path = "../../remote-externalities" }
-jsonrpsee = { version = "0.12.0", default-features = false, features = ["ws-client"] }
+jsonrpsee = { version = "0.13.0", default-features = false, features = ["ws-client"] }
 sc-chain-spec = { version = "4.0.0-dev", path = "../../../../client/chain-spec" }
 sc-cli = { version = "0.10.0-dev", path = "../../../../client/cli" }
 sc-executor = { version = "0.10.0-dev", path = "../../../../client/executor" }


### PR DESCRIPTION
Followup on https://github.com/paritytech/substrate/pull/8783 which adds the `HTTP health API` back.

polkadot companion: https://github.com/paritytech/polkadot/pull/5499
cumulus companion: https://github.com/paritytech/cumulus/pull/1253