### PR TITLE
Bump `wasmtime` to 0.38.0 and `zstd` to 0.11.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,11 +1139,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.82.3"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
+checksum = "2fa7c3188913c2d11a361e0431e135742372a2709a99b103e79758e11a0a797e"
 dependencies = [
- "cranelift-entity 0.82.3",
+ "cranelift-entity 0.84.0",
 ]
 
 [[package]]
@@ -1158,24 +1158,24 @@ dependencies = [
  "cranelift-entity 0.76.0",
  "gimli 0.25.0",
  "log",
- "regalloc 0.0.31",
+ "regalloc",
  "smallvec",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.82.3"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
+checksum = "29285f70fd396a8f64455a15a6e1d390322e4a5f5186de513141313211b0a23e"
 dependencies = [
- "cranelift-bforest 0.82.3",
- "cranelift-codegen-meta 0.82.3",
- "cranelift-codegen-shared 0.82.3",
- "cranelift-entity 0.82.3",
+ "cranelift-bforest 0.84.0",
+ "cranelift-codegen-meta 0.84.0",
+ "cranelift-codegen-shared 0.84.0",
+ "cranelift-entity 0.84.0",
  "gimli 0.26.1",
  "log",
- "regalloc 0.0.34",
+ "regalloc2",
  "smallvec",
  "target-lexicon",
 ]
@@ -1192,11 +1192,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.82.3"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
+checksum = "057eac2f202ec95aebfd8d495e88560ac085f6a415b3c6c28529dc5eb116a141"
 dependencies = [
- "cranelift-codegen-shared 0.82.3",
+ "cranelift-codegen-shared 0.84.0",
 ]
 
 [[package]]
@@ -1207,9 +1207,9 @@ checksum = "9dabb5fe66e04d4652e434195b45ae65b5c8172d520247b8f66d8df42b2b45dc"
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.82.3"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
+checksum = "75d93869efd18874a9341cfd8ad66bcb08164e86357a694a0e939d29e87410b9"
 
 [[package]]
 name = "cranelift-entity"
@@ -1219,9 +1219,9 @@ checksum = "3329733e4d4b8e91c809efcaa4faee80bf66f20164e3dd16d707346bd3494799"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.82.3"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
+checksum = "7e34bd7a1fefa902c90a921b36323f17a398b788fa56a75f07a29d83b6e28808"
 dependencies = [
  "serde",
 ]
@@ -1240,11 +1240,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.82.3"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
+checksum = "457018dd2d6ee300953978f63215b5edf3ae42dbdf8c7c038972f10394599f72"
 dependencies = [
- "cranelift-codegen 0.82.3",
+ "cranelift-codegen 0.84.0",
  "log",
  "smallvec",
  "target-lexicon",
@@ -1252,28 +1252,28 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.82.3"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501241b0cdf903412ec9075385ac9f2b1eb18a89044d1538e97fab603231f70c"
+checksum = "bba027cc41bf1d0eee2ddf16caba2ee1be682d0214520fff0129d2c6557fda89"
 dependencies = [
- "cranelift-codegen 0.82.3",
+ "cranelift-codegen 0.84.0",
  "libc",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.82.3"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d9e4211bbc3268042a96dd4de5bd979cda22434991d035f5f8eacba987fad2"
+checksum = "9b17639ced10b9916c9be120d38c872ea4f9888aa09248568b10056ef0559bfa"
 dependencies = [
- "cranelift-codegen 0.82.3",
- "cranelift-entity 0.82.3",
- "cranelift-frontend 0.82.3",
+ "cranelift-codegen 0.84.0",
+ "cranelift-entity 0.84.0",
+ "cranelift-frontend 0.84.0",
  "itertools",
  "log",
  "smallvec",
- "wasmparser 0.83.0",
+ "wasmparser 0.84.0",
  "wasmtime-types",
 ]
 
@@ -2568,6 +2568,15 @@ dependencies = [
  "pin-project-lite 0.2.6",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -5116,8 +5125,6 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
- "crc32fast",
- "indexmap",
  "memchr",
 ]
 
@@ -7589,13 +7596,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "regalloc"
-version = "0.0.34"
+name = "regalloc2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
+checksum = "904196c12c9f55d3aea578613219f493ced8e05b3d0c6a42d11cb4142d8b4879"
 dependencies = [
+ "fxhash",
  "log",
- "rustc-hash",
+ "slice-group-by",
  "smallvec",
 ]
 
@@ -7827,9 +7835,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.33.5"
+version = "0.33.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03627528abcc4a365554d32a9f3bbf67f7694c102cfeda792dc86a2d6057cc85"
+checksum = "938a344304321a9da4973b9ff4f9f8db9caf4597dfd9dda6a60b523340a0fff0"
 dependencies = [
  "bitflags",
  "errno",
@@ -9536,6 +9544,12 @@ name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "slice-group-by"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 
 [[package]]
 name = "smallvec"
@@ -11898,15 +11912,18 @@ checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
 
 [[package]]
 name = "wasmparser"
-version = "0.83.0"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
+checksum = "77dc97c22bb5ce49a47b745bed8812d30206eff5ef3af31424f2c1820c0974b2"
+dependencies = [
+ "indexmap",
+]
 
 [[package]]
 name = "wasmtime"
-version = "0.35.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ffb4705016d5ca91e18a72ed6822dab50e6d5ddd7045461b17ef19071cdef1"
+checksum = "dfdd1101bdfa0414a19018ec0a091951a20b695d4d04f858d49f6c4cc53cd8dd"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -11916,7 +11933,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "object 0.27.1",
+ "object 0.28.3",
  "once_cell",
  "paste 1.0.6",
  "psm",
@@ -11924,7 +11941,7 @@ dependencies = [
  "region 2.2.0",
  "serde",
  "target-lexicon",
- "wasmparser 0.83.0",
+ "wasmparser 0.84.0",
  "wasmtime-cache",
  "wasmtime-cranelift",
  "wasmtime-environ",
@@ -11935,9 +11952,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "0.35.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c6ab24291fa7cb3a181f5669f6c72599b7ef781669759b45c7828c5999d0c0"
+checksum = "79da81ed0724392948ad7a0fb5088ff1bd15fa937356c8c037c6b1c8b5473cde"
 dependencies = [
  "anyhow",
  "base64",
@@ -11955,51 +11972,51 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.35.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04c810078a491b7bc4866ebe045f714d2b95e6b539e1f64009a4a7606be11de"
+checksum = "16e78edcfb0daa9a9579ac379d00e2d5a5b2a60c0d653c8c95e8412f2166acb9"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.82.3",
- "cranelift-entity 0.82.3",
- "cranelift-frontend 0.82.3",
+ "cranelift-codegen 0.84.0",
+ "cranelift-entity 0.84.0",
+ "cranelift-frontend 0.84.0",
  "cranelift-native",
  "cranelift-wasm",
  "gimli 0.26.1",
  "log",
  "more-asserts",
- "object 0.27.1",
+ "object 0.28.3",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.83.0",
+ "wasmparser 0.84.0",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.35.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61448266ea164b1ac406363cdcfac81c7c44db4d94c7a81c8620ac6c5c6cdf59"
+checksum = "4201389132ec467981980549574b33fc70d493b40f2c045c8ce5c7b54fbad97e"
 dependencies = [
  "anyhow",
- "cranelift-entity 0.82.3",
+ "cranelift-entity 0.84.0",
  "gimli 0.26.1",
  "indexmap",
  "log",
  "more-asserts",
- "object 0.27.1",
+ "object 0.28.3",
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.83.0",
+ "wasmparser 0.84.0",
  "wasmtime-types",
 ]
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.35.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "156b4623c6b0d4b8c24afb846c20525922f538ef464cc024abab7ea8de2109a2"
+checksum = "1587ca7752d00862faa540d00fd28e5ccf1ac61ba19756449193f1153cb2b127"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -12008,7 +12025,7 @@ dependencies = [
  "cpp_demangle",
  "gimli 0.26.1",
  "log",
- "object 0.27.1",
+ "object 0.28.3",
  "region 2.2.0",
  "rustc-demangle",
  "rustix",
@@ -12023,20 +12040,20 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "0.35.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5dc31f811760a6c76b2672c404866fd19b75e5fb3b0075a3e377a6846490654"
+checksum = "b27233ab6c8934b23171c64f215f902ef19d18c1712b46a0674286d1ef28d5dd"
 dependencies = [
  "lazy_static",
- "object 0.27.1",
+ "object 0.28.3",
  "rustix",
 ]
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.35.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f907beaff69d4d920fa4688411ee4cc75c0f01859e424677f9e426e2ef749864"
+checksum = "47d3b0b8f13db47db59d616e498fe45295819d04a55f9921af29561827bdb816"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -12060,14 +12077,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "0.35.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514ef0e5fd197b9609dc9eb74beba0c84d5a12b2417cbae55534633329ba4852"
+checksum = "1630d9dca185299bec7f557a7e73b28742fe5590caf19df001422282a0a98ad1"
 dependencies = [
- "cranelift-entity 0.82.3",
+ "cranelift-entity 0.84.0",
  "serde",
  "thiserror",
- "wasmparser 0.83.0",
+ "wasmparser 0.84.0",
 ]
 
 [[package]]
@@ -12325,18 +12342,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.10.0+zstd.1.5.2"
+version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1365becbe415f3f0fcd024e2f7b45bacfb5bdd055f0dc113571394114e7bdd"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "4.1.4+zstd.1.5.2"
+version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7cd17c9af1a4d6c24beb1cc54b17e2ef7b593dc92f19e9d9acad8b182bbaee"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -12344,9 +12361,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.6.3+zstd.1.5.2"
+version = "2.0.1+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,11 +1139,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fa7c3188913c2d11a361e0431e135742372a2709a99b103e79758e11a0a797e"
+checksum = "899dc8d22f7771e7f887fb8bafa0c0d3ac1dea0c7f2c0ded6e20a855a7a1e890"
 dependencies = [
- "cranelift-entity 0.84.0",
+ "cranelift-entity 0.85.0",
 ]
 
 [[package]]
@@ -1165,14 +1165,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29285f70fd396a8f64455a15a6e1d390322e4a5f5186de513141313211b0a23e"
+checksum = "8dbdc03f695cf67e7bc45da57155528274f47390b85060af8107eb304ef167c4"
 dependencies = [
- "cranelift-bforest 0.84.0",
- "cranelift-codegen-meta 0.84.0",
- "cranelift-codegen-shared 0.84.0",
- "cranelift-entity 0.84.0",
+ "cranelift-bforest 0.85.0",
+ "cranelift-codegen-meta 0.85.0",
+ "cranelift-codegen-shared 0.85.0",
+ "cranelift-entity 0.85.0",
+ "cranelift-isle",
  "gimli 0.26.1",
  "log",
  "regalloc2",
@@ -1192,11 +1193,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057eac2f202ec95aebfd8d495e88560ac085f6a415b3c6c28529dc5eb116a141"
+checksum = "9ea66cbba3eb7fcb3ec9f42839a6d381bd40cf97780397e7167daf9725d4ffa0"
 dependencies = [
- "cranelift-codegen-shared 0.84.0",
+ "cranelift-codegen-shared 0.85.0",
 ]
 
 [[package]]
@@ -1207,9 +1208,9 @@ checksum = "9dabb5fe66e04d4652e434195b45ae65b5c8172d520247b8f66d8df42b2b45dc"
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d93869efd18874a9341cfd8ad66bcb08164e86357a694a0e939d29e87410b9"
+checksum = "712fbebd119a476f59122b4ba51fdce893a66309b5c92bd5506bfb11a0587496"
 
 [[package]]
 name = "cranelift-entity"
@@ -1219,9 +1220,9 @@ checksum = "3329733e4d4b8e91c809efcaa4faee80bf66f20164e3dd16d707346bd3494799"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e34bd7a1fefa902c90a921b36323f17a398b788fa56a75f07a29d83b6e28808"
+checksum = "4cb8b95859c4e14c9e860db78d596a904fdbe9261990233b62bd526346cb56cb"
 dependencies = [
  "serde",
 ]
@@ -1240,40 +1241,46 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457018dd2d6ee300953978f63215b5edf3ae42dbdf8c7c038972f10394599f72"
+checksum = "c7b91b19a7d1221a73f190c0e865c12be77a84f661cac89abfd4ab5820142886"
 dependencies = [
- "cranelift-codegen 0.84.0",
+ "cranelift-codegen 0.85.0",
  "log",
  "smallvec",
  "target-lexicon",
 ]
 
 [[package]]
-name = "cranelift-native"
-version = "0.84.0"
+name = "cranelift-isle"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba027cc41bf1d0eee2ddf16caba2ee1be682d0214520fff0129d2c6557fda89"
+checksum = "86d4f53bc86fb458e59c695c6a95ce8346e6a8377ee7ffc058e3ac08b5f94cb1"
+
+[[package]]
+name = "cranelift-native"
+version = "0.85.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592f035d0ed41214dfeeb37abd536233536a27be6b4c2d39f380cd402f0cff4f"
 dependencies = [
- "cranelift-codegen 0.84.0",
+ "cranelift-codegen 0.85.0",
  "libc",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b17639ced10b9916c9be120d38c872ea4f9888aa09248568b10056ef0559bfa"
+checksum = "295add6bf0b527a8bc50d02e31ff878585d2d2db53cb7e8754d6d82b84480086"
 dependencies = [
- "cranelift-codegen 0.84.0",
- "cranelift-entity 0.84.0",
- "cranelift-frontend 0.84.0",
+ "cranelift-codegen 0.85.0",
+ "cranelift-entity 0.85.0",
+ "cranelift-frontend 0.85.0",
  "itertools",
  "log",
  "smallvec",
- "wasmparser 0.84.0",
+ "wasmparser 0.85.0",
  "wasmtime-types",
 ]
 
@@ -5142,9 +5149,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "oorandom"
@@ -7597,9 +7604,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.1.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904196c12c9f55d3aea578613219f493ced8e05b3d0c6a42d11cb4142d8b4879"
+checksum = "0d37148700dbb38f994cd99a1431613057f37ed934d7e4d799b7ab758c482461"
 dependencies = [
  "fxhash",
  "log",
@@ -11912,18 +11919,18 @@ checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
 
 [[package]]
 name = "wasmparser"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77dc97c22bb5ce49a47b745bed8812d30206eff5ef3af31424f2c1820c0974b2"
+checksum = "570460c58b21e9150d2df0eaaedbb7816c34bcec009ae0dcc976e40ba81463e7"
 dependencies = [
  "indexmap",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdd1101bdfa0414a19018ec0a091951a20b695d4d04f858d49f6c4cc53cd8dd"
+checksum = "c842f9c8e190fe01300fc8d715e9368c775670fb9856247c67abffdb5236d6db"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -11941,7 +11948,7 @@ dependencies = [
  "region 2.2.0",
  "serde",
  "target-lexicon",
- "wasmparser 0.84.0",
+ "wasmparser 0.85.0",
  "wasmtime-cache",
  "wasmtime-cranelift",
  "wasmtime-environ",
@@ -11952,9 +11959,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79da81ed0724392948ad7a0fb5088ff1bd15fa937356c8c037c6b1c8b5473cde"
+checksum = "cce2aa752e864a33eef2a6629edc59554e75f0bc1719431dac5e49eed516af69"
 dependencies = [
  "anyhow",
  "base64",
@@ -11972,14 +11979,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e78edcfb0daa9a9579ac379d00e2d5a5b2a60c0d653c8c95e8412f2166acb9"
+checksum = "922361eb8c03cea8909bc922471202f6c6bc2f0c682fac2fe473740441c86b3b"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.84.0",
- "cranelift-entity 0.84.0",
- "cranelift-frontend 0.84.0",
+ "cranelift-codegen 0.85.0",
+ "cranelift-entity 0.85.0",
+ "cranelift-frontend 0.85.0",
  "cranelift-native",
  "cranelift-wasm",
  "gimli 0.26.1",
@@ -11988,18 +11995,18 @@ dependencies = [
  "object 0.28.3",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.84.0",
+ "wasmparser 0.85.0",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4201389132ec467981980549574b33fc70d493b40f2c045c8ce5c7b54fbad97e"
+checksum = "e602f1120fc40a3f016f1f69d08c86cfeff7b867bed1462901953e6871f85167"
 dependencies = [
  "anyhow",
- "cranelift-entity 0.84.0",
+ "cranelift-entity 0.85.0",
  "gimli 0.26.1",
  "indexmap",
  "log",
@@ -12008,15 +12015,15 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.84.0",
+ "wasmparser 0.85.0",
  "wasmtime-types",
 ]
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1587ca7752d00862faa540d00fd28e5ccf1ac61ba19756449193f1153cb2b127"
+checksum = "49af1445759a8e797a92f27dd0983c155615648263052e0b80d69e7d223896b7"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -12040,9 +12047,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b27233ab6c8934b23171c64f215f902ef19d18c1712b46a0674286d1ef28d5dd"
+checksum = "e6d5dd480cc6dc0a401653e45b79796a3317f8228990d84bc2271bdaf0810071"
 dependencies = [
  "lazy_static",
  "object 0.28.3",
@@ -12051,9 +12058,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d3b0b8f13db47db59d616e498fe45295819d04a55f9921af29561827bdb816"
+checksum = "e875bcd02d1ecfc7d099dd58354d55d73467652eb2b103ff470fe3aecb7d0381"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -12077,14 +12084,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1630d9dca185299bec7f557a7e73b28742fe5590caf19df001422282a0a98ad1"
+checksum = "8fd63a19ba61ac7448add4dc1fecb8d78304812af2a52dad04b89f887791b156"
 dependencies = [
- "cranelift-entity 0.84.0",
+ "cranelift-entity 0.85.0",
  "serde",
  "thiserror",
- "wasmparser 0.84.0",
+ "wasmparser 0.85.0",
 ]
 
 [[package]]

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -18,14 +18,13 @@ codec = { package = "parity-scale-codec", version = "3.0.0" }
 libc = "0.2.121"
 log = "0.4.17"
 parity-wasm = "0.42.0"
-wasmtime = { version = "0.37.0", default-features = false, features = [
+wasmtime = { version = "0.38.0", default-features = false, features = [
 	"cache",
 	"cranelift",
 	"jitdump",
 	"parallel-compilation",
 	"memory-init-cow",
 	"pooling-allocator",
-	"wasm-backtrace",
 ] }
 sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }
 sc-executor-common = { version = "0.10.0-dev", path = "../common" }

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -18,13 +18,14 @@ codec = { package = "parity-scale-codec", version = "3.0.0" }
 libc = "0.2.121"
 log = "0.4.17"
 parity-wasm = "0.42.0"
-wasmtime = { version = "0.35.3", default-features = false, features = [
+wasmtime = { version = "0.37.0", default-features = false, features = [
 	"cache",
 	"cranelift",
 	"jitdump",
 	"parallel-compilation",
 	"memory-init-cow",
 	"pooling-allocator",
+	"wasm-backtrace",
 ] }
 sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }
 sc-executor-common = { version = "0.10.0-dev", path = "../common" }

--- a/client/executor/wasmtime/src/imports.rs
+++ b/client/executor/wasmtime/src/imports.rs
@@ -34,7 +34,7 @@ where
 {
 	let mut pending_func_imports = HashMap::new();
 	for import_ty in module.imports() {
-		let name = import_name(&import_ty)?;
+		let name = import_ty.name();
 
 		if import_ty.module() != "env" {
 			return Err(WasmError::Other(format!(
@@ -120,14 +120,4 @@ impl<'a, 'b> sp_wasm_interface::HostFunctionRegistry for Registry<'a, 'b> {
 
 		Ok(())
 	}
-}
-
-/// When the module linking proposal is supported the import's name can be `None`.
-/// Because we are not using this proposal we could safely unwrap the name.
-/// However, we opt for an error in order to avoid panics at all costs.
-fn import_name<'a, 'b: 'a>(import: &'a ImportType<'b>) -> Result<&'a str, WasmError> {
-	let name = import.name().ok_or_else(|| {
-		WasmError::Other("The module linking proposal is not supported.".to_owned())
-	})?;
-	Ok(name)
 }

--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -323,7 +323,6 @@ fn common_config(semantics: &Semantics) -> std::result::Result<wasmtime::Config,
 	config.wasm_bulk_memory(false);
 	config.wasm_multi_value(false);
 	config.wasm_multi_memory(false);
-	config.wasm_module_linking(false);
 	config.wasm_threads(false);
 	config.wasm_memory64(false);
 

--- a/frame/state-trie-migration/Cargo.toml
+++ b/frame/state-trie-migration/Cargo.toml
@@ -18,7 +18,7 @@ log = { version = "0.4.17", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.133", optional = true }
 thousands = { version = "0.2.0", optional = true }
-zstd = { version = "0.10.0", default-features = false, optional = true }
+zstd = { version = "0.11.2", default-features = false, optional = true }
 frame-benchmarking = { default-features = false, optional = true, path = "../benchmarking" }
 frame-support = { default-features = false, path = "../support" }
 frame-system = { default-features = false, path = "../system" }

--- a/primitives/maybe-compressed-blob/Cargo.toml
+++ b/primitives/maybe-compressed-blob/Cargo.toml
@@ -12,4 +12,4 @@ readme = "README.md"
 
 [dependencies]
 thiserror = "1.0"
-zstd = { version = "0.10.0", default-features = false }
+zstd = { version = "0.11.2", default-features = false }

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -33,7 +33,7 @@ sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 [dev-dependencies]
 rand = "0.7.2"
 serde_json = "1.0.79"
-zstd = { version = "0.10.0", default-features = false }
+zstd = { version = "0.11.2", default-features = false }
 sp-api = { version = "4.0.0-dev", path = "../api" }
 sp-state-machine = { version = "0.12.0", path = "../state-machine" }
 sp-tracing = { version = "5.0.0", path = "../../primitives/tracing" }

--- a/primitives/wasm-interface/Cargo.toml
+++ b/primitives/wasm-interface/Cargo.toml
@@ -18,7 +18,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 impl-trait-for-tuples = "0.2.2"
 log = { version = "0.4.17", optional = true }
 wasmi = { version = "0.9.1", optional = true }
-wasmtime = { version = "0.35.3", default-features = false, optional = true }
+wasmtime = { version = "0.37.0", default-features = false, optional = true }
 sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 
 [features]

--- a/primitives/wasm-interface/Cargo.toml
+++ b/primitives/wasm-interface/Cargo.toml
@@ -18,7 +18,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 impl-trait-for-tuples = "0.2.2"
 log = { version = "0.4.17", optional = true }
 wasmi = { version = "0.9.1", optional = true }
-wasmtime = { version = "0.37.0", default-features = false, optional = true }
+wasmtime = { version = "0.38.0", default-features = false, optional = true }
 sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 
 [features]

--- a/utils/frame/try-runtime/cli/Cargo.toml
+++ b/utils/frame/try-runtime/cli/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "3.1.18", features = ["derive"] }
 log = "0.4.17"
 parity-scale-codec = "3.0.0"
 serde = "1.0.136"
-zstd = { version = "0.10.0", default-features = false }
+zstd = { version = "0.11.2", default-features = false }
 remote-externalities = { version = "0.10.0-dev", path = "../../remote-externalities" }
 jsonrpsee = { version = "0.14.0", default-features = false, features = ["ws-client"] }
 sc-chain-spec = { version = "4.0.0-dev", path = "../../../../client/chain-spec" }


### PR DESCRIPTION
polkadot companion: https://github.com/paritytech/polkadot/pull/5707

This PR bumps `wasmtime`'s version to 0.37.0. 

It has some performance improvements. Up to 25% lower instantiation overhead:

```
call_empty_function_from_kusama_runtime_with_pooling_cow_fresh_on_1_threads
                        time:   [7.1653 us 7.1711 us 7.1774 us]
                        change: [-26.824% -26.436% -26.018%] (p = 0.00 < 0.05)
                        Performance has improved.                                                                                                
call_empty_function_from_kusama_runtime_with_pooling_cow_fresh_on_2_threads
                        time:   [16.442 us 16.740 us 17.046 us]
                        change: [-19.829% -18.164% -16.341%] (p = 0.00 < 0.05)
                        Performance has improved.
call_empty_function_from_kusama_runtime_with_pooling_cow_fresh_on_4_threads
                        time:   [28.369 us 28.550 us 28.737 us]
                        change: [-17.160% -16.588% -15.996%] (p = 0.00 < 0.05)
                        Performance has improved.
call_empty_function_from_kusama_runtime_with_pooling_cow_fresh_on_8_threads
                        time:   [41.177 us 41.506 us 41.841 us]
                        change: [-14.429% -13.711% -12.935%] (p = 0.00 < 0.05)
                        Performance has improved.
call_empty_function_from_kusama_runtime_with_pooling_cow_fresh_on_16_threads
                        time:   [56.969 us 57.401 us 57.832 us]
                        change: [-12.036% -10.770% -9.5150%] (p = 0.00 < 0.05)
                        Performance has improved.
dirty_1mb_of_memory_from_kusama_runtime_with_pooling_cow_fresh_on_1_threads
                        time:   [144.58 us 144.78 us 145.02 us]
                        change: [-3.4725% -3.2229% -2.9525%] (p = 0.00 < 0.05)
                        Performance has improved.
dirty_1mb_of_memory_from_kusama_runtime_with_pooling_cow_fresh_on_2_threads
                        time:   [198.41 us 199.87 us 201.35 us]
                        change: [-6.1089% -5.2478% -4.4113%] (p = 0.00 < 0.05)
                        Performance has improved.
dirty_1mb_of_memory_from_kusama_runtime_with_pooling_cow_fresh_on_4_threads
                        time:   [303.44 us 304.71 us 305.92 us]
                        change: [-0.3752% +0.2747% +0.9313%] (p = 0.41 > 0.05)
                        No change in performance detected.
dirty_1mb_of_memory_from_kusama_runtime_with_pooling_cow_fresh_on_8_threads
                        time:   [496.69 us 509.04 us 521.36 us]
                        change: [-5.0092% -2.7425% -0.4472%] (p = 0.03 < 0.05)
                        Change within noise threshold.
dirty_1mb_of_memory_from_kusama_runtime_with_pooling_cow_fresh_on_16_threads
                        time:   [687.52 us 696.84 us 705.98 us]
                        change: [-2.1831% -0.6879% +0.7880%] (p = 0.37 > 0.05)
                        No change in performance detected.
```

And around ~2% faster block production:

```
Block production/5925 transfers (no proof)
                        time:   [1.7117 s 1.7192 s 1.7263 s]
                        thrpt:  [3.4322 Kelem/s 3.4465 Kelem/s 3.4615 Kelem/s]
                 change:
                        time:   [-1.6638% -1.1832% -0.7267%] (p = 0.00 < 0.05)
                        thrpt:  [+0.7320% +1.1973% +1.6919%]
                        Change within noise threshold.

Block production/5925 transfers (with proof)
                        time:   [1.7445 s 1.7523 s 1.7587 s]
                        thrpt:  [3.3690 Kelem/s 3.3812 Kelem/s 3.3963 Kelem/s]
                 change:
                        time:   [-2.9618% -2.4104% -1.9121%] (p = 0.00 < 0.05)
                        thrpt:  [+1.9494% +2.4699% +3.0522%]
                        Performance has improved.
```

The removal of the `config.wasm_module_linking(false);` in this PR is due to this feature being removed from `wasmtime` itself.

It looks like `wasmtime` 0.38.0 might be released soon; if it is released before this PR is merged I'll update it to 0.38.0.