### PR TITLE
Remove `#[pallet::without_storage_info]` for pallet-remark

### DIFF
--- a/frame/remark/src/lib.rs
+++ b/frame/remark/src/lib.rs
@@ -57,7 +57,6 @@ pub mod pallet {
 	}
 
 	#[pallet::pallet]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 
 	#[pallet::call]


### PR DESCRIPTION
Part of #8629.