### PR TITLE
AuxData Signed Extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6471,9 +6471,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.0.0"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7f3fcf5e45fc28b84dcdab6b983e77f197ec01f325a33f404ba6855afd1070"
+checksum = "9182e4a71cae089267ab03e67c99368db7cd877baf50f931e5d6d4b71e195ac0"
 dependencies = [
  "arrayvec 0.7.1",
  "bitvec",
@@ -6485,9 +6485,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.0.0"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6e626dc84025ff56bf1476ed0e30d10c84d7f89a475ef46ebabee1095a8fba"
+checksum = "9299338969a3d2f491d65f140b00ddec470858402f888af98e8642fb5e8965cd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/frame/authorship/src/lib.rs
+++ b/frame/authorship/src/lib.rs
@@ -222,8 +222,9 @@ pub mod pallet {
 		#[pallet::weight((0, DispatchClass::Mandatory))]
 		pub fn set_uncles(origin: OriginFor<T>, hash: T::Hash) -> DispatchResult {
 			ensure_none(origin)?;
-			let new_uncles: Vec<T::Header> = frame_system::Pallet::<T>::unhashed_limited_vec(hash, MAX_UNCLES)?
-				.ok_or(Error::<T>::TooManyUncles)?;
+			let new_uncles: Vec<T::Header> =
+				frame_system::Pallet::<T>::unhashed_limited_vec(hash, MAX_UNCLES)?
+					.ok_or(Error::<T>::TooManyUncles)?;
 
 			if <DidSetUncles<T>>::get() {
 				return Err(Error::<T>::UnclesAlreadySet.into())
@@ -287,11 +288,11 @@ pub mod pallet {
 		fn check_inherent(
 			call: &Self::Call,
 			_data: &InherentData,
-//			aux_data: &Vec<Vec<u8>>,// <<< TODO
+			//			aux_data: &Vec<Vec<u8>>,// <<< TODO
 		) -> result::Result<(), Self::Error> {
 			match call {
 				Call::set_uncles { ref hash } => {
-/*					let data = aux_data.first().ok_or(InherentError::Uncles("preimage missing"))?;
+					/*					let data = aux_data.first().ok_or(InherentError::Uncles("preimage missing"))?;
 					let real_hash = <T::Hashing as sp_runtime::traits::Hash>::hash(&data[..]);
 					ensure!(hash == real_hash, InherentError::Uncles("wrong preimage"));
 					let uncles = Vec::<T::Header>::decode(&mut &data[..])

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -150,7 +150,7 @@ pub mod pallet {
 		/// The proof of key ownership, used for validating equivocation reports.
 		/// The proof must include the session index and validator count of the
 		/// session at which the equivocation occurred.
-		type KeyOwnerProof: Parameter + GetSessionNumber + GetValidatorCount;
+		type KeyOwnerProof: Parameter + GetSessionNumber + GetValidatorCount + MaxEncodedLen;
 
 		/// The identification of a key owner, used when reporting equivocations.
 		type KeyOwnerIdentification: Parameter;

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -35,7 +35,7 @@ use frame_support::{
 use sp_application_crypto::ByteArray;
 use sp_runtime::{
 	generic::DigestItem,
-	traits::{IsMember, One, SaturatedConversion, Saturating, Zero},
+	traits::{AuxData, IsMember, One, SaturatedConversion, Saturating, Zero},
 	ConsensusEngineId, KeyTypeId, Permill,
 };
 use sp_session::{GetSessionNumber, GetValidatorCount};
@@ -466,11 +466,18 @@ pub mod pallet {
 	#[pallet::validate_unsigned]
 	impl<T: Config> ValidateUnsigned for Pallet<T> {
 		type Call = Call<T>;
-		fn validate_unsigned(source: TransactionSource, call: &Self::Call) -> TransactionValidity {
+		fn validate_unsigned(
+			source: TransactionSource,
+			call: &Self::Call,
+			_aux_data: &AuxData,
+		) -> TransactionValidity {
 			Self::validate_unsigned(source, call)
 		}
 
-		fn pre_dispatch(call: &Self::Call) -> Result<(), TransactionValidityError> {
+		fn pre_dispatch(
+			call: &Self::Call,
+			_aux_data: &AuxData,
+		) -> Result<(), TransactionValidityError> {
 			Self::pre_dispatch(call)
 		}
 	}

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -679,7 +679,7 @@ mod tests {
 
 			const INHERENT_IDENTIFIER: [u8; 8] = *b"test1234";
 
-			fn create_inherent(_data: &InherentData) -> Option<Self::Call> {
+			fn create_inherent(_data: &InherentData) -> Option<(Self::Call, Vec<Vec<u8>>)> {
 				None
 			}
 

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -458,7 +458,7 @@ where
 
 		// Decode parameters and dispatch
 		let dispatch_info = xt.get_dispatch_info();
-		let r = Applyable::apply::<UnsignedValidator>(xt, &dispatch_info, encoded_len)?;
+		let r = Applyable::apply::<UnsignedValidator, <T as system::Config>::TempPreimageRecipient>(xt, &dispatch_info, encoded_len)?;
 
 		<frame_system::Pallet<System>>::note_applied_extrinsic(&r, dispatch_info);
 

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -458,7 +458,11 @@ where
 
 		// Decode parameters and dispatch
 		let dispatch_info = xt.get_dispatch_info();
-		let r = Applyable::apply::<UnsignedValidator, <T as system::Config>::TempPreimageRecipient>(xt, &dispatch_info, encoded_len)?;
+		let r = Applyable::apply::<UnsignedValidator, <T as system::Config>::TempPreimageRecipient>(
+			xt,
+			&dispatch_info,
+			encoded_len,
+		)?;
 
 		<frame_system::Pallet<System>>::note_applied_extrinsic(&r, dispatch_info);
 

--- a/frame/preimage/src/mock.rs
+++ b/frame/preimage/src/mock.rs
@@ -77,6 +77,8 @@ impl frame_system::Config for Test {
 	type SS58Prefix = ();
 	type OnSetCode = ();
 	type MaxConsumers = ConstU32<16>;
+	type PreimageProvider = Preimage;
+	type TempPreimageRecipient = Preimage;
 }
 
 impl pallet_balances::Config for Test {

--- a/frame/preimage/src/tests.rs
+++ b/frame/preimage/src/tests.rs
@@ -32,7 +32,7 @@ fn user_note_preimage_works() {
 
 		let h = hashed([1]);
 		assert!(Preimage::have_preimage(&h));
-		assert_eq!(Preimage::get_preimage(&h), Some(vec![1]));
+		assert_eq!(Preimage::get_preimage(&h).unwrap().into_owned(), vec![1]);
 
 		assert_noop!(
 			Preimage::note_preimage(Origin::signed(2), vec![1]),
@@ -54,7 +54,7 @@ fn manager_note_preimage_works() {
 
 		let h = hashed([1]);
 		assert!(Preimage::have_preimage(&h));
-		assert_eq!(Preimage::get_preimage(&h), Some(vec![1]));
+		assert_eq!(Preimage::get_preimage(&h).unwrap().into_owned(), vec![1]);
 
 		assert_noop!(
 			Preimage::note_preimage(Origin::signed(1), vec![1]),
@@ -137,7 +137,7 @@ fn requested_then_noted_preimage_cannot_be_unnoted() {
 
 		let h = hashed([1]);
 		assert!(Preimage::have_preimage(&h));
-		assert_eq!(Preimage::get_preimage(&h), Some(vec![1]));
+		assert_eq!(Preimage::get_preimage(&h).unwrap().into_owned(), vec![1]);
 	});
 }
 
@@ -172,7 +172,7 @@ fn requested_then_user_noted_preimage_is_free() {
 
 		let h = hashed([1]);
 		assert!(Preimage::have_preimage(&h));
-		assert_eq!(Preimage::get_preimage(&h), Some(vec![1]));
+		assert_eq!(Preimage::get_preimage(&h).unwrap().into_owned(), vec![1]);
 	});
 }
 

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -408,7 +408,7 @@ pub mod pallet {
 		type SessionHandler: SessionHandler<Self::ValidatorId>;
 
 		/// The keys.
-		type Keys: OpaqueKeys + Member + Parameter + MaybeSerializeDeserialize;
+		type Keys: OpaqueKeys + Member + Parameter + MaybeSerializeDeserialize + MaxEncodedLen;
 
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
@@ -596,8 +596,9 @@ pub mod pallet {
 		/// - DbWrites per key id: `KeyOwner`
 		/// # </weight>
 		#[pallet::weight(T::WeightInfo::set_keys())]
-		pub fn set_keys(origin: OriginFor<T>, keys: T::Keys, proof: Vec<u8>) -> DispatchResult {
+		pub fn set_keys(origin: OriginFor<T>, keys: T::Keys, proof: T::Hash) -> DispatchResult {
 			let who = ensure_signed(origin)?;
+			let proof = frame_system::Pallet::<T>::preimage_of(proof).unwrap_or_default();
 			ensure!(keys.ownership_proof_is_valid(&proof), Error::<T>::InvalidProof);
 
 			Self::do_set_keys(&who, keys)?;

--- a/frame/support/procedural/src/construct_runtime/expand/call.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/call.rs
@@ -56,6 +56,7 @@ pub fn expand_outer_dispatch(
 			Clone, PartialEq, Eq,
 			#scrate::codec::Encode,
 			#scrate::codec::Decode,
+			#scrate::codec::MaxEncodedLen,
 			#scrate::scale_info::TypeInfo,
 			#scrate::RuntimeDebug,
 		)]

--- a/frame/support/procedural/src/construct_runtime/expand/inherent.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/inherent.rs
@@ -57,21 +57,22 @@ pub fn expand_outer_inherent(
 			{
 				use #scrate::inherent::ProvideInherent;
 
-				let mut inherents = Vec::new();
+				let mut xts = Vec::new();
 
 				#(
-					if let Some(inherent) = #pallet_names::create_inherent(self) {
-						let inherent = <#unchecked_extrinsic as #scrate::inherent::Extrinsic>::new(
+					if let Some((inherent, required_preimages)) = #pallet_names::create_inherent(self) {
+						let xt = <#unchecked_extrinsic as #scrate::inherent::Extrinsic>::new(
 							inherent.into(),
 							None,
+							required_preimages,
 						).expect("Runtime UncheckedExtrinsic is not Opaque, so it has to return \
 							`Some`; qed");
 
-						inherents.push(inherent);
+						xts.push(xt);
 					}
 				)*
 
-				inherents
+				xts
 			}
 
 			fn check_extrinsics(&self, block: &#block) -> #scrate::inherent::CheckInherentsResult {

--- a/frame/support/procedural/src/construct_runtime/expand/unsigned.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/unsigned.rs
@@ -46,10 +46,10 @@ pub fn expand_outer_validate_unsigned(
 		impl #scrate::unsigned::ValidateUnsigned for #runtime {
 			type Call = Call;
 
-			fn pre_dispatch(call: &Self::Call) -> Result<(), #scrate::unsigned::TransactionValidityError> {
+			fn pre_dispatch(call: &Self::Call, aux_data: &#scrate::AuxData) -> Result<(), #scrate::unsigned::TransactionValidityError> {
 				#[allow(unreachable_patterns)]
 				match call {
-					#( Call::#pallet_names(inner_call) => #pallet_names::pre_dispatch(inner_call), )*
+					#( Call::#pallet_names(inner_call) => #pallet_names::pre_dispatch(inner_call, aux_data), )*
 					// pre-dispatch should not stop inherent extrinsics, validation should prevent
 					// including arbitrary (non-inherent) extrinsics to blocks.
 					_ => Ok(()),
@@ -60,10 +60,11 @@ pub fn expand_outer_validate_unsigned(
 				#[allow(unused_variables)]
 				source: #scrate::unsigned::TransactionSource,
 				call: &Self::Call,
+				aux_data: &#scrate::AuxData,
 			) -> #scrate::unsigned::TransactionValidity {
 				#[allow(unreachable_patterns)]
 				match call {
-					#( Call::#pallet_names(inner_call) => #pallet_names::validate_unsigned(source, inner_call), )*
+					#( Call::#pallet_names(inner_call) => #pallet_names::validate_unsigned(source, inner_call, aux_data), )*
 					_ => #scrate::unsigned::UnknownTransaction::NoUnsignedValidator.into(),
 				}
 			}

--- a/frame/support/procedural/src/pallet/expand/call.rs
+++ b/frame/support/procedural/src/pallet/expand/call.rs
@@ -163,10 +163,12 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 			#frame_support::PartialEqNoBound,
 			#frame_support::codec::Encode,
 			#frame_support::codec::Decode,
+			#frame_support::codec::MaxEncodedLen,
 			#frame_support::scale_info::TypeInfo,
 		)]
 		#[codec(encode_bound())]
 		#[codec(decode_bound())]
+		#[codec(mel_bound())]
 		#[scale_info(skip_type_params(#type_use_gen), capture_docs = #capture_docs)]
 		#[allow(non_camel_case_types)]
 		pub enum #call_ident<#type_decl_bounded_gen> #where_clause {

--- a/frame/support/src/inherent.rs
+++ b/frame/support/src/inherent.rs
@@ -45,7 +45,7 @@ pub trait ProvideInherent {
 	/// E.g. if this provides the timestamp, the call will check that the given timestamp is
 	/// increasing the old timestamp by more than a minimum and it will also check that the
 	/// timestamp hasn't already been set in the current block.
-	fn create_inherent(data: &InherentData) -> Option<Self::Call>;
+	fn create_inherent(data: &InherentData) -> Option<(Self::Call, Vec<Vec<u8>>)>;
 
 	/// Determines whether this inherent is required in this block.
 	///

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -100,7 +100,7 @@ pub use sp_runtime::{
 	self, print, traits::Printable, ConsensusEngineId, MAX_MODULE_ERROR_ENCODED_SIZE,
 };
 
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_runtime::TypeId;
 
@@ -108,11 +108,11 @@ use sp_runtime::TypeId;
 pub const LOG_TARGET: &str = "runtime::frame-support";
 
 /// A type that cannot be instantiated.
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, TypeInfo)]
+#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, TypeInfo, MaxEncodedLen)]
 pub enum Never {}
 
 /// A pallet identifier. These are per pallet and should be stored in a registry somewhere.
-#[derive(Clone, Copy, Eq, PartialEq, Encode, Decode, TypeInfo)]
+#[derive(Clone, Copy, Eq, PartialEq, Encode, Decode, TypeInfo, MaxEncodedLen)]
 pub struct PalletId(pub [u8; 8]);
 
 impl TypeId for PalletId {
@@ -2208,7 +2208,7 @@ pub mod pallet_prelude {
 ///
 /// 		const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
 ///
-/// 		fn create_inherent(_data: &InherentData) -> Option<Self::Call> {
+/// 		fn create_inherent(_data: &InherentData) -> Option<(Self::Call, Vec<Vec<u8>>)> {
 /// 			unimplemented!();
 /// 		}
 ///
@@ -2339,7 +2339,7 @@ pub mod pallet_prelude {
 ///
 /// 		const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
 ///
-/// 		fn create_inherent(_data: &InherentData) -> Option<Self::Call> {
+/// 		fn create_inherent(_data: &InherentData) -> Option<(Self::Call, Vec<Vec<u8>>)> {
 /// 			unimplemented!();
 /// 		}
 ///

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -18,6 +18,8 @@
 //! Support code for the runtime.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(thread_local))]
+#![cfg_attr(not(feature = "std"), feature(const_btree_new))]
 
 /// Export ourself as `frame_support` to make tests happy.
 extern crate self as frame_support;
@@ -61,6 +63,7 @@ mod hash;
 pub mod storage;
 #[macro_use]
 pub mod event;
+mod in_memory_preimages;
 pub mod inherent;
 #[macro_use]
 pub mod error;
@@ -96,6 +99,7 @@ pub use self::{
 		StorageMap, StorageNMap, StoragePrefixedMap, StorageValue,
 	},
 };
+pub use in_memory_preimages::InMemoryPreimages;
 pub use sp_runtime::{
 	self, print, traits::Printable, ConsensusEngineId, MAX_MODULE_ERROR_ENCODED_SIZE,
 };

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -48,7 +48,7 @@ pub use sp_core_hashing_proc_macro;
 #[doc(hidden)]
 pub use sp_io::{self, storage::root as storage_root};
 #[doc(hidden)]
-pub use sp_runtime::{RuntimeDebug, StateVersion};
+pub use sp_runtime::{traits::AuxData, RuntimeDebug, StateVersion};
 #[cfg(feature = "std")]
 #[doc(hidden)]
 pub use sp_state_machine::BasicExternalities;

--- a/frame/support/src/storage/bounded_vec.rs
+++ b/frame/support/src/storage/bounded_vec.rs
@@ -111,6 +111,12 @@ where
 #[scale_info(skip_type_params(S))]
 pub struct BoundedSlice<'a, T, S>(&'a [T], PhantomData<S>);
 
+impl<'a, T, S> AsRef<[T]> for BoundedSlice<'a, T, S> {
+	fn as_ref(&self) -> &[T] {
+		&self.0
+	}
+}
+
 // `BoundedSlice`s encode to something which will always decode into a `BoundedVec`,
 // `WeakBoundedVec`, or a `Vec`.
 impl<'a, T: Encode + Decode, S: Get<u32>> EncodeLike<BoundedVec<T, S>> for BoundedSlice<'a, T, S> {}
@@ -154,6 +160,23 @@ impl<'a, T, S> sp_std::iter::IntoIterator for BoundedSlice<'a, T, S> {
 	type IntoIter = sp_std::slice::Iter<'a, T>;
 	fn into_iter(self) -> Self::IntoIter {
 		self.0.iter()
+	}
+}
+
+impl<'a, T, S> BoundedSlice<'a, T, S> {
+	/// Consume self, and return the inner `Vec`. Henceforth, the `Vec<_>` can be altered in an
+	/// arbitrary way. At some point, if the reverse conversion is required, `TryFrom<Vec<_>>` can
+	/// be used.
+	///
+	/// This is useful for cases if you need access to an internal API of the inner `Vec<_>` which
+	/// is not provided by the wrapper `BoundedVec`.
+	pub fn into_inner(self) -> &'a [T] {
+		self.0
+	}
+
+	/// Returns the number of elements in the slice.
+	pub fn len(&self) -> usize {
+		self.0.len()
 	}
 }
 

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -60,7 +60,7 @@ pub use misc::{
 	EstimateCallFee, ExecuteBlock, ExtrinsicCall, Get, GetBacking, GetDefault, HandleLifetime,
 	IsSubType, IsType, Len, OffchainWorker, OnKilledAccount, OnNewAccount, PreimageProvider,
 	PreimageRecipient, PrivilegeCmp, SameOrOther, Time, TryCollect, TryDrop, TypedGet, UnixTime,
-	WrapperKeepOpaque, WrapperOpaque, TempPreimageRecipient,
+	WrapperKeepOpaque, WrapperOpaque,
 };
 #[doc(hidden)]
 pub use misc::{DEFENSIVE_OP_INTERNAL_ERROR, DEFENSIVE_OP_PUBLIC_ERROR};

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -60,7 +60,7 @@ pub use misc::{
 	EstimateCallFee, ExecuteBlock, ExtrinsicCall, Get, GetBacking, GetDefault, HandleLifetime,
 	IsSubType, IsType, Len, OffchainWorker, OnKilledAccount, OnNewAccount, PreimageProvider,
 	PreimageRecipient, PrivilegeCmp, SameOrOther, Time, TryCollect, TryDrop, TypedGet, UnixTime,
-	WrapperKeepOpaque, WrapperOpaque,
+	WrapperKeepOpaque, WrapperOpaque, TempPreimageRecipient,
 };
 #[doc(hidden)]
 pub use misc::{DEFENSIVE_OP_INTERNAL_ERROR, DEFENSIVE_OP_PUBLIC_ERROR};

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -30,7 +30,7 @@ use sp_runtime::{traits::Block as BlockT, DispatchError};
 use sp_std::{borrow::Cow, cmp::Ordering, prelude::*};
 
 #[doc(hidden)]
-pub use sp_runtime::traits::PreimageHandler;
+pub use sp_runtime::traits::PreimageStash;
 
 #[doc(hidden)]
 pub const DEFENSIVE_OP_PUBLIC_ERROR: &str = "a defensive failure has been triggered; please report the block number at https://github.com/paritytech/substrate/issues";
@@ -898,7 +898,7 @@ pub trait PreimageProvider<Hash> {
 	fn have_preimage(hash: &Hash) -> bool;
 
 	/// Returns the preimage for a given hash.
-	fn get_preimage(hash: &Hash) -> Option<Cow<[u8]>>;
+	fn get_preimage(hash: &Hash) -> Option<Cow<'static, [u8]>>;
 
 	/// Returns whether a preimage request exists for a given hash.
 	fn preimage_requested(hash: &Hash) -> bool;
@@ -915,7 +915,7 @@ impl<Hash> PreimageProvider<Hash> for () {
 	fn have_preimage(_: &Hash) -> bool {
 		false
 	}
-	fn get_preimage(_: &Hash) -> Option<Cow<[u8]>> {
+	fn get_preimage(_: &Hash) -> Option<Cow<'static, [u8]>> {
 		None
 	}
 	fn preimage_requested(_: &Hash) -> bool {
@@ -935,7 +935,7 @@ pub trait PreimageRecipient<Hash>: PreimageProvider<Hash> {
 	type MaxSize: Get<u32>;
 
 	/// Store the bytes of a preimage on chain.
-	fn note_preimage(bytes: crate::BoundedVec<u8, Self::MaxSize>);
+	fn note_preimage(bytes: crate::BoundedSlice<u8, Self::MaxSize>);
 
 	/// Clear a previously noted preimage. This is infallible and should be treated more like a
 	/// hint - if it was not previously noted or if it is now requested, then this will not do
@@ -945,7 +945,7 @@ pub trait PreimageRecipient<Hash>: PreimageProvider<Hash> {
 
 impl<Hash> PreimageRecipient<Hash> for () {
 	type MaxSize = ();
-	fn note_preimage(_: crate::BoundedVec<u8, Self::MaxSize>) {}
+	fn note_preimage(_: crate::BoundedSlice<u8, Self::MaxSize>) {}
 	fn unnote_preimage(_: &Hash) {}
 }
 

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -27,7 +27,10 @@ pub use sp_runtime::traits::{
 	ConstU64, ConstU8, Get, GetDefault, TypedGet,
 };
 use sp_runtime::{traits::Block as BlockT, DispatchError};
-use sp_std::{cmp::Ordering, prelude::*, borrow::Cow};
+use sp_std::{borrow::Cow, cmp::Ordering, prelude::*};
+
+#[doc(hidden)]
+pub use sp_runtime::traits::PreimageHandler;
 
 #[doc(hidden)]
 pub const DEFENSIVE_OP_PUBLIC_ERROR: &str = "a defensive failure has been triggered; please report the block number at https://github.com/paritytech/substrate/issues";
@@ -701,7 +704,7 @@ where
 	Extra: sp_runtime::traits::SignedExtension,
 {
 	fn call(&self) -> &Self::Call {
-		&self.function
+		&self.function.call
 	}
 }
 
@@ -944,25 +947,6 @@ impl<Hash> PreimageRecipient<Hash> for () {
 	type MaxSize = ();
 	fn note_preimage(_: crate::BoundedVec<u8, Self::MaxSize>) {}
 	fn unnote_preimage(_: &Hash) {}
-}
-
-/// A interface for placing preimages on-chain temporarily. These preimages are unbounded.
-pub trait TempPreimageRecipient<Hash>: PreimageProvider<Hash> {
-	/// Store the bytes of a preimage on chain. If you are using borreowed data, it must be valid
-	/// "forever".
-	fn note_preimage(bytes: Cow<'static, [u8]>);
-
-	/// Clear a previously noted preimage.
-	fn unnote_preimage(hash: &Hash);
-
-	/// Clear all previously noted preimages. This might be faster than removing them one at a time.
-	fn clear();
-}
-
-impl<Hash> TempPreimageRecipient<Hash> for () {
-	fn note_preimage(_: Cow<'static, [u8]>) {}
-	fn unnote_preimage(_: &Hash) {}
-	fn clear() {}
 }
 
 #[cfg(test)]

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -27,7 +27,7 @@ pub use sp_runtime::traits::{
 	ConstU64, ConstU8, Get, GetDefault, TypedGet,
 };
 use sp_runtime::{traits::Block as BlockT, DispatchError};
-use sp_std::{cmp::Ordering, prelude::*};
+use sp_std::{cmp::Ordering, prelude::*, borrow::Cow};
 
 #[doc(hidden)]
 pub const DEFENSIVE_OP_PUBLIC_ERROR: &str = "a defensive failure has been triggered; please report the block number at https://github.com/paritytech/substrate/issues";
@@ -895,7 +895,7 @@ pub trait PreimageProvider<Hash> {
 	fn have_preimage(hash: &Hash) -> bool;
 
 	/// Returns the preimage for a given hash.
-	fn get_preimage(hash: &Hash) -> Option<Vec<u8>>;
+	fn get_preimage(hash: &Hash) -> Option<Cow<[u8]>>;
 
 	/// Returns whether a preimage request exists for a given hash.
 	fn preimage_requested(hash: &Hash) -> bool;
@@ -912,7 +912,7 @@ impl<Hash> PreimageProvider<Hash> for () {
 	fn have_preimage(_: &Hash) -> bool {
 		false
 	}
-	fn get_preimage(_: &Hash) -> Option<Vec<u8>> {
+	fn get_preimage(_: &Hash) -> Option<Cow<[u8]>> {
 		None
 	}
 	fn preimage_requested(_: &Hash) -> bool {

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -946,6 +946,25 @@ impl<Hash> PreimageRecipient<Hash> for () {
 	fn unnote_preimage(_: &Hash) {}
 }
 
+/// A interface for placing preimages on-chain temporarily. These preimages are unbounded.
+pub trait TempPreimageRecipient<Hash>: PreimageProvider<Hash> {
+	/// Store the bytes of a preimage on chain. If you are using borreowed data, it must be valid
+	/// "forever".
+	fn note_preimage(bytes: Cow<'static, [u8]>);
+
+	/// Clear a previously noted preimage.
+	fn unnote_preimage(hash: &Hash);
+
+	/// Clear all previously noted preimages. This might be faster than removing them one at a time.
+	fn clear();
+}
+
+impl<Hash> TempPreimageRecipient<Hash> for () {
+	fn note_preimage(_: Cow<'static, [u8]>) {}
+	fn unnote_preimage(_: &Hash) {}
+	fn clear() {}
+}
+
 #[cfg(test)]
 mod test {
 	use super::*;

--- a/frame/support/src/weights.rs
+++ b/frame/support/src/weights.rs
@@ -576,7 +576,7 @@ where
 	Extra: SignedExtension,
 {
 	fn get_dispatch_info(&self) -> DispatchInfo {
-		self.function.get_dispatch_info()
+		self.function.call.get_dispatch_info()
 	}
 }
 
@@ -586,7 +586,7 @@ where
 	Call: GetDispatchInfo,
 {
 	fn get_dispatch_info(&self) -> DispatchInfo {
-		self.function.get_dispatch_info()
+		self.function.call.get_dispatch_info()
 	}
 }
 

--- a/frame/support/test/tests/instance.rs
+++ b/frame/support/test/tests/instance.rs
@@ -127,7 +127,7 @@ mod module1 {
 		type Error = MakeFatalError<()>;
 		const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
 
-		fn create_inherent(_data: &InherentData) -> Option<Self::Call> {
+		fn create_inherent(_data: &InherentData) -> Option<(Self::Call, Vec<Vec<u8>>)> {
 			unimplemented!();
 		}
 
@@ -194,7 +194,7 @@ mod module2 {
 		type Error = MakeFatalError<()>;
 		const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
 
-		fn create_inherent(_data: &InherentData) -> Option<Self::Call> {
+		fn create_inherent(_data: &InherentData) -> Option<(Self::Call, Vec<Vec<u8>>)> {
 			unimplemented!();
 		}
 

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -389,10 +389,10 @@ pub mod pallet {
 
 		const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
 
-		fn create_inherent(_data: &InherentData) -> Option<Self::Call> {
+		fn create_inherent(_data: &InherentData) -> Option<(Self::Call, Vec<Vec<u8>>)> {
 			let _ = T::AccountId::from(SomeType1); // Test for where clause
 			let _ = T::AccountId::from(SomeType6); // Test for where clause
-			Some(Call::foo_no_post_info {})
+			Some((Call::foo_no_post_info {}, Vec::new()))
 		}
 
 		fn is_inherent(call: &Self::Call) -> bool {
@@ -689,6 +689,7 @@ fn inherent_expand() {
 		signature: None,
 	}];
 	assert_eq!(expected, inherents);
+	assert_eq!(required_preimages, vec![]);
 
 	let block = Block::new(
 		Header::new(

--- a/frame/support/test/tests/pallet_instance.rs
+++ b/frame/support/test/tests/pallet_instance.rs
@@ -186,7 +186,7 @@ pub mod pallet {
 
 		const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
 
-		fn create_inherent(_data: &InherentData) -> Option<Self::Call> {
+		fn create_inherent(_data: &InherentData) -> Option<(Self::Call, Vec<Vec<u8>>)> {
 			unimplemented!();
 		}
 

--- a/frame/support/test/tests/pallet_ui/inherent_check_inner_span.stderr
+++ b/frame/support/test/tests/pallet_ui/inherent_check_inner_span.stderr
@@ -7,5 +7,5 @@ error[E0046]: not all trait items implemented, missing: `Call`, `Error`, `INHERE
    = help: implement the missing item: `type Call = Type;`
    = help: implement the missing item: `type Error = Type;`
    = help: implement the missing item: `const INHERENT_IDENTIFIER: [u8; 8] = value;`
-   = help: implement the missing item: `fn create_inherent(_: &InherentData) -> std::option::Option<<Self as ProvideInherent>::Call> { todo!() }`
+   = help: implement the missing item: `fn create_inherent(_: &InherentData) -> std::option::Option<(<Self as ProvideInherent>::Call, Vec<Vec<u8>>)> { todo!() }`
    = help: implement the missing item: `fn is_inherent(_: &<Self as ProvideInherent>::Call) -> bool { todo!() }`

--- a/frame/support/test/tests/pallet_with_name_trait_is_valid.rs
+++ b/frame/support/test/tests/pallet_with_name_trait_is_valid.rs
@@ -77,7 +77,7 @@ impl<T: Trait> frame_support::inherent::ProvideInherent for Module<T> {
 	type Error = frame_support::inherent::MakeFatalError<()>;
 	const INHERENT_IDENTIFIER: frame_support::inherent::InherentIdentifier = INHERENT_IDENTIFIER;
 
-	fn create_inherent(_data: &frame_support::inherent::InherentData) -> Option<Self::Call> {
+	fn create_inherent(_data: &frame_support::inherent::InherentData) -> Option<(Self::Call, Vec<Vec<u8>>)> {
 		unimplemented!();
 	}
 

--- a/frame/support/test/tests/pallet_with_name_trait_is_valid.rs
+++ b/frame/support/test/tests/pallet_with_name_trait_is_valid.rs
@@ -77,7 +77,9 @@ impl<T: Trait> frame_support::inherent::ProvideInherent for Module<T> {
 	type Error = frame_support::inherent::MakeFatalError<()>;
 	const INHERENT_IDENTIFIER: frame_support::inherent::InherentIdentifier = INHERENT_IDENTIFIER;
 
-	fn create_inherent(_data: &frame_support::inherent::InherentData) -> Option<(Self::Call, Vec<Vec<u8>>)> {
+	fn create_inherent(
+		_data: &frame_support::inherent::InherentData,
+	) -> Option<(Self::Call, Vec<Vec<u8>>)> {
 		unimplemented!();
 	}
 

--- a/frame/system/src/extensions/check_genesis.rs
+++ b/frame/system/src/extensions/check_genesis.rs
@@ -19,7 +19,7 @@ use crate::{Config, Pallet};
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::{
-	traits::{DispatchInfoOf, SignedExtension, Zero},
+	traits::{AuxData, DispatchInfoOf, SignedExtension, Zero},
 	transaction_validity::TransactionValidityError,
 };
 
@@ -69,7 +69,8 @@ impl<T: Config + Send + Sync> SignedExtension for CheckGenesis<T> {
 		call: &Self::Call,
 		info: &DispatchInfoOf<Self::Call>,
 		len: usize,
+		aux_data: &AuxData,
 	) -> Result<Self::Pre, TransactionValidityError> {
-		self.validate(who, call, info, len).map(|_| ())
+		self.validate(who, call, info, len, aux_data).map(|_| ())
 	}
 }

--- a/frame/system/src/extensions/check_mortality.rs
+++ b/frame/system/src/extensions/check_mortality.rs
@@ -20,7 +20,7 @@ use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::{
 	generic::Era,
-	traits::{DispatchInfoOf, SaturatedConversion, SignedExtension},
+	traits::{AuxData, DispatchInfoOf, SaturatedConversion, SignedExtension},
 	transaction_validity::{
 		InvalidTransaction, TransactionValidity, TransactionValidityError, ValidTransaction,
 	},
@@ -67,6 +67,7 @@ impl<T: Config + Send + Sync> SignedExtension for CheckMortality<T> {
 		_call: &Self::Call,
 		_info: &DispatchInfoOf<Self::Call>,
 		_len: usize,
+		_aux_data: &AuxData,
 	) -> TransactionValidity {
 		let current_u64 = <Pallet<T>>::block_number().saturated_into::<u64>();
 		let valid_till = self.0.death(current_u64);
@@ -92,8 +93,9 @@ impl<T: Config + Send + Sync> SignedExtension for CheckMortality<T> {
 		call: &Self::Call,
 		info: &DispatchInfoOf<Self::Call>,
 		len: usize,
+		aux_data: &AuxData,
 	) -> Result<Self::Pre, TransactionValidityError> {
-		self.validate(who, call, info, len).map(|_| ())
+		self.validate(who, call, info, len, aux_data).map(|_| ())
 	}
 }
 
@@ -136,7 +138,7 @@ mod tests {
 			System::set_block_number(17);
 			<BlockHash<Test>>::insert(16, H256::repeat_byte(1));
 
-			assert_eq!(ext.validate(&1, CALL, &normal, len).unwrap().longevity, 15);
+			assert_eq!(ext.validate(&1, CALL, &normal, len, &vec![]).unwrap().longevity, 15);
 		})
 	}
 }

--- a/frame/system/src/extensions/check_non_zero_sender.rs
+++ b/frame/system/src/extensions/check_non_zero_sender.rs
@@ -20,7 +20,7 @@ use codec::{Decode, Encode};
 use frame_support::weights::DispatchInfo;
 use scale_info::TypeInfo;
 use sp_runtime::{
-	traits::{DispatchInfoOf, Dispatchable, SignedExtension},
+	traits::{AuxData, DispatchInfoOf, Dispatchable, SignedExtension},
 	transaction_validity::{
 		InvalidTransaction, TransactionValidity, TransactionValidityError, ValidTransaction,
 	},
@@ -71,8 +71,9 @@ where
 		call: &Self::Call,
 		info: &DispatchInfoOf<Self::Call>,
 		len: usize,
+		aux_data: &AuxData,
 	) -> Result<Self::Pre, TransactionValidityError> {
-		self.validate(who, call, info, len).map(|_| ())
+		self.validate(who, call, info, len, aux_data).map(|_| ())
 	}
 
 	fn validate(
@@ -81,6 +82,7 @@ where
 		_call: &Self::Call,
 		_info: &DispatchInfoOf<Self::Call>,
 		_len: usize,
+		_aux_data: &AuxData,
 	) -> TransactionValidity {
 		if who.using_encoded(|d| d.iter().all(|x| *x == 0)) {
 			return Err(TransactionValidityError::Invalid(InvalidTransaction::BadSigner))
@@ -101,10 +103,10 @@ mod tests {
 			let info = DispatchInfo::default();
 			let len = 0_usize;
 			assert_noop!(
-				CheckNonZeroSender::<Test>::new().validate(&0, CALL, &info, len),
+				CheckNonZeroSender::<Test>::new().validate(&0, CALL, &info, len, &vec![]),
 				InvalidTransaction::BadSigner
 			);
-			assert_ok!(CheckNonZeroSender::<Test>::new().validate(&1, CALL, &info, len));
+			assert_ok!(CheckNonZeroSender::<Test>::new().validate(&1, CALL, &info, len, &vec![]));
 		})
 	}
 }

--- a/frame/system/src/extensions/check_nonce.rs
+++ b/frame/system/src/extensions/check_nonce.rs
@@ -20,7 +20,7 @@ use codec::{Decode, Encode};
 use frame_support::weights::DispatchInfo;
 use scale_info::TypeInfo;
 use sp_runtime::{
-	traits::{DispatchInfoOf, Dispatchable, One, SignedExtension},
+	traits::{AuxData, DispatchInfoOf, Dispatchable, One, SignedExtension},
 	transaction_validity::{
 		InvalidTransaction, TransactionLongevity, TransactionValidity, TransactionValidityError,
 		ValidTransaction,
@@ -78,6 +78,7 @@ where
 		_call: &Self::Call,
 		_info: &DispatchInfoOf<Self::Call>,
 		_len: usize,
+		_aux_data: &AuxData,
 	) -> Result<(), TransactionValidityError> {
 		let mut account = crate::Account::<T>::get(who);
 		if self.0 != account.nonce {
@@ -99,6 +100,7 @@ where
 		_call: &Self::Call,
 		_info: &DispatchInfoOf<Self::Call>,
 		_len: usize,
+		_aux_data: &AuxData,
 	) -> TransactionValidity {
 		// check index
 		let account = crate::Account::<T>::get(who);
@@ -146,20 +148,20 @@ mod tests {
 			let len = 0_usize;
 			// stale
 			assert_noop!(
-				CheckNonce::<Test>(0).validate(&1, CALL, &info, len),
+				CheckNonce::<Test>(0).validate(&1, CALL, &info, len, &vec![]),
 				InvalidTransaction::Stale
 			);
 			assert_noop!(
-				CheckNonce::<Test>(0).pre_dispatch(&1, CALL, &info, len),
+				CheckNonce::<Test>(0).pre_dispatch(&1, CALL, &info, len, &vec![]),
 				InvalidTransaction::Stale
 			);
 			// correct
-			assert_ok!(CheckNonce::<Test>(1).validate(&1, CALL, &info, len));
-			assert_ok!(CheckNonce::<Test>(1).pre_dispatch(&1, CALL, &info, len));
+			assert_ok!(CheckNonce::<Test>(1).validate(&1, CALL, &info, len, &vec![]));
+			assert_ok!(CheckNonce::<Test>(1).pre_dispatch(&1, CALL, &info, len, &vec![]));
 			// future
-			assert_ok!(CheckNonce::<Test>(5).validate(&1, CALL, &info, len));
+			assert_ok!(CheckNonce::<Test>(5).validate(&1, CALL, &info, len, &vec![]));
 			assert_noop!(
-				CheckNonce::<Test>(5).pre_dispatch(&1, CALL, &info, len),
+				CheckNonce::<Test>(5).pre_dispatch(&1, CALL, &info, len, &vec![]),
 				InvalidTransaction::Future
 			);
 		})

--- a/frame/system/src/extensions/check_spec_version.rs
+++ b/frame/system/src/extensions/check_spec_version.rs
@@ -19,7 +19,7 @@ use crate::{Config, Pallet};
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::{
-	traits::{DispatchInfoOf, SignedExtension},
+	traits::{AuxData, DispatchInfoOf, SignedExtension},
 	transaction_validity::TransactionValidityError,
 };
 
@@ -69,7 +69,8 @@ impl<T: Config + Send + Sync> SignedExtension for CheckSpecVersion<T> {
 		call: &Self::Call,
 		info: &DispatchInfoOf<Self::Call>,
 		len: usize,
+		aux_data: &AuxData,
 	) -> Result<Self::Pre, TransactionValidityError> {
-		self.validate(who, call, info, len).map(|_| ())
+		self.validate(who, call, info, len, aux_data).map(|_| ())
 	}
 }

--- a/frame/system/src/extensions/check_tx_version.rs
+++ b/frame/system/src/extensions/check_tx_version.rs
@@ -19,7 +19,7 @@ use crate::{Config, Pallet};
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::{
-	traits::{DispatchInfoOf, SignedExtension},
+	traits::{AuxData, DispatchInfoOf, SignedExtension},
 	transaction_validity::TransactionValidityError,
 };
 
@@ -68,7 +68,8 @@ impl<T: Config + Send + Sync> SignedExtension for CheckTxVersion<T> {
 		call: &Self::Call,
 		info: &DispatchInfoOf<Self::Call>,
 		len: usize,
+		aux_data: &AuxData,
 	) -> Result<Self::Pre, TransactionValidityError> {
-		self.validate(who, call, info, len).map(|_| ())
+		self.validate(who, call, info, len, aux_data).map(|_| ())
 	}
 }

--- a/frame/system/src/extensions/check_weight.rs
+++ b/frame/system/src/extensions/check_weight.rs
@@ -23,7 +23,7 @@ use frame_support::{
 };
 use scale_info::TypeInfo;
 use sp_runtime::{
-	traits::{DispatchInfoOf, Dispatchable, PostDispatchInfoOf, SignedExtension},
+	traits::{AuxData, DispatchInfoOf, Dispatchable, PostDispatchInfoOf, SignedExtension},
 	transaction_validity::{InvalidTransaction, TransactionValidity, TransactionValidityError},
 	DispatchResult,
 };
@@ -186,6 +186,7 @@ where
 		_call: &Self::Call,
 		info: &DispatchInfoOf<Self::Call>,
 		len: usize,
+		_aux_data: &AuxData,
 	) -> Result<(), TransactionValidityError> {
 		if info.class == DispatchClass::Mandatory {
 			return Err(InvalidTransaction::MandatoryDispatch.into())
@@ -199,6 +200,7 @@ where
 		_call: &Self::Call,
 		info: &DispatchInfoOf<Self::Call>,
 		len: usize,
+		_aux_data: &AuxData,
 	) -> TransactionValidity {
 		if info.class == DispatchClass::Mandatory {
 			return Err(InvalidTransaction::MandatoryDispatch.into())
@@ -210,6 +212,7 @@ where
 		_call: &Self::Call,
 		info: &DispatchInfoOf<Self::Call>,
 		len: usize,
+		_aux_data: &AuxData,
 	) -> Result<(), TransactionValidityError> {
 		Self::do_pre_dispatch(info, len)
 	}
@@ -218,6 +221,7 @@ where
 		_call: &Self::Call,
 		info: &DispatchInfoOf<Self::Call>,
 		len: usize,
+		_aux_data: &AuxData,
 	) -> TransactionValidity {
 		Self::do_validate(info, len)
 	}

--- a/frame/system/src/mock.rs
+++ b/frame/system/src/mock.rs
@@ -27,8 +27,8 @@ use sp_runtime::{
 	BuildStorage,
 };
 use std::{
+	cell::RefCell,
 	collections::{HashMap, HashSet},
-	cell::RefCell
 };
 
 type UncheckedExtrinsic = mocking::MockUncheckedExtrinsic<Test>;
@@ -100,20 +100,30 @@ thread_local! {
 
 pub struct TestPreimageProvider;
 impl PreimageProvider<H256> for TestPreimageProvider {
-	fn have_preimage(hash: &H256) -> bool { PREIMAGES.with(|x| x.borrow().contains_key(hash)) }
+	fn have_preimage(hash: &H256) -> bool {
+		PREIMAGES.with(|x| x.borrow().contains_key(hash))
+	}
 
 	/// Returns the preimage for a given hash.
-	fn get_preimage(hash: &H256) -> Option<Vec<u8>> { PREIMAGES.with(|x| x.borrow().get(hash).cloned()) }
+	fn get_preimage(hash: &H256) -> Option<Vec<u8>> {
+		PREIMAGES.with(|x| x.borrow().get(hash).cloned())
+	}
 
 	/// Returns whether a preimage request exists for a given hash.
-	fn preimage_requested(hash: &H256) -> bool { PREIMAGE_REQUESTS.with(|r| r.borrow().contains(hash)) }
+	fn preimage_requested(hash: &H256) -> bool {
+		PREIMAGE_REQUESTS.with(|r| r.borrow().contains(hash))
+	}
 
 	/// Request that someone report a preimage. Providers use this to optimise the economics for
 	/// preimage reporting.
-	fn request_preimage(hash: &H256) { PREIMAGE_REQUESTS.with(|r| r.borrow_mut().insert(hash.clone())); }
+	fn request_preimage(hash: &H256) {
+		PREIMAGE_REQUESTS.with(|r| r.borrow_mut().insert(hash.clone()));
+	}
 
 	/// Cancel a previous preimage request.
-	fn unrequest_preimage(hash: &H256) { PREIMAGE_REQUESTS.with(|r| r.borrow_mut().remove(hash)); }
+	fn unrequest_preimage(hash: &H256) {
+		PREIMAGE_REQUESTS.with(|r| r.borrow_mut().remove(hash));
+	}
 }
 
 impl Config for Test {

--- a/frame/system/src/mock.rs
+++ b/frame/system/src/mock.rs
@@ -106,7 +106,7 @@ impl PreimageProvider<H256> for TestPreimageProvider {
 	}
 
 	/// Returns the preimage for a given hash.
-	fn get_preimage(hash: &H256) -> Option<Cow<[u8]>> {
+	fn get_preimage(hash: &H256) -> Option<Cow<'static, [u8]>> {
 		PREIMAGES.with(|x| x.borrow().get(hash).cloned().map(Cow::from))
 	}
 

--- a/frame/system/src/mock.rs
+++ b/frame/system/src/mock.rs
@@ -26,9 +26,10 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 	BuildStorage,
 };
-use std::{
+use sp_std::{
+	borrow::Cow,
 	cell::RefCell,
-	collections::{HashMap, HashSet},
+	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
 };
 
 type UncheckedExtrinsic = mocking::MockUncheckedExtrinsic<Test>;
@@ -94,8 +95,8 @@ impl OnKilledAccount<u64> for RecordKilled {
 }
 
 thread_local! {
-	pub static PREIMAGES: RefCell<HashMap<H256, Vec<u8>>> = RefCell::new(HashMap::new());
-	pub static PREIMAGE_REQUESTS: RefCell<HashSet<H256>> = RefCell::new(HashSet::new());
+	pub static PREIMAGES: RefCell<BTreeMap<H256, Vec<u8>>> = RefCell::new(BTreeMap::new());
+	pub static PREIMAGE_REQUESTS: RefCell<BTreeSet<H256>> = RefCell::new(BTreeSet::new());
 }
 
 pub struct TestPreimageProvider;
@@ -105,8 +106,8 @@ impl PreimageProvider<H256> for TestPreimageProvider {
 	}
 
 	/// Returns the preimage for a given hash.
-	fn get_preimage(hash: &H256) -> Option<Vec<u8>> {
-		PREIMAGES.with(|x| x.borrow().get(hash).cloned())
+	fn get_preimage(hash: &H256) -> Option<Cow<[u8]>> {
+		PREIMAGES.with(|x| x.borrow().get(hash).cloned().map(Cow::from))
 	}
 
 	/// Returns whether a preimage request exists for a given hash.

--- a/frame/system/src/tests.rs
+++ b/frame/system/src/tests.rs
@@ -390,7 +390,8 @@ fn set_code_checks_works() {
 		let mut ext = new_test_ext();
 		ext.register_extension(sp_core::traits::ReadRuntimeVersionExt::new(read_runtime_version));
 		ext.execute_with(|| {
-			let res = System::set_code(RawOrigin::Root.into(), vec![1, 2, 3, 4]);
+			let h = insert_preimage(vec![1, 2, 3, 4]);
+			let res = System::set_code(RawOrigin::Root.into(), h);
 
 			assert_runtime_updated_digest(if res.is_ok() { 1 } else { 0 });
 			assert_eq!(expected.map_err(DispatchErrorWithPostInfo::from), res);
@@ -417,11 +418,8 @@ fn set_code_with_real_wasm_blob() {
 	ext.register_extension(sp_core::traits::ReadRuntimeVersionExt::new(executor));
 	ext.execute_with(|| {
 		System::set_block_number(1);
-		System::set_code(
-			RawOrigin::Root.into(),
-			substrate_test_runtime_client::runtime::wasm_binary_unwrap().to_vec(),
-		)
-		.unwrap();
+		let h = insert_preimage(substrate_test_runtime_client::runtime::wasm_binary_unwrap().to_vec());
+		System::set_code( RawOrigin::Root.into(), h).unwrap();
 
 		assert_eq!(
 			System::events(),

--- a/frame/system/src/tests.rs
+++ b/frame/system/src/tests.rs
@@ -418,8 +418,9 @@ fn set_code_with_real_wasm_blob() {
 	ext.register_extension(sp_core::traits::ReadRuntimeVersionExt::new(executor));
 	ext.execute_with(|| {
 		System::set_block_number(1);
-		let h = insert_preimage(substrate_test_runtime_client::runtime::wasm_binary_unwrap().to_vec());
-		System::set_code( RawOrigin::Root.into(), h).unwrap();
+		let h =
+			insert_preimage(substrate_test_runtime_client::runtime::wasm_binary_unwrap().to_vec());
+		System::set_code(RawOrigin::Root.into(), h).unwrap();
 
 		assert_eq!(
 			System::events(),
@@ -438,14 +439,14 @@ fn runtime_upgraded_with_set_storage() {
 	let mut ext = new_test_ext();
 	ext.register_extension(sp_core::traits::ReadRuntimeVersionExt::new(executor));
 	ext.execute_with(|| {
-		System::set_storage(
-			RawOrigin::Root.into(),
+		let h = insert_preimage(
 			vec![(
 				well_known_keys::CODE.to_vec(),
 				substrate_test_runtime_client::runtime::wasm_binary_unwrap().to_vec(),
-			)],
-		)
-		.unwrap();
+			)]
+			.encode(),
+		);
+		System::set_storage(RawOrigin::Root.into(), h, 1).unwrap();
 	});
 }
 

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -111,7 +111,7 @@ pub mod weights;
 
 use frame_support::traits::{OnTimestampSet, Time, UnixTime};
 use sp_runtime::traits::{AtLeast32Bit, SaturatedConversion, Scale, Zero};
-use sp_std::{cmp, result};
+use sp_std::{prelude::*, cmp, result};
 use sp_timestamp::{InherentError, InherentType, INHERENT_IDENTIFIER};
 pub use weights::WeightInfo;
 
@@ -225,7 +225,7 @@ pub mod pallet {
 		type Error = InherentError;
 		const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
 
-		fn create_inherent(data: &InherentData) -> Option<Self::Call> {
+		fn create_inherent(data: &InherentData) -> Option<(Self::Call, Vec<Vec<u8>>)> {
 			let inherent_data = data
 				.get_data::<InherentType>(&INHERENT_IDENTIFIER)
 				.expect("Timestamp inherent data not correctly encoded")
@@ -233,7 +233,7 @@ pub mod pallet {
 			let data = (*inherent_data).saturated_into::<T::Moment>();
 
 			let next_time = cmp::max(data, Self::now() + T::MinimumPeriod::get());
-			Some(Call::set { now: next_time })
+			Some((Call::set { now: next_time }, Vec::new()))
 		}
 
 		fn check_inherent(

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -111,7 +111,7 @@ pub mod weights;
 
 use frame_support::traits::{OnTimestampSet, Time, UnixTime};
 use sp_runtime::traits::{AtLeast32Bit, SaturatedConversion, Scale, Zero};
-use sp_std::{prelude::*, cmp, result};
+use sp_std::{cmp, prelude::*, result};
 use sp_timestamp::{InherentError, InherentType, INHERENT_IDENTIFIER};
 pub use weights::WeightInfo;
 

--- a/frame/transaction-storage/src/lib.rs
+++ b/frame/transaction-storage/src/lib.rs
@@ -405,7 +405,7 @@ pub mod pallet {
 		type Error = InherentError;
 		const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
 
-		fn create_inherent(data: &InherentData) -> Option<Self::Call> {
+		fn create_inherent(data: &InherentData) -> Option<(Self::Call, Vec<Vec<u8>>)> {
 			let proof = data
 				.get_data::<TransactionStorageProof>(&Self::INHERENT_IDENTIFIER)
 				.unwrap_or(None);

--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -22,7 +22,7 @@ use crate::traits::{
 	BaseArithmetic, Bounded, CheckedAdd, CheckedMul, CheckedSub, One, SaturatedConversion,
 	Saturating, UniqueSaturatedInto, Unsigned, Zero,
 };
-use codec::{CompactAs, Encode};
+use codec::{CompactAs, Encode, MaxEncodedLen};
 use num_traits::{Pow, SaturatingAdd, SaturatingSub};
 use sp_std::{
 	fmt, ops,
@@ -608,7 +608,7 @@ macro_rules! implement_per_thing {
 		///
 		#[doc = $title]
 		#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-		#[derive(Encode, Copy, Clone, PartialEq, Eq, codec::MaxEncodedLen, PartialOrd, Ord, scale_info::TypeInfo)]
+		#[derive(Encode, Copy, Clone, PartialEq, Eq, MaxEncodedLen, PartialOrd, Ord, scale_info::TypeInfo)]
 		pub struct $name($type);
 
 		/// Implementation makes any compact encoding of `PerThing::Inner` valid,

--- a/primitives/consensus/slots/src/lib.rs
+++ b/primitives/consensus/slots/src/lib.rs
@@ -141,3 +141,16 @@ pub struct EquivocationProof<Header, Id> {
 	/// The second header involved in the equivocation.
 	pub second_header: Header,
 }
+
+// Just put a crazy maximum for now.
+impl<Header: Encode, Id: Encode> MaxEncodedLen for EquivocationProof<Header, Id> {
+	fn max_encoded_len() -> usize {
+		500_000
+	}
+}
+
+impl<Header: Encode, Id: Encode> MaxEncodedLen for sp_std::boxed::Box<EquivocationProof<Header, Id>> {
+	fn max_encoded_len() -> usize {
+		500_000
+	}
+}

--- a/primitives/consensus/slots/src/lib.rs
+++ b/primitives/consensus/slots/src/lib.rs
@@ -148,9 +148,3 @@ impl<Header: Encode, Id: Encode> MaxEncodedLen for EquivocationProof<Header, Id>
 		500_000
 	}
 }
-
-impl<Header: Encode, Id: Encode> MaxEncodedLen for sp_std::boxed::Box<EquivocationProof<Header, Id>> {
-	fn max_encoded_len() -> usize {
-		500_000
-	}
-}

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -32,7 +32,7 @@ macro_rules! map {
 }
 
 #[doc(hidden)]
-pub use codec::{Decode, Encode};
+pub use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 pub use serde;
@@ -418,7 +418,7 @@ pub fn to_substrate_wasm_fn_return_value(value: &impl Encode) -> u64 {
 
 /// The void type - it cannot exist.
 // Oh rust, you crack me up...
-#[derive(Clone, Decode, Encode, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[derive(Clone, Decode, Encode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub enum Void {}
 
 /// Macro for creating `Maybe*` marker traits.

--- a/primitives/finality-grandpa/src/lib.rs
+++ b/primitives/finality-grandpa/src/lib.rs
@@ -25,7 +25,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 use serde::Serialize;
 
-use codec::{Codec, Decode, Encode, Input};
+use codec::{Codec, Decode, Encode, Input, MaxEncodedLen};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
@@ -175,6 +175,13 @@ impl<N: Codec> ConsensusLog<N> {
 pub struct EquivocationProof<H, N> {
 	set_id: SetId,
 	equivocation: Equivocation<H, N>,
+}
+
+// Just put a crazy maximum for now.
+impl<H: Encode, N: Encode> MaxEncodedLen for EquivocationProof<H, N> {
+	fn max_encoded_len() -> usize {
+		500_000
+	}
 }
 
 impl<H, N> EquivocationProof<H, N> {

--- a/primitives/runtime/src/generic/checked_extrinsic.rs
+++ b/primitives/runtime/src/generic/checked_extrinsic.rs
@@ -21,7 +21,7 @@
 use crate::{
 	traits::{
 		self, DispatchInfoOf, Dispatchable, FatCall, MaybeDisplay, Member, PostDispatchInfoOf,
-		PreimageHandler, SignedExtension, ValidateUnsigned,
+		PreimageStash, SignedExtension, ValidateUnsigned,
 	},
 	transaction_validity::{TransactionSource, TransactionValidity},
 };
@@ -49,7 +49,7 @@ where
 {
 	type Call = Call;
 
-	fn validate<U: ValidateUnsigned<Call = Self::Call>, P: PreimageHandler>(
+	fn validate<U: ValidateUnsigned<Call = Self::Call>, P: PreimageStash>(
 		&self,
 		// TODO [#5006;ToDr] should source be passed to `SignedExtension`s?
 		// Perhaps a change for 2.0 to avoid breaking too much APIs?
@@ -68,7 +68,7 @@ where
 		}
 	}
 
-	fn apply<U: ValidateUnsigned<Call = Self::Call>, P: PreimageHandler>(
+	fn apply<U: ValidateUnsigned<Call = Self::Call>, P: PreimageStash>(
 		self,
 		info: &DispatchInfoOf<Self::Call>,
 		len: usize,
@@ -86,7 +86,7 @@ where
 
 		// Place the primage data.
 		for data in aux_data.into_iter() {
-			P::note_preimage(sp_std::borrow::Cow::from(data));
+			P::stash(sp_std::borrow::Cow::from(data));
 		}
 		let res = call.dispatch(Origin::from(maybe_who));
 		// Remove the primage data.

--- a/primitives/runtime/src/generic/checked_extrinsic.rs
+++ b/primitives/runtime/src/generic/checked_extrinsic.rs
@@ -20,8 +20,8 @@
 
 use crate::{
 	traits::{
-		self, DispatchInfoOf, Dispatchable, MaybeDisplay, Member, PostDispatchInfoOf,
-		SignedExtension, ValidateUnsigned, PreimageHandler, FatCall,
+		self, DispatchInfoOf, Dispatchable, FatCall, MaybeDisplay, Member, PostDispatchInfoOf,
+		PreimageHandler, SignedExtension, ValidateUnsigned,
 	},
 	transaction_validity::{TransactionSource, TransactionValidity},
 };

--- a/primitives/runtime/src/testing.rs
+++ b/primitives/runtime/src/testing.rs
@@ -22,8 +22,8 @@ use crate::{
 	generic,
 	scale_info::TypeInfo,
 	traits::{
-		self, Applyable, BlakeTwo256, Checkable, DispatchInfoOf, Dispatchable, OpaqueKeys,
-		PostDispatchInfoOf, SignedExtension, ValidateUnsigned, PreimageHandler, FatCall, AuxData,
+		self, Applyable, AuxData, BlakeTwo256, Checkable, DispatchInfoOf, Dispatchable, FatCall,
+		OpaqueKeys, PostDispatchInfoOf, PreimageHandler, SignedExtension, ValidateUnsigned,
 	},
 	transaction_validity::{TransactionSource, TransactionValidity, TransactionValidityError},
 	ApplyExtrinsicResultWithInfo, CryptoTypeId, KeyTypeId,
@@ -344,7 +344,7 @@ impl<Call: Codec + Sync + Send, Extra> traits::Extrinsic for TestXt<Call, Extra>
 		Some(self.signature.is_some())
 	}
 
-	fn new(c: FatCall<Call>, sig: Option<Self::SignaturePayload>) -> Option<Self> {
+	fn from_parts(c: FatCall<Call>, sig: Option<Self::SignaturePayload>) -> Option<Self> {
 		Some(TestXt { signature: sig, call: c.call, aux_data: c.auxilliary_data })
 	}
 }

--- a/primitives/runtime/src/testing.rs
+++ b/primitives/runtime/src/testing.rs
@@ -23,7 +23,7 @@ use crate::{
 	scale_info::TypeInfo,
 	traits::{
 		self, Applyable, AuxData, BlakeTwo256, Checkable, DispatchInfoOf, Dispatchable, FatCall,
-		OpaqueKeys, PostDispatchInfoOf, PreimageHandler, SignedExtension, ValidateUnsigned,
+		OpaqueKeys, PostDispatchInfoOf, PreimageStash, SignedExtension, ValidateUnsigned,
 	},
 	transaction_validity::{TransactionSource, TransactionValidity, TransactionValidityError},
 	ApplyExtrinsicResultWithInfo, CryptoTypeId, KeyTypeId,
@@ -368,7 +368,7 @@ where
 	type Call = Call;
 
 	/// Checks to see if this is a valid *transaction*. It returns information on it if so.
-	fn validate<U: ValidateUnsigned<Call = Self::Call>, P: PreimageHandler>(
+	fn validate<U: ValidateUnsigned<Call = Self::Call>, P: PreimageStash>(
 		&self,
 		source: TransactionSource,
 		info: &DispatchInfoOf<Self::Call>,
@@ -385,7 +385,7 @@ where
 
 	/// Executes all necessary logic needed prior to dispatch and deconstructs into function call,
 	/// index and sender.
-	fn apply<U: ValidateUnsigned<Call = Self::Call>, P: PreimageHandler>(
+	fn apply<U: ValidateUnsigned<Call = Self::Call>, P: PreimageStash>(
 		self,
 		info: &DispatchInfoOf<Self::Call>,
 		len: usize,
@@ -400,7 +400,7 @@ where
 		};
 
 		for i in self.aux_data.into_iter() {
-			P::note_preimage(i.into());
+			P::stash(i.into());
 		}
 		let r = self.call.dispatch(maybe_who.into());
 		P::clear();

--- a/primitives/runtime/src/transaction_validity.rs
+++ b/primitives/runtime/src/transaction_validity.rs
@@ -83,6 +83,8 @@ pub enum InvalidTransaction {
 	BadSigner,
 	/// Auxilliary data was supplied in the extrinsic which was unexpected.
 	UnexpectedData,
+	/// Too many auxilliary data items were includes with the extrinsic.
+	TooManyAuxDataItems,
 }
 
 impl InvalidTransaction {
@@ -115,6 +117,7 @@ impl From<InvalidTransaction> for &'static str {
 			InvalidTransaction::Custom(_) => "InvalidTransaction custom error",
 			InvalidTransaction::BadSigner => "Invalid signing address",
 			InvalidTransaction::UnexpectedData => "Unexpected auxilliary data",
+			InvalidTransaction::TooManyAuxDataItems => "Too many auxilliary data items",
 		}
 	}
 }

--- a/primitives/runtime/src/transaction_validity.rs
+++ b/primitives/runtime/src/transaction_validity.rs
@@ -81,6 +81,8 @@ pub enum InvalidTransaction {
 	MandatoryDispatch,
 	/// The sending address is disabled or known to be invalid.
 	BadSigner,
+	/// Auxilliary data was supplied in the extrinsic which was unexpected.
+	UnexpectedData,
 }
 
 impl InvalidTransaction {
@@ -112,6 +114,7 @@ impl From<InvalidTransaction> for &'static str {
 				"Transaction dispatch is mandatory; transactions may not have mandatory dispatches.",
 			InvalidTransaction::Custom(_) => "InvalidTransaction custom error",
 			InvalidTransaction::BadSigner => "Invalid signing address",
+			InvalidTransaction::UnexpectedData => "Unexpected auxilliary data",
 		}
 	}
 }

--- a/primitives/test-primitives/src/lib.rs
+++ b/primitives/test-primitives/src/lib.rs
@@ -25,7 +25,7 @@ pub use sp_application_crypto;
 use sp_application_crypto::sr25519;
 
 pub use sp_core::{hash::H256, RuntimeDebug};
-use sp_runtime::traits::{BlakeTwo256, Extrinsic as ExtrinsicT, Verify};
+use sp_runtime::traits::{BlakeTwo256, Extrinsic as ExtrinsicT, FatCall, Verify};
 
 /// Extrinsic for test-runtime.
 #[derive(Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug)]
@@ -57,8 +57,12 @@ impl ExtrinsicT for Extrinsic {
 		}
 	}
 
-	fn new(call: Self::Call, _signature_payload: Option<Self::SignaturePayload>) -> Option<Self> {
-		Some(call)
+	fn from_parts(
+		fat_call: FatCall<Self::Call>,
+		_signature_payload: Option<Self::SignaturePayload>,
+	) -> Option<Self> {
+		assert!(fat_call.auxilliary_data.is_empty());
+		Some(fat_call.call)
 	}
 }
 

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -47,8 +47,8 @@ use sp_runtime::traits::NumberFor;
 use sp_runtime::{
 	create_runtime_str, impl_opaque_keys,
 	traits::{
-		BlakeTwo256, BlindCheckable, Block as BlockT, Extrinsic as ExtrinsicT, GetNodeBlockType,
-		GetRuntimeBlockType, IdentityLookup, Verify,
+		BlakeTwo256, BlindCheckable, Block as BlockT, Extrinsic as ExtrinsicT, FatCall,
+		GetNodeBlockType, GetRuntimeBlockType, IdentityLookup, Verify,
 	},
 	transaction_validity::{
 		InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
@@ -226,8 +226,12 @@ impl ExtrinsicT for Extrinsic {
 		}
 	}
 
-	fn new(call: Self::Call, _signature_payload: Option<Self::SignaturePayload>) -> Option<Self> {
-		Some(call)
+	fn from_parts(
+		call: FatCall<Self::Call>,
+		_signature_payload: Option<Self::SignaturePayload>,
+	) -> Option<Self> {
+		assert!(call.auxilliary_data.is_empty());
+		Some(call.call)
 	}
 }
 
@@ -604,7 +608,8 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = ();
 	type OnSetCode = ();
 	type MaxConsumers = ConstU32<16>;
-	type PreimageProvider = ();
+	type PreimageProvider = frame_support::InMemoryPreimages<Hashing>;
+	type TempPreimageRecipient = frame_support::InMemoryPreimages<Hashing>;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -604,6 +604,7 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = ();
 	type OnSetCode = ();
 	type MaxConsumers = ConstU32<16>;
+	type PreimageProvider = ();
 }
 
 impl pallet_timestamp::Config for Runtime {


### PR DESCRIPTION
### TODO
- [x] Update the inherent transaction creator to utilise the `required_preimages`.
- [ ] Update `check_inherent` and its call sites to extract and pass in the `TempPreimages`.
- [ ] Update all `Call` decls to ensure they have bounded, reasonable sized params, using hash & preimages where needed.
- [ ] Make everything build.
- [ ] Remove the existing preimages stuff.

# Changes

## `SignedExtension`

- `validate`, `pre_dispatch`, `validate_unsigned`, `pre_dispatch_unsigned` now accept an additional argument `aux_data: &AuxData`.

## `ValidateUnsigned`
- `validate_unsigned` now accepts an additional argument `aux_data: &AuxData`.
- There is a new call `validate_aux_data` which should check the validity of the auxiliary data of the extrinsic. By default it ensures that there is none.

# Migration notes

## `SignedExtension`

For any implementations of `validate`, `pre_dispatch`, `validate_unsigned`, `pre_dispatch_unsigned` all accept an additional argument `aux_data`. This may be safely ignored but can be used to help verify/validate the `call` if appropriate.
