### PR TITLE
expose grandpa BeforeBestBlockBy voting rule

### DIFF
--- a/client/finality-grandpa/src/voting_rule.rs
+++ b/client/finality-grandpa/src/voting_rule.rs
@@ -89,7 +89,7 @@ where
 /// can prioritize shorter chains over longer ones, the vote may be
 /// closer to the best block than N.
 #[derive(Clone)]
-pub struct BeforeBestBlockBy<N>(N);
+pub struct BeforeBestBlockBy<N>(pub N);
 impl<Block, B> VotingRule<Block, B> for BeforeBestBlockBy<NumberFor<Block>>
 where
 	Block: BlockT,


### PR DESCRIPTION
This is useful for [malus](https://github.com/paritytech/polkadot/blob/master/node/malus/README.md) and zombienet tests in polkadot to test scenarios with delayed finality.