### PR TITLE
Update wasm-instrument 0.1.1

### DIFF
--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 environmental = "1.1.3"
 thiserror = "1.0.30"
-wasm-instrument = "0.1"
+wasm-instrument = "0.1.1"
 wasmer = { version = "2.2", features = ["singlepass"], optional = true }
 wasmi = "0.9.1"
 sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }


### PR DESCRIPTION
Closes: #11608 

update `wasm-instrument = 0.1.1`

https://github.com/paritytech/wasm-instrument/blob/d1648be2745cabbb4bf7edf1ca0b59125433384e/Cargo.toml#L24
The `parity-wasm` in `0.1.2` is `0.45.0`, which will break the compilation.
