### PR TITLE
Speed up `rusty-cachier-notify` job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -223,9 +223,13 @@ deploy-prometheus-alerting-rules:
 
 # This job notifies rusty-cachier about the latest commit with the cache.
 # This info is later used for the cache distribution and an overlay creation.
+# Note that we don't use any .rusty-cachier references as we assume that a pipeline has reached this stage with working rusty-cachier.
 rusty-cachier-notify:
   stage:                           notify
-  extends:                         .docker-env
+  extends:                         .kubernetes-env
+  variables:
+    CI_IMAGE:                      paritytech/rusty-cachier-env:latest
+    GIT_STRATEGY:                  none
   script:
     - rusty-cachier cache notify
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -231,6 +231,7 @@ rusty-cachier-notify:
     CI_IMAGE:                      paritytech/rusty-cachier-env:latest
     GIT_STRATEGY:                  none
   script:
+    - curl -s https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.parity.io/parity/infrastructure/ci_cd/rusty-cachier/client/-/raw/release/util/install.sh | bash
     - rusty-cachier cache notify
 
 #### stage:                        .post


### PR DESCRIPTION
This PR implements [the spec described here](https://github.com/paritytech/ci_cd/issues/506#issuecomment-1180661449):

* Use lightweight image for the `rusty-cachier-notify` job
* Skip all Git operations
* Run the job on the Kubernetes runner