### PR TITLE
[contracts] Stabilize `seal_ecdsa_recover` and `seal_ecdsa_to_eth_address` functions

### DIFF
--- a/frame/contracts/fixtures/ecdsa_recover.wat
+++ b/frame/contracts/fixtures/ecdsa_recover.wat
@@ -4,7 +4,7 @@
 ;; 3) Validates that result is Success
 ;; 4) Returns recovered compressed public key
 (module
-	(import "__unstable__" "seal_ecdsa_recover" (func $seal_ecdsa_recover (param i32 i32 i32) (result i32)))
+	(import "seal0" "seal_ecdsa_recover" (func $seal_ecdsa_recover (param i32 i32 i32) (result i32)))
 	(import "seal0" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "seal0" "seal_input" (func $seal_input (param i32 i32)))
 	(import "env" "memory" (memory 1 1))

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -1949,7 +1949,7 @@ benchmarks! {
 		let code = WasmModule::<T>::from(ModuleDefinition {
 			memory: Some(ImportedMemory::max::<T>()),
 			imported_functions: vec![ImportedFunction {
-				module: "__unstable__",
+				module: "seal0",
 				name: "seal_ecdsa_recover",
 				params: vec![ValueType::I32, ValueType::I32, ValueType::I32],
 				return_type: Some(ValueType::I32),
@@ -1992,7 +1992,7 @@ benchmarks! {
 		let code = WasmModule::<T>::from(ModuleDefinition {
 			memory: Some(ImportedMemory::max::<T>()),
 			imported_functions: vec![ImportedFunction {
-				module: "__unstable__",
+				module: "seal0",
 				name: "seal_ecdsa_to_eth_address",
 				params: vec![ValueType::I32, ValueType::I32],
 				return_type: Some(ValueType::I32),

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -2277,7 +2277,6 @@ fn gas_estimation_call_runtime() {
 }
 
 #[test]
-#[cfg(feature = "unstable-interface")]
 fn ecdsa_recover() {
 	let (wasm, code_hash) = compile_module::<Test>("ecdsa_recover").unwrap();
 

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -1059,7 +1059,6 @@ mod tests {
 		);
 	}
 
-	#[cfg(feature = "unstable-interface")]
 	const CODE_ECDSA_RECOVER: &str = r#"
 (module
 	;; seal_ecdsa_recover(
@@ -1067,7 +1066,7 @@ mod tests {
 	;;    message_hash_ptr: u32,
 	;;    output_ptr: u32
 	;; ) -> u32
-	(import "__unstable__" "seal_ecdsa_recover" (func $seal_ecdsa_recover (param i32 i32 i32) (result i32)))
+	(import "seal0" "seal_ecdsa_recover" (func $seal_ecdsa_recover (param i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 	(func (export "call")
 		(drop
@@ -1097,7 +1096,6 @@ mod tests {
 "#;
 
 	#[test]
-	#[cfg(feature = "unstable-interface")]
 	fn contract_ecdsa_recover() {
 		let mut mock_ext = MockExt::default();
 		assert_ok!(execute(&CODE_ECDSA_RECOVER, vec![], &mut mock_ext));
@@ -1105,13 +1103,12 @@ mod tests {
 	}
 
 	#[test]
-	#[cfg(feature = "unstable-interface")]
 	fn contract_ecdsa_to_eth_address() {
 		/// calls `seal_ecdsa_to_eth_address` for the contstant and ensures the result equals the
 		/// expected one.
 		const CODE_ECDSA_TO_ETH_ADDRESS: &str = r#"
 (module
-	(import "__unstable__" "seal_ecdsa_to_eth_address" (func $seal_ecdsa_to_eth_address (param i32 i32) (result i32)))
+	(import "seal0" "seal_ecdsa_to_eth_address" (func $seal_ecdsa_to_eth_address (param i32 i32) (result i32)))
 	(import "seal0" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -74,7 +74,6 @@ pub enum ReturnCode {
 	/// ECDSA pubkey recovery failed (most probably wrong recovery id or signature), or
 	/// ECDSA compressed pubkey conversion into Ethereum address failed (most probably
 	/// wrong pubkey provided).
-	#[cfg(feature = "unstable-interface")]
 	EcdsaRecoverFailed = 11,
 }
 
@@ -214,7 +213,6 @@ pub enum RuntimeCosts {
 	/// Weight of calling `seal_hash_blake2_128` for the given input size.
 	HashBlake128(u32),
 	/// Weight of calling `seal_ecdsa_recover`.
-	#[cfg(feature = "unstable-interface")]
 	EcdsaRecovery,
 	/// Weight charged by a chain extension through `seal_call_chain_extension`.
 	ChainExtension(u64),
@@ -224,7 +222,6 @@ pub enum RuntimeCosts {
 	/// Weight of calling `seal_set_code_hash`
 	SetCodeHash,
 	/// Weight of calling `ecdsa_to_eth_address`
-	#[cfg(feature = "unstable-interface")]
 	EcdsaToEthAddress,
 }
 
@@ -299,14 +296,11 @@ impl RuntimeCosts {
 			HashBlake128(len) => s
 				.hash_blake2_128
 				.saturating_add(s.hash_blake2_128_per_byte.saturating_mul(len.into())),
-			#[cfg(feature = "unstable-interface")]
 			EcdsaRecovery => s.ecdsa_recover,
 			ChainExtension(amount) => amount,
-
 			#[cfg(feature = "unstable-interface")]
 			CallRuntime(weight) => weight,
 			SetCodeHash => s.set_code_hash,
-			#[cfg(feature = "unstable-interface")]
 			EcdsaToEthAddress => s.ecdsa_to_eth_address,
 		};
 		RuntimeToken {
@@ -1993,7 +1987,7 @@ define_env!(Env, <E: Ext>,
 	// # Errors
 	//
 	// `ReturnCode::EcdsaRecoverFailed`
-	[__unstable__] seal_ecdsa_recover(ctx, signature_ptr: u32, message_hash_ptr: u32, output_ptr: u32) -> ReturnCode => {
+	[seal0] seal_ecdsa_recover(ctx, signature_ptr: u32, message_hash_ptr: u32, output_ptr: u32) -> ReturnCode => {
 		ctx.charge_gas(RuntimeCosts::EcdsaRecovery)?;
 
 		let mut signature: [u8; 65] = [0; 65];
@@ -2069,7 +2063,7 @@ define_env!(Env, <E: Ext>,
 	// # Errors
 	//
 	// `ReturnCode::EcdsaRecoverFailed`
-	[__unstable__] seal_ecdsa_to_eth_address(ctx, key_ptr: u32, out_ptr: u32) -> ReturnCode => {
+	[seal0] seal_ecdsa_to_eth_address(ctx, key_ptr: u32, out_ptr: u32) -> ReturnCode => {
 		ctx.charge_gas(RuntimeCosts::EcdsaToEthAddress)?;
 		let mut compressed_key: [u8; 33] = [0;33];
 		ctx.read_sandbox_memory_into_buf(key_ptr, &mut compressed_key)?;


### PR DESCRIPTION
Since *ink_waterfall* E2E tests were [added](https://github.com/paritytech/ink-waterfall/commit/f783b2149b5bf79484b1e236af8664fd3e02ebf1) (and being [diversified](https://github.com/paritytech/ink/pull/1268)) for
+ `seal_ecdsa_recover`
+ `seal_ecdsa_to_eth_address` 

we can now stabilize them 

