### PR TITLE
Allow fixed `from/to_float` to be used in `no_std`

### DIFF
--- a/primitives/arithmetic/src/fixed_point.rs
+++ b/primitives/arithmetic/src/fixed_point.rs
@@ -429,7 +429,6 @@ macro_rules! implement_fixed {
 			}
 
 			/// Convert from a `float` value.
-			#[cfg(any(feature = "std", test))]
 			pub fn from_float(x: f64) -> Self {
 				Self((x * (<Self as FixedPointNumber>::DIV as f64)) as $inner_type)
 			}
@@ -468,7 +467,6 @@ macro_rules! implement_fixed {
 			}
 
 			/// Convert into a `float` value.
-			#[cfg(any(feature = "std", test))]
 			pub fn to_float(self) -> f64 {
 				self.0 as f64 / <Self as FixedPointNumber>::DIV as f64
 			}


### PR DESCRIPTION
Having the `from_float` is very useful to define pallet configs in runtime for example.

```rust
parameter_types! {
	pub ConversionRatio: FixedI64 = FixedI64::from_float(1.35);
}

impl pallet_example::Config for Test {
    type Event = Event;
    .......
    type DefaultConversionRatio = ConversionRatio;
    .......
}
```

----
polkadot address: 12xH9F4aSGEq27AZxLqG15fheDTtSxh1rJkVSXQ2g59djs7u