### PR TITLE
CI: github no longer checks whitelisted actions this way

### DIFF
--- a/.github/allowed-actions.js
+++ b/.github/allowed-actions.js
@@ -1,7 +1,0 @@
-// This is a whitelist of GitHub Actions that are approved for use in this project.
-// If a new or existing workflow file is updated to use an action or action version
-// not listed here, CI will fail.
-
-module.exports = [
-    'gaurav-nelson/github-action-markdown-link-check@7481451f70251762f149d69596e3e276ebf2b236', // gaurav-nelson/github-action-markdown-link-check@v1.0.8
-]

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,7 +1,0 @@
-{
-    "ignorePatterns": [
-        {
-            "pattern": "^https://crates.io",
-        }
-    ]
-}

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,0 +1,7 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^https://crates.io",
+        }
+    ]
+}


### PR DESCRIPTION
Github no longer checks the allowed actions this way.
We can whitelist them in the [settings](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization) instead.

cc https://github.com/paritytech/ci_cd/issues/79