### PR TITLE
CI adjust job `check-dependent-polkadot` rules

### DIFF
--- a/scripts/ci/gitlab/pipeline/build.yml
+++ b/scripts/ci/gitlab/pipeline/build.yml
@@ -31,6 +31,8 @@ check-dependent-polkadot:
     COMPANION_OVERRIDES: |
       substrate: polkadot-v*
       polkadot: release-v*
+  rules:
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/  #PRs
 
 # TODO: Re-enable after https://github.com/paritytech/pipeline-scripts/issues/44
 #check-dependent-cumulus:


### PR DESCRIPTION
[pipeline-script](https://github.com/paritytech/pipeline-scripts/blob/b8942cb0cc19cf587e0a6019486b87894f955572/check_dependent_project.sh#L489) will be executed only for PR branches, otherwise it will fail. Adjusted `check-dependent-polkadot` rules to run this job only for PR's.