### PR TITLE
[WIP]: fix: beefy rpc tests

### DIFF
--- a/client/beefy/rpc/src/lib.rs
+++ b/client/beefy/rpc/src/lib.rs
@@ -165,7 +165,8 @@ mod tests {
 	use super::*;
 
 	use beefy_gadget::notification::{
-		BeefyBestBlockStream, BeefySignedCommitment, BeefySignedCommitmentSender,
+		BeefyBestBlockSender, BeefyBestBlockStream, BeefySignedCommitment,
+		BeefySignedCommitmentSender,
 	};
 	use beefy_primitives::{known_payload_ids, Payload};
 	use codec::{Decode, Encode};
@@ -173,41 +174,54 @@ mod tests {
 	use sp_runtime::traits::{BlakeTwo256, Hash};
 	use substrate_test_runtime_client::runtime::Block;
 
-	fn setup_io_handler() -> (RpcModule<Beefy<Block>>, BeefySignedCommitmentSender<Block>) {
-		let (_, stream) = BeefyBestBlockStream::<Block>::channel();
-		setup_io_handler_with_best_block_stream(stream)
+	struct BeefyRpcTest {
+		best_block_sender: BeefyBestBlockSender<Block>,
+		rpc: RpcModule<Beefy<Block>>,
+		commitment_sender: BeefySignedCommitmentSender<Block>,
 	}
 
-	fn setup_io_handler_with_best_block_stream(
-		best_block_stream: BeefyBestBlockStream<Block>,
-	) -> (RpcModule<Beefy<Block>>, BeefySignedCommitmentSender<Block>) {
-		let (commitment_sender, commitment_stream) =
-			BeefySignedCommitmentStream::<Block>::channel();
+	impl BeefyRpcTest {
+		fn new() -> Self {
+			let (best_block_sender, best_block_stream) = BeefyBestBlockStream::<Block>::channel();
+			let (commitment_sender, commitment_stream) =
+				BeefySignedCommitmentStream::<Block>::channel();
+			let rpc =
+				Beefy::new(commitment_stream, best_block_stream, sc_rpc::testing::test_executor())
+					.expect("Setting up the BEEFY RPC handler works")
+					.into_rpc();
 
-		let handler =
-			Beefy::new(commitment_stream, best_block_stream, sc_rpc::testing::test_executor())
-				.expect("Setting up the BEEFY RPC handler works");
+			Self { best_block_sender, rpc, commitment_sender }
+		}
+	}
 
-		(handler.into_rpc(), commitment_sender)
+	fn create_commitment() -> BeefySignedCommitment<Block> {
+		let payload = Payload::new(known_payload_ids::MMR_ROOT_ID, "Hello World!".encode());
+		BeefySignedCommitment::<Block> {
+			commitment: beefy_primitives::Commitment {
+				payload,
+				block_number: 5,
+				validator_set_id: 0,
+			},
+			signatures: vec![],
+		}
 	}
 
 	#[tokio::test]
 	async fn uninitialized_rpc_handler() {
-		let (rpc, _) = setup_io_handler();
+		let t = BeefyRpcTest::new();
 		let request = r#"{"jsonrpc":"2.0","method":"beefy_getFinalizedHead","params":[],"id":1}"#;
 		let expected_response = r#"{"jsonrpc":"2.0","error":{"code":1,"message":"BEEFY RPC endpoint not ready"},"id":1}"#.to_string();
-		let (result, _) = rpc.raw_json_request(&request).await.unwrap();
+		let (result, _) = t.rpc.raw_json_request(&request).await.unwrap();
 
-		assert_eq!(expected_response, result,);
+		assert_eq!(expected_response, result);
 	}
 
 	#[tokio::test]
 	async fn latest_finalized_rpc() {
-		let (sender, stream) = BeefyBestBlockStream::<Block>::channel();
-		let (io, _) = setup_io_handler_with_best_block_stream(stream);
+		let t = BeefyRpcTest::new();
 
 		let hash = BlakeTwo256::hash(b"42");
-		let r: Result<(), ()> = sender.notify(|| Ok(hash));
+		let r: Result<(), ()> = t.best_block_sender.notify(|| Ok(hash));
 		r.unwrap();
 
 		// Verify RPC `beefy_getFinalizedHead` returns expected hash.
@@ -227,11 +241,11 @@ mod tests {
 
 		let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
 		while std::time::Instant::now() < deadline {
-			let (response, _) = io.raw_json_request(request).await.expect("RPC requests work");
+			let (response, _) = t.rpc.raw_json_request(request).await.expect("RPC requests work");
 			if response != not_ready {
 				assert_eq!(response, expected);
 				// Success
-				return
+				return;
 			}
 			std::thread::sleep(std::time::Duration::from_millis(50))
 		}
@@ -243,10 +257,11 @@ mod tests {
 
 	#[tokio::test]
 	async fn subscribe_and_unsubscribe_to_justifications() {
-		let (rpc, _) = setup_io_handler();
+		let t = BeefyRpcTest::new();
 
 		// Subscribe call.
-		let sub = rpc
+		let sub = t
+			.rpc
 			.subscribe("beefy_subscribeJustifications", EmptyParams::new())
 			.await
 			.unwrap();
@@ -258,12 +273,12 @@ mod tests {
 			"{{\"jsonrpc\":\"2.0\",\"method\":\"beefy_unsubscribeJustifications\",\"params\":[{}],\"id\":1}}",
 			ser_id
 		);
-		let (response, _) = rpc.raw_json_request(&unsub_req).await.unwrap();
+		let (response, _) = t.rpc.raw_json_request(&unsub_req).await.unwrap();
 
 		assert_eq!(response, r#"{"jsonrpc":"2.0","result":true,"id":1}"#);
 
 		// Unsubscribe again and fail
-		let (response, _) = rpc.raw_json_request(&unsub_req).await.unwrap();
+		let (response, _) = t.rpc.raw_json_request(&unsub_req).await.unwrap();
 		let expected = r#"{"jsonrpc":"2.0","result":false,"id":1}"#;
 
 		assert_eq!(response, expected);
@@ -271,15 +286,18 @@ mod tests {
 
 	#[tokio::test]
 	async fn subscribe_and_unsubscribe_with_wrong_id() {
-		let (rpc, _) = setup_io_handler();
+		let t = BeefyRpcTest::new();
+
 		// Subscribe call.
-		let _sub = rpc
+		let _sub = t
+			.rpc
 			.subscribe("beefy_subscribeJustifications", EmptyParams::new())
 			.await
 			.unwrap();
 
 		// Unsubscribe with wrong ID
-		let (response, _) = rpc
+		let (response, _) = t
+			.rpc
 			.raw_json_request(
 				r#"{"jsonrpc":"2.0","method":"beefy_unsubscribeJustifications","params":["FOO"],"id":1}"#,
 			)
@@ -290,31 +308,20 @@ mod tests {
 		assert_eq!(response, expected);
 	}
 
-	fn create_commitment() -> BeefySignedCommitment<Block> {
-		let payload = Payload::new(known_payload_ids::MMR_ROOT_ID, "Hello World!".encode());
-		BeefySignedCommitment::<Block> {
-			commitment: beefy_primitives::Commitment {
-				payload,
-				block_number: 5,
-				validator_set_id: 0,
-			},
-			signatures: vec![],
-		}
-	}
-
 	#[tokio::test]
 	async fn subscribe_and_listen_to_one_justification() {
-		let (rpc, commitment_sender) = setup_io_handler();
+		let t = BeefyRpcTest::new();
 
 		// Subscribe
-		let mut sub = rpc
+		let mut sub = t
+			.rpc
 			.subscribe("beefy_subscribeJustifications", EmptyParams::new())
 			.await
 			.unwrap();
 
 		// Notify with commitment
 		let commitment = create_commitment();
-		let r: Result<(), ()> = commitment_sender.notify(|| Ok(commitment.clone()));
+		let r: Result<(), ()> = t.commitment_sender.notify(|| Ok(commitment.clone()));
 		r.unwrap();
 
 		// Inspect what we received

--- a/client/beefy/rpc/src/lib.rs
+++ b/client/beefy/rpc/src/lib.rs
@@ -245,7 +245,7 @@ mod tests {
 			if response != not_ready {
 				assert_eq!(response, expected);
 				// Success
-				return;
+				return
 			}
 			std::thread::sleep(std::time::Duration::from_millis(50))
 		}


### PR DESCRIPTION
I suspect that this fails because the actual sender to `block_stream` was dropped in the inner helper function `setup_io_handler`

EDIT: it fails sometimes anyway... :zipper_mouth_face: 
