### PR TITLE
Invalid state transitions in pallet-bounties

### DIFF
--- a/frame/bounties/src/lib.rs
+++ b/frame/bounties/src/lib.rs
@@ -390,7 +390,7 @@ pub mod pallet {
 			Bounties::<T>::try_mutate_exists(bounty_id, |maybe_bounty| -> DispatchResult {
 				let mut bounty = maybe_bounty.as_mut().ok_or(Error::<T>::InvalidIndex)?;
 				match bounty.status {
-					BountyStatus::Proposed | BountyStatus::Approved | BountyStatus::Funded => {},
+					BountyStatus::Funded => {},
 					_ => return Err(Error::<T>::UnexpectedStatus.into()),
 				};
 


### PR DESCRIPTION
Pallet-bounties currently allows for invalid state transitions of a bounty. The extrinsic function `propose_curator` can be applied whenever a bounty is in state `Proposed`, `Approved` or `Funded` and will change the state to `CuratorProposed`.

It should only be applicable for bounties in the state `Funded`. Reasoning:
- If a bounty is in state `Proposed` and it will directly transition to `CuratorProposed`, then it is not possible to ever approve it (via `approve_bounty`) and it will never get any funding (through `spend_funds`).
- If a bounty is in state `Approved` and it will directly transition to `CuratorProposed`, then it can subsequently moved back to the state `Funding` (through `spend_funds`). This can even happen while the state is already `Active`, i.e., the proposed curator accepted in the mean time and reserved a deposit. This means that the curator will be removed without unreserved or slashing the curator deposit.


✄ -----------------------------------------------------------------------------

Thank you for your Pull Request! 🙏

Before you submit, please check that:

- [ ] **Description:** You added a brief description of the PR, e.g.:
  - What does it do?
  - What important points should reviewers know?
  - Is there something left for follow-up PRs?
- [ ] **Labels:** You labeled the PR appropriately if you have permissions to do so:
  - [ ] `A*` for PR status (**one required**)
  - [ ] `B*` for changelog (**one required**)
  - [ ] `C*` for release notes (**exactly one required**)
  - [ ] `D*` for various implications/requirements
  - [ ] Github project assignment
- [ ] **Related Issues:** You mentioned a related issue if this PR is related to it, e.g. `Fixes #228` or `Related #1337`.
- [ ] **2 Reviewers:** You asked at least two reviewers to review. If you aren't sure, start with GH suggestions.
- [ ] **Style Guide:** Your PR adheres to [the style guide](https://github.com/paritytech/substrate/blob/master/docs/STYLE_GUIDE.md)
  - In particular, mind the maximal line length of 100 (120 in exceptional circumstances).
  - There is no commented code checked in unless necessary.
  - Any panickers in the runtime have a proof or were removed.
- [ ] **Runtime Version:** You bumped the runtime version if there are breaking changes in the **runtime**.
- [ ] **Docs:** You updated any rustdocs which may need to change.
- [ ] **Polkadot Companion:** Has the PR altered the external API or interfaces used by Polkadot?
  - [ ] If so, do you have the corresponding Polkadot PR ready?
  - [ ] Optionally: Do you have a corresponding Cumulus PR?

Refer to [the contributing guide](https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc) for details.

After you've read this notice feel free to remove it.
Thank you!

✄ -----------------------------------------------------------------------------
