### PR TITLE
Put `rusty-cachier` before PR merge into `master` for `cargo-check-benches` job

### DIFF
--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -80,6 +80,8 @@ cargo-check-benches:
     - .test-refs
     - .collect-artifacts
   before_script:
+    - !reference [.rust-info-script, script]
+    - !reference [.rusty-cachier, before_script]
     # merges in the master branch on PRs
     - if [ $CI_COMMIT_REF_NAME != "master" ]; then
         git fetch origin +master:master;
@@ -88,8 +90,6 @@ cargo-check-benches:
         git config user.email "ci@gitlab.parity.io";
         git merge $CI_COMMIT_REF_NAME --verbose --no-edit;
       fi
-    - !reference [.rust-info-script, script]
-    - !reference [.rusty-cachier, before_script]
   script:
     - rusty-cachier snapshot create
     - mkdir -p ./artifacts/benches/$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA


### PR DESCRIPTION
Perform `rusty-cachier` operations before any further modifications to the git repo to make `cargo` feel cheated not so much. Fixes fingerprinting problems with `cargo-check-benches` job.