### PR TITLE
check-dependent-cumulus should only be executed for PRs

### DIFF
--- a/scripts/ci/gitlab/pipeline/build.yml
+++ b/scripts/ci/gitlab/pipeline/build.yml
@@ -42,6 +42,8 @@ check-dependent-cumulus:
     COMPANION_OVERRIDES: |
       substrate: polkadot-v*
       polkadot: release-v*
+  rules:
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/  #PRs
 
 build-linux-substrate:
   stage:                           build


### PR DESCRIPTION
The script executed by check-dependent-cumulus only works for PRs, as shown in https://gitlab.parity.io/parity/mirrors/substrate/-/jobs/1630771#L87, which comes from https://github.com/paritytech/pipeline-scripts/blob/3ad10ddc0d985ef5326974a1143229c6429befab/check_dependent_project.sh#L443