### PR TITLE
Fix link in node-template README

### DIFF
--- a/bin/node-template/README.md
+++ b/bin/node-template/README.md
@@ -13,8 +13,8 @@ the [Substrate Playground](https://docs.substrate.io/playground/) :hammer_and_wr
 ### Using Nix
 
 Install [nix](https://nixos.org/) and optionally [direnv](https://github.com/direnv/direnv) and
-[lorri](https://github.com/target/lorri) for a fully plug and play experience for setting up the
-development environment. To get all the correct dependencies activate direnv `direnv allow` and
+[lorri](https://github.com/nix-community/lorri) for a fully plug and play experience for setting up
+the development environment. To get all the correct dependencies activate direnv `direnv allow` and
 lorri `lorri shell`.
 
 ### Rust Setup


### PR DESCRIPTION
The lorri repository has moved from https://github.com/target/lorri to
https://github.com/nix-community/lorri.
