### PR TITLE
Adapter for alliance proposal provider from collectives pallet.

### DIFF
--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -768,7 +768,7 @@ pub trait ProposalProtocol<AccountId, Hash, Proposal>:
 	+ ProposalVote<AccountId, Hash>
 	+ ProposalDisapprove<Hash>
 	+ ProposalClose<Hash>
-	+ ProposalProvider<Hash, Proposal>
+	+ ProposalOfHash<Hash, Proposal>
 {
 }
 
@@ -993,11 +993,11 @@ impl<T: Config<I>, I: 'static> ProposalClose<T::Hash> for Pallet<T, I> {
 	}
 }
 
-pub trait ProposalOf<Hash, Proposal> {
+pub trait ProposalOfHash<Hash, Proposal> {
 	fn proposal_of(proposal_hash: Hash) -> Option<Proposal>;
 }
 
-impl<T: Config<I>, I: 'static> ProposalOf<T::Hash, T::Proposal> for Pallet<T, I> {
+impl<T: Config<I>, I: 'static> ProposalOfHash<T::Hash, T::Proposal> for Pallet<T, I> {
 	fn proposal_of(proposal_hash: T::Hash) -> Option<T::Proposal> {
 		Self::proposal_of(proposal_hash)
 	}


### PR DESCRIPTION
One of a common use case is to use collectives pallet for alliance proposal provider trait to setup an alliance pallet.
Currently this requires to define and implement additional type within runtime setup. Here is an example - [link](https://github.com/paritytech/cumulus/blob/joe-alliance/parachains/runtimes/collectives/collectives-polkadot/src/lib.rs#L441-L477).

There is one of possible solution for generic adapter from collectives pallet to alliance proposal provider trait.