### PR TITLE
`storage-alias`: Check that prefix is not an underscore

### DIFF
--- a/frame/support/procedural/src/storage_alias.rs
+++ b/frame/support/procedural/src/storage_alias.rs
@@ -512,6 +512,10 @@ fn generate_storage_instance(
 	prefix_generics: Option<&TypeGenerics>,
 	visibility: &Visibility,
 ) -> Result<StorageInstance> {
+	if let Some(ident) = prefix.get_ident().filter(|i| *i == "_") {
+		return Err(Error::new(ident.span(), "`_` is not allowed as prefix by `storage_alias`."))
+	}
+
 	let (pallet_prefix, impl_generics, type_generics) =
 		if let Some((prefix_generics, storage_generics)) =
 			prefix_generics.and_then(|p| storage_generics.map(|s| (p, s)))

--- a/frame/support/test/tests/storage_alias_ui.rs
+++ b/frame/support/test/tests/storage_alias_ui.rs
@@ -1,0 +1,32 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[rustversion::attr(not(stable), ignore)]
+#[cfg(not(feature = "disable-ui-tests"))]
+#[test]
+fn storage_alias_ui() {
+	// Only run the ui tests when `RUN_UI_TESTS` is set.
+	if std::env::var("RUN_UI_TESTS").is_err() {
+		return
+	}
+
+	// As trybuild is using `cargo check`, we don't need the real WASM binaries.
+	std::env::set_var("SKIP_WASM_BUILD", "1");
+
+	let t = trybuild::TestCases::new();
+	t.compile_fail("tests/storage_alias_ui/*.rs");
+}

--- a/frame/support/test/tests/storage_alias_ui/checks_for_valid_storage_type.rs
+++ b/frame/support/test/tests/storage_alias_ui/checks_for_valid_storage_type.rs
@@ -1,0 +1,4 @@
+#[frame_support::storage_alias]
+type Ident = StorageValue<hello::World, u32>;
+
+fn main() {}

--- a/frame/support/test/tests/storage_alias_ui/checks_for_valid_storage_type.stderr
+++ b/frame/support/test/tests/storage_alias_ui/checks_for_valid_storage_type.stderr
@@ -1,0 +1,5 @@
+error: If there are no generics, the prefix is only allowed to be an identifier.
+ --> tests/storage_alias_ui/checks_for_valid_storage_type.rs:2:27
+  |
+2 | type Ident = StorageValue<hello::World, u32>;
+  |                           ^^^^^^^^^^^^

--- a/frame/support/test/tests/storage_alias_ui/forbid_underscore_as_prefix.rs
+++ b/frame/support/test/tests/storage_alias_ui/forbid_underscore_as_prefix.rs
@@ -1,0 +1,4 @@
+#[frame_support::storage_alias]
+type Ident = CustomStorage<Hello, u32>;
+
+fn main() {}

--- a/frame/support/test/tests/storage_alias_ui/forbid_underscore_as_prefix.stderr
+++ b/frame/support/test/tests/storage_alias_ui/forbid_underscore_as_prefix.stderr
@@ -1,0 +1,5 @@
+error: expected one of: `StorageValue`, `StorageMap`, `StorageDoubleMap`, `StorageNMap`
+ --> tests/storage_alias_ui/forbid_underscore_as_prefix.rs:2:14
+  |
+2 | type Ident = CustomStorage<Hello, u32>;
+  |              ^^^^^^^^^^^^^

--- a/frame/support/test/tests/storage_alias_ui/prefix_must_be_an_ident.rs
+++ b/frame/support/test/tests/storage_alias_ui/prefix_must_be_an_ident.rs
@@ -1,0 +1,4 @@
+#[frame_support::storage_alias]
+type NoUnderscore = StorageValue<_, u32>;
+
+fn main() {}

--- a/frame/support/test/tests/storage_alias_ui/prefix_must_be_an_ident.stderr
+++ b/frame/support/test/tests/storage_alias_ui/prefix_must_be_an_ident.stderr
@@ -1,0 +1,5 @@
+error: `_` is not allowed as prefix by `storage_alias`.
+ --> tests/storage_alias_ui/prefix_must_be_an_ident.rs:2:34
+  |
+2 | type NoUnderscore = StorageValue<_, u32>;
+  |                                  ^


### PR DESCRIPTION
Besides that it also adds some UI tests.

