### PR TITLE
Bound uses of `Call`

### DIFF
--- a/frame/preimage/src/mock.rs
+++ b/frame/preimage/src/mock.rs
@@ -105,7 +105,6 @@ impl Config for Test {
 	type Event = Event;
 	type Currency = Balances;
 	type ManagerOrigin = EnsureSignedBy<One, u64>;
-	type MaxSize = ConstU32<1024>;
 	type BaseDeposit = ConstU64<2>;
 	type ByteDeposit = ConstU64<1>;
 }

--- a/frame/preimage/src/tests.rs
+++ b/frame/preimage/src/tests.rs
@@ -148,7 +148,7 @@ fn request_note_order_makes_no_difference() {
 		assert_ok!(Preimage::note_preimage(Origin::signed(1), vec![1]));
 		(
 			StatusFor::<Test>::iter().collect::<Vec<_>>(),
-			PreimageFor::<Test>::iter().collect::<Vec<_>>(),
+			Preimage7For::<Test>::iter().collect::<Vec<_>>(),
 		)
 	});
 	new_test_ext().execute_with(|| {
@@ -156,7 +156,7 @@ fn request_note_order_makes_no_difference() {
 		assert_ok!(Preimage::request_preimage(Origin::signed(1), hashed([1])));
 		let other_way = (
 			StatusFor::<Test>::iter().collect::<Vec<_>>(),
-			PreimageFor::<Test>::iter().collect::<Vec<_>>(),
+			Preimage7For::<Test>::iter().collect::<Vec<_>>(),
 		);
 		assert_eq!(one_way, other_way);
 	});
@@ -183,7 +183,7 @@ fn request_user_note_order_makes_no_difference() {
 		assert_ok!(Preimage::note_preimage(Origin::signed(2), vec![1]));
 		(
 			StatusFor::<Test>::iter().collect::<Vec<_>>(),
-			PreimageFor::<Test>::iter().collect::<Vec<_>>(),
+			Preimage7For::<Test>::iter().collect::<Vec<_>>(),
 		)
 	});
 	new_test_ext().execute_with(|| {
@@ -191,7 +191,7 @@ fn request_user_note_order_makes_no_difference() {
 		assert_ok!(Preimage::request_preimage(Origin::signed(1), hashed([1])));
 		let other_way = (
 			StatusFor::<Test>::iter().collect::<Vec<_>>(),
-			PreimageFor::<Test>::iter().collect::<Vec<_>>(),
+			Preimage7For::<Test>::iter().collect::<Vec<_>>(),
 		);
 		assert_eq!(one_way, other_way);
 	});

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -63,19 +63,20 @@ use frame_support::{
 	dispatch::{DispatchError, DispatchResult, Dispatchable, Parameter},
 	traits::{
 		schedule::{self, DispatchTime, MaybeHashed},
-		EnsureOrigin, Get, IsType, OriginTrait, PalletInfoAccess, PrivilegeCmp, StorageVersion,
-		ConstU32,
+		ConstU32, EnsureOrigin, Get, IsType, OriginTrait, PalletInfoAccess, PrivilegeCmp,
+		StorageVersion,
 	},
-	weights::{GetDispatchInfo, Weight}, BoundedVec,
+	weights::{GetDispatchInfo, Weight},
+	BoundedVec,
 };
 use frame_system::{self as system, ensure_signed};
 pub use pallet::*;
 use scale_info::TypeInfo;
+use sp_io::hashing::blake2_256;
 use sp_runtime::{
 	traits::{BadOrigin, One, Saturating, Zero},
 	RuntimeDebug,
 };
-use sp_io::hashing::blake2_256;
 use sp_std::{borrow::Borrow, cmp::Ordering, marker::PhantomData, prelude::*};
 pub use weights::WeightInfo;
 

--- a/frame/support/src/storage/bounded_vec.rs
+++ b/frame/support/src/storage/bounded_vec.rs
@@ -543,13 +543,13 @@ where
 }
 
 impl<T, S: Get<u32>> TryFrom<Vec<T>> for BoundedVec<T, S> {
-	type Error = ();
+	type Error = Vec<T>;
 	fn try_from(t: Vec<T>) -> Result<Self, Self::Error> {
 		if t.len() <= Self::bound() {
 			// explicit check just above
 			Ok(Self::unchecked_from(t))
 		} else {
-			Err(())
+			Err(t)
 		}
 	}
 }

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -105,3 +105,6 @@ mod voting;
 pub use voting::{
 	CurrencyToVote, PollStatus, Polling, SaturatingCurrencyToVote, U128CurrencyToVote, VoteTally,
 };
+
+mod preimages;
+pub use preimages::{Hash, BoundedInline, Encoded, QueryPreimage, StorePreimage, FetchResult};

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -107,4 +107,4 @@ pub use voting::{
 };
 
 mod preimages;
