### PR TITLE
Fix typo in pallet_election_provider_multi_phase

### DIFF
--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -51,7 +51,7 @@
 //! In the signed phase, solutions (of type [`RawSolution`]) are submitted and queued on chain. A
 //! deposit is reserved, based on the size of the solution, for the cost of keeping this solution
 //! on-chain for a number of blocks, and the potential weight of the solution upon being checked. A
-//! maximum of `pallet::Config::MaxSignedSubmissions` solutions are stored. The queue is always
+//! maximum of `pallet::Config::SignedMaxSubmissions` solutions are stored. The queue is always
 //! sorted based on score (worse to best).
 //!
 //! Upon arrival of a new solution:


### PR DESCRIPTION
**Description**
This is a typo fix for the rustdocs. In the [pallet_election_provider_multi_phase](https://crates.parity.io/pallet_election_provider_multi_phase/index.html#) documentation line 54 `pallet::Config::MaxSignedSubmissions` should be `pallet::Config::SignedMaxSubmissions` as one can see in the Polkadot implementation [here](https://github.com/paritytech/polkadot/blob/master/runtime/polkadot/src/lib.rs#L446).