### PR TITLE
Fix for 'note_applied_extrinsic' - consider also actual pays_fee

### DIFF
--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -91,8 +91,8 @@ use frame_support::{
 		OriginTrait, PalletInfo, SortedMembers, StoredMap, TypedGet,
 	},
 	weights::{
-		extract_actual_weight, DispatchClass, DispatchInfo, PerDispatchClass, RuntimeDbWeight,
-		Weight,
+		extract_actual_pays_fee, extract_actual_weight, DispatchClass, DispatchInfo,
+		PerDispatchClass, RuntimeDbWeight, Weight,
 	},
 	Parameter,
 };
@@ -1500,6 +1500,7 @@ impl<T: Config> Pallet<T> {
 	/// To be called immediately after an extrinsic has been applied.
 	pub fn note_applied_extrinsic(r: &DispatchResultWithPostInfo, mut info: DispatchInfo) {
 		info.weight = extract_actual_weight(r, &info);
+		info.pays_fee = extract_actual_pays_fee(r, &info);
 		Self::deposit_event(match r {
 			Ok(_) => Event::ExtrinsicSuccess { dispatch_info: info },
 			Err(err) => {

--- a/frame/system/src/tests.rs
+++ b/frame/system/src/tests.rs
@@ -17,7 +17,9 @@
 
 use crate::*;
 use frame_support::{
-	assert_noop, assert_ok, dispatch::PostDispatchInfo, weights::WithPostDispatchInfo,
+	assert_noop, assert_ok,
+	dispatch::PostDispatchInfo,
+	weights::{Pays, WithPostDispatchInfo},
 };
 use mock::{Origin, *};
 use sp_core::H256;
@@ -216,7 +218,7 @@ fn deposit_event_should_work() {
 }
 
 #[test]
-fn deposit_event_uses_actual_weight() {
+fn deposit_event_uses_actual_weight_and_pays_fee() {
 	new_test_ext().execute_with(|| {
 		System::reset_events();
 		System::initialize(&1, &[0u8; 32].into(), &Default::default());
@@ -230,7 +232,33 @@ fn deposit_event_uses_actual_weight() {
 			&Ok(Some(1200).into()),
 			pre_info,
 		);
+		System::note_applied_extrinsic(&Ok((Some(2_500_000), Pays::Yes).into()), pre_info);
+		System::note_applied_extrinsic(&Ok(Pays::No.into()), pre_info);
+		System::note_applied_extrinsic(&Ok((Some(2_500_000), Pays::No).into()), pre_info);
+		System::note_applied_extrinsic(&Ok((Some(500), Pays::No).into()), pre_info);
 		System::note_applied_extrinsic(&Err(DispatchError::BadOrigin.with_weight(999)), pre_info);
+
+		System::note_applied_extrinsic(
+			&Err(DispatchErrorWithPostInfo {
+				post_info: PostDispatchInfo { actual_weight: None, pays_fee: Pays::Yes },
+				error: DispatchError::BadOrigin,
+			}),
+			pre_info,
+		);
+		System::note_applied_extrinsic(
+			&Err(DispatchErrorWithPostInfo {
+				post_info: PostDispatchInfo { actual_weight: Some(800), pays_fee: Pays::Yes },
+				error: DispatchError::BadOrigin,
+			}),
+			pre_info,
+		);
+		System::note_applied_extrinsic(
+			&Err(DispatchErrorWithPostInfo {
+				post_info: PostDispatchInfo { actual_weight: Some(800), pays_fee: Pays::No },
+				error: DispatchError::BadOrigin,
+			}),
+			pre_info,
+		);
 
 		assert_eq!(
 			System::events(),
@@ -261,9 +289,96 @@ fn deposit_event_uses_actual_weight() {
 				},
 				EventRecord {
 					phase: Phase::ApplyExtrinsic(3),
+					event: SysEvent::ExtrinsicSuccess {
+						dispatch_info: DispatchInfo {
+							weight: 1000,
+							pays_fee: Pays::Yes,
+							..Default::default()
+						},
+					}
+					.into(),
+					topics: vec![]
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(4),
+					event: SysEvent::ExtrinsicSuccess {
+						dispatch_info: DispatchInfo {
+							weight: 1000,
+							pays_fee: Pays::No,
+							..Default::default()
+						},
+					}
+					.into(),
+					topics: vec![]
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(5),
+					event: SysEvent::ExtrinsicSuccess {
+						dispatch_info: DispatchInfo {
+							weight: 1000,
+							pays_fee: Pays::No,
+							..Default::default()
+						},
+					}
+					.into(),
+					topics: vec![]
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(6),
+					event: SysEvent::ExtrinsicSuccess {
+						dispatch_info: DispatchInfo {
+							weight: 500,
+							pays_fee: Pays::No,
+							..Default::default()
+						},
+					}
+					.into(),
+					topics: vec![]
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(7),
 					event: SysEvent::ExtrinsicFailed {
 						dispatch_error: DispatchError::BadOrigin.into(),
 						dispatch_info: DispatchInfo { weight: 999, ..Default::default() },
+					}
+					.into(),
+					topics: vec![]
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(8),
+					event: SysEvent::ExtrinsicFailed {
+						dispatch_error: DispatchError::BadOrigin.into(),
+						dispatch_info: DispatchInfo {
+							weight: 1000,
+							pays_fee: Pays::Yes,
+							..Default::default()
+						},
+					}
+					.into(),
+					topics: vec![]
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(9),
+					event: SysEvent::ExtrinsicFailed {
+						dispatch_error: DispatchError::BadOrigin.into(),
+						dispatch_info: DispatchInfo {
+							weight: 800,
+							pays_fee: Pays::Yes,
+							..Default::default()
+						},
+					}
+					.into(),
+					topics: vec![]
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(10),
+					event: SysEvent::ExtrinsicFailed {
+						dispatch_error: DispatchError::BadOrigin.into(),
+						dispatch_info: DispatchInfo {
+							weight: 800,
+							pays_fee: Pays::No,
+							..Default::default()
+						},
 					}
 					.into(),
 					topics: vec![]


### PR DESCRIPTION
**Wrong stored pays_fee attribute on Extrinsic events**

lets say, I have a dispatch call with `#[pallet::weight((500_000, Pays::Yes))]`, when I try to do a correction (https://docs.substrate.io/main-docs/build/tx-weights-fees/#post-dispatch-weight-correction) with different `pays_fee`, for example return with `Ok(Pays::No.into())`  or `Ok((Some(2_500_000), Pays::No).into())` or with

```
                       ensure!(
				name_len < 10,
				DispatchErrorWithPostInfo {
					post_info: PostDispatchInfo {
						actual_weight: Some(5_000_000),
						pays_fee: Pays::No
					},
					error: Error::<T>::InvalidParameter(InvalidParameterDetails {
						max: 9,
						actual: name_len as u8
					})
					.into()
				}
			);
```

I can see in `polkadot.js.org` block explorer, that `transactionPayment.TransactionFeePaid` is zero or some value according to `Pays::Yes/No`, looks ok as expected,
but all the time, `system.ExtrinsicFailed`  or `system.ExtrinsicSuccess` show  the original `paysFee: Yes`, so it is not properly stored.


**Question/Open point:**
I can see also some usages of `extract_actual_weight` in the `substrate/frame/utility/src/lib.rs`, shouldnt be `extract_actual_pays_fee` also considered here? **Answer: No (see comments bellow)**


Originally reported here:
https://matrix.to/#/!sdFqbvLCnbwaqBLiGw:matrix.parity.io/$165781413448884yAjNQ:matrix.parity.io?via=matrix.parity.io