### PR TITLE
Fix post-update logging in node template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4882,6 +4882,7 @@ dependencies = [
  "sp-timestamp",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
+ "tracing-core",
  "try-runtime-cli",
 ]
 

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -18,6 +18,7 @@ name = "node-template"
 
 [dependencies]
 clap = { version = "3.1.18", features = ["derive"] }
+tracing-core = "=0.1.26"
 
 sc-cli = { version = "0.10.0-dev", path = "../../../client/cli", features = ["wasmtime"] }
 sp-core = { version = "6.0.0", path = "../../../primitives/core" }


### PR DESCRIPTION
The PR locks a node template's dependency in order to fix [this logging issue](https://github.com/paritytech/substrate/issues/11684).

Fixes #11684.