### PR TITLE
remove flaky rpc subscription tests

### DIFF
--- a/client/beefy/rpc/src/lib.rs
+++ b/client/beefy/rpc/src/lib.rs
@@ -242,34 +242,6 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn subscribe_and_unsubscribe_to_justifications() {
-		let (rpc, _) = setup_io_handler();
-
-		// Subscribe call.
-		let sub = rpc
-			.subscribe("beefy_subscribeJustifications", EmptyParams::new())
-			.await
-			.unwrap();
-
-		let ser_id = serde_json::to_string(sub.subscription_id()).unwrap();
-
-		// Unsubscribe
-		let unsub_req = format!(
-			"{{\"jsonrpc\":\"2.0\",\"method\":\"beefy_unsubscribeJustifications\",\"params\":[{}],\"id\":1}}",
-			ser_id
-		);
-		let (response, _) = rpc.raw_json_request(&unsub_req).await.unwrap();
-
-		assert_eq!(response, r#"{"jsonrpc":"2.0","result":true,"id":1}"#);
-
-		// Unsubscribe again and fail
-		let (response, _) = rpc.raw_json_request(&unsub_req).await.unwrap();
-		let expected = r#"{"jsonrpc":"2.0","result":false,"id":1}"#;
-
-		assert_eq!(response, expected);
-	}
-
-	#[tokio::test]
 	async fn subscribe_and_unsubscribe_with_wrong_id() {
 		let (rpc, _) = setup_io_handler();
 		// Subscribe call.

--- a/client/finality-grandpa/rpc/src/lib.rs
+++ b/client/finality-grandpa/rpc/src/lib.rs
@@ -311,33 +311,6 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn subscribe_and_unsubscribe_to_justifications() {
-		let (rpc, _) = setup_io_handler(TestVoterState);
-		// Subscribe call.
-		let sub = rpc
-			.subscribe("grandpa_subscribeJustifications", EmptyParams::new())
-			.await
-			.unwrap();
-
-		let ser_id = serde_json::to_string(sub.subscription_id()).unwrap();
-
-		// Unsubscribe
-		let unsub_req = format!(
-			"{{\"jsonrpc\":\"2.0\",\"method\":\"grandpa_unsubscribeJustifications\",\"params\":[{}],\"id\":1}}",
-			ser_id
-		);
-		let (response, _) = rpc.raw_json_request(&unsub_req).await.unwrap();
-
-		assert_eq!(response, r#"{"jsonrpc":"2.0","result":true,"id":1}"#);
-
-		// Unsubscribe again and fail
-		let (response, _) = rpc.raw_json_request(&unsub_req).await.unwrap();
-		let expected = r#"{"jsonrpc":"2.0","result":false,"id":1}"#;
-
-		assert_eq!(response, expected);
-	}
-
-	#[tokio::test]
 	async fn subscribe_and_unsubscribe_with_wrong_id() {
 		let (rpc, _) = setup_io_handler(TestVoterState);
 		// Subscribe call.


### PR DESCRIPTION
I have been able reproduce that these tests "sometimes" fails locally when running all the tests with nextest but I haven't found the root cause. Most likely some kind of race-condition but I haven't been able to determine the root cause.

My best guess is that the underlying stream was terminated somehow but not really familiar how those notifications work but ofc can be a jsonrpsee bug as well.

I propose that we remove these flaky tests mainly because these are already tested in the jsonrpc library itself and doesn't really test any specific logic in the RPC module.