### PR TITLE
Better transaction pool error

### DIFF
--- a/client/transaction-pool/api/src/lib.rs
+++ b/client/transaction-pool/api/src/lib.rs
@@ -356,7 +356,7 @@ impl<TPool: LocalTransactionPool> OffchainSubmitTransaction<TPool::Block> for TP
 		result.map(|_| ()).map_err(|e| {
 			log::warn!(
 				target: "txpool",
-				"(offchain call) Error submitting a transaction to the pool: {}",
+				"(offchain call) Error submitting a transaction to the pool: {:?}",
 				e
 			)
 		})

--- a/client/transaction-pool/api/src/lib.rs
+++ b/client/transaction-pool/api/src/lib.rs
@@ -356,7 +356,7 @@ impl<TPool: LocalTransactionPool> OffchainSubmitTransaction<TPool::Block> for TP
 		result.map(|_| ()).map_err(|e| {
 			log::warn!(
 				target: "txpool",
-				"(offchain call) Error submitting a transaction to the pool: {:?}",
+				"(offchain call) Error submitting a transaction to the pool: {}",
 				e
 			)
 		})

--- a/client/transaction-pool/src/error.rs
+++ b/client/transaction-pool/src/error.rs
@@ -27,10 +27,10 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum Error {
-	#[error("Transaction pool error")]
+	#[error("Transaction pool error: {0}")]
 	Pool(#[from] TxPoolError),
 
-	#[error("Blockchain error")]
+	#[error("Blockchain error: {0}")]
 	Blockchain(#[from] sp_blockchain::Error),
 
 	#[error("Block conversion error: {0}")]


### PR DESCRIPTION
This trivial change makes debugging experience so much nicer by turning this:
```
2022-06-10 04:44:12 (offchain call) Error submitting a transaction to the pool: Transaction pool error
```
Into this:
```
2022-06-10 04:44:12 (offchain call) Error submitting a transaction to the pool: Transaction pool error: Transaction cannot be propagated and the local node does not author blocks
```