### PR TITLE
When querying an existing block, use the same version of Runtime that was used to construct it.

### DIFF
--- a/client/api/src/call_executor.rs
+++ b/client/api/src/call_executor.rs
@@ -59,6 +59,7 @@ pub trait CallExecutor<B: BlockT>: RuntimeVersionOf {
 		call_data: &[u8],
 		strategy: ExecutionStrategy,
 		extensions: Option<Extensions>,
+		offchain_call: bool,
 	) -> Result<Vec<u8>, sp_blockchain::Error>;
 
 	/// Execute a contextual call on top of state in a block of a given hash.
@@ -88,6 +89,7 @@ pub trait CallExecutor<B: BlockT>: RuntimeVersionOf {
 		native_call: Option<NC>,
 		proof_recorder: &Option<ProofRecorder<B>>,
 		extensions: Option<Extensions>,
+		offchain_call: bool,
 	) -> sp_blockchain::Result<NativeOrEncoded<R>>
 	where
 		ExecutionManager<EM>: Clone;

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -514,6 +514,7 @@ where
 				&[],
 				ExecutionStrategy::NativeElseWasm,
 				None,
+				/* offchain_call: */ true,
 			)
 			.and_then(|call_result| {
 				Decode::decode(&mut &call_result[..]).map_err(|err| {

--- a/client/rpc/src/state/mod.rs
+++ b/client/rpc/src/state/mod.rs
@@ -64,6 +64,7 @@ where
 		block: Option<Block::Hash>,
 		method: String,
 		call_data: Bytes,
+		offchain_call: bool,
 	) -> Result<Bytes, Error>;
 
 	/// Returns the keys with prefix, leave empty to get all the keys.
@@ -208,7 +209,7 @@ where
 	Client: Send + Sync + 'static,
 {
 	fn call(&self, method: String, data: Bytes, block: Option<Block::Hash>) -> RpcResult<Bytes> {
-		self.backend.call(block, method, data).map_err(Into::into)
+		self.backend.call(block, method, data, /* offchain_call: */ true).map_err(Into::into)
 	}
 
 	fn storage_keys(

--- a/client/rpc/src/state/mod.rs
+++ b/client/rpc/src/state/mod.rs
@@ -209,7 +209,9 @@ where
 	Client: Send + Sync + 'static,
 {
 	fn call(&self, method: String, data: Bytes, block: Option<Block::Hash>) -> RpcResult<Bytes> {
-		self.backend.call(block, method, data, /* offchain_call: */ true).map_err(Into::into)
+		self.backend
+			.call(block, method, data, /* offchain_call: */ true)
+			.map_err(Into::into)
 	}
 
 	fn storage_keys(

--- a/client/rpc/src/state/state_full.rs
+++ b/client/rpc/src/state/state_full.rs
@@ -191,6 +191,7 @@ where
 		block: Option<Block::Hash>,
 		method: String,
 		call_data: Bytes,
+		offchain_call: bool,
 	) -> std::result::Result<Bytes, Error> {
 		self.block_or_best(block)
 			.and_then(|block| {
@@ -202,6 +203,7 @@ where
 						&*call_data,
 						self.client.execution_extensions().strategies().other,
 						None,
+						offchain_call,
 					)
 					.map(Into::into)
 			})

--- a/client/service/src/client/call_executor.rs
+++ b/client/service/src/client/call_executor.rs
@@ -151,6 +151,8 @@ where
 		extensions: Option<Extensions>,
 		offchain_call: bool,
 	) -> sp_blockchain::Result<Vec<u8>> {
+		eprintln!("<LocalCallExecutor as CallExecutor>::call [at: {}; offchain_call: {}; method: {}]", at, offchain_call, method);
+
 		let mut changes = OverlayedChanges::default();
 		let state = self.backend.state_at(*at)?;
 		let state_runtime_code = sp_state_machine::backend::BackendRuntimeCode::new(&state);
@@ -205,6 +207,8 @@ where
 	where
 		ExecutionManager<EM>: Clone,
 	{
+		eprintln!("<LocalCallExecutor as CallExecutor>::contextual_call [at: {}; offchain_call: {}; method: {}]", at, offchain_call, method);
+
 		let mut storage_transaction_cache = storage_transaction_cache.map(|c| c.borrow_mut());
 
 		let state = self.backend.state_at(*at)?;

--- a/client/service/src/client/call_executor.rs
+++ b/client/service/src/client/call_executor.rs
@@ -151,7 +151,7 @@ where
 		extensions: Option<Extensions>,
 		offchain_call: bool,
 	) -> sp_blockchain::Result<Vec<u8>> {
-		eprintln!("<LocalCallExecutor as CallExecutor>::call [at: {}; offchain_call: {}; method: {}]", at, offchain_call, method);
+		log::warn!("<LocalCallExecutor as CallExecutor>::call [at: {}; offchain_call: {}; method: {}]", at, offchain_call, method);
 
 		let mut changes = OverlayedChanges::default();
 		let state = self.backend.state_at(*at)?;
@@ -207,7 +207,7 @@ where
 	where
 		ExecutionManager<EM>: Clone,
 	{
-		eprintln!("<LocalCallExecutor as CallExecutor>::contextual_call [at: {}; offchain_call: {}; method: {}]", at, offchain_call, method);
+		log::warn!("<LocalCallExecutor as CallExecutor>::contextual_call [at: {}; offchain_call: {}; method: {}]", at, offchain_call, method);
 
 		let mut storage_transaction_cache = storage_transaction_cache.map(|c| c.borrow_mut());
 

--- a/client/service/src/client/call_executor.rs
+++ b/client/service/src/client/call_executor.rs
@@ -116,14 +116,17 @@ where
 	}
 
 	// choose the block where the runtime code is defined.
-	fn block_with_code(&self, block_id: BlockId<Block>, offchain_call: bool) -> sp_blockchain::Result<BlockId<Block>> {
+	fn block_with_code(
+		&self,
+		block_id: BlockId<Block>,
+		offchain_call: bool,
+	) -> sp_blockchain::Result<BlockId<Block>> {
 		use sp_api::HeaderT;
 		use sp_runtime::traits::Zero;
 
 		let header = self.backend.blockchain().expect_header(block_id)?;
 
-		let block_id_with_code = 
-		match (offchain_call, header.number().is_zero()) {
+		let block_id_with_code = match (offchain_call, header.number().is_zero()) {
 			(_, true) => block_id,
 			(true, false) => BlockId::Hash(*header.parent_hash()),
 			(false, _) => block_id,
@@ -168,13 +171,19 @@ where
 		extensions: Option<Extensions>,
 		offchain_call: bool,
 	) -> sp_blockchain::Result<Vec<u8>> {
-		log::warn!("<LocalCallExecutor as CallExecutor>::call [at: {}; offchain_call: {}; method: {}]", at, offchain_call, method);
+		log::warn!(
+			"<LocalCallExecutor as CallExecutor>::call [at: {}; offchain_call: {}; method: {}]",
+			at,
+			offchain_call,
+			method
+		);
 
 		let mut changes = OverlayedChanges::default();
 		let state = self.backend.state_at(*at)?;
 
 		let state_with_code = self.backend.state_at(self.block_with_code(*at, offchain_call)?)?;
-		let state_runtime_code = sp_state_machine::backend::BackendRuntimeCode::new(&state_with_code);
+		let state_runtime_code =
+			sp_state_machine::backend::BackendRuntimeCode::new(&state_with_code);
 		let runtime_code =
 			state_runtime_code.runtime_code().map_err(sp_blockchain::Error::RuntimeCode)?;
 
@@ -231,7 +240,7 @@ where
 		let mut storage_transaction_cache = storage_transaction_cache.map(|c| c.borrow_mut());
 
 		let state = self.backend.state_at(*at)?;
-		
+
 		let changes = &mut *changes.borrow_mut();
 
 		let at_hash = self.backend.blockchain().block_hash_from_id(at)?.ok_or_else(|| {
@@ -242,7 +251,8 @@ where
 		// recorder to not record it. We also need to fetch the runtime code from `state` to
 		// make sure we use the caching layers.
 		let state_with_code = self.backend.state_at(self.block_with_code(*at, offchain_call)?)?;
-		let state_runtime_code = sp_state_machine::backend::BackendRuntimeCode::new(&state_with_code);
+		let state_runtime_code =
+			sp_state_machine::backend::BackendRuntimeCode::new(&state_with_code);
 
 		let runtime_code =
 			state_runtime_code.runtime_code().map_err(sp_blockchain::Error::RuntimeCode)?;

--- a/client/service/src/client/call_executor.rs
+++ b/client/service/src/client/call_executor.rs
@@ -117,10 +117,15 @@ where
 
 	// choose the block where the runtime code is defined.
 	fn block_with_code(&self, block_id: BlockId<Block>, offchain_call: bool) -> sp_blockchain::Result<BlockId<Block>> {
-		if offchain_call {
-			Ok(block_id)
-		} else {
-			Ok(block_id)
+		use sp_api::HeaderT;
+		use sp_runtime::traits::Zero;
+
+		let header = self.backend.blockchain().expect_header(block_id)?;
+
+		match (offchain_call, header.number().is_zero()) {
+			(_, true) => Ok(block_id),
+			(true, false) => Ok(BlockId::Hash(*header.parent_hash())),
+			(false, _) => Ok(block_id),
 		}
 	}
 }

--- a/client/service/src/client/call_executor.rs
+++ b/client/service/src/client/call_executor.rs
@@ -122,11 +122,14 @@ where
 
 		let header = self.backend.blockchain().expect_header(block_id)?;
 
+		let block_id_with_code = 
 		match (offchain_call, header.number().is_zero()) {
-			(_, true) => Ok(block_id),
-			(true, false) => Ok(BlockId::Hash(*header.parent_hash())),
-			(false, _) => Ok(block_id),
-		}
+			(_, true) => block_id,
+			(true, false) => BlockId::Hash(*header.parent_hash()),
+			(false, _) => block_id,
+		};
+
+		Ok(block_id_with_code)
 	}
 }
 

--- a/client/service/src/client/call_executor.rs
+++ b/client/service/src/client/call_executor.rs
@@ -149,6 +149,7 @@ where
 		call_data: &[u8],
 		strategy: ExecutionStrategy,
 		extensions: Option<Extensions>,
+		offchain_call: bool,
 	) -> sp_blockchain::Result<Vec<u8>> {
 		let mut changes = OverlayedChanges::default();
 		let state = self.backend.state_at(*at)?;
@@ -199,6 +200,7 @@ where
 		native_call: Option<NC>,
 		recorder: &Option<ProofRecorder<Block>>,
 		extensions: Option<Extensions>,
+		offchain_call: bool,
 	) -> Result<NativeOrEncoded<R>, sp_blockchain::Error>
 	where
 		ExecutionManager<EM>: Clone,

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -60,6 +60,7 @@ use sp_consensus::{BlockOrigin, BlockStatus, Error as ConsensusError};
 
 use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedSender};
 use sp_core::{
+	ExecutionContext,
 	storage::{
 		well_known_keys, ChildInfo, ChildType, PrefixedStorageKey, Storage, StorageChild,
 		StorageData, StorageKey,
@@ -1667,6 +1668,7 @@ where
 		params: CallApiAtParams<Block, NC, B::State>,
 	) -> Result<NativeOrEncoded<R>, sp_api::ApiError> {
 		let at = params.at;
+		let offchain_call = matches!(params.context, ExecutionContext::OffchainCall {..});
 
 		let (manager, extensions) =
 			self.execution_extensions.manager_and_extensions(at, params.context);
@@ -1682,6 +1684,7 @@ where
 				params.native_call,
 				params.recorder,
 				Some(extensions),
+				offchain_call,
 			)
 			.map_err(Into::into)
 	}

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -1300,6 +1300,7 @@ mod tests {
 	use sp_api::ProvideRuntimeApi;
 	use sp_consensus::BlockOrigin;
 	use sp_core::storage::well_known_keys::HEAP_PAGES;
+	use sp_core::ExecutionContext;
 	use sp_runtime::generic::BlockId;
 	use sp_state_machine::ExecutionStrategy;
 	use substrate_test_runtime_client::{
@@ -1319,7 +1320,7 @@ mod tests {
 
 		// Try to allocate 1024k of memory on heap. This is going to fail since it is twice larger
 		// than the heap.
-		let ret = client.runtime_api().vec_with_capacity(&block_id, 1048576);
+		let ret = client.runtime_api().vec_with_capacity_with_context(&block_id, ExecutionContext::BlockConstruction, 1048576);
 		assert!(ret.is_err());
 
 		// Create a block that sets the `:heap_pages` to 32 pages of memory which corresponds to
@@ -1335,7 +1336,7 @@ mod tests {
 		futures::executor::block_on(client.import(BlockOrigin::Own, block)).unwrap();
 
 		// Allocation of 1024k while having ~2048k should succeed.
-		let ret = client.runtime_api().vec_with_capacity(&new_block_id, 1048576);
+		let ret = client.runtime_api().vec_with_capacity_with_context(&new_block_id, ExecutionContext::BlockConstruction, 1048576);
 		assert!(ret.is_ok());
 	}
 


### PR DESCRIPTION
Addresses #9997 . 

This is a draft for what is referred "solution-3" in the original issue.

Please do not use the comments-section of this PR to discuss the choice of solution-3 over any other alternative.
If you'd like to discuss the choice of "solution-3" — please consider posting your comments in the [original issue](https://github.com/paritytech/substrate/issues/9997).