### PR TITLE
Disable the interest cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11066,11 +11066,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
- "lazy_static",
+ "once_cell",
  "valuable",
 ]
 
@@ -11090,10 +11090,8 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
- "ahash",
  "lazy_static",
  "log",
- "lru",
  "tracing-core",
 ]
 

--- a/client/tracing/Cargo.toml
+++ b/client/tracing/Cargo.toml
@@ -26,7 +26,7 @@ rustc-hash = "1.1.0"
 serde = "1.0.136"
 thiserror = "1.0.30"
 tracing = "0.1.29"
-tracing-log = { version = "0.1.3", features = ["interest-cache"] }
+tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.2.25", features = ["parking_lot"] }
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sc-rpc-server = { version = "4.0.0-dev", path = "../rpc-servers" }

--- a/client/tracing/src/logging/mod.rs
+++ b/client/tracing/src/logging/mod.rs
@@ -157,7 +157,6 @@ where
 
 	tracing_log::LogTracer::builder()
 		.with_max_level(max_level)
-		.with_interest_cache(tracing_log::InterestCacheConfig::default())
 		.init()?;
 
 	// If we're only logging `INFO` entries then we'll use a simplified logging format.

--- a/client/tracing/src/logging/mod.rs
+++ b/client/tracing/src/logging/mod.rs
@@ -155,9 +155,7 @@ where
 	let max_level_hint = Layer::<FmtSubscriber>::max_level_hint(&env_filter);
 	let max_level = to_log_level_filter(max_level_hint);
 
-	tracing_log::LogTracer::builder()
-		.with_max_level(max_level)
-		.init()?;
+	tracing_log::LogTracer::builder().with_max_level(max_level).init()?;
 
 	// If we're only logging `INFO` entries then we'll use a simplified logging format.
 	let detailed_output = match max_level_hint {

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -32,7 +32,7 @@ futures = { version = "0.3.21", features = ["thread-pool"], optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 secp256k1 = { version = "0.21.2", features = ["recovery", "global-context"], optional = true }
 tracing = { version = "0.1.29", default-features = false }
-tracing-core = { version = "0.1.26", default-features = false}
+tracing-core = { version = "0.1.28", default-features = false}
 
 [features]
 default = ["std"]

--- a/primitives/runtime-interface/test/Cargo.toml
+++ b/primitives/runtime-interface/test/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 tracing = "0.1.29"
-tracing-core = "0.1.26"
+tracing-core = "0.1.28"
 sc-executor = { version = "0.10.0-dev", path = "../../../client/executor" }
 sc-executor-common = { version = "0.10.0-dev", path = "../../../client/executor/common" }
 sp-io = { version = "6.0.0", path = "../../io" }

--- a/primitives/tracing/Cargo.toml
+++ b/primitives/tracing/Cargo.toml
@@ -23,7 +23,7 @@ codec = { version = "3.0.0", package = "parity-scale-codec", default-features = 
 	"derive",
 ] }
 tracing = { version = "0.1.29", default-features = false }
-tracing-core = { version = "0.1.26", default-features = false }
+tracing-core = { version = "0.1.28", default-features = false }
 tracing-subscriber = { version = "0.2.25", optional = true, features = [
 	"tracing-log",
 ] }


### PR DESCRIPTION
The feature is currently broken with the latest `tracing-core`. We will enable it again, when it is
fixed upstream.

