### PR TITLE
Makes NetworkService::add_reserved_peer accept Multiaddr instead of String

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8664,11 +8664,11 @@ version = "0.10.0-dev"
 dependencies = [
  "futures",
  "jsonrpsee",
+ "libp2p",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "sc-chain-spec",
- "sc-network",
  "sc-transaction-pool-api",
  "scale-info",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8667,6 +8667,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "sc-chain-spec",
+ "sc-network",
  "sc-transaction-pool-api",
  "scale-info",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8629,6 +8629,7 @@ dependencies = [
  "hash-db",
  "jsonrpsee",
  "lazy_static",
+ "libp2p",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.0",

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -1082,7 +1082,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 
 	/// Adds a `PeerId` and its address as reserved.
 	///
-	/// Returns an `Err` if peer ID of given peer is the local peer ID).
+	/// Returns an `Err` if peer ID of given peer is the local peer ID.
 	pub fn add_reserved_peer(&self, peer: MultiaddrWithPeerId) -> Result<(), String> {
 		// Make sure the local peer ID is never added to the PSM.
 		if peer.peer_id == self.local_peer_id {

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -30,7 +30,7 @@
 use crate::{
 	behaviour::{self, Behaviour, BehaviourOut},
 	bitswap::Bitswap,
-	config::{parse_str_addr, Params, TransportConfig},
+	config::{MultiaddrWithPeerId, Params, TransportConfig},
 	discovery::DiscoveryConfig,
 	error::Error,
 	network_state::{
@@ -44,7 +44,6 @@ use crate::{
 };
 
 use codec::Encode as _;
-use crate::config::MultiaddrWithPeerId;
 use futures::{channel::oneshot, prelude::*};
 use libp2p::{
 	core::{either::EitherError, upgrade, ConnectedPoint, Executor},
@@ -676,8 +675,7 @@ where
 		self.service.remove_reserved_peer(peer);
 	}
 
-	/// Adds a `PeerId` and its address as reserved. The string should encode the address
-	/// and peer ID of the remote node.
+	/// Adds a `PeerId` and its address as reserved. 
 	pub fn add_reserved_peer(&self, peer: MultiaddrWithPeerId) -> Result<(), String> {
 		self.service.add_reserved_peer(peer)
 	}
@@ -1082,13 +1080,10 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 		let _ = self.to_worker.unbounded_send(ServiceToWorkerMsg::SetReservedOnly(true));
 	}
 
-	/// Adds a `PeerId` and its address as reserved. The string should encode the address
-	/// and peer ID of the remote node.
+	/// Adds a `PeerId` and its address as reserved.
 	///
-	/// Returns an `Err` if the given string is not a valid multiaddress
-	/// or contains an invalid peer ID (which includes the local peer ID).
+	/// Returns an `Err` if peer ID of given peer is the local peer ID).
 	pub fn add_reserved_peer(&self, peer: MultiaddrWithPeerId) -> Result<(), String> {
-		//let (peer_id, addr) = parse_str_addr(&peer).map_err(|e| format!("{:?}", e))?;
 		// Make sure the local peer ID is never added to the PSM.
 		if peer.peer_id == self.local_peer_id {
 			return Err("Local peer ID cannot be added as a reserved peer.".to_string())

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -29,3 +29,5 @@ sp-runtime = { version = "6.0.0", path = "../../primitives/runtime" }
 sp-tracing = { version = "5.0.0", path = "../../primitives/tracing" }
 sp-version = { version = "5.0.0", path = "../../primitives/version" }
 jsonrpsee = { version = "0.13.0", features = ["server", "macros"] }
+sc-network = { version = "0.10.0-dev", path = "../network" }
+

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -15,6 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 futures = "0.3.21"
+libp2p = "0.44.0"
 log = "0.4.17"
 parking_lot = "0.12.0"
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
@@ -29,4 +30,3 @@ sp-runtime = { version = "6.0.0", path = "../../primitives/runtime" }
 sp-tracing = { version = "5.0.0", path = "../../primitives/tracing" }
 sp-version = { version = "5.0.0", path = "../../primitives/version" }
 jsonrpsee = { version = "0.13.0", features = ["server", "macros"] }
-sc-network = { version = "0.10.0-dev", path = "../network" }

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -30,4 +30,3 @@ sp-tracing = { version = "5.0.0", path = "../../primitives/tracing" }
 sp-version = { version = "5.0.0", path = "../../primitives/version" }
 jsonrpsee = { version = "0.13.0", features = ["server", "macros"] }
 sc-network = { version = "0.10.0-dev", path = "../network" }
-

--- a/client/rpc-api/src/system/mod.rs
+++ b/client/rpc-api/src/system/mod.rs
@@ -24,6 +24,7 @@ use jsonrpsee::{
 };
 
 pub use self::helpers::{Health, NodeRole, PeerInfo, SyncState, SystemInfo};
+use sc_network::config::MultiaddrWithPeerId;
 
 pub mod error;
 pub mod helpers;
@@ -89,7 +90,7 @@ pub trait SystemApi<Hash, Number> {
 	/// `/ip4/198.51.100.19/tcp/30333/p2p/QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV`
 	/// is an example of a valid, passing multiaddr with PeerId attached.
 	#[method(name = "system_addReservedPeer")]
-	async fn system_add_reserved_peer(&self, peer: String) -> RpcResult<()>;
+	async fn system_add_reserved_peer(&self, peer: MultiaddrWithPeerId) -> RpcResult<()>;
 
 	/// Remove a reserved peer. Returns the empty string or an error. The string
 	/// should encode only the PeerId e.g. `QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV`.

--- a/client/rpc-api/src/system/mod.rs
+++ b/client/rpc-api/src/system/mod.rs
@@ -22,9 +22,9 @@ use jsonrpsee::{
 	core::{JsonValue, RpcResult},
 	proc_macros::rpc,
 };
+use libp2p::Multiaddr;
 
 pub use self::helpers::{Health, NodeRole, PeerInfo, SyncState, SystemInfo};
-use sc_network::Multiaddr;
 
 pub mod error;
 pub mod helpers;

--- a/client/rpc-api/src/system/mod.rs
+++ b/client/rpc-api/src/system/mod.rs
@@ -24,7 +24,7 @@ use jsonrpsee::{
 };
 
 pub use self::helpers::{Health, NodeRole, PeerInfo, SyncState, SystemInfo};
-use sc_network::config::MultiaddrWithPeerId;
+use sc_network::Multiaddr;
 
 pub mod error;
 pub mod helpers;
@@ -84,9 +84,15 @@ pub trait SystemApi<Hash, Number> {
 	#[method(name = "system_unstable_networkState")]
 	async fn system_network_state(&self) -> RpcResult<JsonValue>;
 
-	/// Adds a reserved peer. Returns the empty string or an error. 
+	/// Adds a reserved peer. Returns the empty string or an error.
+	/// 
+	/// The `Multiaddr` parameter must end with a `/p2p/` component containing the `PeerId`. It can also
+	/// consist of only `/p2p/<peerid>`.
+	///
+	/// `/ip4/198.51.100.19/tcp/30333/p2p/QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV`
+	/// is an example of a valid, passing multiaddr with PeerId attached.
 	#[method(name = "system_addReservedPeer")]
-	async fn system_add_reserved_peer(&self, peer: MultiaddrWithPeerId) -> RpcResult<()>;
+	async fn system_add_reserved_peer(&self, peer: Multiaddr) -> RpcResult<()>;
 
 	/// Remove a reserved peer. Returns the empty string or an error. The string
 	/// should encode only the PeerId e.g. `QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV`.

--- a/client/rpc-api/src/system/mod.rs
+++ b/client/rpc-api/src/system/mod.rs
@@ -84,11 +84,7 @@ pub trait SystemApi<Hash, Number> {
 	#[method(name = "system_unstable_networkState")]
 	async fn system_network_state(&self) -> RpcResult<JsonValue>;
 
-	/// Adds a reserved peer. Returns the empty string or an error. The string
-	/// parameter should encode a `p2p` multiaddr.
-	///
-	/// `/ip4/198.51.100.19/tcp/30333/p2p/QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV`
-	/// is an example of a valid, passing multiaddr with PeerId attached.
+	/// Adds a reserved peer. Returns the empty string or an error. 
 	#[method(name = "system_addReservedPeer")]
 	async fn system_add_reserved_peer(&self, peer: MultiaddrWithPeerId) -> RpcResult<()>;
 

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -37,6 +37,7 @@ sp-rpc = { version = "6.0.0", path = "../../primitives/rpc" }
 sp-runtime = { version = "6.0.0", path = "../../primitives/runtime" }
 sp-session = { version = "4.0.0-dev", path = "../../primitives/session" }
 sp-version = { version = "5.0.0", path = "../../primitives/version" }
+sc-network = { version = "0.10.0-dev", path = "../network" }
 
 tokio = { version = "1.17.0", optional = true }
 

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -18,6 +18,7 @@ futures = "0.3.21"
 hash-db = { version = "0.15.2", default-features = false }
 jsonrpsee = { version = "0.13.0", features = ["server"] }
 lazy_static = { version = "1.4.0", optional = true }
+libp2p = "0.44.0"
 log = "0.4.17"
 parking_lot = "0.12.0"
 serde_json = "1.0.79"
@@ -37,7 +38,6 @@ sp-rpc = { version = "6.0.0", path = "../../primitives/rpc" }
 sp-runtime = { version = "6.0.0", path = "../../primitives/runtime" }
 sp-session = { version = "4.0.0-dev", path = "../../primitives/session" }
 sp-version = { version = "5.0.0", path = "../../primitives/version" }
-sc-network = { version = "0.10.0-dev", path = "../network" }
 
 tokio = { version = "1.17.0", optional = true }
 

--- a/client/rpc/src/system/mod.rs
+++ b/client/rpc/src/system/mod.rs
@@ -26,11 +26,11 @@ use jsonrpsee::{
 	core::{async_trait, error::Error as JsonRpseeError, JsonValue, RpcResult},
 	types::error::{CallError, ErrorCode, ErrorObject},
 };
-use sc_network::config::MultiaddrWithPeerId;
 use sc_rpc_api::DenyUnsafe;
 use sc_tracing::logging;
 use sc_utils::mpsc::TracingUnboundedSender;
 use sp_runtime::traits::{self, Header as HeaderT};
+use libp2p::Multiaddr;
 
 use self::error::Result;
 
@@ -58,7 +58,7 @@ pub enum Request<B: traits::Block> {
 	/// Must return the state of the network.
 	NetworkState(oneshot::Sender<serde_json::Value>),
 	/// Must return any potential parse error.
-	NetworkAddReservedPeer(MultiaddrWithPeerId, oneshot::Sender<Result<()>>),
+	NetworkAddReservedPeer(Multiaddr, oneshot::Sender<Result<()>>),
 	/// Must return any potential parse error.
 	NetworkRemoveReservedPeer(String, oneshot::Sender<Result<()>>),
 	/// Must return the list of reserved peers
@@ -139,7 +139,7 @@ impl<B: traits::Block> SystemApiServer<B::Hash, <B::Header as HeaderT>::Number> 
 		rx.await.map_err(|e| JsonRpseeError::to_call_error(e))
 	}
 
-	async fn system_add_reserved_peer(&self, peer: MultiaddrWithPeerId) -> RpcResult<()> {
+	async fn system_add_reserved_peer(&self, peer: Multiaddr) -> RpcResult<()> {
 		self.deny_unsafe.check_if_safe()?;
 		let (tx, rx) = oneshot::channel();
 		let _ = self.send_back.unbounded_send(Request::NetworkAddReservedPeer(peer, tx));

--- a/client/rpc/src/system/mod.rs
+++ b/client/rpc/src/system/mod.rs
@@ -26,6 +26,7 @@ use jsonrpsee::{
 	core::{async_trait, error::Error as JsonRpseeError, JsonValue, RpcResult},
 	types::error::{CallError, ErrorCode, ErrorObject},
 };
+use sc_network::config::MultiaddrWithPeerId;
 use sc_rpc_api::DenyUnsafe;
 use sc_tracing::logging;
 use sc_utils::mpsc::TracingUnboundedSender;
@@ -57,7 +58,7 @@ pub enum Request<B: traits::Block> {
 	/// Must return the state of the network.
 	NetworkState(oneshot::Sender<serde_json::Value>),
 	/// Must return any potential parse error.
-	NetworkAddReservedPeer(String, oneshot::Sender<Result<()>>),
+	NetworkAddReservedPeer(MultiaddrWithPeerId, oneshot::Sender<Result<()>>),
 	/// Must return any potential parse error.
 	NetworkRemoveReservedPeer(String, oneshot::Sender<Result<()>>),
 	/// Must return the list of reserved peers
@@ -138,7 +139,7 @@ impl<B: traits::Block> SystemApiServer<B::Hash, <B::Header as HeaderT>::Number> 
 		rx.await.map_err(|e| JsonRpseeError::to_call_error(e))
 	}
 
-	async fn system_add_reserved_peer(&self, peer: String) -> RpcResult<()> {
+	async fn system_add_reserved_peer(&self, peer: MultiaddrWithPeerId) -> RpcResult<()> {
 		self.deny_unsafe.check_if_safe()?;
 		let (tx, rx) = oneshot::channel();
 		let _ = self.send_back.unbounded_send(Request::NetworkAddReservedPeer(peer, tx));

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -382,7 +382,7 @@ where
 			for (_, service, _, _) in network.full_nodes.iter().skip(1) {
 				service
 					.network()
-					.add_reserved_peer(first_address.to_string())
+					.add_reserved_peer(first_address)
 					.expect("Error adding reserved peer");
 			}
 
@@ -414,7 +414,7 @@ where
 					if let Some((_, service, _, node_id)) = network.full_nodes.get(i) {
 						service
 							.network()
-							.add_reserved_peer(address.to_string())
+							.add_reserved_peer(address)
 							.expect("Error adding reserved peer");
 						address = node_id.clone();
 					}
@@ -479,7 +479,7 @@ pub fn sync<G, E, Fb, F, B, ExF, U>(
 	for (_, service, _, _) in network.full_nodes.iter().skip(1) {
 		service
 			.network()
-			.add_reserved_peer(first_address.to_string())
+			.add_reserved_peer(first_address)
 			.expect("Error adding reserved peer");
 	}
 
@@ -532,13 +532,13 @@ pub fn consensus<G, E, Fb, F>(
 	for (_, service, _, _) in network.full_nodes.iter() {
 		service
 			.network()
-			.add_reserved_peer(first_address.to_string())
+			.add_reserved_peer(first_address)
 			.expect("Error adding reserved peer");
 	}
 	for (_, service, _, _) in network.authority_nodes.iter().skip(1) {
 		service
 			.network()
-			.add_reserved_peer(first_address.to_string())
+			.add_reserved_peer(first_address)
 			.expect("Error adding reserved peer");
 	}
 	network.run_until_all_full(|_index, service| {
@@ -556,7 +556,7 @@ pub fn consensus<G, E, Fb, F>(
 	for (_, service, _, _) in network.full_nodes.iter() {
 		service
 			.network()
-			.add_reserved_peer(first_address.to_string())
+			.add_reserved_peer(first_address)
 			.expect("Error adding reserved peer");
 	}
 

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -382,7 +382,7 @@ where
 			for (_, service, _, _) in network.full_nodes.iter().skip(1) {
 				service
 					.network()
-					.add_reserved_peer(first_address)
+					.add_reserved_peer(first_address.clone())
 					.expect("Error adding reserved peer");
 			}
 
@@ -479,7 +479,7 @@ pub fn sync<G, E, Fb, F, B, ExF, U>(
 	for (_, service, _, _) in network.full_nodes.iter().skip(1) {
 		service
 			.network()
-			.add_reserved_peer(first_address)
+			.add_reserved_peer(first_address.clone())
 			.expect("Error adding reserved peer");
 	}
 
@@ -532,13 +532,13 @@ pub fn consensus<G, E, Fb, F>(
 	for (_, service, _, _) in network.full_nodes.iter() {
 		service
 			.network()
-			.add_reserved_peer(first_address)
+			.add_reserved_peer(first_address.clone())
 			.expect("Error adding reserved peer");
 	}
 	for (_, service, _, _) in network.authority_nodes.iter().skip(1) {
 		service
 			.network()
-			.add_reserved_peer(first_address)
+			.add_reserved_peer(first_address.clone())
 			.expect("Error adding reserved peer");
 	}
 	network.run_until_all_full(|_index, service| {
@@ -556,7 +556,7 @@ pub fn consensus<G, E, Fb, F>(
 	for (_, service, _, _) in network.full_nodes.iter() {
 		service
 			.network()
-			.add_reserved_peer(first_address)
+			.add_reserved_peer(first_address.clone())
 			.expect("Error adding reserved peer");
 	}
 


### PR DESCRIPTION
This PR makes NetworkService::add_reserved_peer accept a MultiaddrWithPeerId type instead of String type.

Resolves [Accept Multiaddr in NetworkService::add_reserved_peer instead of String #8834](https://github.com/paritytech/substrate/issues/8834)


