### PR TITLE
Fix minor typos

### DIFF
--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -165,8 +165,8 @@ pub trait AddressGenerator<T: frame_system::Config> {
 /// Default address generator.
 ///
 /// This is the default address generator used by contract instantiation. Its result
-/// is only dependend on its inputs. It can therefore be used to reliably predict the
-/// address of a contract. This is akin to the formular of eth's CREATE2 opcode. There
+/// is only dependant on its inputs. It can therefore be used to reliably predict the
+/// address of a contract. This is akin to the formula of eth's CREATE2 opcode. There
 /// is no CREATE equivalent because CREATE2 is strictly more powerful.
 ///
 /// Formula: `hash(deploying_address ++ code_hash ++ salt)`
@@ -231,7 +231,7 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
-		/// The time implementation used to supply timestamps to conntracts through `seal_now`.
+		/// The time implementation used to supply timestamps to contracts through `seal_now`.
 		type Time: Time;
 
 		/// The generator used to supply randomness to contracts through `seal_random`.
@@ -339,7 +339,7 @@ pub mod pallet {
 		///
 		/// For more information check out: <https://github.com/paritytech/substrate/issues/10301>
 		///
-		/// [`DefaultContractAccessWeight`] is a safe default to be used for polkadot or kusama
+		/// [`DefaultContractAccessWeight`] is a safe default to be used for Polkadot or Kusama
 		/// parachains.
 		///
 		/// # Note
@@ -1031,7 +1031,7 @@ where
 						})?;
 					// The open deposit will be charged during execution when the
 					// uploaded module does not already exist. This deposit is not part of the
-					// storage meter because it is not transfered to the contract but
+					// storage meter because it is not transferred to the contract but
 					// reserved on the uploading account.
 					(executable.open_deposit(), executable)
 				},

--- a/frame/contracts/src/storage/meter.rs
+++ b/frame/contracts/src/storage/meter.rs
@@ -35,10 +35,10 @@ pub type DepositOf<T> = Deposit<BalanceOf<T>>;
 /// A production root storage meter that actually charges from its origin.
 pub type Meter<T> = RawMeter<T, ReservingExt, Root>;
 
-/// A poduction nested storage meter that actually charges from its origin.
+/// A production nested storage meter that actually charges from its origin.
 pub type NestedMeter<T> = RawMeter<T, ReservingExt, Nested>;
 
-/// A poduction storage meter that actually charges from its origin.
+/// A production storage meter that actually charges from its origin.
 ///
 /// This can be used where we want to be generic over the state (Root vs. Nested).
 pub type GenericMeter<T, S> = RawMeter<T, ReservingExt, S>;
@@ -53,8 +53,8 @@ pub trait Ext<T: Config> {
 	///
 	/// `origin`: The origin of the call stack from which is responsible for putting down a deposit.
 	/// `limit`: The limit with which the meter was constructed.
-	/// `min_leftover`: How much `free_balance` in addition to the ed should be left inside the
-	/// `origin` account.
+	/// `min_leftover`: How much `free_balance` in addition to the existential deposit (ed) should be
+	/// left inside the `origin` account.
 	///
 	/// Returns the limit that should be used by the meter. If origin can't afford the `limit`
 	/// it returns `Err`.
@@ -551,7 +551,7 @@ mod tests {
 		let mut meter = TestMeter::new(&ALICE, Some(1_000), 0).unwrap();
 		assert_eq!(meter.available(), 1_000);
 
-		// an empty charge foes not create a `Charge` entry
+		// an empty charge does not create a `Charge` entry
 		let mut nested0 = meter.nested();
 		nested0.charge(&Default::default()).unwrap();
 		meter.absorb(nested0, &ALICE, &BOB, None);


### PR DESCRIPTION
This PR fixes some minor typos in the contracts pallet docs.