### PR TITLE
Fix one-by-off in `BoundedSlice::try_from`

### DIFF
--- a/frame/support/src/storage/bounded_vec.rs
+++ b/frame/support/src/storage/bounded_vec.rs
@@ -135,7 +135,7 @@ impl<T: Ord, Bound: Get<u32>> Ord for BoundedVec<T, Bound> {
 impl<'a, T, S: Get<u32>> TryFrom<&'a [T]> for BoundedSlice<'a, T, S> {
 	type Error = ();
 	fn try_from(t: &'a [T]) -> Result<Self, Self::Error> {
-		if t.len() < S::get() as usize {
+		if t.len() <= S::get() as usize {
 			Ok(BoundedSlice(t, PhantomData))
 		} else {
 			Err(())
@@ -1006,5 +1006,19 @@ pub mod test {
 			Err(msg) => assert_eq!(msg.to_string(), "out of bounds at line 1 column 11"),
 			_ => unreachable!("deserializer must raise error"),
 		}
+	}
+
+	#[test]
+	fn bounded_vec_try_from_works() {
+		assert!(BoundedVec::<u32, ConstU32<2>>::try_from(vec![0]).is_ok());
+		assert!(BoundedVec::<u32, ConstU32<2>>::try_from(vec![0, 1]).is_ok());
+		assert!(BoundedVec::<u32, ConstU32<2>>::try_from(vec![0, 1, 2]).is_err());
+	}
+
+	#[test]
+	fn bounded_slice_try_from_works() {
+		assert!(BoundedSlice::<u32, ConstU32<2>>::try_from(&[0][..]).is_ok());
+		assert!(BoundedSlice::<u32, ConstU32<2>>::try_from(&[0, 1][..]).is_ok());
+		assert!(BoundedSlice::<u32, ConstU32<2>>::try_from(&[0, 1, 2][..]).is_err());
 	}
 }


### PR DESCRIPTION
I was wondering why `BoundedSlice::try_from` was failing even though the number of items I was passing to it was exactly the maximum length, and it seems like there's an off-by-one bug here where it actually enforces `max - 1` instead of `max`. (The `Vec::try_from` works as expected, as illustrated by the test I've added.)