### PR TITLE
Unify rpc api and implementation name

### DIFF
--- a/bin/node-template/node/src/rpc.rs
+++ b/bin/node-template/node/src/rpc.rs
@@ -39,14 +39,14 @@ where
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + 'static,
 {
-	use pallet_transaction_payment_rpc::{TransactionPaymentApiServer, TransactionPaymentRpc};
-	use substrate_frame_rpc_system::{SystemApiServer, SystemRpc};
+	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
+	use substrate_frame_rpc_system::{System, SystemApiServer};
 
 	let mut module = RpcModule::new(());
 	let FullDeps { client, pool, deny_unsafe } = deps;
 
-	module.merge(SystemRpc::new(client.clone(), pool.clone(), deny_unsafe).into_rpc())?;
-	module.merge(TransactionPaymentRpc::new(client).into_rpc())?;
+	module.merge(System::new(client.clone(), pool.clone(), deny_unsafe).into_rpc())?;
+	module.merge(TransactionPayment::new(client).into_rpc())?;
 
 	// Extend this RPC with a custom API by using the following syntax.
 	// `YourRpcStruct` should have a reference to a client, which is needed

--- a/bin/node/rpc/src/lib.rs
+++ b/bin/node/rpc/src/lib.rs
@@ -118,15 +118,15 @@ where
 	B: sc_client_api::Backend<Block> + Send + Sync + 'static,
 	B::State: sc_client_api::backend::StateBackend<sp_runtime::traits::HashFor<Block>>,
 {
-	use pallet_contracts_rpc::{ContractsApiServer, ContractsRpc};
-	use pallet_mmr_rpc::{MmrApiServer, MmrRpc};
-	use pallet_transaction_payment_rpc::{TransactionPaymentApiServer, TransactionPaymentRpc};
-	use sc_consensus_babe_rpc::{BabeApiServer, BabeRpc};
-	use sc_finality_grandpa_rpc::{GrandpaApiServer, GrandpaRpc};
+	use pallet_contracts_rpc::{Contracts, ContractsApiServer};
+	use pallet_mmr_rpc::{Mmr, MmrApiServer};
+	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
+	use sc_consensus_babe_rpc::{Babe, BabeApiServer};
+	use sc_finality_grandpa_rpc::{Grandpa, GrandpaApiServer};
 	use sc_rpc::dev::{Dev, DevApiServer};
-	use sc_sync_state_rpc::{SyncStateApiServer, SyncStateRpc};
-	use substrate_frame_rpc_system::{SystemApiServer, SystemRpc};
-	use substrate_state_trie_migration_rpc::{StateMigrationApiServer, StateMigrationRpc};
+	use sc_sync_state_rpc::{SyncState, SyncStateApiServer};
+	use substrate_frame_rpc_system::{System, SystemApiServer};
+	use substrate_state_trie_migration_rpc::{StateMigration, StateMigrationApiServer};
 
 	let mut io = RpcModule::new(());
 	let FullDeps { client, pool, select_chain, chain_spec, deny_unsafe, babe, grandpa } = deps;
@@ -140,15 +140,15 @@ where
 		finality_provider,
 	} = grandpa;
 
-	io.merge(SystemRpc::new(client.clone(), pool, deny_unsafe).into_rpc())?;
+	io.merge(System::new(client.clone(), pool, deny_unsafe).into_rpc())?;
 	// Making synchronous calls in light client freezes the browser currently,
 	// more context: https://github.com/paritytech/substrate/pull/3480
 	// These RPCs should use an asynchronous caller instead.
-	io.merge(ContractsRpc::new(client.clone()).into_rpc())?;
-	io.merge(MmrRpc::new(client.clone()).into_rpc())?;
-	io.merge(TransactionPaymentRpc::new(client.clone()).into_rpc())?;
+	io.merge(Contracts::new(client.clone()).into_rpc())?;
+	io.merge(Mmr::new(client.clone()).into_rpc())?;
+	io.merge(TransactionPayment::new(client.clone()).into_rpc())?;
 	io.merge(
-		BabeRpc::new(
+		Babe::new(
 			client.clone(),
 			shared_epoch_changes.clone(),
 			keystore,
@@ -159,7 +159,7 @@ where
 		.into_rpc(),
 	)?;
 	io.merge(
-		GrandpaRpc::new(
+		Grandpa::new(
 			subscription_executor,
 			shared_authority_set.clone(),
 			shared_voter_state,
@@ -170,11 +170,11 @@ where
 	)?;
 
 	io.merge(
-		SyncStateRpc::new(chain_spec, client.clone(), shared_authority_set, shared_epoch_changes)?
+		SyncState::new(chain_spec, client.clone(), shared_authority_set, shared_epoch_changes)?
 			.into_rpc(),
 	)?;
 
-	io.merge(StateMigrationRpc::new(client.clone(), backend, deny_unsafe).into_rpc())?;
+	io.merge(StateMigration::new(client.clone(), backend, deny_unsafe).into_rpc())?;
 	io.merge(Dev::new(client, deny_unsafe).into_rpc())?;
 
 	Ok(io)

--- a/bin/node/rpc/src/lib.rs
+++ b/bin/node/rpc/src/lib.rs
@@ -37,12 +37,10 @@ use jsonrpsee::RpcModule;
 use node_primitives::{AccountId, Balance, Block, BlockNumber, Hash, Index};
 use sc_client_api::AuxStore;
 use sc_consensus_babe::{Config, Epoch};
-use sc_consensus_babe_rpc::BabeRpc;
 use sc_consensus_epochs::SharedEpochChanges;
 use sc_finality_grandpa::{
 	FinalityProofProvider, GrandpaJustificationStream, SharedAuthoritySet, SharedVoterState,
 };
-use sc_finality_grandpa_rpc::GrandpaRpc;
 use sc_rpc::SubscriptionTaskExecutor;
 pub use sc_rpc_api::DenyUnsafe;
 use sc_transaction_pool_api::TransactionPool;
@@ -123,12 +121,12 @@ where
 	use pallet_contracts_rpc::{ContractsApiServer, ContractsRpc};
 	use pallet_mmr_rpc::{MmrApiServer, MmrRpc};
 	use pallet_transaction_payment_rpc::{TransactionPaymentApiServer, TransactionPaymentRpc};
-	use sc_consensus_babe_rpc::BabeApiServer;
-	use sc_finality_grandpa_rpc::GrandpaApiServer;
+	use sc_consensus_babe_rpc::{BabeApiServer, BabeRpc};
+	use sc_finality_grandpa_rpc::{GrandpaApiServer, GrandpaRpc};
 	use sc_rpc::dev::{Dev, DevApiServer};
-	use sc_sync_state_rpc::{SyncStateRpc, SyncStateRpcApiServer};
+	use sc_sync_state_rpc::{SyncStateApiServer, SyncStateRpc};
 	use substrate_frame_rpc_system::{SystemApiServer, SystemRpc};
-	use substrate_state_trie_migration_rpc::StateMigrationApiServer;
+	use substrate_state_trie_migration_rpc::{StateMigrationApiServer, StateMigrationRpc};
 
 	let mut io = RpcModule::new(());
 	let FullDeps { client, pool, select_chain, chain_spec, deny_unsafe, babe, grandpa } = deps;
@@ -176,10 +174,7 @@ where
 			.into_rpc(),
 	)?;
 
-	io.merge(
-		substrate_state_trie_migration_rpc::MigrationRpc::new(client.clone(), backend, deny_unsafe)
-			.into_rpc(),
-	)?;
+	io.merge(StateMigrationRpc::new(client.clone(), backend, deny_unsafe).into_rpc())?;
 	io.merge(Dev::new(client, deny_unsafe).into_rpc())?;
 
 	Ok(io)

--- a/client/beefy/rpc/src/lib.rs
+++ b/client/beefy/rpc/src/lib.rs
@@ -110,7 +110,7 @@ impl<Block> Beefy<Block>
 where
 	Block: BlockT,
 {
-	/// Creates a new BeefyRpcHandler instance.
+	/// Creates a new Beefy Rpc handler instance.
 	pub fn new(
 		signed_commitment_stream: BeefySignedCommitmentStream<Block>,
 		best_block_stream: BeefyBestBlockStream<Block>,
@@ -198,7 +198,7 @@ mod tests {
 		let expected_response = r#"{"jsonrpc":"2.0","error":{"code":1,"message":"BEEFY RPC endpoint not ready"},"id":1}"#.to_string();
 		let (result, _) = rpc.raw_json_request(&request).await.unwrap();
 
-		assert_eq!(expected_response, result);
+		assert_eq!(expected_response, result,);
 	}
 
 	#[tokio::test]

--- a/client/beefy/rpc/src/lib.rs
+++ b/client/beefy/rpc/src/lib.rs
@@ -100,13 +100,13 @@ pub trait BeefyApi<Notification, Hash> {
 }
 
 /// Implements the BeefyApi RPC trait for interacting with BEEFY.
-pub struct BeefyRpc<Block: BlockT> {
+pub struct Beefy<Block: BlockT> {
 	signed_commitment_stream: BeefySignedCommitmentStream<Block>,
 	beefy_best_block: Arc<RwLock<Option<Block::Hash>>>,
 	executor: SubscriptionTaskExecutor,
 }
 
-impl<Block> BeefyRpc<Block>
+impl<Block> Beefy<Block>
 where
 	Block: BlockT,
 {
@@ -131,7 +131,7 @@ where
 }
 
 #[async_trait]
-impl<Block> BeefyApiServer<notification::EncodedSignedCommitment, Block::Hash> for BeefyRpc<Block>
+impl<Block> BeefyApiServer<notification::EncodedSignedCommitment, Block::Hash> for Beefy<Block>
 where
 	Block: BlockT,
 {
@@ -173,19 +173,19 @@ mod tests {
 	use sp_runtime::traits::{BlakeTwo256, Hash};
 	use substrate_test_runtime_client::runtime::Block;
 
-	fn setup_io_handler() -> (RpcModule<BeefyRpc<Block>>, BeefySignedCommitmentSender<Block>) {
+	fn setup_io_handler() -> (RpcModule<Beefy<Block>>, BeefySignedCommitmentSender<Block>) {
 		let (_, stream) = BeefyBestBlockStream::<Block>::channel();
 		setup_io_handler_with_best_block_stream(stream)
 	}
 
 	fn setup_io_handler_with_best_block_stream(
 		best_block_stream: BeefyBestBlockStream<Block>,
-	) -> (RpcModule<BeefyRpc<Block>>, BeefySignedCommitmentSender<Block>) {
+	) -> (RpcModule<Beefy<Block>>, BeefySignedCommitmentSender<Block>) {
 		let (commitment_sender, commitment_stream) =
 			BeefySignedCommitmentStream::<Block>::channel();
 
 		let handler =
-			BeefyRpc::new(commitment_stream, best_block_stream, sc_rpc::testing::test_executor())
+			Beefy::new(commitment_stream, best_block_stream, sc_rpc::testing::test_executor())
 				.expect("Setting up the BEEFY RPC handler works");
 
 		(handler.into_rpc(), commitment_sender)

--- a/client/consensus/babe/rpc/src/lib.rs
+++ b/client/consensus/babe/rpc/src/lib.rs
@@ -49,7 +49,7 @@ pub trait BabeApi {
 }
 
 /// Provides RPC methods for interacting with Babe.
-pub struct BabeRpc<B: BlockT, C, SC> {
+pub struct Babe<B: BlockT, C, SC> {
 	/// shared reference to the client.
 	client: Arc<C>,
 	/// shared reference to EpochChanges
@@ -64,7 +64,7 @@ pub struct BabeRpc<B: BlockT, C, SC> {
 	deny_unsafe: DenyUnsafe,
 }
 
-impl<B: BlockT, C, SC> BabeRpc<B, C, SC> {
+impl<B: BlockT, C, SC> Babe<B, C, SC> {
 	/// Creates a new instance of the BabeRpc handler.
 	pub fn new(
 		client: Arc<C>,
@@ -79,7 +79,7 @@ impl<B: BlockT, C, SC> BabeRpc<B, C, SC> {
 }
 
 #[async_trait]
-impl<B: BlockT, C, SC> BabeApiServer for BabeRpc<B, C, SC>
+impl<B: BlockT, C, SC> BabeApiServer for Babe<B, C, SC>
 where
 	B: BlockT,
 	C: ProvideRuntimeApi<B>
@@ -239,7 +239,7 @@ mod tests {
 
 	fn test_babe_rpc_module(
 		deny_unsafe: DenyUnsafe,
-	) -> BabeRpc<Block, TestClient, sc_consensus::LongestChain<Backend, Block>> {
+	) -> Babe<Block, TestClient, sc_consensus::LongestChain<Backend, Block>> {
 		let builder = TestClientBuilder::new();
 		let (client, longest_chain) = builder.build_with_longest_chain();
 		let client = Arc::new(client);
@@ -250,7 +250,7 @@ mod tests {
 		let epoch_changes = link.epoch_changes().clone();
 		let keystore = create_temp_keystore::<AuthorityPair>(Sr25519Keyring::Alice).0;
 
-		BabeRpc::new(client.clone(), epoch_changes, keystore, config, longest_chain, deny_unsafe)
+		Babe::new(client.clone(), epoch_changes, keystore, config, longest_chain, deny_unsafe)
 	}
 
 	#[tokio::test]

--- a/client/consensus/babe/rpc/src/lib.rs
+++ b/client/consensus/babe/rpc/src/lib.rs
@@ -65,7 +65,7 @@ pub struct Babe<B: BlockT, C, SC> {
 }
 
 impl<B: BlockT, C, SC> Babe<B, C, SC> {
-	/// Creates a new instance of the BabeRpc handler.
+	/// Creates a new instance of the Babe Rpc handler.
 	pub fn new(
 		client: Arc<C>,
 		shared_epoch_changes: SharedEpochChanges<B, Epoch>,

--- a/client/consensus/manual-seal/src/rpc.rs
+++ b/client/consensus/manual-seal/src/rpc.rs
@@ -86,7 +86,7 @@ pub trait ManualSealApi<Hash> {
 }
 
 /// A struct that implements the [`ManualSealApiServer`].
-pub struct ManualSeal<Hash> {
+pub struct ManualSealRpc<Hash> {
 	import_block_channel: mpsc::Sender<EngineCommand<Hash>>,
 }
 
@@ -99,7 +99,7 @@ pub struct CreatedBlock<Hash> {
 	pub aux: ImportedAux,
 }
 
-impl<Hash> ManualSeal<Hash> {
+impl<Hash> ManualSealRpc<Hash> {
 	/// Create new `ManualSeal` with the given reference to the client.
 	pub fn new(import_block_channel: mpsc::Sender<EngineCommand<Hash>>) -> Self {
 		Self { import_block_channel }
@@ -107,7 +107,7 @@ impl<Hash> ManualSeal<Hash> {
 }
 
 #[async_trait]
-impl<Hash: Send + 'static> ManualSealApiServer<Hash> for ManualSeal<Hash> {
+impl<Hash: Send + 'static> ManualSealApiServer<Hash> for ManualSealRpc<Hash> {
 	async fn create_block(
 		&self,
 		create_empty: bool,

--- a/client/consensus/manual-seal/src/rpc.rs
+++ b/client/consensus/manual-seal/src/rpc.rs
@@ -86,7 +86,7 @@ pub trait ManualSealApi<Hash> {
 }
 
 /// A struct that implements the [`ManualSealApiServer`].
-pub struct ManualSealRpc<Hash> {
+pub struct ManualSeal<Hash> {
 	import_block_channel: mpsc::Sender<EngineCommand<Hash>>,
 }
 
@@ -99,7 +99,7 @@ pub struct CreatedBlock<Hash> {
 	pub aux: ImportedAux,
 }
 
-impl<Hash> ManualSealRpc<Hash> {
+impl<Hash> ManualSeal<Hash> {
 	/// Create new `ManualSeal` with the given reference to the client.
 	pub fn new(import_block_channel: mpsc::Sender<EngineCommand<Hash>>) -> Self {
 		Self { import_block_channel }
@@ -107,7 +107,7 @@ impl<Hash> ManualSealRpc<Hash> {
 }
 
 #[async_trait]
-impl<Hash: Send + 'static> ManualSealApiServer<Hash> for ManualSealRpc<Hash> {
+impl<Hash: Send + 'static> ManualSealApiServer<Hash> for ManualSeal<Hash> {
 	async fn create_block(
 		&self,
 		create_empty: bool,

--- a/client/finality-grandpa/rpc/src/lib.rs
+++ b/client/finality-grandpa/rpc/src/lib.rs
@@ -76,7 +76,7 @@ pub struct Grandpa<AuthoritySet, VoterState, Block: BlockT, ProofProvider> {
 impl<AuthoritySet, VoterState, Block: BlockT, ProofProvider>
 	Grandpa<AuthoritySet, VoterState, Block, ProofProvider>
 {
-	/// Prepare a new [`GrandpaRpc`]
+	/// Prepare a new [`Grandpa`] Rpc handler.
 	pub fn new(
 		executor: SubscriptionTaskExecutor,
 		authority_set: AuthoritySet,

--- a/client/finality-grandpa/rpc/src/lib.rs
+++ b/client/finality-grandpa/rpc/src/lib.rs
@@ -66,7 +66,7 @@ pub trait GrandpaApi<Notification, Hash, Number> {
 }
 
 /// Provides RPC methods for interacting with GRANDPA.
-pub struct GrandpaRpc<AuthoritySet, VoterState, Block: BlockT, ProofProvider> {
+pub struct Grandpa<AuthoritySet, VoterState, Block: BlockT, ProofProvider> {
 	executor: SubscriptionTaskExecutor,
 	authority_set: AuthoritySet,
 	voter_state: VoterState,
@@ -74,7 +74,7 @@ pub struct GrandpaRpc<AuthoritySet, VoterState, Block: BlockT, ProofProvider> {
 	finality_proof_provider: Arc<ProofProvider>,
 }
 impl<AuthoritySet, VoterState, Block: BlockT, ProofProvider>
-	GrandpaRpc<AuthoritySet, VoterState, Block, ProofProvider>
+	Grandpa<AuthoritySet, VoterState, Block, ProofProvider>
 {
 	/// Prepare a new [`GrandpaRpc`]
 	pub fn new(
@@ -91,7 +91,7 @@ impl<AuthoritySet, VoterState, Block: BlockT, ProofProvider>
 #[async_trait]
 impl<AuthoritySet, VoterState, Block, ProofProvider>
 	GrandpaApiServer<JustificationNotification, Block::Hash, NumberFor<Block>>
-	for GrandpaRpc<AuthoritySet, VoterState, Block, ProofProvider>
+	for Grandpa<AuthoritySet, VoterState, Block, ProofProvider>
 where
 	VoterState: ReportVoterState + Send + Sync + 'static,
 	AuthoritySet: ReportAuthoritySet + Send + Sync + 'static,
@@ -243,7 +243,7 @@ mod tests {
 	fn setup_io_handler<VoterState>(
 		voter_state: VoterState,
 	) -> (
-		RpcModule<GrandpaRpc<TestAuthoritySet, VoterState, Block, TestFinalityProofProvider>>,
+		RpcModule<Grandpa<TestAuthoritySet, VoterState, Block, TestFinalityProofProvider>>,
 		GrandpaJustificationSender<Block>,
 	)
 	where
@@ -256,7 +256,7 @@ mod tests {
 		voter_state: VoterState,
 		finality_proof: Option<FinalityProof<Header>>,
 	) -> (
-		RpcModule<GrandpaRpc<TestAuthoritySet, VoterState, Block, TestFinalityProofProvider>>,
+		RpcModule<Grandpa<TestAuthoritySet, VoterState, Block, TestFinalityProofProvider>>,
 		GrandpaJustificationSender<Block>,
 	)
 	where
@@ -266,7 +266,7 @@ mod tests {
 		let finality_proof_provider = Arc::new(TestFinalityProofProvider { finality_proof });
 		let executor = Arc::new(TaskExecutor::default());
 
-		let rpc = GrandpaRpc::new(
+		let rpc = Grandpa::new(
 			executor,
 			TestAuthoritySet,
 			voter_state,

--- a/client/rpc/src/state/mod.rs
+++ b/client/rpc/src/state/mod.rs
@@ -202,7 +202,6 @@ pub struct State<Block, Client> {
 	deny_unsafe: DenyUnsafe,
 }
 
-#[async_trait]
 impl<Block, Client> StateApiServer<Block::Hash> for State<Block, Client>
 where
 	Block: BlockT + 'static,

--- a/client/rpc/src/state/mod.rs
+++ b/client/rpc/src/state/mod.rs
@@ -168,7 +168,7 @@ pub fn new_full<BE, Block: BlockT, Client>(
 	executor: SubscriptionTaskExecutor,
 	deny_unsafe: DenyUnsafe,
 	rpc_max_payload: Option<usize>,
-) -> (StateApi<Block, Client>, ChildState<Block, Client>)
+) -> (State<Block, Client>, ChildState<Block, Client>)
 where
 	Block: BlockT + 'static,
 	Block::Hash: Unpin,
@@ -193,18 +193,18 @@ where
 		rpc_max_payload,
 	));
 	let backend = Box::new(self::state_full::FullState::new(client, executor, rpc_max_payload));
-	(StateApi { backend, deny_unsafe }, ChildState { backend: child_backend })
+	(State { backend, deny_unsafe }, ChildState { backend: child_backend })
 }
 
 /// State API with subscriptions support.
-pub struct StateApi<Block, Client> {
+pub struct State<Block, Client> {
 	backend: Box<dyn StateBackend<Block, Client>>,
 	/// Whether to deny unsafe calls
 	deny_unsafe: DenyUnsafe,
 }
 
 #[async_trait]
-impl<Block, Client> StateApiServer<Block::Hash> for StateApi<Block, Client>
+impl<Block, Client> StateApiServer<Block::Hash> for State<Block, Client>
 where
 	Block: BlockT + 'static,
 	Client: Send + Sync + 'static,

--- a/client/sync-state-rpc/src/lib.rs
+++ b/client/sync-state-rpc/src/lib.rs
@@ -42,7 +42,7 @@
 #![deny(unused_crate_dependencies)]
 
 use jsonrpsee::{
-	core::{Error as JsonRpseeError, RpcResult},
+	core::{Error as RpcError, RpcResult},
 	proc_macros::rpc,
 	types::{error::CallError, ErrorObject},
 };
@@ -79,7 +79,7 @@ pub enum Error<Block: BlockT> {
 	LightSyncStateExtensionNotFound,
 }
 
-impl<Block: BlockT> From<Error<Block>> for JsonRpseeError {
+impl<Block: BlockT> From<Error<Block>> for RpcError {
 	fn from(error: Error<Block>) -> Self {
 		let message = match error {
 			Error::JsonRpc(s) => s,
@@ -125,7 +125,7 @@ pub struct LightSyncState<Block: BlockT> {
 
 /// An api for sync state RPC calls.
 #[rpc(client, server)]
-pub trait SyncStateRpcApi {
+pub trait SyncStateApi {
 	/// Returns the JSON serialized chainspec running the node, with a sync state.
 	#[method(name = "sync_state_genSyncSpec")]
 	fn system_gen_sync_spec(&self, raw: bool) -> RpcResult<serde_json::Value>;
@@ -180,7 +180,7 @@ where
 	}
 }
 
-impl<Block, Backend> SyncStateRpcApiServer for SyncStateRpc<Block, Backend>
+impl<Block, Backend> SyncStateApiServer for SyncStateRpc<Block, Backend>
 where
 	Block: BlockT,
 	Backend: HeaderBackend<Block> + sc_client_api::AuxStore + 'static,

--- a/client/sync-state-rpc/src/lib.rs
+++ b/client/sync-state-rpc/src/lib.rs
@@ -37,12 +37,12 @@
 //! ```
 //!
 //! If the [`LightSyncStateExtension`] is not added as an extension to the chain spec,
-//! the [`SyncStateRpc`] will fail at instantiation.
+//! the [`SyncState`] will fail at instantiation.
 
 #![deny(unused_crate_dependencies)]
 
 use jsonrpsee::{
-	core::{Error as RpcError, RpcResult},
+	core::{Error as JsonRpseeError, RpcResult},
 	proc_macros::rpc,
 	types::{error::CallError, ErrorObject},
 };
@@ -79,7 +79,7 @@ pub enum Error<Block: BlockT> {
 	LightSyncStateExtensionNotFound,
 }
 
-impl<Block: BlockT> From<Error<Block>> for RpcError {
+impl<Block: BlockT> From<Error<Block>> for JsonRpseeError {
 	fn from(error: Error<Block>) -> Self {
 		let message = match error {
 			Error::JsonRpc(s) => s,

--- a/client/sync-state-rpc/src/lib.rs
+++ b/client/sync-state-rpc/src/lib.rs
@@ -132,14 +132,14 @@ pub trait SyncStateApi {
 }
 
 /// An api for sync state RPC calls.
-pub struct SyncStateRpc<Block: BlockT, Client> {
+pub struct SyncState<Block: BlockT, Client> {
 	chain_spec: Box<dyn sc_chain_spec::ChainSpec>,
 	client: Arc<Client>,
 	shared_authority_set: SharedAuthoritySet<Block>,
 	shared_epoch_changes: SharedEpochChanges<Block>,
 }
 
-impl<Block, Client> SyncStateRpc<Block, Client>
+impl<Block, Client> SyncState<Block, Client>
 where
 	Block: BlockT,
 	Client: HeaderBackend<Block> + sc_client_api::AuxStore + 'static,
@@ -180,7 +180,7 @@ where
 	}
 }
 
-impl<Block, Backend> SyncStateApiServer for SyncStateRpc<Block, Backend>
+impl<Block, Backend> SyncStateApiServer for SyncState<Block, Backend>
 where
 	Block: BlockT,
 	Backend: HeaderBackend<Block> + sc_client_api::AuxStore + 'static,

--- a/frame/contracts/rpc/src/lib.rs
+++ b/frame/contracts/rpc/src/lib.rs
@@ -173,12 +173,12 @@ where
 }
 
 /// Contracts RPC methods.
-pub struct ContractsRpc<Client, Block> {
+pub struct Contracts<Client, Block> {
 	client: Arc<Client>,
 	_marker: PhantomData<Block>,
 }
 
-impl<Client, Block> ContractsRpc<Client, Block> {
+impl<Client, Block> Contracts<Client, Block> {
 	/// Create new `Contracts` with the given reference to the client.
 	pub fn new(client: Arc<Client>) -> Self {
 		Self { client, _marker: Default::default() }
@@ -193,7 +193,7 @@ impl<Client, Block, AccountId, Balance, Hash>
 		AccountId,
 		Balance,
 		Hash,
-	> for ContractsRpc<Client, Block>
+	> for Contracts<Client, Block>
 where
 	Block: BlockT,
 	Client: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,

--- a/frame/merkle-mountain-range/rpc/src/lib.rs
+++ b/frame/merkle-mountain-range/rpc/src/lib.rs
@@ -131,12 +131,12 @@ pub trait MmrApi<BlockHash> {
 }
 
 /// MMR RPC methods.
-pub struct MmrRpc<Client, Block> {
+pub struct Mmr<Client, Block> {
 	client: Arc<Client>,
 	_marker: PhantomData<Block>,
 }
 
-impl<C, B> MmrRpc<C, B> {
+impl<C, B> Mmr<C, B> {
 	/// Create new `Mmr` with the given reference to the client.
 	pub fn new(client: Arc<C>) -> Self {
 		Self { client, _marker: Default::default() }
@@ -144,8 +144,7 @@ impl<C, B> MmrRpc<C, B> {
 }
 
 #[async_trait]
-impl<Client, Block, MmrHash> MmrApiServer<<Block as BlockT>::Hash>
-	for MmrRpc<Client, (Block, MmrHash)>
+impl<Client, Block, MmrHash> MmrApiServer<<Block as BlockT>::Hash> for Mmr<Client, (Block, MmrHash)>
 where
 	Block: BlockT,
 	Client: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,

--- a/frame/transaction-payment/rpc/src/lib.rs
+++ b/frame/transaction-payment/rpc/src/lib.rs
@@ -58,7 +58,7 @@ pub struct TransactionPayment<C, P> {
 }
 
 impl<C, P> TransactionPayment<C, P> {
-	/// Creates a new instance of the TransactionPaymentRpc helper.
+	/// Creates a new instance of the TransactionPayment Rpc helper.
 	pub fn new(client: Arc<C>) -> Self {
 		Self { client, _marker: Default::default() }
 	}

--- a/frame/transaction-payment/rpc/src/lib.rs
+++ b/frame/transaction-payment/rpc/src/lib.rs
@@ -51,13 +51,13 @@ pub trait TransactionPaymentApi<BlockHash, ResponseType> {
 }
 
 /// Provides RPC methods to query a dispatchable's class, weight and fee.
-pub struct TransactionPaymentRpc<C, P> {
+pub struct TransactionPayment<C, P> {
 	/// Shared reference to the client.
 	client: Arc<C>,
 	_marker: std::marker::PhantomData<P>,
 }
 
-impl<C, P> TransactionPaymentRpc<C, P> {
+impl<C, P> TransactionPayment<C, P> {
 	/// Creates a new instance of the TransactionPaymentRpc helper.
 	pub fn new(client: Arc<C>) -> Self {
 		Self { client, _marker: Default::default() }
@@ -84,7 +84,7 @@ impl From<Error> for i32 {
 #[async_trait]
 impl<C, Block, Balance>
 	TransactionPaymentApiServer<<Block as BlockT>::Hash, RuntimeDispatchInfo<Balance>>
-	for TransactionPaymentRpc<C, Block>
+	for TransactionPayment<C, Block>
 where
 	Block: BlockT,
 	C: ProvideRuntimeApi<Block> + HeaderBackend<Block> + Send + Sync + 'static,

--- a/utils/frame/rpc/state-trie-migration-rpc/src/lib.rs
+++ b/utils/frame/rpc/state-trie-migration-rpc/src/lib.rs
@@ -122,21 +122,21 @@ pub trait StateMigrationApi<BlockHash> {
 }
 
 /// An implementation of state migration specific RPC methods.
-pub struct MigrationRpc<C, B, BA> {
+pub struct StateMigrationRpc<C, B, BA> {
 	client: Arc<C>,
 	backend: Arc<BA>,
 	deny_unsafe: DenyUnsafe,
 	_marker: std::marker::PhantomData<(B, BA)>,
 }
 
-impl<C, B, BA> MigrationRpc<C, B, BA> {
+impl<C, B, BA> StateMigrationRpc<C, B, BA> {
 	/// Create new state migration rpc for the given reference to the client.
 	pub fn new(client: Arc<C>, backend: Arc<BA>, deny_unsafe: DenyUnsafe) -> Self {
-		MigrationRpc { client, backend, deny_unsafe, _marker: Default::default() }
+		StateMigrationRpc { client, backend, deny_unsafe, _marker: Default::default() }
 	}
 }
 
-impl<C, B, BA> StateMigrationApiServer<<B as BlockT>::Hash> for MigrationRpc<C, B, BA>
+impl<C, B, BA> StateMigrationApiServer<<B as BlockT>::Hash> for StateMigrationRpc<C, B, BA>
 where
 	B: BlockT,
 	C: Send + Sync + 'static + sc_client_api::HeaderBackend<B>,

--- a/utils/frame/rpc/state-trie-migration-rpc/src/lib.rs
+++ b/utils/frame/rpc/state-trie-migration-rpc/src/lib.rs
@@ -122,21 +122,21 @@ pub trait StateMigrationApi<BlockHash> {
 }
 
 /// An implementation of state migration specific RPC methods.
-pub struct StateMigrationRpc<C, B, BA> {
+pub struct StateMigration<C, B, BA> {
 	client: Arc<C>,
 	backend: Arc<BA>,
 	deny_unsafe: DenyUnsafe,
 	_marker: std::marker::PhantomData<(B, BA)>,
 }
 
-impl<C, B, BA> StateMigrationRpc<C, B, BA> {
+impl<C, B, BA> StateMigration<C, B, BA> {
 	/// Create new state migration rpc for the given reference to the client.
 	pub fn new(client: Arc<C>, backend: Arc<BA>, deny_unsafe: DenyUnsafe) -> Self {
-		StateMigrationRpc { client, backend, deny_unsafe, _marker: Default::default() }
+		StateMigration { client, backend, deny_unsafe, _marker: Default::default() }
 	}
 }
 
-impl<C, B, BA> StateMigrationApiServer<<B as BlockT>::Hash> for StateMigrationRpc<C, B, BA>
+impl<C, B, BA> StateMigrationApiServer<<B as BlockT>::Hash> for StateMigration<C, B, BA>
 where
 	B: BlockT,
 	C: Send + Sync + 'static + sc_client_api::HeaderBackend<B>,

--- a/utils/frame/rpc/system/src/lib.rs
+++ b/utils/frame/rpc/system/src/lib.rs
@@ -70,14 +70,14 @@ impl From<Error> for i32 {
 }
 
 /// An implementation of System-specific RPC methods on full client.
-pub struct SystemRpc<P: TransactionPool, C, B> {
+pub struct System<P: TransactionPool, C, B> {
 	client: Arc<C>,
 	pool: Arc<P>,
 	deny_unsafe: DenyUnsafe,
 	_marker: std::marker::PhantomData<B>,
 }
 
-impl<P: TransactionPool, C, B> SystemRpc<P, C, B> {
+impl<P: TransactionPool, C, B> System<P, C, B> {
 	/// Create new `FullSystem` given client and transaction pool.
 	pub fn new(client: Arc<C>, pool: Arc<P>, deny_unsafe: DenyUnsafe) -> Self {
 		Self { client, pool, deny_unsafe, _marker: Default::default() }
@@ -86,7 +86,7 @@ impl<P: TransactionPool, C, B> SystemRpc<P, C, B> {
 
 #[async_trait]
 impl<P, C, Block, AccountId, Index>
-	SystemApiServer<<Block as traits::Block>::Hash, AccountId, Index> for SystemRpc<P, C, Block>
+	SystemApiServer<<Block as traits::Block>::Hash, AccountId, Index> for System<P, C, Block>
 where
 	C: sp_api::ProvideRuntimeApi<Block>,
 	C: HeaderBackend<Block>,
@@ -251,7 +251,7 @@ mod tests {
 		let ext1 = new_transaction(1);
 		block_on(pool.submit_one(&BlockId::number(0), source, ext1)).unwrap();
 
-		let accounts = SystemRpc::new(client, pool, DenyUnsafe::Yes);
+		let accounts = System::new(client, pool, DenyUnsafe::Yes);
 
 		// when
 		let nonce = accounts.nonce(AccountKeyring::Alice.into()).await;
@@ -270,7 +270,7 @@ mod tests {
 		let pool =
 			BasicPool::new_full(Default::default(), true.into(), None, spawner, client.clone());
 
-		let accounts = SystemRpc::new(client, pool, DenyUnsafe::Yes);
+		let accounts = System::new(client, pool, DenyUnsafe::Yes);
 
 		// when
 		let res = accounts.dry_run(vec![].into(), None).await;
@@ -289,7 +289,7 @@ mod tests {
 		let pool =
 			BasicPool::new_full(Default::default(), true.into(), None, spawner, client.clone());
 
-		let accounts = SystemRpc::new(client, pool, DenyUnsafe::No);
+		let accounts = System::new(client, pool, DenyUnsafe::No);
 
 		let tx = Transfer {
 			from: AccountKeyring::Alice.into(),
@@ -317,7 +317,7 @@ mod tests {
 		let pool =
 			BasicPool::new_full(Default::default(), true.into(), None, spawner, client.clone());
 
-		let accounts = SystemRpc::new(client, pool, DenyUnsafe::No);
+		let accounts = System::new(client, pool, DenyUnsafe::No);
 
 		let tx = Transfer {
 			from: AccountKeyring::Alice.into(),


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

Different rpc api and impl naming is confusing, I'm not sure if I need to modify `sc-rpc` to be consistent, like

~~`Author` ==> `AuthorRpc`~~
~~`Chain` ==> `ChainRpc`~~
~~`System` ==> `SystemRpc`~~
~~`State` ==> `StateRpc`~~
~~`ChildState` ==> `ChildStateRpc`~~
~~`Offchain` ==> `OffchainRpc`~~
~~`Dev` ==> `DevRpc`~~

 polkadot companion: https://github.com/paritytech/polkadot/pull/5569