### PR TITLE
Fix all warnings when building for wasm

### DIFF
--- a/frame/contracts/proc-macro/src/lib.rs
+++ b/frame/contracts/proc-macro/src/lib.rs
@@ -24,7 +24,7 @@ extern crate alloc;
 use alloc::string::ToString;
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
-use syn::{parse_macro_input, spanned::Spanned, Data, DataStruct, DeriveInput, Fields, Ident};
+use syn::{parse_macro_input, Data, DeriveInput, Ident};
 
 /// This derives `Debug` for a struct where each field must be of some numeric type.
 /// It interprets each field as its represents some weight and formats it as times so that
@@ -84,7 +84,9 @@ fn derive_debug(
 
 /// This is only used then the `full` feature is activated.
 #[cfg(feature = "full")]
-fn iterate_fields(data: &DataStruct, fmt: impl Fn(&Ident) -> TokenStream) -> TokenStream {
+fn iterate_fields(data: &syn::DataStruct, fmt: impl Fn(&Ident) -> TokenStream) -> TokenStream {
+	use syn::{Fields, spanned::Spanned};
+
 	match &data.fields {
 		Fields::Named(fields) => {
 			let recurse = fields.named.iter().filter_map(|f| {

--- a/frame/nomination-pools/src/lib.rs
+++ b/frame/nomination-pools/src/lib.rs
@@ -316,7 +316,7 @@ use frame_support::{
 		Currency, Defensive, DefensiveOption, DefensiveResult, DefensiveSaturating,
 		ExistenceRequirement, Get,
 	},
-	CloneNoBound, DefaultNoBound, PartialEqNoBound, RuntimeDebugNoBound,
+	CloneNoBound, DefaultNoBound, RuntimeDebugNoBound,
 };
 use scale_info::TypeInfo;
 use sp_core::U256;
@@ -398,7 +398,7 @@ enum AccountType {
 
 /// A member in a pool.
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, RuntimeDebugNoBound, CloneNoBound)]
-#[cfg_attr(feature = "std", derive(PartialEqNoBound, DefaultNoBound))]
+#[cfg_attr(feature = "std", derive(frame_support::PartialEqNoBound, DefaultNoBound))]
 #[codec(mel_bound(T: Config))]
 #[scale_info(skip_type_params(T))]
 pub struct PoolMember<T: Config> {

--- a/frame/try-runtime/src/lib.rs
+++ b/frame/try-runtime/src/lib.rs
@@ -20,7 +20,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::weights::Weight;
-use sp_std::prelude::*;
 
 sp_api::decl_runtime_apis! {
 	/// Runtime api for testing the execution of a runtime upgrade.

--- a/primitives/block-builder/src/lib.rs
+++ b/primitives/block-builder/src/lib.rs
@@ -20,10 +20,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use sp_inherents::{CheckInherentsResult, InherentData};
-use sp_runtime::{
-	legacy::byte_sized_error::ApplyExtrinsicResult as ApplyExtrinsicResultBeforeV6,
-	traits::Block as BlockT, ApplyExtrinsicResult,
-};
+use sp_runtime::{traits::Block as BlockT, ApplyExtrinsicResult};
 
 sp_api::decl_runtime_apis! {
 	/// The `BlockBuilder` api trait that provides the required functionality for building a block.
@@ -36,7 +33,9 @@ sp_api::decl_runtime_apis! {
 		fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult;
 
 		#[changed_in(6)]
-		fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResultBeforeV6;
+		fn apply_extrinsic(
+			extrinsic: <Block as BlockT>::Extrinsic,
+		) -> sp_runtime::legacy::byte_sized_error::ApplyExtrinsicResult;
 
 		/// Finish the current block.
 		#[renamed("finalise_block", 3)]

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -1522,17 +1522,17 @@ mod tracing_setup {
 		fn new_span(&self, attrs: &Attributes<'_>) -> Id {
 			Id::from_u64(wasm_tracing::enter_span(Crossing(attrs.into())))
 		}
-		fn enter(&self, span: &Id) {
+		fn enter(&self, _: &Id) {
 			// Do nothing, we already entered the span previously
 		}
 		/// Not implemented! We do not support recording values later
 		/// Will panic when used.
-		fn record(&self, span: &Id, values: &Record<'_>) {
+		fn record(&self, _: &Id, _: &Record<'_>) {
 			unimplemented! {} // this usage is not supported
 		}
 		/// Not implemented! We do not support recording values later
 		/// Will panic when used.
-		fn record_follows_from(&self, span: &Id, follows: &Id) {
+		fn record_follows_from(&self, _: &Id, _: &Id) {
 			unimplemented! {} // this usage is not supported
 		}
 		fn event(&self, event: &Event<'_>) {

--- a/primitives/state-machine/src/trie_backend_essence.rs
+++ b/primitives/state-machine/src/trie_backend_essence.rs
@@ -29,7 +29,7 @@ use sp_trie::{
 	child_delta_trie_root, delta_trie_root, empty_child_trie_root, read_child_trie_value,
 	read_trie_value,
 	trie_types::{TrieDB, TrieError},
-	DBValue, KeySpacedDB, LayoutV1 as Layout, PrefixedMemoryDB, Trie, TrieDBIterator,
+	DBValue, KeySpacedDB, LayoutV1 as Layout, Trie, TrieDBIterator,
 	TrieDBKeyIterator,
 };
 #[cfg(feature = "std")]
@@ -619,7 +619,7 @@ pub trait TrieBackendStorage<H: Hasher>: Send + Sync {
 // This implementation is used by normal storage trie clients.
 #[cfg(feature = "std")]
 impl<H: Hasher> TrieBackendStorage<H> for Arc<dyn Storage<H>> {
-	type Overlay = PrefixedMemoryDB<H>;
+	type Overlay = sp_trie::PrefixedMemoryDB<H>;
 
 	fn get(&self, key: &H::Out, prefix: Prefix) -> Result<Option<DBValue>> {
 		Storage::<H>::get(std::ops::Deref::deref(self), key, prefix)

--- a/primitives/version/src/lib.rs
+++ b/primitives/version/src/lib.rs
@@ -273,6 +273,7 @@ impl fmt::Display for RuntimeVersion {
 	}
 }
 
+#[cfg(feature = "std")]
 fn has_api_with<P: Fn(u32) -> bool>(apis: &ApisVec, id: &ApiId, predicate: P) -> bool {
 	apis.iter().any(|(s, v)| s == id && predicate(*v))
 }

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -205,6 +205,7 @@ test-linux-stable:
     RUSTFLAGS:                     "-Cdebug-assertions=y -Dwarnings"
     RUST_BACKTRACE:                1
     WASM_BUILD_NO_COLOR:           1
+    WASM_BUILD_RUSTFLAGS:          "-Cdebug-assertions=y -Dwarnings"
     # Ensure we run the UI tests.
     RUN_UI_TESTS:                  1
   script:
@@ -247,6 +248,7 @@ test-linux-stable-int:
     RUSTFLAGS:                     "-Cdebug-assertions=y -Dwarnings"
     RUST_BACKTRACE:                1
     WASM_BUILD_NO_COLOR:           1
+    WASM_BUILD_RUSTFLAGS:          "-Cdebug-assertions=y -Dwarnings"
     # Ensure we run the UI tests.
     RUN_UI_TESTS:                  1
   script:


### PR DESCRIPTION
Besides that it also enables warnings as errors for wasm builds in the CI.


