### PR TITLE
Add tool to help identify faulty Cargo features selections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,9 +966,13 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
+ "ansi_term",
+ "atty",
  "bitflags",
+ "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -983,7 +987,7 @@ dependencies = [
  "clap_lex",
  "indexmap",
  "lazy_static",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.0",
 ]
@@ -1035,6 +1039,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7b858541263efe664aead4a5209a4ae5c5d2811167d4ed4ee0944503f8d2089"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -1527,7 +1541,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn",
 ]
 
@@ -1566,6 +1580,19 @@ checksum = "f0f83e699727abca3c56e187945f303389590305ab2f0185ea445aa66e8d5f2a"
 dependencies = [
  "data-encoding",
  "syn",
+]
+
+[[package]]
+name = "deps-check"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "log",
+ "pretty_env_logger",
+ "structopt",
+ "thiserror",
+ "toml_edit",
+ "walkdir",
 ]
 
 [[package]]
@@ -6987,6 +7014,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_env_logger"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+dependencies = [
+ "env_logger 0.7.1",
+ "log",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10477,9 +10514,39 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap 2.34.0",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck 0.3.2",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "strum"
@@ -11091,6 +11158,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
+dependencies = [
+ "combine",
+ "indexmap",
+ "itertools",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11489,6 +11567,12 @@ name = "vec-arena"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
 	"bin/node/runtime",
 	"bin/node/testing",
 	"bin/utils/chain-spec-builder",
+	"bin/utils/deps-check",
 	"bin/utils/subkey",
 	"client/api",
 	"client/authority-discovery",

--- a/bin/utils/deps-check/Cargo.toml
+++ b/bin/utils/deps-check/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "deps-check"
+version = "0.1.0"
+edition = "2021"
+authors = ["Parity Technologies <admin@parity.io>"]
+repository = "https://github.com/paritytech/substrate/"
+publish = false
+
+[[bin]]
+path = "src/main.rs"
+name = "deps-check"
+
+[dependencies]
+toml_edit = "0.14"
+anyhow = "1.0"
+thiserror = "1.0"
+structopt = "0.3"
+log = "0.4"
+pretty_env_logger = "0.4"
+walkdir = "2.3"

--- a/bin/utils/deps-check/README.md
+++ b/bin/utils/deps-check/README.md
@@ -1,0 +1,14 @@
+# deps-check
+
+As requested in [Opstooling #55](https://github.com/paritytech/opstooling/issues/55),
+deps-check is a tool to print dependency crates that have `default-features = false` but
+are not part of the `std` feature of the crate.
+
+## Usage
+
+```sh
+# Recursively check all `Cargo.toml`s below the current directory
+cargo run -p deps-check
+# Check one specific `Cargo.toml`
+cargo run -p deps-check -- /path/to/Cargo.toml
+```

--- a/bin/utils/deps-check/src/main.rs
+++ b/bin/utils/deps-check/src/main.rs
@@ -1,0 +1,144 @@
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+use structopt::StructOpt;
+use thiserror::Error;
+use toml_edit::{Document, Item, Value};
+
+fn main() -> Result<()> {
+	let opt = Opt::from_args();
+	pretty_env_logger::formatted_timed_builder().filter(None, opt.log_level).init();
+
+	let tomls = if opt.tomls.is_empty() { find_tomls()? } else { opt.tomls };
+
+	for path in tomls {
+		match check_toml(&path) {
+			Ok(res) if !res.is_empty() => {
+				for dep in res {
+					println!(
+						"{}: {} has `default-features = false` but is not present in feature `std`",
+						path.to_string_lossy(),
+						dep
+					);
+				}
+			},
+			Err(e) => log::debug!("Failed to check {}: {}", path.to_string_lossy(), e),
+			_ => {},
+		}
+	}
+
+	Ok(())
+}
+
+// Returns a list of dependencies that have `default-features = false` and are not part of the
+// `std` feature.
+fn check_toml<P: AsRef<Path>>(path: P) -> Result<Vec<String>> {
+	let toml = parse_cargo_toml(path.as_ref())?;
+
+	let mut res = vec![];
+	let non_default_features_deps = get_non_default_features_deps(&toml)?;
+	let std_crates = get_std_crates(&toml)?;
+	for dep in non_default_features_deps {
+		if !std_crates.contains(&dep) {
+			res.push(dep);
+		}
+	}
+	Ok(res)
+}
+
+// Return a list of `[dependencies]` from the provided toml where `default-features = false`.
+fn get_non_default_features_deps(toml: &Document) -> Result<Vec<String>> {
+	let deps = match toml.get("dependencies").ok_or(Error::NoDependenciesSection)? {
+		Item::Table(table) => table.get_values(),
+		_ => Err(Error::MalformedDependencies)?,
+	};
+
+	let deps = deps
+		.iter()
+		.filter_map(|(keys, value)| {
+			if let Value::InlineTable(dep_spec) = value {
+				if let Some((_key, value)) = dep_spec.get_key_value("default-features") {
+					let default_features = value.as_bool()?;
+					if !default_features {
+						let key = (keys[0] as &str).to_string();
+						Some(key)
+					} else {
+						None
+					}
+				} else {
+					None
+				}
+			} else {
+				None
+			}
+		})
+		.collect::<Vec<String>>();
+	Ok(deps)
+}
+
+// Return a list of crates included if the `std` feature is enabled
+fn get_std_crates(toml: &Document) -> Result<Vec<String>> {
+	let (_key, values) = match toml.get("features").ok_or(Error::NoFeaturesSection)? {
+		Item::Table(table) => table.get_key_value("std").ok_or(Error::NoStdFeature)?,
+		_ => Err(Error::MalformedFeatures)?,
+	};
+	let values = values
+		.as_array()
+		.ok_or(Error::NoStdFeature)?
+		.iter()
+		.filter_map(|val| val.as_str())
+		.filter_map(|val| val.split('/').nth(0))
+		.map(|val| val.to_string())
+		.collect::<Vec<String>>();
+	Ok(values)
+}
+
+// Parse the given TOML to a `toml_edit::Document`
+fn parse_cargo_toml<P: AsRef<Path>>(path: P) -> Result<Document> {
+	let contents = std::fs::read_to_string(path)?;
+	let toml = contents.parse::<Document>()?;
+	Ok(toml)
+}
+
+// Recursively find `Cargo.toml`s in the current directory
+fn find_tomls() -> Result<Vec<PathBuf>> {
+	let res = walkdir::WalkDir::new("./")
+		.into_iter()
+		.filter_map(|entry| {
+			let entry = entry.ok()?;
+			if entry.file_name() == "Cargo.toml" {
+				Some(entry.path().into())
+			} else {
+				None
+			}
+		})
+		.collect();
+	Ok(res)
+}
+
+#[derive(StructOpt, Debug)]
+#[structopt(
+	name = "deps-check",
+	about = "Print `default-features = false` crates that are not present in the `std` feature"
+)]
+struct Opt {
+	/// List of `Cargo.toml`s to check. Default is to recursively scan the current directly.
+	#[structopt(env)]
+	tomls: Vec<PathBuf>,
+	/// Log level
+	#[structopt(short, long, env, default_value = "info")]
+	log_level: log::LevelFilter,
+}
+
+#[derive(Error, Debug)]
+enum Error {
+	#[error("No 'dependencies' key in TOML")]
+	NoDependenciesSection,
+	#[error("'dependencies' in TOML malformed (not a table?)")]
+	MalformedDependencies,
+	#[error("No 'features' key in TOML")]
+	NoFeaturesSection,
+	#[error("'features' in TOML malformed (not a table?)")]
+	MalformedFeatures,
+	#[error("No 'std' feature in TOML")]
+	NoStdFeature,
+}


