### PR TITLE
Do not require Ord for pallet_offences::Config::IdentificationTuple

### DIFF
--- a/frame/offences/src/lib.rs
+++ b/frame/offences/src/lib.rs
@@ -59,7 +59,7 @@ pub mod pallet {
 		/// The overarching event type.
 		type Event: From<Event> + IsType<<Self as frame_system::Config>::Event>;
 		/// Full identification of the validator.
-		type IdentificationTuple: Parameter + Ord;
+		type IdentificationTuple: Parameter;
 		/// A handler called for every offence report.
 		type OnOffenceHandler: OnOffenceHandler<Self::AccountId, Self::IdentificationTuple, Weight>;
 	}


### PR DESCRIPTION
This is a small PR that relaxes the requirements on the `IdentificationTuple` at the `pallet_offences`.

There seems to be no need for it, as the pallet checks just fine, and it's an issue for our implementation at Humanode as our `IdentificationTuple` doesn't implement `Ord`.

FYI @dmitrylavrenov