### PR TITLE
Reduce call size of Referenda pallet

### DIFF
--- a/frame/referenda/src/benchmarking.rs
+++ b/frame/referenda/src/benchmarking.rs
@@ -46,7 +46,7 @@ fn create_referendum<T: Config>() -> (T::AccountId, ReferendumIndex) {
 	whitelist_account!(caller);
 	assert_ok!(Referenda::<T>::submit(
 		RawOrigin::Signed(caller.clone()).into(),
-		RawOrigin::Root.into(),
+		Box::new(RawOrigin::Root.into()),
 		T::Hashing::hash_of(&0),
 		DispatchTime::After(0u32.into())
 	));
@@ -177,7 +177,7 @@ benchmarks! {
 		whitelist_account!(caller);
 	}: _(
 		RawOrigin::Signed(caller),
-		RawOrigin::Root.into(),
+		Box::new(RawOrigin::Root.into()),
 		T::Hashing::hash_of(&0),
 		DispatchTime::After(0u32.into())
 	) verify {

--- a/frame/referenda/src/lib.rs
+++ b/frame/referenda/src/lib.rs
@@ -355,7 +355,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::submit())]
 		pub fn submit(
 			origin: OriginFor<T>,
-			proposal_origin: PalletsOriginOf<T>,
+			proposal_origin: Box<PalletsOriginOf<T>>,
 			proposal_hash: T::Hash,
 			enactment_moment: DispatchTime<T::BlockNumber>,
 		) -> DispatchResult {
@@ -373,7 +373,7 @@ pub mod pallet {
 			let nudge_call = Call::nudge_referendum { index };
 			let status = ReferendumStatus {
 				track,
-				origin: proposal_origin,
+				origin: *proposal_origin,
 				proposal_hash,
 				enactment: enactment_moment,
 				submitted: now,

--- a/frame/referenda/src/mock.rs
+++ b/frame/referenda/src/mock.rs
@@ -310,7 +310,7 @@ pub fn set_balance_proposal_hash(value: u64) -> H256 {
 pub fn propose_set_balance(who: u64, value: u64, delay: u64) -> DispatchResult {
 	Referenda::submit(
 		Origin::signed(who),
-		frame_system::RawOrigin::Root.into(),
+		Box::new(frame_system::RawOrigin::Root.into()),
 		set_balance_proposal_hash(value),
 		DispatchTime::After(delay),
 	)
@@ -438,7 +438,7 @@ impl RefState {
 	pub fn create(self) -> ReferendumIndex {
 		assert_ok!(Referenda::submit(
 			Origin::signed(1),
-			frame_support::dispatch::RawOrigin::Root.into(),
+			Box::new(frame_support::dispatch::RawOrigin::Root.into()),
 			set_balance_proposal_hash(1),
 			DispatchTime::At(10),
 		));

--- a/frame/referenda/src/tests.rs
+++ b/frame/referenda/src/tests.rs
@@ -364,7 +364,12 @@ fn submit_errors_work() {
 
 		// No funds for deposit
 		assert_noop!(
-			Referenda::submit(Origin::signed(10), Box::new(RawOrigin::Root.into()), h, DispatchTime::At(10),),
+			Referenda::submit(
+				Origin::signed(10),
+				Box::new(RawOrigin::Root.into()),
+				h,
+				DispatchTime::At(10),
+			),
 			BalancesError::<Test>::InsufficientBalance
 		);
 	});

--- a/frame/referenda/src/tests.rs
+++ b/frame/referenda/src/tests.rs
@@ -43,7 +43,7 @@ fn basic_happy_path_works() {
 		// #1: submit
 		assert_ok!(Referenda::submit(
 			Origin::signed(1),
-			RawOrigin::Root.into(),
+			Box::new(RawOrigin::Root.into()),
 			set_balance_proposal_hash(1),
 			DispatchTime::At(10),
 		));
@@ -174,7 +174,7 @@ fn queueing_works() {
 		// Submit a proposal into a track with a queue len of 1.
 		assert_ok!(Referenda::submit(
 			Origin::signed(5),
-			RawOrigin::Root.into(),
+			Box::new(RawOrigin::Root.into()),
 			set_balance_proposal_hash(0),
 			DispatchTime::After(0),
 		));
@@ -186,7 +186,7 @@ fn queueing_works() {
 		for i in 1..=4 {
 			assert_ok!(Referenda::submit(
 				Origin::signed(i),
-				RawOrigin::Root.into(),
+				Box::new(RawOrigin::Root.into()),
 				set_balance_proposal_hash(i),
 				DispatchTime::After(0),
 			));
@@ -271,7 +271,7 @@ fn auto_timeout_should_happen_with_nothing_but_submit() {
 		// #1: submit
 		assert_ok!(Referenda::submit(
 			Origin::signed(1),
-			RawOrigin::Root.into(),
+			Box::new(RawOrigin::Root.into()),
 			set_balance_proposal_hash(1),
 			DispatchTime::At(20),
 		));
@@ -291,13 +291,13 @@ fn tracks_are_distinguished() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Referenda::submit(
 			Origin::signed(1),
-			RawOrigin::Root.into(),
+			Box::new(RawOrigin::Root.into()),
 			set_balance_proposal_hash(1),
 			DispatchTime::At(10),
 		));
 		assert_ok!(Referenda::submit(
 			Origin::signed(2),
-			RawOrigin::None.into(),
+			Box::new(RawOrigin::None.into()),
 			set_balance_proposal_hash(2),
 			DispatchTime::At(20),
 		));
@@ -355,7 +355,7 @@ fn submit_errors_work() {
 		assert_noop!(
 			Referenda::submit(
 				Origin::signed(1),
-				RawOrigin::Signed(2).into(),
+				Box::new(RawOrigin::Signed(2).into()),
 				h,
 				DispatchTime::At(10),
 			),
@@ -364,7 +364,7 @@ fn submit_errors_work() {
 
 		// No funds for deposit
 		assert_noop!(
-			Referenda::submit(Origin::signed(10), RawOrigin::Root.into(), h, DispatchTime::At(10),),
+			Referenda::submit(Origin::signed(10), Box::new(RawOrigin::Root.into()), h, DispatchTime::At(10),),
 			BalancesError::<Test>::InsufficientBalance
 		);
 	});
@@ -379,7 +379,7 @@ fn decision_deposit_errors_work() {
 		let h = set_balance_proposal_hash(1);
 		assert_ok!(Referenda::submit(
 			Origin::signed(1),
-			RawOrigin::Root.into(),
+			Box::new(RawOrigin::Root.into()),
 			h,
 			DispatchTime::At(10),
 		));
@@ -401,7 +401,7 @@ fn refund_deposit_works() {
 		let h = set_balance_proposal_hash(1);
 		assert_ok!(Referenda::submit(
 			Origin::signed(1),
-			RawOrigin::Root.into(),
+			Box::new(RawOrigin::Root.into()),
 			h,
 			DispatchTime::At(10),
 		));
@@ -423,7 +423,7 @@ fn cancel_works() {
 		let h = set_balance_proposal_hash(1);
 		assert_ok!(Referenda::submit(
 			Origin::signed(1),
-			RawOrigin::Root.into(),
+			Box::new(RawOrigin::Root.into()),
 			h,
 			DispatchTime::At(10),
 		));
@@ -442,7 +442,7 @@ fn cancel_errors_works() {
 		let h = set_balance_proposal_hash(1);
 		assert_ok!(Referenda::submit(
 			Origin::signed(1),
-			RawOrigin::Root.into(),
+			Box::new(RawOrigin::Root.into()),
 			h,
 			DispatchTime::At(10),
 		));
@@ -460,7 +460,7 @@ fn kill_works() {
 		let h = set_balance_proposal_hash(1);
 		assert_ok!(Referenda::submit(
 			Origin::signed(1),
-			RawOrigin::Root.into(),
+			Box::new(RawOrigin::Root.into()),
 			h,
 			DispatchTime::At(10),
 		));
@@ -480,7 +480,7 @@ fn kill_errors_works() {
 		let h = set_balance_proposal_hash(1);
 		assert_ok!(Referenda::submit(
 			Origin::signed(1),
-			RawOrigin::Root.into(),
+			Box::new(RawOrigin::Root.into()),
 			h,
 			DispatchTime::At(10),
 		));

--- a/frame/support/procedural/src/construct_runtime/expand/call.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/call.rs
@@ -65,7 +65,7 @@ pub fn expand_outer_dispatch(
 		#[cfg(test)]
 		impl Call {
 			/// Return a list of the module names together with their size in memory.
-			pub fn sizes() -> &'static [( &'static str, usize )] {
+			pub const fn sizes() -> &'static [( &'static str, usize )] {
 				use #scrate::dispatch::Callable;
 				use core::mem::size_of;
 				&[#(
@@ -76,7 +76,8 @@ pub fn expand_outer_dispatch(
 				)*]
 			}
 
-			pub fn check_size(limit: usize) {
+			/// Panics with diagnostic information if the size is greater than the given `limit`.
+			pub fn assert_size_under(limit: usize) {
 				let size = core::mem::size_of::<Self>();
 				let call_oversize = size > limit;
 				if call_oversize {

--- a/frame/support/procedural/src/construct_runtime/expand/call.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/call.rs
@@ -43,9 +43,6 @@ pub fn expand_outer_dispatch(
 		variant_defs.extend(
 			quote!(#[codec(index = #index)] #name( #scrate::dispatch::CallableCallFor<#name, #runtime> ),),
 		);
-/*		variant_types.extend(
-			quote!( #scrate::dispatch::CallableCallFor::<#name, #runtime> ),
-		);*/
 		variant_patterns.push(quote!(Call::#name(call)));
 		pallet_names.push(name);
 		query_call_part_macros.push(quote! {

--- a/frame/support/procedural/src/construct_runtime/expand/call.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/call.rs
@@ -27,7 +27,6 @@ pub fn expand_outer_dispatch(
 	scrate: &TokenStream,
 ) -> TokenStream {
 	let mut variant_defs = TokenStream::new();
-//	let mut variant_types = TokenStream::new();
 	let mut variant_patterns = Vec::new();
 	let mut query_call_part_macros = Vec::new();
 	let mut pallet_names = Vec::new();

--- a/frame/support/procedural/src/construct_runtime/expand/call.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/call.rs
@@ -27,6 +27,7 @@ pub fn expand_outer_dispatch(
 	scrate: &TokenStream,
 ) -> TokenStream {
 	let mut variant_defs = TokenStream::new();
+//	let mut variant_types = TokenStream::new();
 	let mut variant_patterns = Vec::new();
 	let mut query_call_part_macros = Vec::new();
 	let mut pallet_names = Vec::new();
@@ -42,6 +43,9 @@ pub fn expand_outer_dispatch(
 		variant_defs.extend(
 			quote!(#[codec(index = #index)] #name( #scrate::dispatch::CallableCallFor<#name, #runtime> ),),
 		);
+/*		variant_types.extend(
+			quote!( #scrate::dispatch::CallableCallFor::<#name, #runtime> ),
+		);*/
 		variant_patterns.push(quote!(Call::#name(call)));
 		pallet_names.push(name);
 		query_call_part_macros.push(quote! {
@@ -61,6 +65,41 @@ pub fn expand_outer_dispatch(
 		)]
 		pub enum Call {
 			#variant_defs
+		}
+		#[cfg(test)]
+		impl Call {
+			/// Return a list of the module names together with their size in memory.
+			pub fn sizes() -> &'static [( &'static str, usize )] {
+				use #scrate::dispatch::Callable;
+				use core::mem::size_of;
+				&[#(
+					(
+						stringify!(#pallet_names),
+						size_of::< <#pallet_names as Callable<#runtime>>::Call >(),
+					),
+				)*]
+			}
+
+			pub fn check_size(limit: usize) {
+				let size = core::mem::size_of::<Self>();
+				let call_oversize = size > limit;
+				if call_oversize {
+					println!("Size of `Call` is {} bytes (provided limit is {} bytes)", size, limit);
+					let mut sizes = Self::sizes().to_vec();
+					sizes.sort_by_key(|x| -(x.1 as isize));
+					for (i, &(name, size)) in sizes.iter().enumerate().take(5) {
+						println!("Offender #{}: {} at {} bytes", i + 1, name, size);
+					}
+					if let Some((_, next_size)) = sizes.get(5) {
+						println!("{} others of size {} bytes or less", sizes.len() - 5, next_size);
+					}
+					panic!(
+						"Size of `Call` is more than limit; use `Box` on complex parameter types to reduce the
+						size of `Call`.
+						If the limit is too strong, maybe consider providing a higher limit."
+					);
+				}
+			}
 		}
 		impl #scrate::dispatch::GetDispatchInfo for Call {
 			fn get_dispatch_info(&self) -> #scrate::dispatch::DispatchInfo {


### PR DESCRIPTION
Also add a couple of helper functions for discovering which pallet is bloating the call size.