### PR TITLE
Return a successful response on repeated small block request

### DIFF
--- a/client/network/sync/src/block_request_handler.rs
+++ b/client/network/sync/src/block_request_handler.rs
@@ -204,14 +204,14 @@ where
 
 		let mut reputation_change = None;
 
+		let small_request = attributes
+			.difference(BlockAttributes::HEADER | BlockAttributes::JUSTIFICATION)
+			.is_empty();
+
 		match self.seen_requests.get_mut(&key) {
 			Some(SeenRequestsValue::First) => {},
 			Some(SeenRequestsValue::Fulfilled(ref mut requests)) => {
 				*requests = requests.saturating_add(1);
-
-				let small_request = attributes
-					.difference(BlockAttributes::HEADER | BlockAttributes::JUSTIFICATION)
-					.is_empty();
 
 				if *requests > MAX_NUMBER_OF_SAME_REQUESTS_PER_PEER {
 					reputation_change = Some(if small_request {
@@ -237,7 +237,7 @@ where
 			attributes,
 		);
 
-		let result = if reputation_change.is_none() {
+		let result = if reputation_change.is_none() || small_request {
 			let block_response = self.get_block_response(
 				attributes,
 				from_block_id,


### PR DESCRIPTION
This PR is a small follow-up to #11084. That PR reduced the penalty for "small" block requests, such as requests performed as part of a common ancestor search, to avoid banning honest peers. However, that PR missed the fact that we would still return an error response on duplicate small requests. 

This leads to cases like:
1. Node A requests the header of block X
2. Node B responds successfully
(time passes)
3. Node A requests the header of block X (again)
4. Node B reduces A's reputation 
5. Node B returns an error for the request
6. Node A views the error as a refusal to fulfill the request
7. Node A bans B for refusing to fulfill its request

This PR makes it so we return a successful response on duplicate small block requests, preventing situations such as above.