### PR TITLE
MaxEncodedLen on collective

### DIFF
--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -42,14 +42,13 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![recursion_limit = "128"]
 
-use codec::MaxEncodedLen;
 use scale_info::TypeInfo;
 use sp_io::storage;
 use sp_runtime::{traits::Hash, RuntimeDebug};
 use sp_std::{marker::PhantomData, prelude::*, result};
 
 use frame_support::{
-	codec::{Decode, Encode},
+	codec::{Decode, Encode, MaxEncodedLen},
 	dispatch::{DispatchError, DispatchResultWithPostInfo, Dispatchable, PostDispatchInfo},
 	ensure,
 	traits::{Backing, ChangeMembers, EnsureOrigin, Get, GetBacking, InitializeMembers},
@@ -981,7 +980,9 @@ impl<T: Config<I>, I: 'static> InitializeMembers<T::AccountId> for Pallet<T, I> 
 		// TODO: (dp) this looks odd – check if empty and then assert on the same predicate again?
 		if !members.is_empty() {
 			assert!(<Members<T, I>>::get().is_empty(), "Members are already initialized!");
-			<Members<T, I>>::put(BoundedSlice::try_from(members).expect("TODO: (dp) – truncate to MaxMembers?"));
+			<Members<T, I>>::put(
+				BoundedSlice::try_from(members).expect("TODO: (dp) – truncate to MaxMembers?"),
+			);
 		}
 	}
 }

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -962,7 +962,7 @@ impl<T: Config<I>, I: 'static> ChangeMembers<T::AccountId> for Pallet<T, I> {
 		}
 		Members::<T, I>::put(
 			BoundedSlice::try_from(new)
-				.expect("TODO – should we truncate the `new` slice to MaxMembers here?"),
+				.expect("TODO: (dp) – should we truncate the `new` slice to MaxMembers here?"),
 		);
 		Prime::<T, I>::kill();
 	}

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -556,8 +556,8 @@ pub mod pallet {
 					Votes {
 						index,
 						threshold,
-						ayes: vec![].try_into().expect("MaxMembers should not be set to zero"),
-						nays: vec![].try_into().expect("MaxMembers should not be set to zero"),
+						ayes: Default::default(),
+						nays: Default::default(),
 						end,
 					}
 				};
@@ -948,14 +948,14 @@ impl<T: Config<I>, I: 'static> ChangeMembers<T::AccountId> for Pallet<T, I> {
 						.filter(|i| outgoing.binary_search(i).is_err())
 						.collect::<Vec<T::AccountId>>()
 						.try_into()
-						.expect("Ayes does not exceed max members; qed");
+						.expect("Ayes do not exceed max members; qed");
 					votes.nays = votes
 						.nays
 						.into_iter()
 						.filter(|i| outgoing.binary_search(i).is_err())
 						.collect::<Vec<T::AccountId>>()
 						.try_into()
-						.expect("Nays does not exceed max members; qed");
+						.expect("Nays do not exceed max members; qed");
 					*v = Some(votes);
 				}
 			});

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -981,7 +981,7 @@ impl<T: Config<I>, I: 'static> InitializeMembers<T::AccountId> for Pallet<T, I> 
 		// TODO: (dp) this looks odd – check if empty and then assert on the same predicate again?
 		if !members.is_empty() {
 			assert!(<Members<T, I>>::get().is_empty(), "Members are already initialized!");
-			<Members<T, I>>::put(BoundedSlice::try_from(members).expect("TODO"));
+			<Members<T, I>>::put(BoundedSlice::try_from(members).expect("TODO: (dp) – truncate to MaxMembers?"));
 		}
 	}
 }

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -191,6 +191,7 @@ pub mod pallet {
 		type MotionDuration: Get<Self::BlockNumber>;
 
 		/// Maximum number of proposals allowed to be active in parallel.
+		#[pallet::constant]
 		type MaxProposals: Get<ProposalIndex>;
 
 		/// The maximum number of members supported by the pallet. Used for weight estimation.
@@ -198,6 +199,7 @@ pub mod pallet {
 		/// NOTE:
 		/// + Benchmarks will need to be re-run and weights adjusted if this changes.
 		/// + This pallet assumes that dependents keep to the limit without enforcing it.
+		#[pallet::constant]
 		type MaxMembers: Get<MemberCount>;
 
 		/// Default vote strategy of this collective.


### PR DESCRIPTION
Part of  #8629 

Removes `#[pallet::without_storage_info]` on `pallet-collective` and (tries to) handle fall-out.