-pub use preimages::{Hash, BoundedInline, Encoded, QueryPreimage, StorePreimage, FetchResult};
+pub use preimages::{BoundedInline, Encoded, FetchResult, Hash, QueryPreimage, StorePreimage};

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -931,7 +931,7 @@ pub trait PreimageRecipient<Hash>: PreimageProvider<Hash> {
 	/// Maximum size of a preimage.
 	type MaxSize: Get<u32>;
 
-	/// Store the bytes of a preimage on chain.
+	/// Store the bytes of a preimage on chain infallible due to the bounded type.
 	fn note_preimage(bytes: crate::BoundedVec<u8, Self::MaxSize>);
 
 	/// Clear a previously noted preimage. This is infallible and should be treated more like a

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -675,8 +675,7 @@ impl From<DispatchError> for &'static str {
 			Other(msg) => msg,
 			CannotLookup => "Cannot lookup",
 			BadOrigin => "Bad origin",
-			Module(ModuleError { message, .. }) =>
-				message.unwrap_or("Unknown module error"),
+			Module(ModuleError { message, .. }) => message.unwrap_or("Unknown module error"),
 			ConsumerRemaining => "Consumer remaining",
 			NoProviders => "No providers",
 			TooManyConsumers => "Too many consumers",

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -540,6 +540,12 @@ pub enum DispatchError {
 	/// The number of transactional layers has been reached, or we are not in a transactional
 	/// layer.
 	Transactional(TransactionalError),
+	/// Resources exhausted, e.g. attempt to read/write data which is too large to manipulate.
+	Exhausted,
+	/// The state is corrupt; this is generally not going to fix itself.
+	Corruption,
+	/// Some resource (e.g. a preimage) is unavailable right now. This might fix itself later.
+	Unavailable,
 }
 
 /// Result of a `Dispatchable` which contains the `DispatchResult` and additional information about
@@ -664,18 +670,22 @@ impl From<&'static str> for DispatchError {
 
 impl From<DispatchError> for &'static str {
 	fn from(err: DispatchError) -> &'static str {
+		use DispatchError::*;
 		match err {
-			DispatchError::Other(msg) => msg,
-			DispatchError::CannotLookup => "Cannot lookup",
-			DispatchError::BadOrigin => "Bad origin",
-			DispatchError::Module(ModuleError { message, .. }) =>
+			Other(msg) => msg,
+			CannotLookup => "Cannot lookup",
+			BadOrigin => "Bad origin",
+			Module(ModuleError { message, .. }) =>
 				message.unwrap_or("Unknown module error"),
-			DispatchError::ConsumerRemaining => "Consumer remaining",
-			DispatchError::NoProviders => "No providers",
-			DispatchError::TooManyConsumers => "Too many consumers",
-			DispatchError::Token(e) => e.into(),
-			DispatchError::Arithmetic(e) => e.into(),
-			DispatchError::Transactional(e) => e.into(),
+			ConsumerRemaining => "Consumer remaining",
+			NoProviders => "No providers",
+			TooManyConsumers => "Too many consumers",
+			Token(e) => e.into(),
+			Arithmetic(e) => e.into(),
+			Transactional(e) => e.into(),
+			Exhausted => "Resources exhausted",
+			Corruption => "State corrupt",
+			Unavailable => "Resource unavailable",
 		}
 	}
 }
@@ -691,33 +701,37 @@ where
 
 impl traits::Printable for DispatchError {
 	fn print(&self) {
+		use DispatchError::*;
 		"DispatchError".print();
 		match self {
-			Self::Other(err) => err.print(),
-			Self::CannotLookup => "Cannot lookup".print(),
-			Self::BadOrigin => "Bad origin".print(),
-			Self::Module(ModuleError { index, error, message }) => {
+			Other(err) => err.print(),
+			CannotLookup => "Cannot lookup".print(),
+			BadOrigin => "Bad origin".print(),
+			Module(ModuleError { index, error, message }) => {
 				index.print();
 				error.print();
 				if let Some(msg) = message {
 					msg.print();
 				}
 			},
-			Self::ConsumerRemaining => "Consumer remaining".print(),
-			Self::NoProviders => "No providers".print(),
-			Self::TooManyConsumers => "Too many consumers".print(),
-			Self::Token(e) => {
+			ConsumerRemaining => "Consumer remaining".print(),
+			NoProviders => "No providers".print(),
+			TooManyConsumers => "Too many consumers".print(),
+			Token(e) => {
 				"Token error: ".print();
 				<&'static str>::from(*e).print();
 			},
-			Self::Arithmetic(e) => {
+			Arithmetic(e) => {
 				"Arithmetic error: ".print();
 				<&'static str>::from(*e).print();
 			},
-			Self::Transactional(e) => {
+			Transactional(e) => {
 				"Transactional error: ".print();
 				<&'static str>::from(*e).print();
 			},
+			Exhausted => "Resources exhausted".print(),
+			Corruption => "State corrupt".print(),
+			Unavailable => "Resource unavailable".print(),
 		}
 	}
 }


### PR DESCRIPTION
Introduces a new utility type `Bounded<T>` and two new traits `QueryPreimage` and `StorePreimage` which are meant to be used over the new-deprecated `PreimageProvider` and `PreimageRecipient`.

Preimage pallet implements these two new traits and is altered so it no longer has a `MaxSize` parameter but instead handles all reasonable sizes in a series of maps. By using different maps for differently bounded `Vec`s, we can optimise the worst-case PoV weight.

`Bounded<T>` may be created with a `StorePreimage::into_bounded(T) -> Result<Bounded<T>>`, or alternatively with `Bounded<T>::unrequested(hash: Hash, len: u32)` or `Bounded<T>::requested(hash: Hash, len: u32)` and efficiently placed in storage. If the latter API is used, then it cannot be retrieved until the hash's preimage is introduced into the preimages backend (e.g. the Preimage pallet). This makes it quite useful for governance use-cases like Referenda where only the hash is supplied initially.

When the original `T` value is needed, it can be retrieved with `QueryPreimage::into_value(b: &Bounded<T>) -> Result<T>`.