### PR TITLE
Make fields of `EraRewardPoints` public

### DIFF
--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -369,9 +369,9 @@ pub struct ActiveEraInfo {
 #[derive(PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
 pub struct EraRewardPoints<AccountId: Ord> {
 	/// Total number of points. Equals the sum of reward points for each validator.
-	total: RewardPoint,
+	pub total: RewardPoint,
 	/// The reward points earned by a given validator.
-	individual: BTreeMap<AccountId, RewardPoint>,
+	pub individual: BTreeMap<AccountId, RewardPoint>,
 }
 
 impl<AccountId: Ord> Default for EraRewardPoints<AccountId> {


### PR DESCRIPTION
Currently, there is no 'non-hacky' way of getting the validator points per era. As users of the pallet-staking, we can have access to this information by using `EraRewardPoints` but since its fields are private we need to do some hacky shenanigans with encoding/decoding to be able to read it.
This pr makes it possible to get such information easier by making fields of the `EraRewardPoints` public.

