### PR TITLE
CI: fix `build-subkey-macos` build job

### DIFF
--- a/scripts/ci/gitlab/pipeline/build.yml
+++ b/scripts/ci/gitlab/pipeline/build.yml
@@ -52,7 +52,7 @@ build-linux-substrate:
     - .build-refs
   variables:
     # this variable gets overriden by "rusty-cachier environment inject", use the value as default
-    CARGO_TARGET_DIR:              "target"
+    CARGO_TARGET_DIR:              "$CI_PROJECT_DIR/target"
   needs:
     - job:                         test-linux-stable
       artifacts:                   false
@@ -84,7 +84,7 @@ build-linux-substrate:
     - .build-refs
   variables:
     # this variable gets overriden by "rusty-cachier environment inject", use the value as default
-    CARGO_TARGET_DIR:              "target"
+    CARGO_TARGET_DIR:              "$CI_PROJECT_DIR/target"
   needs:
     - job:                         cargo-check-subkey
       artifacts:                   false
@@ -139,7 +139,7 @@ build-rustdoc:
     DOC_INDEX_PAGE:                "sc_service/index.html" # default redirected page
     RUSTY_CACHIER_TOOLCHAIN:       nightly
     # this variable gets overriden by "rusty-cachier environment inject", use the value as default
-    CARGO_TARGET_DIR:              "target"
+    CARGO_TARGET_DIR:              "$CI_PROJECT_DIR/target"
   artifacts:
     name:                          "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}-doc"
     when:                          on_success

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -181,7 +181,7 @@ test-deterministic-wasm:
   variables:
     WASM_BUILD_NO_COLOR:           1
     # this variable gets overriden by "rusty-cachier environment inject", use the value as default
-    CARGO_TARGET_DIR:              "target"
+    CARGO_TARGET_DIR:              "$CI_PROJECT_DIR/target"
   script:
     - rusty-cachier snapshot create
     # build runtime


### PR DESCRIPTION
* Remove the mentioned job's `after_script:` section as it tries to run `rusty-cachier` on macOS
* Fix `CARGO_TARGET_DIR` relative path declaration as the current one results [in error](https://gitlab.parity.io/parity/mirrors/substrate/-/jobs/1604814#L549)