### PR TITLE
Use header instead of its hash in `create_inherent_data_providers`

### DIFF
--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -432,12 +432,13 @@ pub fn new_full_base(
 			block_import,
 			sync_oracle: network.clone(),
 			justification_sync_link: network.clone(),
-			create_inherent_data_providers: move |parent, ()| {
+			create_inherent_data_providers: move |parent_header: <Block as BlockT>::Header, ()| {
 				let client_clone = client_clone.clone();
+				let parent_hash = parent_header.hash();
 				async move {
 					let uncles = sc_consensus_uncles::create_uncles_inherent_data_provider(
 						&*client_clone,
-						parent,
+						parent_hash,
 					)?;
 
 					let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
@@ -451,7 +452,7 @@ pub fn new_full_base(
 					let storage_proof =
 						sp_transaction_storage_proof::registration::new_data_provider(
 							&*client_clone,
-							&parent,
+							&parent_hash,
 						)?;
 
 					Ok((timestamp, slot, uncles, storage_proof))

--- a/client/consensus/aura/src/import_queue.rs
+++ b/client/consensus/aura/src/import_queue.rs
@@ -209,7 +209,7 @@ where
 
 		let create_inherent_data_providers = self
 			.create_inherent_data_providers
-			.create_inherent_data_providers(parent_hash, ())
+			.create_inherent_data_providers(block.header.clone(), ())
 			.await
 			.map_err(|e| Error::<B>::Client(sp_blockchain::Error::Application(e)))?;
 

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -1223,7 +1223,7 @@ where
 
 		let create_inherent_data_providers = self
 			.create_inherent_data_providers
-			.create_inherent_data_providers(parent_hash, ())
+			.create_inherent_data_providers(block.header.clone(), ())
 			.await
 			.map_err(|e| Error::<Block>::Client(sp_consensus::Error::from(e).into()))?;
 

--- a/client/consensus/manual-seal/src/seal_block.rs
+++ b/client/consensus/manual-seal/src/seal_block.rs
@@ -108,7 +108,7 @@ pub async fn seal_block<B, BI, SC, C, E, TP, CIDP>(
 		};
 
 		let inherent_data_providers = create_inherent_data_providers
-			.create_inherent_data_providers(parent.hash(), ())
+			.create_inherent_data_providers(parent.clone(), ())
 			.await
 			.map_err(|e| Error::Other(e))?;
 

--- a/client/consensus/pow/src/lib.rs
+++ b/client/consensus/pow/src/lib.rs
@@ -364,7 +364,7 @@ where
 				check_block.clone(),
 				BlockId::Hash(parent_hash),
 				self.create_inherent_data_providers
-					.create_inherent_data_providers(parent_hash, ())
+					.create_inherent_data_providers(block.header.clone(), ())
 					.await?,
 				block.origin.into(),
 			)
@@ -604,7 +604,7 @@ where
 			};
 
 			let inherent_data_providers = match create_inherent_data_providers
-				.create_inherent_data_providers(best_hash, ())
+				.create_inherent_data_providers(best_header.clone(), ())
 				.await
 			{
 				Ok(x) => x,

--- a/primitives/inherents/src/client_side.rs
+++ b/primitives/inherents/src/client_side.rs
@@ -34,7 +34,7 @@ pub trait CreateInherentDataProviders<Block: BlockT, ExtraArgs>: Send + Sync {
 	/// Create the inherent data providers at the given `parent` block using the given `extra_args`.
 	async fn create_inherent_data_providers(
 		&self,
-		parent: Block::Hash,
+		parent: Block::Header,
 		extra_args: ExtraArgs,
 	) -> Result<Self::InherentDataProviders, Box<dyn std::error::Error + Send + Sync>>;
 }
@@ -43,7 +43,7 @@ pub trait CreateInherentDataProviders<Block: BlockT, ExtraArgs>: Send + Sync {
 impl<F, Block, IDP, ExtraArgs, Fut> CreateInherentDataProviders<Block, ExtraArgs> for F
 where
 	Block: BlockT,
-	F: Fn(Block::Hash, ExtraArgs) -> Fut + Sync + Send,
+	F: Fn(Block::Header, ExtraArgs) -> Fut + Sync + Send,
 	Fut: std::future::Future<Output = Result<IDP, Box<dyn std::error::Error + Send + Sync>>>
 		+ Send
 		+ 'static,
@@ -54,7 +54,7 @@ where
 
 	async fn create_inherent_data_providers(
 		&self,
-		parent: Block::Hash,
+		parent: Block::Header,
 		extra_args: ExtraArgs,
 	) -> Result<Self::InherentDataProviders, Box<dyn std::error::Error + Send + Sync>> {
 		(*self)(parent, extra_args).await
@@ -70,7 +70,7 @@ impl<Block: BlockT, ExtraArgs: Send, IDPS: InherentDataProvider>
 
 	async fn create_inherent_data_providers(
 		&self,
-		parent: Block::Hash,
+		parent: Block::Header,
 		extra_args: ExtraArgs,
 	) -> Result<Self::InherentDataProviders, Box<dyn std::error::Error + Send + Sync>> {
 		(**self).create_inherent_data_providers(parent, extra_args).await


### PR DESCRIPTION
I needed parent block number in `create_inherent_data_providers` and while header is already available in all cases, I had to make a call into a client. Maybe the whole header can be exposed right away?