### PR TITLE
MEL: Origin, Referenda, ConvictionVoting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6471,9 +6471,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.0.0"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7f3fcf5e45fc28b84dcdab6b983e77f197ec01f325a33f404ba6855afd1070"
+checksum = "04bc9583b5e01cc8c70d89acc9af14ef9b1c29ee3a0074b2a9eea8c0fa396690"
 dependencies = [
  "arrayvec 0.7.1",
  "bitvec",
@@ -6485,9 +6485,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.0.0"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6e626dc84025ff56bf1476ed0e30d10c84d7f89a475ef46ebabee1095a8fba"
+checksum = "9299338969a3d2f491d65f140b00ddec470858402f888af98e8642fb5e8965cd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -48,7 +48,7 @@ use sp_runtime::{traits::Hash, RuntimeDebug};
 use sp_std::{marker::PhantomData, prelude::*, result};
 
 use frame_support::{
-	codec::{Decode, Encode},
+	codec::{Decode, Encode, MaxEncodedLen},
 	dispatch::{DispatchError, DispatchResultWithPostInfo, Dispatchable, PostDispatchInfo},
 	ensure,
 	traits::{Backing, ChangeMembers, EnsureOrigin, Get, GetBacking, InitializeMembers},
@@ -122,7 +122,7 @@ impl DefaultVote for MoreThanMajorityThenPrimeDefaultVote {
 }
 
 /// Origin for the collective module.
-#[derive(PartialEq, Eq, Clone, RuntimeDebug, Encode, Decode, TypeInfo)]
+#[derive(PartialEq, Eq, Clone, RuntimeDebug, Encode, Decode, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(I))]
 pub enum RawOrigin<AccountId, I> {
 	/// It has been condoned by a given number of members of the collective from a given total.

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -124,6 +124,7 @@ impl DefaultVote for MoreThanMajorityThenPrimeDefaultVote {
 /// Origin for the collective module.
 #[derive(PartialEq, Eq, Clone, RuntimeDebug, Encode, Decode, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(I))]
+#[codec(mel_bound(AccountId: MaxEncodedLen))]
 pub enum RawOrigin<AccountId, I> {
 	/// It has been condoned by a given number of members of the collective from a given total.
 	Members(MemberCount, MemberCount),

--- a/frame/conviction-voting/Cargo.toml
+++ b/frame/conviction-voting/Cargo.toml
@@ -14,8 +14,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 assert_matches = "1.3.0"
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.0.3", default-features = false, features = [
 	"derive",
+	"max-encoded-len",
 ] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.136", features = ["derive"], optional = true }

--- a/frame/conviction-voting/src/types.rs
+++ b/frame/conviction-voting/src/types.rs
@@ -43,6 +43,7 @@ use crate::{AccountVote, Conviction, Vote};
 	MaxEncodedLen,
 )]
 #[scale_info(skip_type_params(Total))]
+#[codec(mel_bound(Votes: MaxEncodedLen))]
 pub struct Tally<Votes: Clone + PartialEq + Eq + Debug + TypeInfo + Codec, Total> {
 	/// The number of aye votes, expressed in terms of post-conviction lock-vote.
 	pub ayes: Votes,

--- a/frame/conviction-voting/src/vote.rs
+++ b/frame/conviction-voting/src/vote.rs
@@ -162,6 +162,7 @@ pub struct Delegating<Balance, AccountId, BlockNumber> {
 /// Information concerning the direct vote-casting of some voting power.
 #[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(MaxVotes))]
+#[codec(mel_bound(Balance: MaxEncodedLen, BlockNumber: MaxEncodedLen, PollIndex: MaxEncodedLen))]
 pub struct Casting<Balance, BlockNumber, PollIndex, MaxVotes>
 where
 	MaxVotes: Get<u32>,
@@ -177,6 +178,10 @@ where
 /// An indicator for what an account is doing; it can either be delegating or voting.
 #[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(MaxVotes))]
+#[codec(mel_bound(
+	Balance: MaxEncodedLen, AccountId: MaxEncodedLen, BlockNumber: MaxEncodedLen,
+	PollIndex: MaxEncodedLen,
+))]
 pub enum Voting<Balance, AccountId, BlockNumber, PollIndex, MaxVotes>
 where
 	MaxVotes: Get<u32>,

--- a/frame/ranked-collective/src/lib.rs
+++ b/frame/ranked-collective/src/lib.rs
@@ -86,6 +86,7 @@ pub type Votes = u32;
 	MaxEncodedLen,
 )]
 #[scale_info(skip_type_params(M))]
