### PR TITLE
sync: Fixed clearing subsequent ranges

### DIFF
--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -1521,6 +1521,9 @@ where
 		for (_, hash) in &results {
 			self.queue_blocks.remove(hash);
 			self.blocks.clear_queued(hash);
+			if let Some(gap_sync) = &mut self.gap_sync {
+				gap_sync.blocks.clear_queued(hash);
+			}
 		}
 		for (result, hash) in results {
 			if has_error {


### PR DESCRIPTION
Fixes another issue introduced in #11094
`queued_blocks` records ranges using `from`, which can be arbitrary. Sync calls this function with `from` set to current best block to make sure no blocks will be returned if there's a gap in the downloaded ranges. The correct way to record a returned range here is using `start` rather than `from`.  Furthermore, all ranges need to be recorded and not just the first one.

Fixes #11812