### PR DESCRIPTION
As requested in [Opstooling #55](https://github.com/paritytech/opstooling/issues/55), add
a tool to print dependency crates that have `default-features = false` but are not part of
the `std` feature.

Usage: `cargo run -p deps-check` to recursively check all `Cargo.toml`s below the current
directory or `cargo run -p deps-check -- /path/to/Cargo.toml` to check a specific
`Cargo.toml`.



✄ -----------------------------------------------------------------------------

Thank you for your Pull Request! 🙏

Before you submit, please check that:

- [ ] **Description:** You added a brief description of the PR, e.g.:
  - What does it do?
  - What important points should reviewers know?
  - Is there something left for follow-up PRs?
- [ ] **Labels:** You labeled the PR appropriately if you have permissions to do so:
  - [ ] `A*` for PR status (**one required**)
  - [ ] `B*` for changelog (**one required**)
  - [ ] `C*` for release notes (**exactly one required**)
  - [ ] `D*` for various implications/requirements
  - [ ] Github project assignment
- [ ] **Related Issues:** You mentioned a related issue if this PR is related to it, e.g. `Fixes #228` or `Related #1337`.
- [ ] **2 Reviewers:** You asked at least two reviewers to review. If you aren't sure, start with GH suggestions.
- [ ] **Style Guide:** Your PR adheres to [the style guide](https://github.com/paritytech/substrate/blob/master/docs/STYLE_GUIDE.md)
  - In particular, mind the maximal line length of 100 (120 in exceptional circumstances).
  - There is no commented code checked in unless necessary.
  - Any panickers in the runtime have a proof or were removed.
- [ ] **Runtime Version:** You bumped the runtime version if there are breaking changes in the **runtime**.
- [ ] **Docs:** You updated any rustdocs which may need to change.
- [ ] **Polkadot Companion:** Has the PR altered the external API or interfaces used by Polkadot?
  - [ ] If so, do you have the corresponding Polkadot PR ready?
  - [ ] Optionally: Do you have a corresponding Cumulus PR?

Refer to [the contributing guide](https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc) for details.

After you've read this notice feel free to remove it.
Thank you!

✄ -----------------------------------------------------------------------------
