### PR TITLE
Adjust maximum memory pages hard limit for the pooling instantiation strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8278,6 +8278,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parity-wasm 0.42.2",
+ "paste 1.0.6",
  "sc-allocator",
  "sc-executor-common",
  "sc-runtime-test",

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -37,3 +37,4 @@ wat = "1.0"
 sc-runtime-test = { version = "2.0.0", path = "../runtime-test" }
 sp-io = { version = "6.0.0", path = "../../../primitives/io" }
 tempfile = "3.3.0"
+paste = "1.0"


### PR DESCRIPTION
Instead of always using a hardcoded limit of 4096 pages when using the pooling instantiation strategy this PR makes it so that it is:

1) set to be equal to `max_memory_size` (for PVFs), 
2) set to the the maximum possible value (for the normal runtime); technically we could calculate exactly how much is necessary here and set it to exactly that value, but considering that we want to support dynamic heap growth in the future we'd have to set it higher than necessary anyway, so it's better to just go with the maximum value now and see whether it has any practical downsides (if it does we can just adjust it to a more "reasonable" maximum later)

Setting this to a higher value than necessary mostly only affects how much address space is reserved for the memfd internally allocated by `wasmtime` from what I can see. I've ran some preliminary benchmarks and it doesn't seem to affect the performance negatively.

cc @shawntabrizi @ggwpez This should fix the benchmarking when run with `--heap-pages` set to a high value.