### PR TITLE
Fix Lifetime Warnings

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -510,7 +510,7 @@ impl pallet_session::historical::Config for Runtime {
 }
 
 pallet_staking_reward_curve::build! {
-	const REWARD_CURVE: PiecewiseLinear<'static> = curve!(
+	const REWARD_CURVE: PiecewiseLinear = curve!(
 		min_inflation: 0_025_000,
 		max_inflation: 0_100_000,
 		ideal_stake: 0_500_000,
@@ -524,7 +524,7 @@ parameter_types! {
 	pub const SessionsPerEra: sp_staking::SessionIndex = 6;
 	pub const BondingDuration: sp_staking::EraIndex = 24 * 28;
 	pub const SlashDeferDuration: sp_staking::EraIndex = 24 * 7; // 1/4 the bonding duration.
-	pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
+	pub const RewardCurve: &'static PiecewiseLinear = &REWARD_CURVE;
 	pub const MaxNominatorRewardedPerValidator: u32 = 256;
 	pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
 	pub OffchainRepeat: BlockNumber = 5;

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -154,7 +154,7 @@ impl pallet_balances::Config for Test {
 }
 
 pallet_staking_reward_curve::build! {
-	const REWARD_CURVE: PiecewiseLinear<'static> = curve!(
+	const REWARD_CURVE: PiecewiseLinear = curve!(
 		min_inflation: 0_025_000u64,
 		max_inflation: 0_100_000,
 		ideal_stake: 0_500_000,
@@ -168,7 +168,7 @@ parameter_types! {
 	pub const SessionsPerEra: SessionIndex = 3;
 	pub const BondingDuration: EraIndex = 3;
 	pub const SlashDeferDuration: EraIndex = 0;
-	pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
+	pub const RewardCurve: &'static PiecewiseLinear = &REWARD_CURVE;
 	pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(16);
 }
 

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -159,7 +159,7 @@ impl pallet_timestamp::Config for Test {
 }
 
 pallet_staking_reward_curve::build! {
-	const REWARD_CURVE: PiecewiseLinear<'static> = curve!(
+	const REWARD_CURVE: PiecewiseLinear = curve!(
 		min_inflation: 0_025_000u64,
 		max_inflation: 0_100_000,
 		ideal_stake: 0_500_000,
@@ -172,7 +172,7 @@ pallet_staking_reward_curve::build! {
 parameter_types! {
 	pub const SessionsPerEra: SessionIndex = 3;
 	pub const BondingDuration: EraIndex = 3;
-	pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
+	pub const RewardCurve: &'static PiecewiseLinear = &REWARD_CURVE;
 	pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
 }
 

--- a/frame/nomination-pools/benchmarking/src/mock.rs
+++ b/frame/nomination-pools/benchmarking/src/mock.rs
@@ -74,7 +74,7 @@ impl pallet_balances::Config for Runtime {
 }
 
 pallet_staking_reward_curve::build! {
-	const I_NPOS: sp_runtime::curve::PiecewiseLinear<'static> = curve!(
+	const I_NPOS: sp_runtime::curve::PiecewiseLinear = curve!(
 		min_inflation: 0_025_000,
 		max_inflation: 0_100_000,
 		ideal_stake: 0_500_000,
@@ -84,7 +84,7 @@ pallet_staking_reward_curve::build! {
 	);
 }
 parameter_types! {
-	pub const RewardCurve: &'static sp_runtime::curve::PiecewiseLinear<'static> = &I_NPOS;
+	pub const RewardCurve: &'static sp_runtime::curve::PiecewiseLinear = &I_NPOS;
 }
 impl pallet_staking::Config for Runtime {
 	type MaxNominations = ConstU32<16>;

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -133,7 +133,7 @@ impl pallet_session::Config for Test {
 }
 
 pallet_staking_reward_curve::build! {
-	const I_NPOS: sp_runtime::curve::PiecewiseLinear<'static> = curve!(
+	const I_NPOS: sp_runtime::curve::PiecewiseLinear = curve!(
 		min_inflation: 0_025_000,
 		max_inflation: 0_100_000,
 		ideal_stake: 0_500_000,
@@ -143,7 +143,7 @@ pallet_staking_reward_curve::build! {
 	);
 }
 parameter_types! {
-	pub const RewardCurve: &'static sp_runtime::curve::PiecewiseLinear<'static> = &I_NPOS;
+	pub const RewardCurve: &'static sp_runtime::curve::PiecewiseLinear = &I_NPOS;
 }
 
 pub type Extrinsic = sp_runtime::testing::TestXt<Call, ()>;

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -131,7 +131,7 @@ impl pallet_session::Config for Test {
 	type WeightInfo = ();
 }
 pallet_staking_reward_curve::build! {
-	const I_NPOS: sp_runtime::curve::PiecewiseLinear<'static> = curve!(
+	const I_NPOS: sp_runtime::curve::PiecewiseLinear = curve!(
 		min_inflation: 0_025_000,
 		max_inflation: 0_100_000,
 		ideal_stake: 0_500_000,
@@ -141,7 +141,7 @@ pallet_staking_reward_curve::build! {
 	);
 }
 parameter_types! {
-	pub const RewardCurve: &'static sp_runtime::curve::PiecewiseLinear<'static> = &I_NPOS;
+	pub const RewardCurve: &'static sp_runtime::curve::PiecewiseLinear = &I_NPOS;
 }
 
 pub type Extrinsic = sp_runtime::testing::TestXt<Call, ()>;

--- a/frame/staking/reward-curve/src/lib.rs
+++ b/frame/staking/reward-curve/src/lib.rs
@@ -60,7 +60,7 @@ use syn::parse::{Parse, ParseStream};
 /// use sp_runtime::curve::PiecewiseLinear;
 ///
 /// pallet_staking_reward_curve::build! {
-///     const I_NPOS: PiecewiseLinear<'static> = curve!(
+///     const I_NPOS: PiecewiseLinear = curve!(
 ///         min_inflation: 0_025_000,
 ///         max_inflation: 0_100_000,
 ///         ideal_stake: 0_500_000,

--- a/frame/staking/reward-curve/src/lib.rs
+++ b/frame/staking/reward-curve/src/lib.rs
@@ -371,7 +371,7 @@ fn generate_piecewise_linear(points: Vec<(u32, u32)>) -> TokenStream2 {
 	}
 
 	quote!(
-		_sp_runtime::curve::PiecewiseLinear::<'static> {
+		_sp_runtime::curve::PiecewiseLinear {
 			points: & [ #points_tokens ],
 			maximum: _sp_runtime::Perbill::from_parts(#max),
 		}

--- a/frame/staking/reward-curve/tests/test.rs
+++ b/frame/staking/reward-curve/tests/test.rs
@@ -20,7 +20,7 @@
 
 mod test_small_falloff {
 	pallet_staking_reward_curve::build! {
-		const REWARD_CURVE: sp_runtime::curve::PiecewiseLinear<'static> = curve!(
+		const REWARD_CURVE: sp_runtime::curve::PiecewiseLinear = curve!(
 			min_inflation: 0_020_000,
 			max_inflation: 0_200_000,
 			ideal_stake: 0_600_000,
@@ -33,7 +33,7 @@ mod test_small_falloff {
 
 mod test_big_falloff {
 	pallet_staking_reward_curve::build! {
-		const REWARD_CURVE: sp_runtime::curve::PiecewiseLinear<'static> = curve!(
+		const REWARD_CURVE: sp_runtime::curve::PiecewiseLinear = curve!(
 			min_inflation: 0_100_000,
 			max_inflation: 0_400_000,
 			ideal_stake: 0_400_000,

--- a/frame/staking/src/inflation.rs
+++ b/frame/staking/src/inflation.rs
@@ -30,7 +30,7 @@ use sp_runtime::{curve::PiecewiseLinear, traits::AtLeast32BitUnsigned, Perbill};
 ///
 /// `era_duration` is expressed in millisecond.
 pub fn compute_total_payout<N>(
-	yearly_inflation: &PiecewiseLinear<'static>,
+	yearly_inflation: &PiecewiseLinear,
 	npos_token_staked: N,
 	total_tokens: N,
 	era_duration: u64,
@@ -54,7 +54,7 @@ mod test {
 	use sp_runtime::curve::PiecewiseLinear;
 
 	pallet_staking_reward_curve::build! {
-		const I_NPOS: PiecewiseLinear<'static> = curve!(
+		const I_NPOS: PiecewiseLinear = curve!(
 			min_inflation: 0_025_000,
 			max_inflation: 0_100_000,
 			ideal_stake: 0_500_000,

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -778,8 +778,8 @@ impl<Balance: Default> EraPayout<Balance> for () {
 /// Adaptor to turn a `PiecewiseLinear` curve definition into an `EraPayout` impl, used for
 /// backwards compatibility.
 pub struct ConvertCurve<T>(sp_std::marker::PhantomData<T>);
-impl<Balance: AtLeast32BitUnsigned + Clone, T: Get<&'static PiecewiseLinear>>
-	EraPayout<Balance> for ConvertCurve<T>
+impl<Balance: AtLeast32BitUnsigned + Clone, T: Get<&'static PiecewiseLinear>> EraPayout<Balance>
+	for ConvertCurve<T>
 {
 	fn era_payout(
 		total_staked: Balance,

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -778,7 +778,7 @@ impl<Balance: Default> EraPayout<Balance> for () {
 /// Adaptor to turn a `PiecewiseLinear` curve definition into an `EraPayout` impl, used for
 /// backwards compatibility.
 pub struct ConvertCurve<T>(sp_std::marker::PhantomData<T>);
-impl<Balance: AtLeast32BitUnsigned + Clone, T: Get<&'static PiecewiseLinear<'static>>>
+impl<Balance: AtLeast32BitUnsigned + Clone, T: Get<&'static PiecewiseLinear>>
 	EraPayout<Balance> for ConvertCurve<T>
 {
 	fn era_payout(

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -201,7 +201,7 @@ impl pallet_timestamp::Config for Test {
 }
 
 pallet_staking_reward_curve::build! {
-	const I_NPOS: PiecewiseLinear<'static> = curve!(
+	const I_NPOS: PiecewiseLinear = curve!(
 		min_inflation: 0_025_000,
 		max_inflation: 0_100_000,
 		ideal_stake: 0_500_000,
@@ -212,7 +212,7 @@ pallet_staking_reward_curve::build! {
 }
 parameter_types! {
 	pub const BondingDuration: EraIndex = 3;
-	pub const RewardCurve: &'static PiecewiseLinear<'static> = &I_NPOS;
+	pub const RewardCurve: &'static PiecewiseLinear = &I_NPOS;
 	pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(75);
 }
 

--- a/frame/support/src/storage/bounded_vec.rs
+++ b/frame/support/src/storage/bounded_vec.rs
@@ -109,13 +109,16 @@ where
 /// Similar to a `BoundedVec`, but not owned and cannot be decoded.
 #[derive(Encode, scale_info::TypeInfo)]
 #[scale_info(skip_type_params(S))]
-pub struct BoundedSlice<T: 'static, S>(&'static [T], PhantomData<S>);
+pub struct BoundedSlice<'a, T, S>(&'a [T], PhantomData<S>);
 
 // `BoundedSlice`s encode to something which will always decode into a `BoundedVec`,
 // `WeakBoundedVec`, or a `Vec`.
-impl<T: Encode + Decode, S: Get<u32>> EncodeLike<BoundedVec<T, S>> for BoundedSlice<T, S> {}
-impl<T: Encode + Decode, S: Get<u32>> EncodeLike<WeakBoundedVec<T, S>> for BoundedSlice<T, S> {}
-impl<T: Encode + Decode, S: Get<u32>> EncodeLike<Vec<T>> for BoundedSlice<T, S> {}
+impl<'a, T: Encode + Decode, S: Get<u32>> EncodeLike<BoundedVec<T, S>> for BoundedSlice<'a, T, S> {}
+impl<'a, T: Encode + Decode, S: Get<u32>> EncodeLike<WeakBoundedVec<T, S>>
+	for BoundedSlice<'a, T, S>
+{
+}
+impl<'a, T: Encode + Decode, S: Get<u32>> EncodeLike<Vec<T>> for BoundedSlice<'a, T, S> {}
 
 impl<T: PartialOrd, Bound: Get<u32>> PartialOrd for BoundedVec<T, Bound> {
 	fn partial_cmp(&self, other: &Self) -> Option<sp_std::cmp::Ordering> {
@@ -129,9 +132,9 @@ impl<T: Ord, Bound: Get<u32>> Ord for BoundedVec<T, Bound> {
 	}
 }
 
-impl<T: 'static, S: Get<u32>> TryFrom<&'static [T]> for BoundedSlice<T, S> {
+impl<'a, T, S: Get<u32>> TryFrom<&'a [T]> for BoundedSlice<'a, T, S> {
 	type Error = ();
-	fn try_from(t: &'static [T]) -> Result<Self, Self::Error> {
+	fn try_from(t: &'a [T]) -> Result<Self, Self::Error> {
 		if t.len() <= S::get() as usize {
 			Ok(BoundedSlice(t, PhantomData))
 		} else {
@@ -140,8 +143,8 @@ impl<T: 'static, S: Get<u32>> TryFrom<&'static [T]> for BoundedSlice<T, S> {
 	}
 }
 
-impl<T: 'static, S> From<BoundedSlice<T, S>> for &'static [T] {
-	fn from(t: BoundedSlice<T, S>) -> Self {
+impl<'a, T, S> From<BoundedSlice<'a, T, S>> for &'a [T] {
+	fn from(t: BoundedSlice<'a, T, S>) -> Self {
 		t.0
 	}
 }

--- a/frame/support/src/storage/bounded_vec.rs
+++ b/frame/support/src/storage/bounded_vec.rs
@@ -109,16 +109,13 @@ where
 /// Similar to a `BoundedVec`, but not owned and cannot be decoded.
 #[derive(Encode, scale_info::TypeInfo)]
 #[scale_info(skip_type_params(S))]
-pub struct BoundedSlice<'a, T, S>(&'a [T], PhantomData<S>);
+pub struct BoundedSlice<T: 'static, S>(&'static [T], PhantomData<S>);
 
 // `BoundedSlice`s encode to something which will always decode into a `BoundedVec`,
 // `WeakBoundedVec`, or a `Vec`.
-impl<'a, T: Encode + Decode, S: Get<u32>> EncodeLike<BoundedVec<T, S>> for BoundedSlice<'a, T, S> {}
-impl<'a, T: Encode + Decode, S: Get<u32>> EncodeLike<WeakBoundedVec<T, S>>
-	for BoundedSlice<'a, T, S>
-{
-}
-impl<'a, T: Encode + Decode, S: Get<u32>> EncodeLike<Vec<T>> for BoundedSlice<'a, T, S> {}
+impl<T: Encode + Decode, S: Get<u32>> EncodeLike<BoundedVec<T, S>> for BoundedSlice<T, S> {}
+impl<T: Encode + Decode, S: Get<u32>> EncodeLike<WeakBoundedVec<T, S>> for BoundedSlice<T, S> {}
+impl<T: Encode + Decode, S: Get<u32>> EncodeLike<Vec<T>> for BoundedSlice<T, S> {}
 
 impl<T: PartialOrd, Bound: Get<u32>> PartialOrd for BoundedVec<T, Bound> {
 	fn partial_cmp(&self, other: &Self) -> Option<sp_std::cmp::Ordering> {
@@ -132,9 +129,9 @@ impl<T: Ord, Bound: Get<u32>> Ord for BoundedVec<T, Bound> {
 	}
 }
 
-impl<'a, T, S: Get<u32>> TryFrom<&'a [T]> for BoundedSlice<'a, T, S> {
+impl<T: 'static, S: Get<u32>> TryFrom<&'static [T]> for BoundedSlice<T, S> {
 	type Error = ();
-	fn try_from(t: &'a [T]) -> Result<Self, Self::Error> {
+	fn try_from(t: &'static [T]) -> Result<Self, Self::Error> {
 		if t.len() < S::get() as usize {
 			Ok(BoundedSlice(t, PhantomData))
 		} else {
@@ -143,8 +140,8 @@ impl<'a, T, S: Get<u32>> TryFrom<&'a [T]> for BoundedSlice<'a, T, S> {
 	}
 }
 
-impl<'a, T, S> From<BoundedSlice<'a, T, S>> for &'a [T] {
-	fn from(t: BoundedSlice<'a, T, S>) -> Self {
+impl<T: 'static, S> From<BoundedSlice<T, S>> for &'static [T] {
+	fn from(t: BoundedSlice<T, S>) -> Self {
 		t.0
 	}
 }

--- a/primitives/runtime/src/curve.rs
+++ b/primitives/runtime/src/curve.rs
@@ -25,9 +25,9 @@ use core::ops::Sub;
 
 /// Piecewise Linear function in [0, 1] -> [0, 1].
 #[derive(PartialEq, Eq, sp_core::RuntimeDebug, scale_info::TypeInfo)]
-pub struct PiecewiseLinear<'a> {
+pub struct PiecewiseLinear {
 	/// Array of points. Must be in order from the lowest abscissas to the highest.
-	pub points: &'a [(Perbill, Perbill)],
+	pub points: &'static [(Perbill, Perbill)],
 	/// The maximum value that can be returned.
 	pub maximum: Perbill,
 }
@@ -36,7 +36,7 @@ fn abs_sub<N: Ord + Sub<Output = N> + Clone>(a: N, b: N) -> N where {
 	a.clone().max(b.clone()) - a.min(b)
 }
 
-impl<'a> PiecewiseLinear<'a> {
+impl PiecewiseLinear {
 	/// Compute `f(n/d)*d` with `n <= d`. This is useful to avoid loss of precision.
 	pub fn calculate_for_fraction_times_denominator<N>(&self, n: N, d: N) -> N
 	where


### PR DESCRIPTION
Fix these warnings:

```
warning: unnecessary lifetime parameter `'a`
  --> primitives/runtime/src/curve.rs:28:28
   |
28 | pub struct PiecewiseLinear<'a> {
   |                            ^^
   |
   = help: you can use the `'static` lifetime directly, in place of `'a`

warning: `sp-runtime` (lib) generated 1 warning
   Compiling frame-support v4.0.0-dev (/Users/shawntabrizi/Documents/GitHub/substrate2/frame/support)
warning: unnecessary lifetime parameter `'a`
   --> frame/support/src/storage/bounded_vec.rs:112:25
    |
112 | pub struct BoundedSlice<'a, T, S>(&'a [T], PhantomData<S>);
    |                         ^^
    |
    = help: you can use the `'static` lifetime directly, in place of `'a`

   Compiling frame-system v4.0.0-dev (/Users/shawntabrizi/Documents/GitHub/substrate2/frame/system)
warning: `frame-support` (lib) generated 1 warning
```

The second warning about `BoundedVec` seems we should ignore.

Needs: https://github.com/rust-lang/rust/issues/96956