### PR TITLE
Fix Babe revert when last finalized block is a leaf

### DIFF
--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -1875,14 +1875,10 @@ where
 	let finalized = client.info().finalized_number;
 	let revertible = blocks.min(best_number - finalized);
 
-	let revert_number = best_number - revertible;
-	let revert_hash =
-		client
-			.block_hash_from_id(&BlockId::Number(revert_number))?
-			.ok_or(ClientError::Backend(format!(
-				"Unexpected hash lookup failure for block number: {}",
-				revert_number
-			)))?;
+	let revert_up_to_number = best_number - revertible;
+	let revert_up_to_hash = client.hash(revert_up_to_number)?.ok_or(ClientError::Backend(
+		format!("Unexpected hash lookup failure for block number: {}", revert_up_to_number),
+	))?;
 
 	// Revert epoch changes tree.
 
@@ -1891,11 +1887,11 @@ where
 		aux_schema::load_epoch_changes::<Block, Client>(&*client, config.genesis_config())?;
 	let mut epoch_changes = epoch_changes.shared_data();
 
-	if revert_number == Zero::zero() {
+	if revert_up_to_number == Zero::zero() {
 		// Special case, no epoch changes data were present on genesis.
 		*epoch_changes = EpochChangesFor::<Block, Epoch>::default();
 	} else {
-		epoch_changes.revert(descendent_query(&*client), revert_hash, revert_number);
+		epoch_changes.revert(descendent_query(&*client), revert_up_to_hash, revert_up_to_number);
 	}
 
 	// Remove block weights added after the revert point.
@@ -1903,7 +1899,7 @@ where
 	let mut weight_keys = HashSet::with_capacity(revertible.saturated_into());
 
 	let leaves = backend.blockchain().leaves()?.into_iter().filter(|&leaf| {
-		sp_blockchain::tree_route(&*client, revert_hash, leaf)
+		sp_blockchain::tree_route(&*client, revert_up_to_hash, leaf)
 			.map(|route| route.retracted().is_empty())
 			.unwrap_or_default()
 	});
@@ -1912,7 +1908,7 @@ where
 		let mut hash = leaf;
 		loop {
 			let meta = client.header_metadata(hash)?;
-			if meta.number <= revert_number ||
+			if meta.number <= revert_up_to_number ||
 				!weight_keys.insert(aux_schema::block_weight_key(hash))
 			{
 				// We've reached the revert point or an already processed branch, stop here.

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -1912,8 +1912,7 @@ where
 		let mut hash = leaf;
 		loop {
 			let meta = client.header_metadata(hash)?;
-			if hash == revert_hash ||
-				meta.number <= revert_number ||
+			if meta.number <= revert_number ||
 				!weight_keys.insert(aux_schema::block_weight_key(hash))
 			{
 				// We've reached the revert point or an already processed branch, stop here.

--- a/client/consensus/babe/src/tests.rs
+++ b/client/consensus/babe/src/tests.rs
@@ -815,7 +815,7 @@ fn revert_prunes_epoch_changes_and_removes_weights() {
 }
 
 #[test]
-fn revert_not_allowed_below_finalized() {
+fn revert_not_allowed_for_finalized() {
 	let mut net = BabeTestNet::new(1);
 
 	let peer = net.peer(0);

--- a/client/consensus/babe/src/tests.rs
+++ b/client/consensus/babe/src/tests.rs
@@ -815,6 +815,44 @@ fn revert_prunes_epoch_changes_and_removes_weights() {
 }
 
 #[test]
+fn revert_not_allowed_below_finalized() {
+	let mut net = BabeTestNet::new(1);
+
+	let peer = net.peer(0);
+	let data = peer.data.as_ref().expect("babe link set up during initialization");
+
+	let client = peer.client().as_client();
+	let backend = peer.client().as_backend();
+	let mut block_import = data.block_import.lock().take().expect("import set up during init");
+
+	let mut proposer_factory = DummyFactory {
+		client: client.clone(),
+		config: data.link.config.clone(),
+		epoch_changes: data.link.epoch_changes.clone(),
+		mutator: Arc::new(|_, _| ()),
+	};
+
+	let mut propose_and_import_blocks_wrap = |parent_id, n| {
+		propose_and_import_blocks(&client, &mut proposer_factory, &mut block_import, parent_id, n)
+	};
+
+	let canon = propose_and_import_blocks_wrap(BlockId::Number(0), 3);
+
+	// Finalize best block
+	client.finalize_block(BlockId::Hash(canon[2]), None, false).unwrap();
+
+	// Revert canon chain to last finalized block
+	revert(client.clone(), backend, 100).expect("revert should work for baked test scenario");
+
+	let weight_data_check = |hashes: &[Hash], expected: bool| {
+		hashes.iter().all(|hash| {
+			aux_schema::load_block_weight(&*client, hash).unwrap().is_some() == expected
+		})
+	};
+	assert!(weight_data_check(&canon, true));
+}
+
+#[test]
 fn importing_epoch_change_block_prunes_tree() {
 	let mut net = BabeTestNet::new(1);
 


### PR DESCRIPTION
This PR fix an error condition triggered when the last finalized block is equal to the best block.

Fail scenario can be easily reproduced by issuing a double revert from the CLI:
- 1st revert => to set the best block equal to last finalized
- 2nd revert => removes the weight of the last finalized block **<=== BAD**

This PR prevents removal of weight data of last finalized block
