### PR TITLE
Add `ExtendedCallData`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5956,6 +5967,7 @@ dependencies = [
 name = "pallet-preimage"
 version = "4.0.0-dev"
 dependencies = [
+ "derivative",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -25,7 +25,7 @@ use frame_system_rpc_runtime_api::AccountNonceApi;
 use futures::prelude::*;
 use node_executor::ExecutorDispatch;
 use node_primitives::Block;
-use node_runtime::RuntimeApi;
+use node_runtime::{Runtime, RuntimeApi};
 use sc_client_api::{BlockBackend, ExecutorProvider};
 use sc_consensus_babe::{self, SlotProportion};
 use sc_executor::NativeElseWasmExecutor;
@@ -83,17 +83,18 @@ pub fn create_extrinsic(
 		.unwrap_or(2) as u64;
 	let tip = 0;
 	let extra: node_runtime::SignedExtra = (
-		frame_system::CheckNonZeroSender::<node_runtime::Runtime>::new(),
-		frame_system::CheckSpecVersion::<node_runtime::Runtime>::new(),
-		frame_system::CheckTxVersion::<node_runtime::Runtime>::new(),
-		frame_system::CheckGenesis::<node_runtime::Runtime>::new(),
-		frame_system::CheckEra::<node_runtime::Runtime>::from(generic::Era::mortal(
+		frame_system::CheckNonZeroSender::<Runtime>::new(),
+		frame_system::CheckSpecVersion::<Runtime>::new(),
+		frame_system::CheckTxVersion::<Runtime>::new(),
+		frame_system::CheckGenesis::<Runtime>::new(),
+		frame_system::CheckEra::<Runtime>::from(generic::Era::mortal(
 			period,
 			best_block.saturated_into(),
 		)),
-		frame_system::CheckNonce::<node_runtime::Runtime>::from(nonce),
-		frame_system::CheckWeight::<node_runtime::Runtime>::new(),
-		pallet_asset_tx_payment::ChargeAssetTxPayment::<node_runtime::Runtime>::from(tip, None),
+		frame_system::CheckNonce::<Runtime>::from(nonce),
+		frame_system::ExtendedCallData::<Runtime>::new(),
+		frame_system::CheckWeight::<Runtime>::new(),
+		pallet_asset_tx_payment::ChargeAssetTxPayment::<Runtime>::from(tip, None),
 	);
 
 	let raw_payload = node_runtime::SignedPayload::from_raw(
@@ -106,6 +107,7 @@ pub fn create_extrinsic(
 			genesis_hash,
 			best_hash,
 			(),
+			None,
 			(),
 			(),
 		),

--- a/bin/node/executor/tests/fees.rs
+++ b/bin/node/executor/tests/fees.rs
@@ -129,6 +129,41 @@ fn fee_multiplier_increases_and_decreases_on_big_weight() {
 	});
 }
 
+#[test]
+fn extended_call_data_works() {
+	let mut tt = new_test_ext(compact_code_unwrap());
+
+	let time = 42 * 1000;
+	let block = construct_block(
+		&mut tt,
+		1,
+		GENESIS_HASH.into(),
+		vec![CheckedExtrinsic {
+			signed: None,
+			function: Call::System(frame_system::Call::dump_ecd {}),
+		}],
+		(time1 / SLOT_DURATION).into(),
+	);
+
+	// execute a big block.
+	executor_call::<NeverNativeValue, fn() -> _>(
+		&mut t,
+		"Core_execute_block",
+		&block.0,
+		true,
+		None,
+	)
+	.0
+	.unwrap();
+
+	// weight multiplier is increased for next block.
+	//t.execute_with(|| {
+	//	let fm = TransactionPayment::next_fee_multiplier();
+	//	println!("After a small block: {:?} -> {:?}", prev_multiplier, fm);
+	//	assert!(fm < prev_multiplier);
+	//});
+}
+
 fn new_account_info(free_dollars: u128) -> Vec<u8> {
 	frame_system::AccountInfo {
 		nonce: 0u32,

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1197,6 +1197,7 @@ where
 			frame_system::CheckGenesis::<Runtime>::new(),
 			frame_system::CheckEra::<Runtime>::from(era),
 			frame_system::CheckNonce::<Runtime>::from(nonce),
+			frame_system::ExtendedCallData::<Runtime>::new(),
 			frame_system::CheckWeight::<Runtime>::new(),
 			pallet_asset_tx_payment::ChargeAssetTxPayment::<Runtime>::from(tip, None),
 		);
@@ -1591,6 +1592,7 @@ pub type SignedExtra = (
 	frame_system::CheckGenesis<Runtime>,
 	frame_system::CheckEra<Runtime>,
 	frame_system::CheckNonce<Runtime>,
+	frame_system::ExtendedCallData<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	pallet_asset_tx_payment::ChargeAssetTxPayment<Runtime>,
 );

--- a/bin/node/testing/src/keyring.rs
+++ b/bin/node/testing/src/keyring.rs
@@ -76,6 +76,7 @@ pub fn signed_extra(nonce: Index, extra_fee: Balance) -> SignedExtra {
 		frame_system::CheckGenesis::new(),
 		frame_system::CheckEra::from(Era::mortal(256, 0)),
 		frame_system::CheckNonce::from(nonce),
+		frame_system::ExtendedCallData::new(),
 		frame_system::CheckWeight::new(),
 		pallet_asset_tx_payment::ChargeAssetTxPayment::from(extra_fee, None),
 	)

--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -40,8 +40,9 @@
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
+	defensive, log,
 	traits::{DisabledValidators, FindAuthor, Get, OnTimestampSet, OneSessionHandler},
-	BoundedSlice, ConsensusEngineId, Parameter, WeakBoundedVec,
+	BoundedSlice, BoundedVec, ConsensusEngineId, Parameter,
 };
 use sp_consensus_aura::{AuthorityIndex, ConsensusLog, Slot, AURA_ENGINE_ID};
 use sp_runtime::{
@@ -116,7 +117,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn authorities)]
 	pub(super) type Authorities<T: Config> =
-		StorageValue<_, WeakBoundedVec<T::AuthorityId, T::MaxAuthorities>, ValueQuery>;
+		StorageValue<_, BoundedVec<T::AuthorityId, T::MaxAuthorities>, ValueQuery>;
 
 	/// The current slot of this block.
 	///
@@ -150,7 +151,7 @@ impl<T: Config> Pallet<T> {
 	///
 	/// The storage will be applied immediately.
 	/// And aura consensus log will be appended to block's log.
-	pub fn change_authorities(new: WeakBoundedVec<T::AuthorityId, T::MaxAuthorities>) {
+	pub fn change_authorities(new: BoundedVec<T::AuthorityId, T::MaxAuthorities>) {
 		<Authorities<T>>::put(&new);
 
 		let log = DigestItem::Consensus(
@@ -219,10 +220,13 @@ impl<T: Config> OneSessionHandler<T::AccountId> for Pallet<T> {
 			let next_authorities = validators.map(|(_, k)| k).collect::<Vec<_>>();
 			let last_authorities = Self::authorities();
 			if last_authorities != next_authorities {
-				let bounded = <WeakBoundedVec<_, T::MaxAuthorities>>::force_from(
-					next_authorities,
-					Some("AuRa new session"),
-				);
+				if next_authorities.len() as u32 > T::MaxAuthorities::get() {
+					defensive!(
+						"next authorities list larger than {}, truncating",
+						T::MaxAuthorities::get(),
+					);
+				}
+				let bounded = <BoundedVec<_, T::MaxAuthorities>>::truncate_from(next_authorities);
 				Self::change_authorities(bounded);
 			}
 		}

--- a/frame/examples/basic/src/lib.rs
+++ b/frame/examples/basic/src/lib.rs
@@ -562,19 +562,6 @@ pub mod pallet {
 			// All good, no refund.
 			Ok(())
 		}
-
-		/// Demonstrates how to use extended call data.
-		#[pallet::weight(0)]
-		pub fn set_from_ecd(origin: OriginFor<T>) -> DispatchResult {
-			ensure_root(origin)?;
-
-			let ecd = frame_system::Pallet::<T>::extended_call_data().expect("Need ECD");
-			let new_value: T::Balance = Decode::decode(&mut &ecd[..]).expect("Must decode balance");
-			<Dummy<T>>::put(new_value);
-
-			Self::deposit_event(Event::SetDummy { balance: new_value });
-			Ok(())
-		}
 	}
 
 	/// Events are a simple means of reporting upecific conditions and

--- a/frame/examples/basic/src/lib.rs
+++ b/frame/examples/basic/src/lib.rs
@@ -562,9 +562,22 @@ pub mod pallet {
 			// All good, no refund.
 			Ok(())
 		}
+
+		/// Demonstrates how to use extended call data.
+		#[pallet::weight(0)]
+		pub fn set_from_ecd(origin: OriginFor<T>) -> DispatchResult {
+			ensure_root(origin)?;
+
+			let ecd = frame_system::Pallet::<T>::extended_call_data().expect("Need ECD");
+			let new_value: T::Balance = Decode::decode(&mut &ecd[..]).expect("Must decode balance");
+			<Dummy<T>>::put(new_value);
+
+			Self::deposit_event(Event::SetDummy { balance: new_value });
+			Ok(())
+		}
 	}
 
-	/// Events are a simple means of reporting specific conditions and
+	/// Events are a simple means of reporting upecific conditions and
 	/// circumstances that have happened that users, Dapps and/or chain explorers would find
 	/// interesting and otherwise difficult to detect.
 	#[pallet::event]

--- a/frame/preimage/Cargo.toml
+++ b/frame/preimage/Cargo.toml
@@ -19,6 +19,7 @@ sp-core = { version = "6.0.0", default-features = false, optional = true, path =
 sp-io = { version = "6.0.0", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "6.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-std = { version = "4.0.0", default-features = false, path = "../../primitives/std" }
+derivative = "2.2.0"
 
 [dev-dependencies]
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }

--- a/frame/system/src/extensions/extended_call_data.rs
+++ b/frame/system/src/extensions/extended_call_data.rs
@@ -17,11 +17,11 @@
 
 use crate::Config;
 use codec::{Decode, Encode, MaxEncodedLen};
-use frame_support::{traits::ConstU32, weights::DispatchInfo, *};
+use frame_support::{pallet_prelude::DispatchResult, traits::ConstU32, weights::DispatchInfo, *};
 use scale_info::TypeInfo;
 use sp_core::Hasher;
 use sp_runtime::{
-	traits::{DispatchInfoOf, Dispatchable, One, SignedExtension},
+	traits::{DispatchInfoOf, Dispatchable, One, PostDispatchInfoOf, SignedExtension},
 	transaction_validity::{
 		InvalidTransaction, TransactionLongevity, TransactionValidity, TransactionValidityError,
 		ValidTransaction,
@@ -86,12 +86,12 @@ where
 		// TODO refactor into interface
 		//crate::Scheduler::note_bytes(self.0, None).expect("todo");
 
-		let has = crate::ECDStorage::<T>::take().is_some();
+		let has = crate::ExtendedCallDataStorage::<T>::take().is_some();
 		assert!(!has, "Should not be present from past block");
 
 		if let Some(data) = self.0 {
-			let v: Vec<u8> = data.try_into().expect("Must fit");
-			crate::ECDStorage::<T>::set(Some(v.try_into().expect("lol")));
+			let v: Vec<u8> = data.try_into().expect("TODO");
+			crate::ExtendedCallDataStorage::<T>::set(Some(v.try_into().expect("TODO")));
 		}
 		Ok(Default::default())
 	}
@@ -103,9 +103,24 @@ where
 		_info: &DispatchInfoOf<Self::Call>,
 		_len: usize,
 	) -> TransactionValidity {
-		let has = crate::ECDStorage::<T>::get().is_some();
+		// TODO remove
+		let has = crate::ExtendedCallDataStorage::<T>::get().is_some();
 		assert!(has, "Should be present from `pre_validate`");
 
 		Ok(Default::default())
+	}
+
+	fn post_dispatch(
+		_pre: Option<Self::Pre>,
+		_info: &DispatchInfoOf<Self::Call>,
+		_post_info: &PostDispatchInfoOf<Self::Call>,
+		_len: usize,
+		_result: &DispatchResult,
+	) -> Result<(), TransactionValidityError> {
+		// TODO remove
+		let had = crate::ExtendedCallDataStorage::<T>::take().is_some();
+		assert!(had, "Should be present from `pre_validate`");
+
+		Ok(())
 	}
 }

--- a/frame/system/src/extensions/extended_call_data.rs
+++ b/frame/system/src/extensions/extended_call_data.rs
@@ -1,0 +1,111 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Config;
+use codec::{Decode, Encode, MaxEncodedLen};
+use frame_support::{traits::ConstU32, weights::DispatchInfo, *};
+use scale_info::TypeInfo;
+use sp_core::Hasher;
+use sp_runtime::{
+	traits::{DispatchInfoOf, Dispatchable, One, SignedExtension},
+	transaction_validity::{
+		InvalidTransaction, TransactionLongevity, TransactionValidity, TransactionValidityError,
+		ValidTransaction,
+	},
+};
+use sp_std::vec::Vec;
+
+/// A Extended Call Data (ECD) provides binary data which is only available in the current
+/// extrinsic.
+///
+/// The size of a ECD is only effectively limited by the maximal extrinsic size.
+#[derive(Encode, Decode, CloneNoBound, EqNoBound, PartialEqNoBound, TypeInfo, MaxEncodedLen)]
+#[scale_info(skip_type_params(T))]
+// TODO: Rust is fucked https://github.com/rust-lang/rust/issues/26925
+// implement something like SyncNoBound + SendNoBound
+pub struct ExtendedCallData<T: Config + Send + Sync>(
+	Option<BoundedVec<u8, ConstU32<4_000_000 /* FIXME */>>>,
+	sp_std::marker::PhantomData<T>,
+);
+
+impl<T> ExtendedCallData<T>
+where
+	T: Config + Send + Sync,
+{
+	pub fn new() -> Self {
+		Self(None, sp_std::marker::PhantomData::<T>)
+	}
+
+	/// Creates a new [`Self`] from some ephemeral data.
+	pub fn from(data: BoundedVec<u8, ConstU32<4_000_000>>) -> Self {
+		Self(Some(data), sp_std::marker::PhantomData::<T>)
+	}
+}
+
+impl<T: Config + Send + Sync> sp_std::fmt::Debug for ExtendedCallData<T> {
+	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+		write!(f, "ExtendedCallData")
+	}
+}
+
+impl<T> SignedExtension for ExtendedCallData<T>
+where
+	T: Config + Send + Sync,
+{
+	const IDENTIFIER: &'static str = "ExtendedCallData";
+	type AccountId = T::AccountId;
+	type Call = <T as Config>::Call;
+	type AdditionalSigned = Option<BoundedVec<u8, ConstU32<4_000_000>>>;
+	type Pre = ();
+
+	fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+		Ok(self.0.clone())
+	}
+
+	fn pre_dispatch(
+		self,
+		_who: &Self::AccountId,
+		_call: &Self::Call,
+		_info: &DispatchInfoOf<Self::Call>,
+		_len: usize,
+	) -> Result<Self::Pre, TransactionValidityError> {
+		// TODO refactor into interface
+		//crate::Scheduler::note_bytes(self.0, None).expect("todo");
+
+		let has = crate::ECDStorage::<T>::take().is_some();
+		assert!(!has, "Should not be present from past block");
+
+		if let Some(data) = self.0 {
+			let v: Vec<u8> = data.try_into().expect("Must fit");
+			crate::ECDStorage::<T>::set(Some(v.try_into().expect("lol")));
+		}
+		Ok(Default::default())
+	}
+
+	fn validate(
+		&self,
+		_who: &Self::AccountId,
+		_call: &Self::Call,
+		_info: &DispatchInfoOf<Self::Call>,
+		_len: usize,
+	) -> TransactionValidity {
+		let has = crate::ECDStorage::<T>::get().is_some();
+		assert!(has, "Should be present from `pre_validate`");
+
+		Ok(Default::default())
+	}
+}

--- a/frame/system/src/extensions/mod.rs
+++ b/frame/system/src/extensions/mod.rs
@@ -22,3 +22,6 @@ pub mod check_nonce;
 pub mod check_spec_version;
 pub mod check_tx_version;
 pub mod check_weight;
+pub mod extended_call_data;
+#[cfg(test)]
+mod test;

--- a/frame/system/src/extensions/test.rs
+++ b/frame/system/src/extensions/test.rs
@@ -1,0 +1,59 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for [`ExtendedCallData`].
+//! They are in a separate module for faster compilation after a change.
+
+#![cfg(test)]
+
+use super::*;
+use crate::{
+	mock::{new_test_ext, Test, CALL},
+	Config, ExtendedCallData, Pallet as System,
+};
+use codec::{Decode, Encode, MaxEncodedLen};
+use frame_support::{assert_noop, assert_ok, traits::ConstU32, weights::DispatchInfo, *};
+use scale_info::TypeInfo;
+use sp_core::Hasher;
+use sp_runtime::{
+	traits::{DispatchInfoOf, Dispatchable, One, SignedExtension},
+	transaction_validity::{
+		InvalidTransaction, TransactionLongevity, TransactionValidity, TransactionValidityError,
+		ValidTransaction,
+	},
+};
+use sp_std::vec::Vec;
+
+#[test]
+fn extended_call_data_works() {
+	new_test_ext().execute_with(|| {
+		let info = DispatchInfo::default();
+		let len = 0_usize;
+		// Too large for normal Call data.
+		let raw = vec![0u8; 4_000_000];
+		let ecd: BoundedVec<_, _> = raw.try_into().unwrap();
+
+		let extension = ExtendedCallData::<Test>::from(ecd.clone());
+		// The user must sign the complete ECD.
+		assert_eq!(extension.additional_signed().unwrap(), Some(ecd.clone()));
+		assert!(extension.pre_dispatch(&0, CALL, &info, len).is_ok());
+
+		// Interesting part here:
+		// Any extrinsic can now access the ECD via this getter function.
+		assert_eq!(System::<Test>::extended_call_data(), Some(ecd));
+	})
+}

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -122,7 +122,7 @@ pub use extensions::{
 	check_genesis::CheckGenesis, check_mortality::CheckMortality,
 	check_non_zero_sender::CheckNonZeroSender, check_nonce::CheckNonce,
 	check_spec_version::CheckSpecVersion, check_tx_version::CheckTxVersion,
-	check_weight::CheckWeight,
+	check_weight::CheckWeight, extended_call_data::ExtendedCallData,
 };
 // Backward compatible re-export.
 pub use extensions::check_mortality::CheckMortality as CheckEra;
@@ -571,6 +571,12 @@ pub mod pallet {
 	#[pallet::getter(fn extrinsic_data)]
 	pub(super) type ExtrinsicData<T: Config> =
 		StorageMap<_, Twox64Concat, u32, Vec<u8>, ValueQuery>;
+
+	/// Extended Call Data (ECD) storage for the current extrinsic.
+	#[pallet::storage]
+	#[pallet::getter(fn extended_call_data)]
+	pub(super) type ECDStorage<T: Config> =
+		StorageValue<_, BoundedVec<u8, ConstU32<4_000_000>>, OptionQuery>;
 
 	/// The current block number being processed. Set by `execute_block`.
 	#[pallet::storage]

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -375,6 +375,18 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		/// Demonstrates how to use extended call data.
+		#[pallet::weight(0)]
+		pub fn dump_ecd(origin: OriginFor<T>) -> DispatchResult {
+			// Load the extended call data from the system storage.
+			let ecd = Pallet::<T>::extended_call_data();
+			if let Some(ecd) = ecd {
+				panic!("ECD: {:?}", &ecd);
+			}
+
+			Ok(())
+		}
+
 		/// Make some on-chain remark.
 		///
 		/// # <weight>
@@ -573,9 +585,14 @@ pub mod pallet {
 		StorageMap<_, Twox64Concat, u32, Vec<u8>, ValueQuery>;
 
 	/// Extended Call Data (ECD) storage for the current extrinsic.
+	///
+	/// This value can be set by the [`ExtendedCallData`] signed extension.
+	/// It only exists for the current extrinsic and gets cleaned up after the extrinsic is done.
+	/// This can be used to upload large blobs of data for example when using `set_code` while still
+	/// allowing `Call` to be `MaxEncodedLen`.
 	#[pallet::storage]
 	#[pallet::getter(fn extended_call_data)]
-	pub(super) type ECDStorage<T: Config> =
+	pub(super) type ExtendedCallDataStorage<T: Config> =
 		StorageValue<_, BoundedVec<u8, ConstU32<4_000_000>>, OptionQuery>;
 
 	/// The current block number being processed. Set by `execute_block`.


### PR DESCRIPTION
Tries to solve the problem about `MEL`-bounding `Call` by adding a `SignedExtension` that puts some additional data into a new storage item: `System::ExtendedCallDataStorage`.  
This storage item can then be accessed by any extrinsic via a getter function `extended_call_data`.  
The `ECD` is only available for the current extrinsic and gets cleared in the `post_dispatch` hook.  
This should not impact performance since it stays entirely within the storage overlay and never hits the Disk.

WIP since Im not sure if this is the best approach