### PR TITLE
Implement more IntoIter traits for bounded types

### DIFF
--- a/frame/support/src/storage/bounded_btree_map.rs
+++ b/frame/support/src/storage/bounded_btree_map.rs
@@ -252,6 +252,24 @@ impl<K, V, S> IntoIterator for BoundedBTreeMap<K, V, S> {
 	}
 }
 
+impl<'a, K, V, S> IntoIterator for &'a BoundedBTreeMap<K, V, S> {
+	type Item = (&'a K, &'a V);
+	type IntoIter = sp_std::collections::btree_map::Iter<'a, K, V>;
+
+	fn into_iter(self) -> Self::IntoIter {
+		self.0.iter()
+	}
+}
+
+impl<'a, K, V, S> IntoIterator for &'a mut BoundedBTreeMap<K, V, S> {
+	type Item = (&'a K, &'a mut V);
+	type IntoIter = sp_std::collections::btree_map::IterMut<'a, K, V>;
+
+	fn into_iter(self) -> Self::IntoIter {
+		self.0.iter_mut()
+	}
+}
+
 impl<K, V, S> MaxEncodedLen for BoundedBTreeMap<K, V, S>
 where
 	K: MaxEncodedLen,

--- a/frame/support/src/storage/bounded_btree_set.rs
+++ b/frame/support/src/storage/bounded_btree_set.rs
@@ -230,6 +230,15 @@ impl<T, S> IntoIterator for BoundedBTreeSet<T, S> {
 	}
 }
 
+impl<'a, T, S> IntoIterator for &'a BoundedBTreeSet<T, S> {
+	type Item = &'a T;
+	type IntoIter = sp_std::collections::btree_set::Iter<'a, T>;
+
+	fn into_iter(self) -> Self::IntoIter {
+		self.0.iter()
+	}
+}
+
 impl<T, S> MaxEncodedLen for BoundedBTreeSet<T, S>
 where
 	T: MaxEncodedLen,

--- a/frame/support/src/storage/bounded_vec.rs
+++ b/frame/support/src/storage/bounded_vec.rs
@@ -149,6 +149,14 @@ impl<'a, T, S> From<BoundedSlice<'a, T, S>> for &'a [T] {
 	}
 }
 
+impl<'a, T, S> sp_std::iter::IntoIterator for BoundedSlice<'a, T, S> {
+	type Item = &'a T;
+	type IntoIter = sp_std::slice::Iter<'a, T>;
+	fn into_iter(self) -> Self::IntoIter {
+		self.0.iter()
+	}
+}
+
 impl<T: Decode, S: Get<u32>> Decode for BoundedVec<T, S> {
 	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
 		let inner = Vec::<T>::decode(input)?;
@@ -602,6 +610,22 @@ impl<T, S> sp_std::iter::IntoIterator for BoundedVec<T, S> {
 	type IntoIter = sp_std::vec::IntoIter<T>;
 	fn into_iter(self) -> Self::IntoIter {
 		self.0.into_iter()
+	}
+}
+
+impl<'a, T, S> sp_std::iter::IntoIterator for &'a BoundedVec<T, S> {
+	type Item = &'a T;
+	type IntoIter = sp_std::slice::Iter<'a, T>;
+	fn into_iter(self) -> Self::IntoIter {
+		self.0.iter()
+	}
+}
+
+impl<'a, T, S> sp_std::iter::IntoIterator for &'a mut BoundedVec<T, S> {
+	type Item = &'a mut T;
+	type IntoIter = sp_std::slice::IterMut<'a, T>;
+	fn into_iter(self) -> Self::IntoIter {
+		self.0.iter_mut()
 	}
 }
 

--- a/frame/support/src/storage/weak_bounded_vec.rs
+++ b/frame/support/src/storage/weak_bounded_vec.rs
@@ -262,6 +262,22 @@ impl<T, S> sp_std::iter::IntoIterator for WeakBoundedVec<T, S> {
 	}
 }
 
+impl<'a, T, S> sp_std::iter::IntoIterator for &'a WeakBoundedVec<T, S> {
+	type Item = &'a T;
+	type IntoIter = sp_std::slice::Iter<'a, T>;
+	fn into_iter(self) -> Self::IntoIter {
+		self.0.iter()
+	}
+}
+
+impl<'a, T, S> sp_std::iter::IntoIterator for &'a mut WeakBoundedVec<T, S> {
+	type Item = &'a mut T;
+	type IntoIter = sp_std::slice::IterMut<'a, T>;
+	fn into_iter(self) -> Self::IntoIter {
+		self.0.iter_mut()
+	}
+}
+
 impl<T, S> codec::DecodeLength for WeakBoundedVec<T, S> {
 	fn len(self_encoded: &[u8]) -> Result<usize, codec::Error> {
 		// `WeakBoundedVec<T, _>` stored just a `Vec<T>`, thus the length is at the beginning in


### PR DESCRIPTION
Per title, this PR implements `IntoIterator` for references of the bounded types, so that you can use the `for foo in &bar` or `for foo in &mut bar` syntax to iterate on references and mutable references of the elements.