### PR TITLE
fix: regression of `sync_state_genSyncSpec` #11435 (#11437)

### DIFF
--- a/client/sync-state-rpc/src/lib.rs
+++ b/client/sync-state-rpc/src/lib.rs
@@ -128,7 +128,7 @@ pub struct LightSyncState<Block: BlockT> {
 pub trait SyncStateRpcApi {
 	/// Returns the JSON serialized chainspec running the node, with a sync state.
 	#[method(name = "sync_state_genSyncSpec")]
-	fn system_gen_sync_spec(&self, raw: bool) -> RpcResult<String>;
+	fn system_gen_sync_spec(&self, raw: bool) -> RpcResult<serde_json::Value>;
 }
 
 /// An api for sync state RPC calls.
@@ -185,7 +185,7 @@ where
 	Block: BlockT,
 	Backend: HeaderBackend<Block> + sc_client_api::AuxStore + 'static,
 {
-	fn system_gen_sync_spec(&self, raw: bool) -> RpcResult<String> {
+	fn system_gen_sync_spec(&self, raw: bool) -> RpcResult<serde_json::Value> {
 		let current_sync_state = self.build_sync_state()?;
 		let mut chain_spec = self.chain_spec.cloned_box();
 
@@ -197,6 +197,7 @@ where
 		let val = serde_json::to_value(&current_sync_state)?;
 		*extension = Some(val);
 
-		chain_spec.as_json(raw).map_err(|e| Error::<Block>::JsonRpc(e).into())
+		let json_str = chain_spec.as_json(raw).map_err(|e| Error::<Block>::JsonRpc(e))?;
+		serde_json::from_str(&json_str).map_err(Into::into)
 	}
 }


### PR DESCRIPTION
Backport of  #11437 

* fix: #11435

* address grumbles: better safe than sorry

polkadot companion branch: release-v0.9.22
