### PR TITLE
emit event per runtime upgrade

### DIFF
--- a/frame/support/procedural/src/pallet/expand/hooks.rs
+++ b/frame/support/procedural/src/pallet/expand/hooks.rs
@@ -127,6 +127,17 @@ pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 			#frame_support::traits::OnRuntimeUpgrade
 			for #pallet_ident<#type_use_gen> #where_clause
 		{
+			fn deposit_event() {
+				let pallet_name = <
+					<T as #frame_system::Config>::PalletInfo
+					as
+					#frame_support::traits::PalletInfo
+				>::name::<Self>().unwrap_or("<unknown pallet name>");
+				#frame_system::Pallet::<T>::deposit_event(
+					#frame_system::Event::<T>::RuntimeUpgradeExecuted(pallet_name.into())
+				)
+			}
+
 			fn on_runtime_upgrade() -> #frame_support::weights::Weight {
 				#frame_support::sp_tracing::enter_span!(
 					#frame_support::sp_tracing::trace_span!("on_runtime_update")

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -82,6 +82,7 @@ mod hooks;
 pub use hooks::GenesisBuild;
 pub use hooks::{
 	Hooks, OnFinalize, OnGenesis, OnIdle, OnInitialize, OnRuntimeUpgrade, OnTimestampSet,
+	RuntimeUpgradeIdentifier,
 };
 #[cfg(feature = "try-runtime")]
 pub use hooks::{OnRuntimeUpgradeHelpersExt, ON_RUNTIME_UPGRADE_PREFIX};

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -503,6 +503,8 @@ pub mod pallet {
 		ExtrinsicFailed { dispatch_error: DispatchError, dispatch_info: DispatchInfo },
 		/// `:code` was updated.
 		CodeUpdated,
+		/// A `OnRuntimeUpgrade` hook with the given identifier was executed.
+		RuntimeUpgradeExecuted(frame_support::traits::RuntimeUpgradeIdentifier),
 		/// A new account was created.
 		NewAccount { account: T::AccountId },
 		/// An account was reaped.


### PR DESCRIPTION
Not done, nor am I happy with the outcome so far, just putting it out there as a draft for now, hoping to get more input. Also open to someone else pushing it to the finish line. 

Ideally, I wanted each `OnRuntimeUpgrade` to only define something like `fn ident() -> &'static str` or `const IDENT: &'static str;`, but tuplifying that at the `frame_support` was not possible, or at least I couldn't figure out how to do it. Therefore, I changed the abstraction to each `OnRuntimeUpgrade` defining the full `fn deposit_event()` that it wants to do. All default implementations delegate this by using the frame-system's `deposit_event`. Unfortunately, a custom implementation of `OnRuntimeUpgrade` has to do that for now manually. 

CC @ggwpez @chevdor 