### PR TITLE
Fix compilation after wasm-instrument patch release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6544,6 +6544,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 
 [[package]]
+name = "parity-wasm"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11464,11 +11470,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-instrument"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962e5b0401bbb6c887f54e69b8c496ea36f704df65db73e81fd5ff8dc3e63a9f"
+checksum = "a5728bf206e1c487a57128a102cb632cfee04a778b735a90de876fd63e7b3add"
 dependencies = [
- "parity-wasm 0.42.2",
+ "parity-wasm 0.45.0",
 ]
 
 [[package]]

--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 environmental = "1.1.3"
 thiserror = "1.0.30"
-wasm-instrument = "0.1"
+wasm-instrument = "0.1.2"
 wasmer = { version = "2.2", features = ["singlepass"], optional = true }
 wasmi = "0.9.1"
 sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }

--- a/client/executor/wasmi/src/lib.rs
+++ b/client/executor/wasmi/src/lib.rs
@@ -673,7 +673,7 @@ pub struct WasmiRuntime {
 	/// Enable stub generation for functions that are not available in `host_functions`.
 	/// These stubs will error when the wasm blob tries to call them.
 	allow_missing_func_imports: bool,
-	/// Numer of heap pages this runtime uses.
+	/// Number of heap pages this runtime uses.
 	heap_pages: u64,
 
 	global_vals_snapshot: GlobalValsSnapshot,
@@ -714,8 +714,10 @@ pub fn create_runtime(
 	let data_segments_snapshot =
 		DataSegmentsSnapshot::take(&blob).map_err(|e| WasmError::Other(e.to_string()))?;
 
-	let module =
-		Module::from_parity_wasm_module(blob.into_inner()).map_err(|_| WasmError::InvalidModule)?;
+	let module = Module::from_buffer(
+		blob.into_inner().into_bytes().map_err(|e| WasmError::Other(e.to_string()))?,
+	)
+	.map_err(|_| WasmError::InvalidModule)?;
 
 	let global_vals_snapshot = {
 		let (instance, _, _) = instantiate_module(

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 ] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 log = { version = "0.4", default-features = false }
-wasm-instrument = { version = "0.1", default-features = false }
+wasm-instrument = { version = "0.1.2", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 smallvec = { version = "1", default-features = false, features = [
 	"const_generics",

--- a/frame/contracts/src/benchmarking/code.rs
+++ b/frame/contracts/src/benchmarking/code.rs
@@ -254,7 +254,7 @@ where
 			code = inject_stack_metering::<T>(code);
 		}
 
-		let code = code.to_bytes().unwrap();
+		let code = code.into_bytes().unwrap();
 		let hash = T::Hashing::hash(&code);
 		Self { code, hash, memory: def.memory }
 	}
@@ -285,7 +285,7 @@ where
 			.find_map(|e| if let External::Memory(mem) = e.external() { Some(mem) } else { None })
 			.unwrap()
 			.limits();
-		let code = module.to_bytes().unwrap();
+		let code = module.into_bytes().unwrap();
 		let hash = T::Hashing::hash(&code);
 		let memory =
 			ImportedMemory { min_pages: limits.initial(), max_pages: limits.maximum().unwrap() };


### PR DESCRIPTION
Downstream users can fix this easily by pinning the `0.1.1` release of `wasm-instrument` until they
get this patch.

Closes: https://github.com/paritytech/substrate/issues/11608
Closes: https://github.com/paritytech/substrate/issues/11612
