### PR TITLE
Fix weight templates for `cargo doc` check

### DIFF
--- a/bin/node-template/node/src/rpc.rs
+++ b/bin/node-template/node/src/rpc.rs
@@ -39,14 +39,14 @@ where
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + 'static,
 {
-	use pallet_transaction_payment_rpc::{TransactionPaymentApiServer, TransactionPaymentRpc};
-	use substrate_frame_rpc_system::{SystemApiServer, SystemRpc};
+	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
+	use substrate_frame_rpc_system::{System, SystemApiServer};
 
 	let mut module = RpcModule::new(());
 	let FullDeps { client, pool, deny_unsafe } = deps;
 
-	module.merge(SystemRpc::new(client.clone(), pool.clone(), deny_unsafe).into_rpc())?;
-	module.merge(TransactionPaymentRpc::new(client).into_rpc())?;
+	module.merge(System::new(client.clone(), pool.clone(), deny_unsafe).into_rpc())?;
+	module.merge(TransactionPayment::new(client).into_rpc())?;
 
 	// Extend this RPC with a custom API by using the following syntax.
 	// `YourRpcStruct` should have a reference to a client, which is needed

--- a/client/beefy/rpc/src/lib.rs
+++ b/client/beefy/rpc/src/lib.rs
@@ -100,17 +100,17 @@ pub trait BeefyApi<Notification, Hash> {
 }
 
 /// Implements the BeefyApi RPC trait for interacting with BEEFY.
-pub struct BeefyRpcHandler<Block: BlockT> {
+pub struct Beefy<Block: BlockT> {
 	signed_commitment_stream: BeefySignedCommitmentStream<Block>,
 	beefy_best_block: Arc<RwLock<Option<Block::Hash>>>,
 	executor: SubscriptionTaskExecutor,
 }
 
-impl<Block> BeefyRpcHandler<Block>
+impl<Block> Beefy<Block>
 where
 	Block: BlockT,
 {
-	/// Creates a new BeefyRpcHandler instance.
+	/// Creates a new Beefy Rpc handler instance.
 	pub fn new(
 		signed_commitment_stream: BeefySignedCommitmentStream<Block>,
 		best_block_stream: BeefyBestBlockStream<Block>,
@@ -131,8 +131,7 @@ where
 }
 
 #[async_trait]
-impl<Block> BeefyApiServer<notification::EncodedSignedCommitment, Block::Hash>
-	for BeefyRpcHandler<Block>
+impl<Block> BeefyApiServer<notification::EncodedSignedCommitment, Block::Hash> for Beefy<Block>
 where
 	Block: BlockT,
 {
@@ -174,24 +173,20 @@ mod tests {
 	use sp_runtime::traits::{BlakeTwo256, Hash};
 	use substrate_test_runtime_client::runtime::Block;
 
-	fn setup_io_handler() -> (RpcModule<BeefyRpcHandler<Block>>, BeefySignedCommitmentSender<Block>)
-	{
+	fn setup_io_handler() -> (RpcModule<Beefy<Block>>, BeefySignedCommitmentSender<Block>) {
 		let (_, stream) = BeefyBestBlockStream::<Block>::channel();
 		setup_io_handler_with_best_block_stream(stream)
 	}
 
 	fn setup_io_handler_with_best_block_stream(
 		best_block_stream: BeefyBestBlockStream<Block>,
-	) -> (RpcModule<BeefyRpcHandler<Block>>, BeefySignedCommitmentSender<Block>) {
+	) -> (RpcModule<Beefy<Block>>, BeefySignedCommitmentSender<Block>) {
 		let (commitment_sender, commitment_stream) =
 			BeefySignedCommitmentStream::<Block>::channel();
 
-		let handler = BeefyRpcHandler::new(
-			commitment_stream,
-			best_block_stream,
-			sc_rpc::testing::test_executor(),
-		)
-		.expect("Setting up the BEEFY RPC handler works");
+		let handler =
+			Beefy::new(commitment_stream, best_block_stream, sc_rpc::testing::test_executor())
+				.expect("Setting up the BEEFY RPC handler works");
 
 		(handler.into_rpc(), commitment_sender)
 	}

--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -115,6 +115,11 @@ pub struct RunCmd {
 	#[clap(long)]
 	pub rpc_max_response_size: Option<usize>,
 
+	/// Set the the maximum concurrent subscriptions per connection.
+	/// Default is 1024.
+	#[clap(long)]
+	pub rpc_max_subscriptions_per_connection: Option<usize>,
+
 	/// Expose Prometheus exporter on all interfaces.
 	///
 	/// Default is local.
@@ -457,6 +462,18 @@ impl CliConfiguration for RunCmd {
 
 	fn rpc_max_payload(&self) -> Result<Option<usize>> {
 		Ok(self.rpc_max_payload)
+	}
+
+	fn rpc_max_request_size(&self) -> Result<Option<usize>> {
+		Ok(self.rpc_max_request_size)
+	}
+
+	fn rpc_max_response_size(&self) -> Result<Option<usize>> {
+		Ok(self.rpc_max_response_size)
+	}
+
+	fn rpc_max_subscriptions_per_connection(&self) -> Result<Option<usize>> {
+		Ok(self.rpc_max_subscriptions_per_connection)
 	}
 
 	fn ws_max_out_buffer_capacity(&self) -> Result<Option<usize>> {

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -369,6 +369,11 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		Ok(None)
 	}
 
+	/// Get maximum number of subscriptions per connection.
+	fn rpc_max_subscriptions_per_connection(&self) -> Result<Option<usize>> {
+		Ok(None)
+	}
+
 	/// Get maximum WS output buffer capacity.
 	fn ws_max_out_buffer_capacity(&self) -> Result<Option<usize>> {
 		Ok(None)
@@ -539,7 +544,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 			rpc_max_request_size: self.rpc_max_request_size()?,
 			rpc_max_response_size: self.rpc_max_response_size()?,
 			rpc_id_provider: None,
-			rpc_max_subs_per_conn: None,
+			rpc_max_subs_per_conn: self.rpc_max_subscriptions_per_connection()?,
 			ws_max_out_buffer_capacity: self.ws_max_out_buffer_capacity()?,
 			prometheus_config: self
 				.prometheus_config(DCV::prometheus_listen_port(), &chain_spec)?,

--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -163,7 +163,7 @@ impl NetworkParams {
 		let port = self.port.unwrap_or(default_listen_port);
 
 		let listen_addresses = if self.listen_addr.is_empty() {
-			if is_validator {
+			if is_validator || is_dev {
 				vec![
 					Multiaddr::empty()
 						.with(Protocol::Ip6([0, 0, 0, 0, 0, 0, 0, 0].into()))

--- a/client/consensus/babe/rpc/src/lib.rs
+++ b/client/consensus/babe/rpc/src/lib.rs
@@ -49,7 +49,7 @@ pub trait BabeApi {
 }
 
 /// Provides RPC methods for interacting with Babe.
-pub struct BabeRpc<B: BlockT, C, SC> {
+pub struct Babe<B: BlockT, C, SC> {
 	/// shared reference to the client.
 	client: Arc<C>,
 	/// shared reference to EpochChanges
@@ -64,8 +64,8 @@ pub struct BabeRpc<B: BlockT, C, SC> {
 	deny_unsafe: DenyUnsafe,
 }
 
-impl<B: BlockT, C, SC> BabeRpc<B, C, SC> {
-	/// Creates a new instance of the BabeRpc handler.
+impl<B: BlockT, C, SC> Babe<B, C, SC> {
+	/// Creates a new instance of the Babe Rpc handler.
 	pub fn new(
 		client: Arc<C>,
 		shared_epoch_changes: SharedEpochChanges<B, Epoch>,
@@ -79,7 +79,7 @@ impl<B: BlockT, C, SC> BabeRpc<B, C, SC> {
 }
 
 #[async_trait]
-impl<B: BlockT, C, SC> BabeApiServer for BabeRpc<B, C, SC>
+impl<B: BlockT, C, SC> BabeApiServer for Babe<B, C, SC>
 where
 	B: BlockT,
 	C: ProvideRuntimeApi<B>
@@ -239,7 +239,7 @@ mod tests {
 
 	fn test_babe_rpc_module(
 		deny_unsafe: DenyUnsafe,
-	) -> BabeRpc<Block, TestClient, sc_consensus::LongestChain<Backend, Block>> {
+	) -> Babe<Block, TestClient, sc_consensus::LongestChain<Backend, Block>> {
 		let builder = TestClientBuilder::new();
 		let (client, longest_chain) = builder.build_with_longest_chain();
 		let client = Arc::new(client);
@@ -250,7 +250,7 @@ mod tests {
 		let epoch_changes = link.epoch_changes().clone();
 		let keystore = create_temp_keystore::<AuthorityPair>(Sr25519Keyring::Alice).0;
 
-		BabeRpc::new(client.clone(), epoch_changes, keystore, config, longest_chain, deny_unsafe)
+		Babe::new(client.clone(), epoch_changes, keystore, config, longest_chain, deny_unsafe)
 	}
 
 	#[tokio::test]

--- a/client/finality-grandpa/rpc/src/lib.rs
+++ b/client/finality-grandpa/rpc/src/lib.rs
@@ -66,7 +66,7 @@ pub trait GrandpaApi<Notification, Hash, Number> {
 }
 
 /// Provides RPC methods for interacting with GRANDPA.
-pub struct GrandpaRpc<AuthoritySet, VoterState, Block: BlockT, ProofProvider> {
+pub struct Grandpa<AuthoritySet, VoterState, Block: BlockT, ProofProvider> {
 	executor: SubscriptionTaskExecutor,
 	authority_set: AuthoritySet,
 	voter_state: VoterState,
@@ -74,9 +74,9 @@ pub struct GrandpaRpc<AuthoritySet, VoterState, Block: BlockT, ProofProvider> {
 	finality_proof_provider: Arc<ProofProvider>,
 }
 impl<AuthoritySet, VoterState, Block: BlockT, ProofProvider>
-	GrandpaRpc<AuthoritySet, VoterState, Block, ProofProvider>
+	Grandpa<AuthoritySet, VoterState, Block, ProofProvider>
 {
-	/// Prepare a new [`GrandpaRpc`]
+	/// Prepare a new [`Grandpa`] Rpc handler.
 	pub fn new(
 		executor: SubscriptionTaskExecutor,
 		authority_set: AuthoritySet,
@@ -91,7 +91,7 @@ impl<AuthoritySet, VoterState, Block: BlockT, ProofProvider>
 #[async_trait]
 impl<AuthoritySet, VoterState, Block, ProofProvider>
 	GrandpaApiServer<JustificationNotification, Block::Hash, NumberFor<Block>>
-	for GrandpaRpc<AuthoritySet, VoterState, Block, ProofProvider>
+	for Grandpa<AuthoritySet, VoterState, Block, ProofProvider>
 where
 	VoterState: ReportVoterState + Send + Sync + 'static,
 	AuthoritySet: ReportAuthoritySet + Send + Sync + 'static,
@@ -243,7 +243,7 @@ mod tests {
 	fn setup_io_handler<VoterState>(
 		voter_state: VoterState,
 	) -> (
-		RpcModule<GrandpaRpc<TestAuthoritySet, VoterState, Block, TestFinalityProofProvider>>,
+		RpcModule<Grandpa<TestAuthoritySet, VoterState, Block, TestFinalityProofProvider>>,
 		GrandpaJustificationSender<Block>,
 	)
 	where
@@ -256,7 +256,7 @@ mod tests {
 		voter_state: VoterState,
 		finality_proof: Option<FinalityProof<Header>>,
 	) -> (
-		RpcModule<GrandpaRpc<TestAuthoritySet, VoterState, Block, TestFinalityProofProvider>>,
+		RpcModule<Grandpa<TestAuthoritySet, VoterState, Block, TestFinalityProofProvider>>,
 		GrandpaJustificationSender<Block>,
 	)
 	where
@@ -266,7 +266,7 @@ mod tests {
 		let finality_proof_provider = Arc::new(TestFinalityProofProvider { finality_proof });
 		let executor = Arc::new(TaskExecutor::default());
 
-		let rpc = GrandpaRpc::new(
+		let rpc = Grandpa::new(
 			executor,
 			TestAuthoritySet,
 			voter_state,

--- a/client/rpc/src/state/mod.rs
+++ b/client/rpc/src/state/mod.rs
@@ -167,7 +167,7 @@ pub fn new_full<BE, Block: BlockT, Client>(
 	executor: SubscriptionTaskExecutor,
 	deny_unsafe: DenyUnsafe,
 	rpc_max_payload: Option<usize>,
-) -> (StateApi<Block, Client>, ChildState<Block, Client>)
+) -> (State<Block, Client>, ChildState<Block, Client>)
 where
 	Block: BlockT + 'static,
 	Block::Hash: Unpin,
@@ -192,17 +192,17 @@ where
 		rpc_max_payload,
 	));
 	let backend = Box::new(self::state_full::FullState::new(client, executor, rpc_max_payload));
-	(StateApi { backend, deny_unsafe }, ChildState { backend: child_backend })
+	(State { backend, deny_unsafe }, ChildState { backend: child_backend })
 }
 
 /// State API with subscriptions support.
-pub struct StateApi<Block, Client> {
+pub struct State<Block, Client> {
 	backend: Box<dyn StateBackend<Block, Client>>,
 	/// Whether to deny unsafe calls
 	deny_unsafe: DenyUnsafe,
 }
 
-impl<Block, Client> StateApiServer<Block::Hash> for StateApi<Block, Client>
+impl<Block, Client> StateApiServer<Block::Hash> for State<Block, Client>
 where
 	Block: BlockT + 'static,
 	Client: Send + Sync + 'static,

--- a/client/sync-state-rpc/src/lib.rs
+++ b/client/sync-state-rpc/src/lib.rs
@@ -37,7 +37,7 @@
 //! ```
 //!
 //! If the [`LightSyncStateExtension`] is not added as an extension to the chain spec,
-//! the [`SyncStateRpc`] will fail at instantiation.
+//! the [`SyncState`] will fail at instantiation.
 
 #![deny(unused_crate_dependencies)]
 
@@ -125,21 +125,21 @@ pub struct LightSyncState<Block: BlockT> {
 
 /// An api for sync state RPC calls.
 #[rpc(client, server)]
-pub trait SyncStateRpcApi {
+pub trait SyncStateApi {
 	/// Returns the JSON serialized chainspec running the node, with a sync state.
 	#[method(name = "sync_state_genSyncSpec")]
 	fn system_gen_sync_spec(&self, raw: bool) -> RpcResult<serde_json::Value>;
 }
 
 /// An api for sync state RPC calls.
-pub struct SyncStateRpc<Block: BlockT, Client> {
+pub struct SyncState<Block: BlockT, Client> {
 	chain_spec: Box<dyn sc_chain_spec::ChainSpec>,
 	client: Arc<Client>,
 	shared_authority_set: SharedAuthoritySet<Block>,
 	shared_epoch_changes: SharedEpochChanges<Block>,
 }
 
-impl<Block, Client> SyncStateRpc<Block, Client>
+impl<Block, Client> SyncState<Block, Client>
 where
 	Block: BlockT,
 	Client: HeaderBackend<Block> + sc_client_api::AuxStore + 'static,
@@ -180,7 +180,7 @@ where
 	}
 }
 
-impl<Block, Backend> SyncStateRpcApiServer for SyncStateRpc<Block, Backend>
+impl<Block, Backend> SyncStateApiServer for SyncState<Block, Backend>
 where
 	Block: BlockT,
 	Backend: HeaderBackend<Block> + sc_client_api::AuxStore + 'static,

--- a/frame/contracts/rpc/src/lib.rs
+++ b/frame/contracts/rpc/src/lib.rs
@@ -173,12 +173,12 @@ where
 }
 
 /// Contracts RPC methods.
-pub struct ContractsRpc<Client, Block> {
+pub struct Contracts<Client, Block> {
 	client: Arc<Client>,
 	_marker: PhantomData<Block>,
 }
 
-impl<Client, Block> ContractsRpc<Client, Block> {
+impl<Client, Block> Contracts<Client, Block> {
 	/// Create new `Contracts` with the given reference to the client.
 	pub fn new(client: Arc<Client>) -> Self {
 		Self { client, _marker: Default::default() }
@@ -193,7 +193,7 @@ impl<Client, Block, AccountId, Balance, Hash>
 		AccountId,
 		Balance,
 		Hash,
-	> for ContractsRpc<Client, Block>
+	> for Contracts<Client, Block>
 where
 	Block: BlockT,
 	Client: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,

--- a/frame/merkle-mountain-range/rpc/src/lib.rs
+++ b/frame/merkle-mountain-range/rpc/src/lib.rs
@@ -131,12 +131,12 @@ pub trait MmrApi<BlockHash> {
 }
 
 /// MMR RPC methods.
-pub struct MmrRpc<Client, Block> {
+pub struct Mmr<Client, Block> {
 	client: Arc<Client>,
 	_marker: PhantomData<Block>,
 }
 
-impl<C, B> MmrRpc<C, B> {
+impl<C, B> Mmr<C, B> {
 	/// Create new `Mmr` with the given reference to the client.
 	pub fn new(client: Arc<C>) -> Self {
 		Self { client, _marker: Default::default() }
@@ -144,8 +144,7 @@ impl<C, B> MmrRpc<C, B> {
 }
 
 #[async_trait]
-impl<Client, Block, MmrHash> MmrApiServer<<Block as BlockT>::Hash>
-	for MmrRpc<Client, (Block, MmrHash)>
+impl<Client, Block, MmrHash> MmrApiServer<<Block as BlockT>::Hash> for Mmr<Client, (Block, MmrHash)>
 where
 	Block: BlockT,
 	Client: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,

--- a/frame/state-trie-migration/src/lib.rs
+++ b/frame/state-trie-migration/src/lib.rs
@@ -848,6 +848,8 @@ mod benchmarks {
 			// function.
 			let null = MigrationLimits::default();
 			let caller = frame_benchmarking::whitelisted_caller();
+			// Allow signed migrations.
+			SignedMigrationMaxLimits::<T>::put(MigrationLimits { size: 1024, item: 5 });
 		}: _(frame_system::RawOrigin::Signed(caller), null, 0, StateTrieMigration::<T>::migration_process())
 		verify {
 			assert_eq!(StateTrieMigration::<T>::migration_process(), Default::default())
@@ -1146,14 +1148,7 @@ mod mock {
 		}
 
 		sp_tracing::try_init_simple();
-		let mut ext: sp_io::TestExternalities = (custom_storage, version).into();
-
-		// set some genesis values for this pallet as well.
-		ext.execute_with(|| {
-			SignedMigrationMaxLimits::<Test>::put(MigrationLimits { size: 1024, item: 5 });
-		});
-
-		ext
+		(custom_storage, version).into()
 	}
 
 	pub(crate) fn run_to_block(n: u32) -> (H256, u64) {
@@ -1291,6 +1286,9 @@ mod test {
 	fn signed_migrate_works() {
 		new_test_ext(StateVersion::V0, true, None, None).execute_with(|| {
 			assert_eq!(MigrationProcess::<Test>::get(), Default::default());
+
+			// Allow signed migrations.
+			SignedMigrationMaxLimits::<Test>::put(MigrationLimits { size: 1024, item: 5 });
 
 			// can't submit if limit is too high.
 			frame_support::assert_err!(

--- a/frame/transaction-payment/rpc/src/lib.rs
+++ b/frame/transaction-payment/rpc/src/lib.rs
@@ -51,14 +51,14 @@ pub trait TransactionPaymentApi<BlockHash, ResponseType> {
 }
 
 /// Provides RPC methods to query a dispatchable's class, weight and fee.
-pub struct TransactionPaymentRpc<C, P> {
+pub struct TransactionPayment<C, P> {
 	/// Shared reference to the client.
 	client: Arc<C>,
 	_marker: std::marker::PhantomData<P>,
 }
 
-impl<C, P> TransactionPaymentRpc<C, P> {
-	/// Creates a new instance of the TransactionPaymentRpc helper.
+impl<C, P> TransactionPayment<C, P> {
+	/// Creates a new instance of the TransactionPayment Rpc helper.
 	pub fn new(client: Arc<C>) -> Self {
 		Self { client, _marker: Default::default() }
 	}
@@ -84,7 +84,7 @@ impl From<Error> for i32 {
 #[async_trait]
 impl<C, Block, Balance>
 	TransactionPaymentApiServer<<Block as BlockT>::Hash, RuntimeDispatchInfo<Balance>>
-	for TransactionPaymentRpc<C, Block>
+	for TransactionPayment<C, Block>
 where
 	Block: BlockT,
 	C: ProvideRuntimeApi<Block> + HeaderBackend<Block> + Send + Sync + 'static,

--- a/primitives/state-machine/src/basic.rs
+++ b/primitives/state-machine/src/basic.rs
@@ -30,7 +30,7 @@ use sp_core::{
 	Blake2Hasher,
 };
 use sp_externalities::{Extension, Extensions};
-use sp_trie::{empty_child_trie_root, LayoutV0, LayoutV1, TrieConfiguration};
+use sp_trie::{empty_child_trie_root, HashKey, LayoutV0, LayoutV1, TrieConfiguration};
 use std::{
 	any::{Any, TypeId},
 	collections::BTreeMap,
@@ -310,7 +310,7 @@ impl Externalities for BasicExternalities {
 	) -> Vec<u8> {
 		if let Some(child) = self.inner.children_default.get(child_info.storage_key()) {
 			let delta = child.data.iter().map(|(k, v)| (k.as_ref(), Some(v.as_ref())));
-			crate::in_memory_backend::new_in_mem::<Blake2Hasher>()
+			crate::in_memory_backend::new_in_mem::<Blake2Hasher, HashKey<_>>()
 				.child_storage_root(&child.child_info, delta, state_version)
 				.0
 		} else {

--- a/primitives/state-machine/src/in_memory_backend.rs
+++ b/primitives/state-machine/src/in_memory_backend.rs
@@ -23,22 +23,36 @@ use crate::{
 use codec::Codec;
 use hash_db::Hasher;
 use sp_core::storage::{ChildInfo, StateVersion, Storage};
-use sp_trie::{empty_trie_root, LayoutV1, MemoryDB};
+use sp_trie::{empty_trie_root, GenericMemoryDB, HashKey, KeyFunction, LayoutV1, MemoryDB};
 use std::collections::{BTreeMap, HashMap};
 
 /// Create a new empty instance of in-memory backend.
-pub fn new_in_mem<H: Hasher>() -> TrieBackend<MemoryDB<H>, H>
+///
+/// It will use [`HashKey`] to store the keys internally.
+pub fn new_in_mem_hash_key<H>() -> TrieBackend<MemoryDB<H>, H>
 where
+	H: Hasher,
 	H::Out: Codec + Ord,
 {
-	let db = MemoryDB::default();
+	new_in_mem::<H, HashKey<H>>()
+}
+
+/// Create a new empty instance of in-memory backend.
+pub fn new_in_mem<H, KF>() -> TrieBackend<GenericMemoryDB<H, KF>, H>
+where
+	H: Hasher,
+	H::Out: Codec + Ord,
+	KF: KeyFunction<H> + Send + Sync,
+{
+	let db = GenericMemoryDB::default();
 	// V1 is same as V0 for an empty trie.
 	TrieBackend::new(db, empty_trie_root::<LayoutV1<H>>())
 }
 
-impl<H: Hasher> TrieBackend<MemoryDB<H>, H>
+impl<H: Hasher, KF> TrieBackend<GenericMemoryDB<H, KF>, H>
 where
 	H::Out: Codec + Ord,
+	KF: KeyFunction<H> + Send + Sync,
 {
 	/// Copy the state, with applied updates
 	pub fn update<T: IntoIterator<Item = (Option<ChildInfo>, StorageCollection)>>(
@@ -70,14 +84,14 @@ where
 	}
 
 	/// Merge trie nodes into this backend.
-	pub fn update_backend(&self, root: H::Out, changes: MemoryDB<H>) -> Self {
+	pub fn update_backend(&self, root: H::Out, changes: GenericMemoryDB<H, KF>) -> Self {
 		let mut clone = self.backend_storage().clone();
 		clone.consolidate(changes);
 		Self::new(clone, root)
 	}
 
 	/// Apply the given transaction to this backend and set the root to the given value.
-	pub fn apply_transaction(&mut self, root: H::Out, transaction: MemoryDB<H>) {
+	pub fn apply_transaction(&mut self, root: H::Out, transaction: GenericMemoryDB<H, KF>) {
 		let mut storage = sp_std::mem::take(self).into_storage();
 		storage.consolidate(transaction);
 		*self = TrieBackend::new(storage, root);
@@ -89,28 +103,33 @@ where
 	}
 }
 
-impl<H: Hasher> Clone for TrieBackend<MemoryDB<H>, H>
+impl<H: Hasher, KF> Clone for TrieBackend<GenericMemoryDB<H, KF>, H>
 where
 	H::Out: Codec + Ord,
+	KF: KeyFunction<H> + Send + Sync,
 {
 	fn clone(&self) -> Self {
 		TrieBackend::new(self.backend_storage().clone(), *self.root())
 	}
 }
 
-impl<H: Hasher> Default for TrieBackend<MemoryDB<H>, H>
+impl<H, KF> Default for TrieBackend<GenericMemoryDB<H, KF>, H>
 where
+	H: Hasher,
 	H::Out: Codec + Ord,
+	KF: KeyFunction<H> + Send + Sync,
 {
 	fn default() -> Self {
 		new_in_mem()
 	}
 }
 
-impl<H: Hasher> From<(HashMap<Option<ChildInfo>, BTreeMap<StorageKey, StorageValue>>, StateVersion)>
-	for TrieBackend<MemoryDB<H>, H>
+impl<H: Hasher, KF>
+	From<(HashMap<Option<ChildInfo>, BTreeMap<StorageKey, StorageValue>>, StateVersion)>
+	for TrieBackend<GenericMemoryDB<H, KF>, H>
 where
 	H::Out: Codec + Ord,
+	KF: KeyFunction<H> + Send + Sync,
 {
 	fn from(
 		(inner, state_version): (
@@ -129,9 +148,10 @@ where
 	}
 }
 
-impl<H: Hasher> From<(Storage, StateVersion)> for TrieBackend<MemoryDB<H>, H>
+impl<H: Hasher, KF> From<(Storage, StateVersion)> for TrieBackend<GenericMemoryDB<H, KF>, H>
 where
 	H::Out: Codec + Ord,
+	KF: KeyFunction<H> + Send + Sync,
 {
 	fn from((inners, state_version): (Storage, StateVersion)) -> Self {
 		let mut inner: HashMap<Option<ChildInfo>, BTreeMap<StorageKey, StorageValue>> = inners
@@ -144,10 +164,11 @@ where
 	}
 }
 
-impl<H: Hasher> From<(BTreeMap<StorageKey, StorageValue>, StateVersion)>
-	for TrieBackend<MemoryDB<H>, H>
+impl<H: Hasher, KF> From<(BTreeMap<StorageKey, StorageValue>, StateVersion)>
+	for TrieBackend<GenericMemoryDB<H, KF>, H>
 where
 	H::Out: Codec + Ord,
+	KF: KeyFunction<H> + Send + Sync,
 {
 	fn from((inner, state_version): (BTreeMap<StorageKey, StorageValue>, StateVersion)) -> Self {
 		let mut expanded = HashMap::new();
@@ -156,10 +177,11 @@ where
 	}
 }
 
-impl<H: Hasher> From<(Vec<(Option<ChildInfo>, StorageCollection)>, StateVersion)>
-	for TrieBackend<MemoryDB<H>, H>
+impl<H: Hasher, KF> From<(Vec<(Option<ChildInfo>, StorageCollection)>, StateVersion)>
+	for TrieBackend<GenericMemoryDB<H, KF>, H>
 where
 	H::Out: Codec + Ord,
+	KF: KeyFunction<H> + Send + Sync,
 {
 	fn from(
 		(inner, state_version): (Vec<(Option<ChildInfo>, StorageCollection)>, StateVersion),
@@ -189,7 +211,7 @@ mod tests {
 	#[test]
 	fn in_memory_with_child_trie_only() {
 		let state_version = StateVersion::default();
-		let storage = new_in_mem::<BlakeTwo256>();
+		let storage = new_in_mem_hash_key::<BlakeTwo256>();
 		let child_info = ChildInfo::new_default(b"1");
 		let child_info = &child_info;
 		let storage = storage.update(
@@ -205,7 +227,7 @@ mod tests {
 	#[test]
 	fn insert_multiple_times_child_data_works() {
 		let state_version = StateVersion::default();
-		let mut storage = new_in_mem::<BlakeTwo256>();
+		let mut storage = new_in_mem_hash_key::<BlakeTwo256>();
 		let child_info = ChildInfo::new_default(b"1");
 
 		storage.insert(

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -143,7 +143,7 @@ mod std_reexport {
 	pub use crate::{
 		basic::BasicExternalities,
 		error::{Error, ExecutionError},
-		in_memory_backend::new_in_mem,
+		in_memory_backend::{new_in_mem, new_in_mem_hash_key},
 		proving_backend::{
 			create_proof_check_backend, ProofRecorder, ProvingBackend, ProvingBackendRecorder,
 		},
@@ -1347,7 +1347,7 @@ mod execution {
 #[cfg(test)]
 mod tests {
 	use super::{ext::Ext, *};
-	use crate::execution::CallResult;
+	use crate::{execution::CallResult, in_memory_backend::new_in_mem_hash_key};
 	use codec::{Decode, Encode};
 	use sp_core::{
 		map,
@@ -1687,7 +1687,7 @@ mod tests {
 	fn set_child_storage_works() {
 		let child_info = ChildInfo::new_default(b"sub1");
 		let child_info = &child_info;
-		let state = new_in_mem::<BlakeTwo256>();
+		let state = new_in_mem_hash_key::<BlakeTwo256>();
 		let backend = state.as_trie_backend().unwrap();
 		let mut overlay = OverlayedChanges::default();
 		let mut cache = StorageTransactionCache::default();
@@ -1703,7 +1703,7 @@ mod tests {
 	fn append_storage_works() {
 		let reference_data = vec![b"data1".to_vec(), b"2".to_vec(), b"D3".to_vec(), b"d4".to_vec()];
 		let key = b"key".to_vec();
-		let state = new_in_mem::<BlakeTwo256>();
+		let state = new_in_mem_hash_key::<BlakeTwo256>();
 		let backend = state.as_trie_backend().unwrap();
 		let mut overlay = OverlayedChanges::default();
 		let mut cache = StorageTransactionCache::default();
@@ -1740,7 +1740,7 @@ mod tests {
 
 		let key = b"events".to_vec();
 		let mut cache = StorageTransactionCache::default();
-		let state = new_in_mem::<BlakeTwo256>();
+		let state = new_in_mem_hash_key::<BlakeTwo256>();
 		let backend = state.as_trie_backend().unwrap();
 		let mut overlay = OverlayedChanges::default();
 

--- a/primitives/trie/src/lib.rs
+++ b/primitives/trie/src/lib.rs
@@ -31,9 +31,8 @@ pub use error::Error;
 /// Various re-exports from the `hash-db` crate.
 pub use hash_db::{HashDB as HashDBT, EMPTY_PREFIX};
 use hash_db::{Hasher, Prefix};
-pub use memory_db::prefixed_key;
 /// Various re-exports from the `memory-db` crate.
-pub use memory_db::KeyFunction;
+pub use memory_db::{prefixed_key, HashKey, KeyFunction, PrefixedKey};
 /// The Substrate format implementation of `NodeCodec`.
 pub use node_codec::NodeCodec;
 use sp_std::{borrow::Borrow, boxed::Box, marker::PhantomData, vec::Vec};

--- a/utils/frame/benchmarking-cli/src/overhead/weights.hbs
+++ b/utils/frame/benchmarking-cli/src/overhead/weights.hbs
@@ -41,13 +41,13 @@ parameter_types! {
 	{{/if}}
 	/// Calculated by multiplying the *{{params.weight.weight_metric}}* with `{{params.weight.weight_mul}}` and adding `{{params.weight.weight_add}}`.
 	///
-	/// Stats [NS]:
+	/// Statistics in nanoseconds:
 	///   Min, Max: {{underscore stats.min}}, {{underscore stats.max}}
 	///   Average:  {{underscore stats.avg}}
 	///   Median:   {{underscore stats.median}}
 	///   Std-Dev:  {{stats.stddev}}
 	///
-	/// Percentiles [NS]:
+	/// Percentiles in nanoseconds:
 	///   99th: {{underscore stats.p99}}
 	///   95th: {{underscore stats.p95}}
 	///   75th: {{underscore stats.p75}}

--- a/utils/frame/benchmarking-cli/src/storage/weights.hbs
+++ b/utils/frame/benchmarking-cli/src/storage/weights.hbs
@@ -49,13 +49,13 @@ pub mod constants {
 			/// Time to read one storage item.
 			/// Calculated by multiplying the *{{params.weight_params.weight_metric}}* of all values with `{{params.weight_params.weight_mul}}` and adding `{{params.weight_params.weight_add}}`.
 			///
-			/// Stats [NS]:
+			/// Statistics in nanoseconds:
 			///   Min, Max: {{underscore read.0.min}}, {{underscore read.0.max}}
 			///   Average:  {{underscore read.0.avg}}
 			///   Median:   {{underscore read.0.median}}
 			///   Std-Dev:  {{read.0.stddev}}
 			///
-			/// Percentiles [NS]:
+			/// Percentiles in nanoseconds:
 			///   99th: {{underscore read.0.p99}}
 			///   95th: {{underscore read.0.p95}}
 			///   75th: {{underscore read.0.p75}}
@@ -64,13 +64,13 @@ pub mod constants {
 			/// Time to write one storage item.
 			/// Calculated by multiplying the *{{params.weight_params.weight_metric}}* of all values with `{{params.weight_params.weight_mul}}` and adding `{{params.weight_params.weight_add}}`.
 			///
-			/// Stats [NS]:
+			/// Statistics in nanoseconds:
 			///   Min, Max: {{underscore write.0.min}}, {{underscore write.0.max}}
 			///   Average:  {{underscore write.0.avg}}
 			///   Median:   {{underscore write.0.median}}
 			///   Std-Dev:  {{write.0.stddev}}
 			///
-			/// Percentiles [NS]:
+			/// Percentiles in nanoseconds:
 			///   99th: {{underscore write.0.p99}}
 			///   95th: {{underscore write.0.p95}}
 			///   75th: {{underscore write.0.p75}}

--- a/utils/frame/rpc/state-trie-migration-rpc/src/lib.rs
+++ b/utils/frame/rpc/state-trie-migration-rpc/src/lib.rs
@@ -122,21 +122,21 @@ pub trait StateMigrationApi<BlockHash> {
 }
 
 /// An implementation of state migration specific RPC methods.
-pub struct MigrationRpc<C, B, BA> {
+pub struct StateMigration<C, B, BA> {
 	client: Arc<C>,
 	backend: Arc<BA>,
 	deny_unsafe: DenyUnsafe,
 	_marker: std::marker::PhantomData<(B, BA)>,
 }
 
-impl<C, B, BA> MigrationRpc<C, B, BA> {
+impl<C, B, BA> StateMigration<C, B, BA> {
 	/// Create new state migration rpc for the given reference to the client.
 	pub fn new(client: Arc<C>, backend: Arc<BA>, deny_unsafe: DenyUnsafe) -> Self {
-		MigrationRpc { client, backend, deny_unsafe, _marker: Default::default() }
+		StateMigration { client, backend, deny_unsafe, _marker: Default::default() }
 	}
 }
 
-impl<C, B, BA> StateMigrationApiServer<<B as BlockT>::Hash> for MigrationRpc<C, B, BA>
+impl<C, B, BA> StateMigrationApiServer<<B as BlockT>::Hash> for StateMigration<C, B, BA>
 where
 	B: BlockT,
 	C: Send + Sync + 'static + sc_client_api::HeaderBackend<B>,

--- a/utils/frame/rpc/system/src/lib.rs
+++ b/utils/frame/rpc/system/src/lib.rs
@@ -70,14 +70,14 @@ impl From<Error> for i32 {
 }
 
 /// An implementation of System-specific RPC methods on full client.
-pub struct SystemRpc<P: TransactionPool, C, B> {
+pub struct System<P: TransactionPool, C, B> {
 	client: Arc<C>,
 	pool: Arc<P>,
 	deny_unsafe: DenyUnsafe,
 	_marker: std::marker::PhantomData<B>,
 }
 
-impl<P: TransactionPool, C, B> SystemRpc<P, C, B> {
+impl<P: TransactionPool, C, B> System<P, C, B> {
 	/// Create new `FullSystem` given client and transaction pool.
 	pub fn new(client: Arc<C>, pool: Arc<P>, deny_unsafe: DenyUnsafe) -> Self {
 		Self { client, pool, deny_unsafe, _marker: Default::default() }
@@ -86,7 +86,7 @@ impl<P: TransactionPool, C, B> SystemRpc<P, C, B> {
 
 #[async_trait]
 impl<P, C, Block, AccountId, Index>
-	SystemApiServer<<Block as traits::Block>::Hash, AccountId, Index> for SystemRpc<P, C, Block>
+	SystemApiServer<<Block as traits::Block>::Hash, AccountId, Index> for System<P, C, Block>
 where
 	C: sp_api::ProvideRuntimeApi<Block>,
 	C: HeaderBackend<Block>,
@@ -251,7 +251,7 @@ mod tests {
 		let ext1 = new_transaction(1);
 		block_on(pool.submit_one(&BlockId::number(0), source, ext1)).unwrap();
 
-		let accounts = SystemRpc::new(client, pool, DenyUnsafe::Yes);
+		let accounts = System::new(client, pool, DenyUnsafe::Yes);
 
 		// when
 		let nonce = accounts.nonce(AccountKeyring::Alice.into()).await;
@@ -270,7 +270,7 @@ mod tests {
 		let pool =
 			BasicPool::new_full(Default::default(), true.into(), None, spawner, client.clone());
 
-		let accounts = SystemRpc::new(client, pool, DenyUnsafe::Yes);
+		let accounts = System::new(client, pool, DenyUnsafe::Yes);
 
 		// when
 		let res = accounts.dry_run(vec![].into(), None).await;
@@ -289,7 +289,7 @@ mod tests {
 		let pool =
 			BasicPool::new_full(Default::default(), true.into(), None, spawner, client.clone());
 
-		let accounts = SystemRpc::new(client, pool, DenyUnsafe::No);
+		let accounts = System::new(client, pool, DenyUnsafe::No);
 
 		let tx = Transfer {
 			from: AccountKeyring::Alice.into(),
@@ -317,7 +317,7 @@ mod tests {
 		let pool =
 			BasicPool::new_full(Default::default(), true.into(), None, spawner, client.clone());
 
-		let accounts = SystemRpc::new(client, pool, DenyUnsafe::No);
+		let accounts = System::new(client, pool, DenyUnsafe::No);
 
 		let tx = Transfer {
 			from: AccountKeyring::Alice.into(),


### PR DESCRIPTION
The doc check in https://github.com/paritytech/substrate/pull/11493 fails since it treats `[NS]` as link :man_facepalming:   

Fixed by not using abbreviations.