### PR TITLE
Expose ValidatedTransaction from transaction pool

### DIFF
--- a/client/transaction-pool/src/lib.rs
+++ b/client/transaction-pool/src/lib.rs
@@ -36,7 +36,9 @@ use futures::{
 	future::{self, ready},
 	prelude::*,
 };
-pub use graph::{base_pool::Limit as PoolLimit, ChainApi, Options, Pool, Transaction};
+pub use graph::{
+	base_pool::Limit as PoolLimit, ChainApi, Options, Pool, Transaction, ValidatedTransaction,
+};
 use parking_lot::Mutex;
 use std::{
 	collections::{HashMap, HashSet},
@@ -407,7 +409,6 @@ where
 		at: &BlockId<Self::Block>,
 		xt: sc_transaction_pool_api::LocalTransactionFor<Self>,
 	) -> Result<Self::Hash, Self::Error> {
-		use graph::ValidatedTransaction;
 		use sp_runtime::{
 			traits::SaturatedConversion, transaction_validity::TransactionValidityError,
 		};


### PR DESCRIPTION
This is required to make a tx pool wrapper for some custom transaction validation, specifically
required to make a wrapper around the `LocalTransactionPool` implementation (https://github.com/subspace/subspace/blob/f54881a9b5/crates/subspace-service/src/pool.rs#L232-L269).

There probably is some other nicer way to make a tx pool wrapper but this can be the quickest one with minimal changes to make it possible.

Related: https://github.com/paritytech/substrate/discussions/11520