+#[codec(mel_bound())]
 pub struct Tally<M: GetMaxVoters> {
 	bare_ayes: MemberIndex,
 	ayes: Votes,

--- a/frame/referenda/Cargo.toml
+++ b/frame/referenda/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 assert_matches = { version = "1.5", optional = true }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.0.3", default-features = false, features = [
 	"derive",
 ] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }

--- a/frame/referenda/src/lib.rs
+++ b/frame/referenda/src/lib.rs
@@ -118,7 +118,6 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T, I = ()>(_);
 
 	#[pallet::config]
@@ -159,7 +158,8 @@ pub mod pallet {
 			+ Codec
 			+ Eq
 			+ Debug
-			+ TypeInfo;
+			+ TypeInfo
+			+ MaxEncodedLen;
 
 		// Constants
 		/// The minimum amount to be used as a deposit for a public referendum proposal.

--- a/frame/support/procedural/src/construct_runtime/expand/origin.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/origin.rs
@@ -200,7 +200,7 @@ pub fn expand_outer_origin(
 
 		#[derive(
 			Clone, PartialEq, Eq, #scrate::RuntimeDebug, #scrate::codec::Encode,
-			#scrate::codec::Decode, #scrate::scale_info::TypeInfo,
+			#scrate::codec::Decode, #scrate::scale_info::TypeInfo, #scrate::codec::MaxEncodedLen,
 		)]
 		#[allow(non_camel_case_types)]
 		pub enum OriginCaller {

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -19,7 +19,9 @@
 //! generating values representing lazy module function calls.
 
 pub use crate::{
-	codec::{Codec, Decode, Encode, EncodeAsRef, EncodeLike, HasCompact, Input, Output},
+	codec::{
+		Codec, Decode, Encode, EncodeAsRef, EncodeLike, HasCompact, Input, MaxEncodedLen, Output,
+	},
 	scale_info::TypeInfo,
 	sp_std::{
 		fmt, marker,
@@ -63,7 +65,7 @@ pub trait Callable<T> {
 pub type CallableCallFor<A, R> = <A as Callable<R>>::Call;
 
 /// Origin for the System pallet.
-#[derive(PartialEq, Eq, Clone, RuntimeDebug, Encode, Decode, TypeInfo)]
+#[derive(PartialEq, Eq, Clone, RuntimeDebug, Encode, Decode, TypeInfo, MaxEncodedLen)]
 pub enum RawOrigin<AccountId> {
 	/// The system itself ordained this dispatch to happen: this is the highest privilege level.
 	Root,

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -2700,7 +2700,9 @@ mod tests {
 		}
 	}
 
-	#[derive(TypeInfo, crate::RuntimeDebug, Eq, PartialEq, Clone, Encode, Decode)]
+	#[derive(
+		TypeInfo, crate::RuntimeDebug, Eq, PartialEq, Clone, Encode, Decode, MaxEncodedLen,
+	)]
 	pub struct OuterOrigin;
 
 	impl From<RawOrigin<<TraitImpl as system::Config>::AccountId>> for OuterOrigin {

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -103,5 +103,6 @@ pub use dispatch::{
 
 mod voting;
 pub use voting::{
-	CurrencyToVote, PollStatus, Polling, SaturatingCurrencyToVote, U128CurrencyToVote, VoteTally,
+	ClassCountOf, CurrencyToVote, PollStatus, Polling, SaturatingCurrencyToVote,
+	U128CurrencyToVote, VoteTally,
 };

--- a/frame/support/src/traits/dispatch.rs
+++ b/frame/support/src/traits/dispatch.rs
@@ -18,6 +18,7 @@
 //! Traits for dealing with dispatching calls and the origin from which they are dispatched.
 
 use crate::dispatch::{DispatchResultWithPostInfo, Parameter, RawOrigin};
+use codec::MaxEncodedLen;
 use sp_runtime::{
 	traits::{BadOrigin, Member, Morph, TryMorph},
 	Either,
@@ -258,7 +259,11 @@ pub trait OriginTrait: Sized {
 	type Call;
 
 	/// The caller origin, overarching type of all pallets origins.
-	type PalletsOrigin: Parameter + Member + Into<Self> + From<RawOrigin<Self::AccountId>>;
+	type PalletsOrigin: Parameter
+		+ Member
+		+ Into<Self>
+		+ From<RawOrigin<Self::AccountId>>
+		+ MaxEncodedLen;
 
 	/// The AccountId used across the system.
 	type AccountId;

--- a/frame/support/src/traits/schedule.rs
+++ b/frame/support/src/traits/schedule.rs
@@ -134,7 +134,7 @@ pub mod v1 {
 	/// A type that can be used as a scheduler.
 	pub trait Anon<BlockNumber, Call, Origin> {
 		/// An address which can be used for removing a scheduled task.
-		type Address: Codec + Clone + Eq + EncodeLike + Debug + TypeInfo;
+		type Address: Codec + Clone + Eq + EncodeLike + Debug + TypeInfo + MaxEncodedLen;
 
 		/// Schedule a dispatch to happen at the beginning of some block in the future.
 		///
@@ -179,7 +179,7 @@ pub mod v1 {
 	/// A type that can be used as a scheduler.
 	pub trait Named<BlockNumber, Call, Origin> {
 		/// An address which can be used for removing a scheduled task.
-		type Address: Codec + Clone + Eq + EncodeLike + sp_std::fmt::Debug;
+		type Address: Codec + Clone + Eq + EncodeLike + sp_std::fmt::Debug + MaxEncodedLen;
 
 		/// Schedule a dispatch to happen at the beginning of some block in the future.
 		///
@@ -289,7 +289,7 @@ pub mod v2 {
 	/// A type that can be used as a scheduler.
 	pub trait Anon<BlockNumber, Call, Origin> {
 		/// An address which can be used for removing a scheduled task.
-		type Address: Codec + Clone + Eq + EncodeLike + Debug + TypeInfo;
+		type Address: Codec + Clone + Eq + EncodeLike + Debug + TypeInfo + MaxEncodedLen;
 		/// A means of expressing a call by the hash of its encoded data.
 		type Hash;
 
@@ -336,7 +336,7 @@ pub mod v2 {
 	/// A type that can be used as a scheduler.
 	pub trait Named<BlockNumber, Call, Origin> {
 		/// An address which can be used for removing a scheduled task.
-		type Address: Codec + Clone + Eq + EncodeLike + sp_std::fmt::Debug;
+		type Address: Codec + Clone + Eq + EncodeLike + sp_std::fmt::Debug + MaxEncodedLen;
 		/// A means of expressing a call by the hash of its encoded data.
 		type Hash;
 

--- a/frame/support/src/traits/voting.rs
+++ b/frame/support/src/traits/voting.rs
@@ -122,6 +122,13 @@ impl<Tally, Moment, Class> PollStatus<Tally, Moment, Class> {
 	}
 }
 
+pub struct ClassCountOf<P, T>(std::marker::PhantomData<(P, T)>);
+impl<T, P: Polling<T>> sp_runtime::traits::Get<u32> for ClassCountOf<P, T> {
+	fn get() -> u32 {
+		P::classes().len() as u32
+	}
+}
+
 pub trait Polling<Tally> {
 	type Index: Parameter + Member + Ord + PartialOrd + Copy + HasCompact + MaxEncodedLen;
 	type Votes: Parameter + Member + Ord + PartialOrd + Copy + HasCompact + MaxEncodedLen;

--- a/frame/support/src/traits/voting.rs
+++ b/frame/support/src/traits/voting.rs
@@ -122,7 +122,7 @@ impl<Tally, Moment, Class> PollStatus<Tally, Moment, Class> {
 	}
 }
 
-pub struct ClassCountOf<P, T>(std::marker::PhantomData<(P, T)>);
+pub struct ClassCountOf<P, T>(sp_std::marker::PhantomData<(P, T)>);
 impl<T, P: Polling<T>> sp_runtime::traits::Get<u32> for ClassCountOf<P, T> {
 	fn get() -> u32 {
 		P::classes().len() as u32

--- a/frame/support/test/tests/construct_runtime.rs
+++ b/frame/support/test/tests/construct_runtime.rs
@@ -21,6 +21,7 @@
 
 #![recursion_limit = "128"]
 
+use codec::MaxEncodedLen;
 use frame_support::traits::{CrateVersion, PalletInfo as _};
 use scale_info::TypeInfo;
 use sp_core::{sr25519, H256};
@@ -55,7 +56,9 @@ mod module1 {
 		}
 	}
 
-	#[derive(Clone, PartialEq, Eq, Debug, codec::Encode, codec::Decode, TypeInfo)]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, codec::Encode, codec::Decode, TypeInfo, MaxEncodedLen,
+	)]
 	pub struct Origin<T, I: Instance = DefaultInstance>(pub core::marker::PhantomData<(T, I)>);
 
 	frame_support::decl_event! {
@@ -97,7 +100,9 @@ mod module2 {
 		}
 	}
 
-	#[derive(Clone, PartialEq, Eq, Debug, codec::Encode, codec::Decode, TypeInfo)]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, codec::Encode, codec::Decode, TypeInfo, MaxEncodedLen,
+	)]
 	pub struct Origin;
 
 	frame_support::decl_event! {
@@ -140,7 +145,9 @@ mod nested {
 			}
 		}
 
-		#[derive(Clone, PartialEq, Eq, Debug, codec::Encode, codec::Decode, TypeInfo)]
+		#[derive(
+			Clone, PartialEq, Eq, Debug, codec::Encode, codec::Decode, TypeInfo, MaxEncodedLen,
+		)]
 		pub struct Origin;
 
 		frame_support::decl_event! {
@@ -196,7 +203,9 @@ pub mod module3 {
 		}
 	}
 
-	#[derive(Clone, PartialEq, Eq, Debug, codec::Encode, codec::Decode, TypeInfo)]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, codec::Encode, codec::Decode, TypeInfo, MaxEncodedLen,
+	)]
 	pub struct Origin<T>(pub core::marker::PhantomData<T>);
 
 	frame_support::decl_event! {

--- a/frame/support/test/tests/instance.rs
+++ b/frame/support/test/tests/instance.rs
@@ -17,7 +17,7 @@
 
 #![recursion_limit = "128"]
 
-use codec::{Codec, Decode, Encode, EncodeLike};
+use codec::{Codec, Decode, Encode, EncodeLike, MaxEncodedLen};
 use frame_support::{
 	inherent::{InherentData, InherentIdentifier, MakeFatalError, ProvideInherent},
 	metadata::{
@@ -108,7 +108,9 @@ mod module1 {
 		}
 	}
 
-	#[derive(PartialEq, Eq, Clone, sp_runtime::RuntimeDebug, Encode, Decode, TypeInfo)]
+	#[derive(
+		PartialEq, Eq, Clone, sp_runtime::RuntimeDebug, Encode, Decode, TypeInfo, MaxEncodedLen,
+	)]
 	pub enum Origin<T: Config<I>, I>
 	where
 		T::BlockNumber: From<u32>,
@@ -181,7 +183,9 @@ mod module2 {
 		}
 	}
 
-	#[derive(PartialEq, Eq, Clone, sp_runtime::RuntimeDebug, Encode, Decode, TypeInfo)]
+	#[derive(
+		PartialEq, Eq, Clone, sp_runtime::RuntimeDebug, Encode, Decode, TypeInfo, MaxEncodedLen,
+	)]
 	pub enum Origin<T: Config<I>, I = DefaultInstance> {
 		Members(u32),
 		_Phantom(std::marker::PhantomData<(T, I)>),

--- a/frame/support/test/tests/origin.rs
+++ b/frame/support/test/tests/origin.rs
@@ -19,6 +19,7 @@
 
 #![recursion_limit = "128"]
 
+use codec::MaxEncodedLen;
 use frame_support::traits::{Contains, OriginTrait};
 use scale_info::TypeInfo;
 use sp_core::{sr25519, H256};
@@ -30,6 +31,7 @@ mod nested {
 	use super::*;
 
 	pub mod module {
+
 		use super::*;
 
 		pub trait Config: system::Config {}
@@ -45,7 +47,9 @@ mod nested {
 			}
 		}
 
-		#[derive(Clone, PartialEq, Eq, Debug, codec::Encode, codec::Decode, TypeInfo)]
+		#[derive(
+			Clone, PartialEq, Eq, Debug, codec::Encode, codec::Decode, TypeInfo, MaxEncodedLen,
+		)]
 		pub struct Origin;
 
 		frame_support::decl_event! {
@@ -101,7 +105,9 @@ pub mod module {
 		}
 	}
 
-	#[derive(Clone, PartialEq, Eq, Debug, codec::Encode, codec::Decode, TypeInfo)]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, codec::Encode, codec::Decode, TypeInfo, MaxEncodedLen,
+	)]
 	pub struct Origin<T>(pub core::marker::PhantomData<T>);
 
 	frame_support::decl_event! {

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -359,7 +359,14 @@ pub mod pallet {
 
 	#[pallet::origin]
 	#[derive(
-		EqNoBound, RuntimeDebugNoBound, CloneNoBound, PartialEqNoBound, Encode, Decode, TypeInfo,
+		EqNoBound,
+		RuntimeDebugNoBound,
+		CloneNoBound,
+		PartialEqNoBound,
+		Encode,
+		Decode,
+		TypeInfo,
+		MaxEncodedLen,
 	)]
 	pub struct Origin<T>(PhantomData<T>);
 

--- a/frame/support/test/tests/pallet_instance.rs
+++ b/frame/support/test/tests/pallet_instance.rs
@@ -30,6 +30,7 @@ use sp_runtime::{DispatchError, ModuleError};
 
 #[frame_support::pallet]
 pub mod pallet {
+	use codec::MaxEncodedLen;
 	use frame_support::{pallet_prelude::*, scale_info};
 	use frame_system::pallet_prelude::*;
 	use sp_std::any::TypeId;
@@ -164,6 +165,7 @@ pub mod pallet {
 		Encode,
 		Decode,
 		scale_info::TypeInfo,
+		MaxEncodedLen,
 	)]
 	#[scale_info(skip_type_params(T, I))]
 	pub struct Origin<T, I = ()>(PhantomData<(T, I)>);

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -32,7 +32,7 @@ macro_rules! map {
 }
 
 #[doc(hidden)]
-pub use codec::{Decode, Encode};
+pub use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 pub use serde;
@@ -418,7 +418,7 @@ pub fn to_substrate_wasm_fn_return_value(value: &impl Encode) -> u64 {
 
 /// The void type - it cannot exist.
 // Oh rust, you crack me up...
-#[derive(Clone, Decode, Encode, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[derive(Clone, Decode, Encode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub enum Void {}
 
 /// Macro for creating `Maybe*` marker traits.

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -23,7 +23,7 @@
 pub mod genesismap;
 pub mod system;
 
-use codec::{Decode, Encode, Error, Input};
+use codec::{Decode, Encode, Error, Input, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_std::{marker::PhantomData, prelude::*};
 
@@ -439,7 +439,7 @@ impl GetRuntimeBlockType for Runtime {
 	type RuntimeBlock = Block;
 }
 
-#[derive(Clone, RuntimeDebug, Encode, Decode, PartialEq, Eq, TypeInfo)]
+#[derive(Clone, RuntimeDebug, Encode, Decode, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
 pub struct Origin;
 
 impl From<frame_system::Origin<Runtime>> for Origin {


### PR DESCRIPTION
This puts a `MaxEncodedLen` bound on `PalletsOrigin` trait and fixes Referenda and ConvictionVoting pallets.

polkadot companion: paritytech/polkadot#5671
cumulus companion: paritytech/cumulus#1363