### PR TITLE
Fix node lookup on fork-tree after a warp-sync

### DIFF
--- a/utils/fork-tree/src/lib.rs
+++ b/utils/fork-tree/src/lib.rs
@@ -289,6 +289,10 @@ where
 	/// index in the traverse path goes last. If a node is found that matches the predicate
 	/// the returned path should always contain at least one index, otherwise `None` is
 	/// returned.
+	// WARNING: some users of this method (i.e. Babe epoch changes tree) currently silently
+	// rely on a **post-order DFS** traversal of the tree. In particular via the
+	// `is_descendent_of` that when used after a warp-sync may query the backend for a
+	// root that is not present.
 	pub fn find_node_index_where<F, E, P>(
 		&self,
 		hash: &H,

--- a/utils/fork-tree/src/lib.rs
+++ b/utils/fork-tree/src/lib.rs
@@ -290,10 +290,10 @@ where
 	/// the returned path should always contain at least one index, otherwise `None` is
 	/// returned.
 	// WARNING: some users of this method (i.e. consensus epoch changes tree) currently silently
-	// rely on a **DFS** traversal. If we are using instead a top-down traversal method then
-	// the `is_descendent_of` closure, when used after a warp-sync, will end up querying the
-	// backend for a block (the one corresponding to the root) that is not present and thus
-	// will return a wrong result. Here we are implementing a post-order DFS.
+	// rely on a **post-order DFS** traversal. If we are using instead a top-down traversal method
+	// then the `is_descendent_of` closure, when used after a warp-sync, will end up querying the
+	// backend for a block (the one corresponding to the root) that is not present and thus will
+	// return a wrong result. Here we are implementing a post-order DFS.
 	pub fn find_node_index_where<F, E, P>(
 		&self,
 		hash: &H,


### PR DESCRIPTION
Closes https://github.com/paritytech/polkadot/issues/5556

After a warp-sync, the error condition was triggered by the absence of the parent node of the first imported block.

To elaborate, some users of this method (i.e. consensus epoch changes tree) currently silently rely on a **POST-ORDER DFS** traversal of the tree.

If we are using instead a top-down traversal method then  the `is_descendent_of` closure, when used after a warp-sync, will end up querying the backend for a block (the one corresponding to the root) that is not present and thus will return a wrong result. 

In the last iterative implementation we started using a **pre-order** DFS instead, thus triggering the error condition.

This fairly strong assumption has been documented within the code with a **big fat warning**