### PR TITLE
[contracts] Fixed the bug with transfer value for delegate call

### DIFF
--- a/frame/contracts/common/src/lib.rs
+++ b/frame/contracts/common/src/lib.rs
@@ -116,8 +116,6 @@ bitflags! {
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	#[cfg_attr(feature = "std", serde(rename_all = "camelCase", transparent))]
 	pub struct ReturnFlags: u32 {
-		/// If all bits are zero it is successful case.
-		const SUCCESS = 0x0;
 		/// If this bit is set all changes made by the contract execution are rolled back.
 		const REVERT = 0x0000_0001;
 	}

--- a/frame/contracts/common/src/lib.rs
+++ b/frame/contracts/common/src/lib.rs
@@ -116,6 +116,8 @@ bitflags! {
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	#[cfg_attr(feature = "std", serde(rename_all = "camelCase", transparent))]
 	pub struct ReturnFlags: u32 {
+		/// If all bits are zero it is successful case.
+		const SUCCESS = 0x0;
 		/// If this bit is set all changes made by the contract execution are rolled back.
 		const REVERT = 0x0000_0001;
 	}

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -798,9 +798,7 @@ where
 			}
 
 			// Every non delegate call or instantiate also optionally transfers the balance.
-			if self.top_frame().delegate_caller.is_none() {
-				self.initial_transfer()?;
-			}
+			self.initial_transfer()?;
 
 			// Call into the wasm blob.
 			let output = executable
@@ -961,8 +959,14 @@ where
 	// The transfer as performed by a call or instantiate.
 	fn initial_transfer(&self) -> DispatchResult {
 		let frame = self.top_frame();
-		let value = frame.value_transferred;
 
+		// If it is a delegate call, then we've already transferred tokens in the
+		// last non-delegate frame.
+		if frame.delegate_caller.is_some() {
+			return Ok(())
+		}
+
+		let value = frame.value_transferred;
 		Self::transfer(ExistenceRequirement::KeepAlive, self.caller(), &frame.account_id, value)
 	}
 

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -1570,7 +1570,7 @@ mod tests {
 
 		let success_ch = MockLoader::insert(Call, move |ctx, _| {
 			assert_eq!(ctx.ext.value_transferred(), value);
-			Ok(ExecReturnValue { flags: ReturnFlags::SUCCESS, data: Bytes(Vec::new()) })
+			Ok(ExecReturnValue { flags: ReturnFlags::empty(), data: Bytes(Vec::new()) })
 		});
 
 		ExtBuilder::default().build().execute_with(|| {
@@ -1605,13 +1605,13 @@ mod tests {
 
 		let success_ch = MockLoader::insert(Call, move |ctx, _| {
 			assert_eq!(ctx.ext.value_transferred(), value);
-			Ok(ExecReturnValue { flags: ReturnFlags::SUCCESS, data: Bytes(Vec::new()) })
+			Ok(ExecReturnValue { flags: ReturnFlags::empty(), data: Bytes(Vec::new()) })
 		});
 
 		let delegate_ch = MockLoader::insert(Call, move |ctx, _| {
 			assert_eq!(ctx.ext.value_transferred(), value);
 			let _ = ctx.ext.delegate_call(success_ch, Vec::new())?;
-			Ok(ExecReturnValue { flags: ReturnFlags::SUCCESS, data: Bytes(Vec::new()) })
+			Ok(ExecReturnValue { flags: ReturnFlags::empty(), data: Bytes(Vec::new()) })
 		});
 
 		ExtBuilder::default().build().execute_with(|| {

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -1594,7 +1594,7 @@ mod tests {
 				vec![],
 				None,
 			)
-				.unwrap();
+			.unwrap();
 
 			assert_eq!(get_balance(&origin), 100 - value);
 			assert_eq!(get_balance(&dest), balance + value);
@@ -1635,7 +1635,7 @@ mod tests {
 				vec![],
 				None,
 			)
-				.unwrap();
+			.unwrap();
 
 			assert_eq!(get_balance(&origin), 100 - value);
 			assert_eq!(get_balance(&dest), balance + value);


### PR DESCRIPTION
During the implementation of `delegate_call`, the case with the transfer of native token was missed.

If you transfer tokens to a call that does `delegate_call` inside, it causes a double-spend(or more if there are many delegate calls).

It is because for `delegate_call` we add a new frame(like for standard call) and pass `value` inside. On each new frame, we transfer tokens to the contract's account.

The fix is not to transfer tokens for frames caused by delegate calls.
