### PR TITLE
Improve inspection and generation of node keys

### DIFF
--- a/bin/utils/subkey/src/lib.rs
+++ b/bin/utils/subkey/src/lib.rs
@@ -30,8 +30,8 @@ use sc_cli::{
 	version
 )]
 pub enum Subkey {
-	/// Generate a random node libp2p key, save it to file or print it to stdout
-	/// and print its peer ID to stderr.
+	/// Generate a random node key, write it to a file or stdout and write the corresponding
+	/// peer-id to stderr
 	GenerateNodeKey(GenerateNodeKeyCmd),
 
 	/// Generate a random account
@@ -40,7 +40,7 @@ pub enum Subkey {
 	/// Gets a public key and a SS58 address from the provided Secret URI
 	Inspect(InspectKeyCmd),
 
-	/// Print the peer ID corresponding to the node key in the given file
+	/// Load a node key from a file or stdin and print the corresponding peer-id
 	InspectNodeKey(InspectNodeKeyCmd),
 
 	/// Sign a message, with a given (secret) key.

--- a/bin/utils/subkey/src/lib.rs
+++ b/bin/utils/subkey/src/lib.rs
@@ -30,8 +30,8 @@ use sc_cli::{
 	version
 )]
 pub enum Subkey {
-	/// Generate a random node key, write it to a file or stdout and write the corresponding
-	/// peer-id to stderr
+	/// Generate a random node key, write it to a file or stdout and write the
+	/// corresponding peer-id to stderr
 	GenerateNodeKey(GenerateNodeKeyCmd),
 
 	/// Generate a random account

--- a/client/cli/src/commands/generate_node_key.rs
+++ b/client/cli/src/commands/generate_node_key.rs
@@ -32,8 +32,8 @@ use std::{
 #[derive(Debug, Parser)]
 #[clap(
 	name = "generate-node-key",
-	about = "Generate a random node key, write it to a file or stdout
-             and write the corresponding peer-id to stderr"
+	about = "Generate a random node key, write it to a file or stdout \
+		 	and write the corresponding peer-id to stderr"
 )]
 pub struct GenerateNodeKeyCmd {
 	/// Name of file to save secret key to.
@@ -64,7 +64,7 @@ impl GenerateNodeKeyCmd {
 
 		match &self.file {
 			Some(file) => fs::write(file, file_data)?,
-			None => io::stdout().write_all(file_data.as_bytes_ref())?,
+			None => io::stdout().lock().write_all(file_data.as_bytes_ref())?,
 		}
 
 		let peer_id = PublicKey::Ed25519(keypair.public()).to_peer_id();

--- a/client/cli/src/commands/generate_node_key.rs
+++ b/client/cli/src/commands/generate_node_key.rs
@@ -65,8 +65,7 @@ impl GenerateNodeKeyCmd {
 			None => io::stdout().lock().write_all(&file_data)?,
 		}
 
-		let peer_id = PublicKey::Ed25519(keypair.public()).to_peer_id();
-		eprintln!("Peer-ID: {}", peer_id);
+		eprintln!("{}", PublicKey::Ed25519(keypair.public()).to_peer_id());
 
 		Ok(())
 	}

--- a/client/cli/src/commands/generate_node_key.rs
+++ b/client/cli/src/commands/generate_node_key.rs
@@ -20,9 +20,7 @@
 use crate::Error;
 use clap::Parser;
 use libp2p::identity::{ed25519 as libp2p_ed25519, PublicKey};
-use sp_core::hexdisplay::AsBytesRef;
 use std::{
-	borrow::Cow,
 	fs,
 	io::{self, Write},
 	path::PathBuf,
@@ -57,14 +55,14 @@ impl GenerateNodeKeyCmd {
 		let secret = keypair.secret();
 
 		let file_data = if self.bin {
-			Cow::Borrowed(secret.as_ref())
+			secret.as_ref().to_owned()
 		} else {
-			Cow::Owned(hex::encode(secret.as_ref()).into_bytes())
+			hex::encode(secret.as_ref()).into_bytes()
 		};
 
 		match &self.file {
 			Some(file) => fs::write(file, file_data)?,
-			None => io::stdout().lock().write_all(file_data.as_bytes_ref())?,
+			None => io::stdout().lock().write_all(&file_data)?,
 		}
 
 		let peer_id = PublicKey::Ed25519(keypair.public()).to_peer_id();

--- a/client/cli/src/commands/inspect_node_key.rs
+++ b/client/cli/src/commands/inspect_node_key.rs
@@ -62,8 +62,11 @@ impl InspectNodeKeyCmd {
 			// With hex input, give to the user a bit of tolerance about whitespaces
 			let is_not_ascii_whitespace = |c: &u8| !c.is_ascii_whitespace();
 			let beg = file_data.iter().position(is_not_ascii_whitespace).unwrap_or_default();
-			let end =
-				file_data.iter().rposition(is_not_ascii_whitespace).unwrap_or(file_data.len()) + 1;
+			let end = file_data
+				.iter()
+				.rposition(is_not_ascii_whitespace)
+				.map(|off| off + 1)
+				.unwrap_or_default();
 			file_data =
 				hex::decode(&file_data[beg..end]).map_err(|_| "failed to decode secret as hex")?;
 		}

--- a/client/cli/src/commands/inspect_node_key.rs
+++ b/client/cli/src/commands/inspect_node_key.rs
@@ -17,39 +17,64 @@
 
 //! Implementation of the `inspect-node-key` subcommand
 
-use crate::{Error, NetworkSchemeFlag};
+use crate::Error;
 use clap::Parser;
 use libp2p::identity::{ed25519, PublicKey};
-use std::{fs, path::PathBuf};
+use std::{
+	fs,
+	io::{self, Read},
+	path::PathBuf,
+};
 
 /// The `inspect-node-key` command
 #[derive(Debug, Parser)]
 #[clap(
 	name = "inspect-node-key",
-	about = "Print the peer ID corresponding to the node key in the given file."
+	about = "Load a node key from a file or stdin and print the corresponding peer-id."
 )]
 pub struct InspectNodeKeyCmd {
 	/// Name of file to read the secret key from.
+	///
+	/// If not given, the secret key is read from stdin (up to EOF).
 	#[clap(long)]
-	file: PathBuf,
+	file: Option<PathBuf>,
 
-	#[allow(missing_docs)]
-	#[clap(flatten)]
-	pub network_scheme: NetworkSchemeFlag,
+	/// The input is in raw binary format.
+	///
+	/// If not given, the input is read as an hex encoded string.
+	#[clap(long)]
+	bin: bool,
 }
 
 impl InspectNodeKeyCmd {
 	/// runs the command
 	pub fn run(&self) -> Result<(), Error> {
-		let mut file_content =
-			hex::decode(fs::read(&self.file)?).map_err(|_| "failed to decode secret as hex")?;
+		let mut file_data = match &self.file {
+			Some(file) => fs::read(&file)?,
+			None => {
+				let mut buf = Vec::with_capacity(64);
+				io::stdin().lock().read_to_end(&mut buf)?;
+				buf
+			},
+		};
+
+		if !self.bin {
+			// With hex input, give to the user a bit of tolerance about whitespaces
+			let is_not_ascii_whitespace = |c: &u8| !c.is_ascii_whitespace();
+			let beg = file_data.iter().position(is_not_ascii_whitespace).unwrap_or_default();
+			let end =
+				file_data.iter().rposition(is_not_ascii_whitespace).unwrap_or(file_data.len()) + 1;
+			file_data =
+				hex::decode(&file_data[beg..end]).map_err(|_| "failed to decode secret as hex")?;
+		}
+
 		let secret =
-			ed25519::SecretKey::from_bytes(&mut file_content).map_err(|_| "Bad node key file")?;
+			ed25519::SecretKey::from_bytes(&mut file_data).map_err(|_| "Bad node key file")?;
 
 		let keypair = ed25519::Keypair::from(secret);
-		let peer_id = PublicKey::Ed25519(keypair.public()).to_peer_id();
 
-		println!("{}", peer_id);
+		let peer_id = PublicKey::Ed25519(keypair.public()).to_peer_id();
+		println!("Peer-ID: {}", peer_id);
 
 		Ok(())
 	}

--- a/client/cli/src/commands/key.rs
+++ b/client/cli/src/commands/key.rs
@@ -26,8 +26,8 @@ use crate::{Error, SubstrateCli};
 /// Key utilities for the cli.
 #[derive(Debug, clap::Subcommand)]
 pub enum KeySubcommand {
-	/// Generate a random node libp2p key, save it to file or print it to stdout
-	/// and print its peer ID to stderr.
+	/// Generate a random node key, write it to a file or stdout and write the
+	/// corresponding peer-id to stderr
 	GenerateNodeKey(GenerateNodeKeyCmd),
 
 	/// Generate a random account
@@ -36,7 +36,7 @@ pub enum KeySubcommand {
 	/// Gets a public key and a SS58 address from the provided Secret URI
 	Inspect(InspectKeyCmd),
 
-	/// Print the peer ID corresponding to the node key in the given file
+	/// Load a node key from a file or stdin and print the corresponding peer-id
 	InspectNodeKey(InspectNodeKeyCmd),
 
 	/// Insert a key to the keystore of a node.


### PR DESCRIPTION
Closes https://github.com/paritytech/substrate/issues/11518

---

This PR wants to improve the user experience of `subkey` by expanding a bit the possibilities offered by Substrate's `InspectNodeKeyCmd` and `GenerateNodeKeyCmd`.

---

### Node Key Generation.

The command has been extended to allow the user to:
- write the output in binary format (added `--bin` flag). Default is hex string as before.

### Node Key Inspection

The command has been extended to allow the user to:
- read the input in binary format (added `--bin` flag). Default is hex string as before.
  Now is also easier to parse the node key file under the `network` folder (when auto-generated at node startup, this is stored in raw binary format).
- the file input is now optional (as it is for key generation), if the file is not passed the key is read from stdin.
- some tolerance for whitespaces when input is not binary (trim front/back)

---

The new interface allows to more easily to use the `subkey` CLI together with other commands via Unix pipes.

Examples (not doing anything special... just to show the new possibilities):

```bash
#  write as raw binary to stdout  |  convert to hex string   |  read as hex string from stdin 
$ subkey generate-node-key --bin | xxd -p -c 32 | subkey inspect-node-key
                           
#  write as hex string to stdout  |  convert to binary   |  read as raw binary from stdin 
$ subkey generate-node-key | xxd -p -r | subkey inspect-node-key --bin

# write as raw binary to file
$ subkey generate-node-key --file secret.out --bin 

# read as raw binary from stdin
$ cat secret.out | subkey inspect-node-key --bin 

# trim whitespaces from hex strings
$ echo "     07b03b7a2f4bc8e1885b2ae2a51b1fcb96178048ed0ada021f2905c75c5099d4    " | subkey inspect-node-key
```

---

Additionally the `--network` command has been ~removed from the `inspect-node-key` option~ deprecated since:
1. it was not used at all
2. it was not used because actually the network type doesn't influence the node-key (i.e. a peer id of libp2p)