### PR TITLE
aura: export change_authorities and initialize_authorities

### DIFF
--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -164,7 +164,7 @@ impl<T: Config> Pallet<T> {
 	///
 	/// The storage will be applied immediately.
 	///
-	/// The authorities length must be equal or less than [`T::MaxAuthorities`].
+	/// The authorities length must be equal or less than T::MaxAuthorities.
 	pub fn initialize_authorities(authorities: &[T::AuthorityId]) {
 		if !authorities.is_empty() {
 			assert!(<Authorities<T>>::get().is_empty(), "Authorities are already initialized!");

--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -146,6 +146,10 @@ pub mod pallet {
 }
 
 impl<T: Config> Pallet<T> {
+	/// Change authorities.
+	///
+	/// The storage will be applied immediately.
+	/// And aura consensus log will be appended to block's log.
 	pub fn change_authorities(new: WeakBoundedVec<T::AuthorityId, T::MaxAuthorities>) {
 		<Authorities<T>>::put(&new);
 
@@ -156,6 +160,11 @@ impl<T: Config> Pallet<T> {
 		<frame_system::Pallet<T>>::deposit_log(log);
 	}
 
+	/// Initial authorities.
+	///
+	/// The storage will be applied immediately.
+	///
+	/// The authorities length must be equal or less than [`T::MaxAuthorities`].
 	pub fn initialize_authorities(authorities: &[T::AuthorityId]) {
 		if !authorities.is_empty() {
 			assert!(<Authorities<T>>::get().is_empty(), "Authorities are already initialized!");

--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -146,7 +146,7 @@ pub mod pallet {
 }
 
 impl<T: Config> Pallet<T> {
-	fn change_authorities(new: WeakBoundedVec<T::AuthorityId, T::MaxAuthorities>) {
+	pub fn change_authorities(new: WeakBoundedVec<T::AuthorityId, T::MaxAuthorities>) {
 		<Authorities<T>>::put(&new);
 
 		let log = DigestItem::Consensus(
@@ -156,7 +156,7 @@ impl<T: Config> Pallet<T> {
 		<frame_system::Pallet<T>>::deposit_log(log);
 	}
 
-	fn initialize_authorities(authorities: &[T::AuthorityId]) {
+	pub fn initialize_authorities(authorities: &[T::AuthorityId]) {
 		if !authorities.is_empty() {
 			assert!(<Authorities<T>>::get().is_empty(), "Authorities are already initialized!");
 			let bounded = <BoundedSlice<'_, _, T::MaxAuthorities>>::try_from(authorities)


### PR DESCRIPTION
Since some apis in grandpa such as `schedule_change` is `pub`.  And so is `babe`.
Should Aura export these apis such as `change_authorities`