### PR TITLE
Remove Storage Layer Limit

### DIFF
--- a/frame/support/src/storage/transactional.rs
+++ b/frame/support/src/storage/transactional.rs
@@ -33,7 +33,8 @@ use sp_runtime::{DispatchError, TransactionOutcome, TransactionalError};
 pub type Layer = u32;
 /// The key that is holds the current number of active layers.
 pub const TRANSACTION_LEVEL_KEY: &[u8] = b":transaction_level:";
-/// The maximum number of nested layers. If `None`, then there is no limit.
+/// The maximum number of nested layers. If `None`, then there is no limit (beyond the U32::MAX
+/// limit).
 pub const TRANSACTIONAL_LIMIT: Option<Layer> = None;
 
 /// Returns the current number of nested transactional layers.

--- a/frame/support/src/storage/transactional.rs
+++ b/frame/support/src/storage/transactional.rs
@@ -274,6 +274,9 @@ mod tests {
 					recursive_transactional(limit + 1),
 					sp_runtime::TransactionalError::LimitReached
 				);
+			} else {
+				// It is possible to create at least 257 layers.
+				assert_ok!(recursive_transactional(257));
 			}
 
 			assert_eq!(get_transaction_level(), 0);


### PR DESCRIPTION
This PR removes the limit of creating new transactional storage layers.

Instead, we will rely on the stack depth limit and sensible runtime development patterns to avoid people abusing the limit on transactional storage layers. And sensible depth of transactional layers should have a nominal impact into the measured performance of extrinsics.

Note that it is still important that we track the number of storage layers, since we want to be able to tell that we are in a transactional layer at any point in time.