### PR TITLE
`rusty-cachier` pipeline impovements and fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,7 +108,7 @@ default:
     - $(rusty-cachier environment inject)
     - rusty-cachier project mtime
   after_script:
-    - rusty-cachier snapshot destroy
+    - env RUSTY_CACHIER_SUPRESS_OUTPUT=true rusty-cachier snapshot destroy
 
 .test-refs:
   rules:
@@ -225,8 +225,7 @@ deploy-prometheus-alerting-rules:
 # This info is later used for the cache distribution and an overlay creation.
 rusty-cachier-notify:
   stage:                           notify
-  extends:
-    - .docker-env
+  extends:                         .docker-env
   script:
     - rusty-cachier cache notify
 

--- a/scripts/ci/gitlab/pipeline/build.yml
+++ b/scripts/ci/gitlab/pipeline/build.yml
@@ -50,6 +50,9 @@ build-linux-substrate:
     - .collect-artifacts
     - .docker-env
     - .build-refs
+  variables:
+    # this variable gets overriden by "rusty-cachier environment inject", use the value as default
+    CARGO_TARGET_DIR:              "./target"
   needs:
     - job:                         test-linux-stable
       artifacts:                   false
@@ -59,7 +62,7 @@ build-linux-substrate:
   script:
     - rusty-cachier snapshot create
     - WASM_BUILD_NO_COLOR=1 time cargo build --release --verbose
-    - mv /cargo_target_dir/release/substrate ./artifacts/substrate/.
+    - mv $CARGO_TARGET_DIR/release/substrate ./artifacts/substrate/.
     - echo -n "Substrate version = "
     - if [ "${CI_COMMIT_TAG}" ]; then
         echo "${CI_COMMIT_TAG}" | tee ./artifacts/substrate/VERSION;
@@ -79,6 +82,9 @@ build-linux-substrate:
     - .collect-artifacts
     - .docker-env
     - .build-refs
+  variables:
+    # this variable gets overriden by "rusty-cachier environment inject", use the value as default
+    CARGO_TARGET_DIR:              "./target"
   needs:
     - job:                         cargo-check-subkey
       artifacts:                   false
@@ -90,7 +96,7 @@ build-linux-substrate:
     - cd ./bin/utils/subkey
     - SKIP_WASM_BUILD=1 time cargo build --release --verbose
     - cd -
-    - mv /cargo_target_dir/release/subkey ./artifacts/subkey/.
+    - mv $CARGO_TARGET_DIR/release/subkey ./artifacts/subkey/.
     - echo -n "Subkey version = "
     - ./artifacts/subkey/subkey --version |
         sed -n -E 's/^subkey ([0-9.]+.*)/\1/p' |
@@ -131,6 +137,8 @@ build-rustdoc:
     SKIP_WASM_BUILD:               1
     DOC_INDEX_PAGE:                "sc_service/index.html" # default redirected page
     RUSTY_CACHIER_TOOLCHAIN:       nightly
+    # this variable gets overriden by "rusty-cachier environment inject", use the value as default
+    CARGO_TARGET_DIR:              "./target"
   artifacts:
     name:                          "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}-doc"
     when:                          on_success
@@ -140,8 +148,8 @@ build-rustdoc:
   script:
     - rusty-cachier snapshot create
     - time cargo +nightly doc --workspace --all-features --verbose
-    - rm -f /cargo_target_dir/doc/.lock
-    - mv /cargo_target_dir/doc ./crate-docs
+    - rm -f $CARGO_TARGET_DIR/doc/.lock
+    - mv $CARGO_TARGET_DIR/doc ./crate-docs
     # FIXME: remove me after CI image gets nonroot
     - chown -R nonroot:nonroot ./crate-docs
     - echo "<meta http-equiv=refresh content=0;url=${DOC_INDEX_PAGE}>" > ./crate-docs/index.html

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -180,18 +180,22 @@ test-deterministic-wasm:
     - .test-refs
   variables:
     WASM_BUILD_NO_COLOR:           1
+    # this variable gets overriden by "rusty-cachier environment inject", use the value as default
+    CARGO_TARGET_DIR:              "./target"
   script:
     - rusty-cachier snapshot create
     # build runtime
     - cargo build --verbose --release -p node-runtime
     # make checksum
-    - sha256sum /cargo_target_dir/release/wbuild/node-runtime/target/wasm32-unknown-unknown/release/node_runtime.wasm > checksum.sha256
-    # clean up – FIXME: can we reuse some of the artifacts?
-    - cargo clean
+    - sha256sum $CARGO_TARGET_DIR/release/wbuild/node-runtime/target/wasm32-unknown-unknown/release/node_runtime.wasm > checksum.sha256
+    # clean up
+    - rm -rf $CARGO_TARGET_DIR/release/wbuild
     # build again
     - cargo build --verbose --release -p node-runtime
     # confirm checksum
     - sha256sum -c ./checksum.sha256
+    # clean up again, don't put release binaries into the cache
+    - rm -rf $CARGO_TARGET_DIR/release/wbuild
     - rusty-cachier cache upload
 
 test-linux-stable:


### PR DESCRIPTION
* Supress `rusty-cachier` output for `rusty-cachier snapshot destroy` command to stop emitting stack traces in case of a graceful failure
* Don't hardcode `CARGO_TARGET_DIR` paths
* Adopt `test-deterministic-wasm` job for `rusty-cachier`