### PR TITLE
[ci] Adjust job order in pipeline test stage with Gitlab DAG

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -218,6 +218,8 @@ cancel-pipeline:
       artifacts:                   false
     - job:                         cargo-check-benches
       artifacts:                   false
+    - job:                         check-tracing
+      artifacts:                   false
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       when: on_failure

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -212,6 +212,12 @@ cancel-pipeline:
   needs:
     - job:                         test-linux-stable
       artifacts:                   false
+    - job:                         test-linux-stable-int
+      artifacts:                   false
+    - job:                         cargo-check-subkey
+      artifacts:                   false
+    - job:                         cargo-check-benches
+      artifacts:                   false
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       when: on_failure

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -201,3 +201,21 @@ deploy-prometheus-alerting-rules:
       changes:
         - .gitlab-ci.yml
         - ./scripts/ci/monitoring/**/*
+
+#### stage:                        .post
+
+# This job cancels the whole pipeline if any of provided jobs fail.
+# In a DAG, every jobs chain is executed independently of others. The `fail_fast` principle suggests
+# to fail the pipeline as soon as possible to shorten the feedback loop.
+cancel-pipeline:
+  stage:                           .post
+  needs:
+    - job:                         test-linux-stable
+      artifacts:                   false
+  rules:
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+      when: on_failure
+  variables:
+    PROJECT_ID:                    "${CI_PROJECT_ID}"
+    PIPELINE_ID:                   "${CI_PIPELINE_ID}"
+  trigger:                         "parity/infrastructure/ci_cd/pipeline-stopper"

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -30,6 +30,10 @@ cargo-fmt:
 
 cargo-clippy:
   stage:                           test
+  # this is an artificial job dependency, for pipeline optimization using GitLab's DAGs
+  needs:
+    - job:                         cargo-fmt
+      artifacts:                   false
   extends:
     - .docker-env
     - .test-refs
@@ -38,6 +42,10 @@ cargo-clippy:
 
 cargo-check-nixos:
   stage:                           test
+  # this is an artificial job dependency, for pipeline optimization using GitLab's DAGs
+  needs:
+    - job:                         cargo-clippy
+      artifacts:                   false
   extends:
     - .docker-env
     - .test-refs
@@ -117,6 +125,10 @@ cargo-check-subkey:
 
 cargo-check-try-runtime:
   stage:                           test
+  # this is an artificial job dependency, for pipeline optimization using GitLab's DAGs
+  needs:
+    - job:                         cargo-check-subkey
+      artifacts:                   false
   extends:
     - .docker-env
     - .test-refs
@@ -125,6 +137,10 @@ cargo-check-try-runtime:
 
 cargo-check-wasmer-sandbox:
   stage:                           test
+  # this is an artificial job dependency, for pipeline optimization using GitLab's DAGs
+  needs:
+    - job:                         cargo-check-try-runtime
+      artifacts:                   false
   extends:
     - .docker-env
     - .test-refs
@@ -133,6 +149,10 @@ cargo-check-wasmer-sandbox:
 
 test-deterministic-wasm:
   stage:                           test
+  # this is an artificial job dependency, for pipeline optimization using GitLab's DAGs
+  needs:
+    - job:                         cargo-check-wasmer-sandbox
+      artifacts:                   false
   extends:
     - .docker-env
     - .test-refs
@@ -217,6 +237,10 @@ test-linux-stable-int:
 
 check-tracing:
   stage:                           test
+  # this is an artificial job dependency, for pipeline optimization using GitLab's DAGs
+  needs:
+    - job:                         test-linux-stable-int
+      artifacts:                   false
   extends:
     - .docker-env
     - .test-refs
@@ -227,6 +251,10 @@ check-tracing:
 
 test-full-crypto-feature:
   stage:                           test
+  # this is an artificial job dependency, for pipeline optimization using GitLab's DAGs
+  needs:
+    - job:                         check-tracing
+      artifacts:                   false
   extends:
     - .docker-env
     - .test-refs


### PR DESCRIPTION
The PR adds DAG for jobs in the test stage. It optimises runner usage and doesn't affect the pipeline duration.

Close https://github.com/paritytech/ci_cd/issues/368