### PR TITLE
remove deposit from fungibles::metadata set implementation

### DIFF
--- a/frame/assets/src/functions.rs
+++ b/frame/assets/src/functions.rs
@@ -819,6 +819,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		name: Vec<u8>,
 		symbol: Vec<u8>,
 		decimals: u8,
+		pays_deposit: bool,
 	) -> DispatchResult {
 		let bounded_name: BoundedVec<u8, T::StringLimit> =
 			name.clone().try_into().map_err(|_| Error::<T, I>::BadMetadata)?;
@@ -831,15 +832,19 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Metadata::<T, I>::try_mutate_exists(id, |metadata| {
 			ensure!(metadata.as_ref().map_or(true, |m| !m.is_frozen), Error::<T, I>::NoPermission);
 
-			let old_deposit = metadata.take().map_or(Zero::zero(), |m| m.deposit);
-			let new_deposit = T::MetadataDepositPerByte::get()
-				.saturating_mul(((name.len() + symbol.len()) as u32).into())
-				.saturating_add(T::MetadataDepositBase::get());
+			let mut new_deposit = Zero::zero();
 
-			if new_deposit > old_deposit {
-				T::Currency::reserve(from, new_deposit - old_deposit)?;
-			} else {
-				T::Currency::unreserve(from, old_deposit - new_deposit);
+			if pays_deposit {
+				let old_deposit = metadata.take().map_or(Zero::zero(), |m| m.deposit);
+				new_deposit = T::MetadataDepositPerByte::get()
+					.saturating_mul(((name.len() + symbol.len()) as u32).into())
+					.saturating_add(T::MetadataDepositBase::get());
+
+				if new_deposit > old_deposit {
+					T::Currency::reserve(from, new_deposit - old_deposit)?;
+				} else {
+					T::Currency::unreserve(from, old_deposit - new_deposit);
+				}
 			}
 
 			*metadata = Some(AssetMetadata {

--- a/frame/assets/src/impl_fungibles.rs
+++ b/frame/assets/src/impl_fungibles.rs
@@ -221,7 +221,7 @@ impl<T: Config<I>, I: 'static> fungibles::metadata::Mutate<<T as SystemConfig>::
 		symbol: Vec<u8>,
 		decimals: u8,
 	) -> DispatchResult {
-		Self::do_set_metadata(asset, from, name, symbol, decimals)
+		Self::do_set_metadata(asset, from, name, symbol, decimals, false)
 	}
 }
 

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -987,7 +987,7 @@ pub mod pallet {
 			decimals: u8,
 		) -> DispatchResult {
 			let origin = ensure_signed(origin)?;
-			Self::do_set_metadata(id, &origin, name, symbol, decimals)
+			Self::do_set_metadata(id, &origin, name, symbol, decimals, true)
 		}
 
 		/// Clear the metadata for an asset.

--- a/frame/assets/src/tests.rs
+++ b/frame/assets/src/tests.rs
@@ -977,3 +977,24 @@ fn transfer_large_asset() {
 		assert_ok!(Assets::transfer(Origin::signed(1), 0, 2, amount - 1));
 	})
 }
+
+#[test]
+fn fungibles_can_set_metadata_without_deposit() {
+	new_test_ext().execute_with(|| {
+		use frame_support::traits::tokens::fungibles::metadata::Inspect;
+		assert_eq!(Balances::free_balance(99), 0);
+		// create assets without deposit
+		assert_ok!(
+			<Assets as fungibles::Create<<Test as frame_system::Config>::AccountId>>::create(
+				0, 99, true, 1
+			)
+		);
+		// set metadata without deposit
+		assert_ok!(<Assets as fungibles::metadata::Mutate<
+			<Test as frame_system::Config>::AccountId,
+		>>::set(0, &99, vec![0u8; 10], vec![1u8; 10], 12));
+		assert_eq!(Assets::name(0), vec![0u8; 10]);
+		assert_eq!(Assets::symbol(0), vec![1u8; 10]);
+		assert_eq!(Assets::decimals(0), 12);
+	})
+}


### PR DESCRIPTION
Changelog:
- Modifies the `do_set_metadata` function to add an extra param of `pays_deposit`, the deposit is charged only if this param is true.

Why this change?
- This aligns with the `create` implementation of the `fungibles::Create` trait in the same file, where no deposit is charged. This does not change the `set_metadata` extrinsic behaviour but removes the need to pay deposit when calling the `fungibles::metadata::Mutate->set` function.