### PR TITLE
v0.9.25: limit max_negotiating_inbound_streams to 512

### DIFF
--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -379,7 +379,8 @@ where
 				)
 				.substream_upgrade_protocol_override(upgrade::Version::V1Lazy)
 				.notify_handler_buffer_size(NonZeroUsize::new(32).expect("32 != 0; qed"))
-				.connection_event_buffer_size(1024);
+				.connection_event_buffer_size(1024)
+				.max_negotiating_inbound_streams(512);
 			if let Some(spawner) = params.executor {
 				struct SpawnImpl<F>(F);
 				impl<F: Fn(Pin<Box<dyn Future<Output = ()> + Send>>)> Executor for SpawnImpl<F> {


### PR DESCRIPTION
As suggested by @tomaka 