### PR TITLE
Improve `wasmtime` error reporting

### DIFF
--- a/client/executor/wasmtime/src/imports.rs
+++ b/client/executor/wasmtime/src/imports.rs
@@ -112,7 +112,7 @@ impl<'a, 'b> sp_wasm_interface::HostFunctionRegistry for Registry<'a, 'b> {
 		if self.pending_func_imports.remove(fn_name).is_some() {
 			self.linker.func_wrap("env", fn_name, func).map_err(|error| {
 				WasmError::Other(format!(
-					"failed to register host function '{}' with the WASM linker: {}",
+					"failed to register host function '{}' with the WASM linker: {:#}",
 					fn_name, error
 				))
 			})?;

--- a/client/executor/wasmtime/src/instance_wrapper.rs
+++ b/client/executor/wasmtime/src/instance_wrapper.rs
@@ -187,7 +187,7 @@ impl InstanceWrapper {
 		let mut store = create_store(engine, max_memory_size);
 		let instance = instance_pre.instantiate(&mut store).map_err(|error| {
 			WasmError::Other(
-				format!("failed to instantiate a new WASM module instance: {}", error,),
+				format!("failed to instantiate a new WASM module instance: {:#}", error,),
 			)
 		})?;
 

--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -257,12 +257,12 @@ fn setup_wasmtime_caching(
 
 	let wasmtime_cache_root = cache_path.join("wasmtime");
 	fs::create_dir_all(&wasmtime_cache_root)
-		.map_err(|err| format!("cannot create the dirs to cache: {:?}", err))?;
+		.map_err(|err| format!("cannot create the dirs to cache: {}", err))?;
 
 	// Canonicalize the path after creating the directories.
 	let wasmtime_cache_root = wasmtime_cache_root
 		.canonicalize()
-		.map_err(|err| format!("failed to canonicalize the path: {:?}", err))?;
+		.map_err(|err| format!("failed to canonicalize the path: {}", err))?;
 
 	// Write the cache config file
 	let cache_config_path = wasmtime_cache_root.join("cache-config.toml");
@@ -275,11 +275,11 @@ directory = \"{cache_dir}\"
 		cache_dir = wasmtime_cache_root.display()
 	);
 	fs::write(&cache_config_path, config_content)
-		.map_err(|err| format!("cannot write the cache config: {:?}", err))?;
+		.map_err(|err| format!("cannot write the cache config: {}", err))?;
 
 	config
 		.cache_config_load(cache_config_path)
-		.map_err(|err| format!("failed to parse the config: {:?}", err))?;
+		.map_err(|err| format!("failed to parse the config: {:#}", err))?;
 
 	Ok(())
 }
@@ -304,14 +304,14 @@ fn common_config(semantics: &Semantics) -> std::result::Result<wasmtime::Config,
 	};
 	config
 		.profiler(profiler)
-		.map_err(|e| WasmError::Instantiation(format!("fail to set profiler: {}", e)))?;
+		.map_err(|e| WasmError::Instantiation(format!("fail to set profiler: {:#}", e)))?;
 
 	if let Some(DeterministicStackLimit { native_stack_max, .. }) =
 		semantics.deterministic_stack_limit
 	{
 		config
 			.max_wasm_stack(native_stack_max as usize)
-			.map_err(|e| WasmError::Other(format!("cannot set max wasm stack: {}", e)))?;
+			.map_err(|e| WasmError::Other(format!("cannot set max wasm stack: {:#}", e)))?;
 	}
 
 	config.parallel_compilation(semantics.parallel_compilation);
@@ -618,7 +618,7 @@ where
 	}
 
 	let engine = Engine::new(&wasmtime_config)
-		.map_err(|e| WasmError::Other(format!("cannot create the wasmtime engine: {}", e)))?;
+		.map_err(|e| WasmError::Other(format!("cannot create the wasmtime engine: {:#}", e)))?;
 
 	let (module, instantiation_strategy) = match code_supply_mode {
 		CodeSupplyMode::Fresh(blob) => {
@@ -626,7 +626,7 @@ where
 			let serialized_blob = blob.clone().serialize();
 
 			let module = wasmtime::Module::new(&engine, &serialized_blob)
-				.map_err(|e| WasmError::Other(format!("cannot create module: {}", e)))?;
+				.map_err(|e| WasmError::Other(format!("cannot create module: {:#}", e)))?;
 
 			match config.semantics.instantiation_strategy {
 				InstantiationStrategy::LegacyInstanceReuse => {
@@ -664,7 +664,7 @@ where
 			//
 			//         See [`create_runtime_from_artifact`] for more details.
 			let module = wasmtime::Module::deserialize_file(&engine, compiled_artifact_path)
-				.map_err(|e| WasmError::Other(format!("cannot deserialize module: {}", e)))?;
+				.map_err(|e| WasmError::Other(format!("cannot deserialize module: {:#}", e)))?;
 
 			(module, InternalInstantiationStrategy::Builtin)
 		},
@@ -677,7 +677,7 @@ where
 		crate::instance_wrapper::create_store(module.engine(), config.semantics.max_memory_size);
 	let instance_pre = linker
 		.instantiate_pre(&mut store, &module)
-		.map_err(|e| WasmError::Other(format!("cannot preinstantiate module: {}", e)))?;
+		.map_err(|e| WasmError::Other(format!("cannot preinstantiate module: {:#}", e)))?;
 
 	Ok(WasmtimeRuntime {
 		engine,
@@ -729,11 +729,11 @@ pub fn prepare_runtime_artifact(
 	let blob = prepare_blob_for_compilation(blob, &semantics)?;
 
 	let engine = Engine::new(&common_config(&semantics)?)
-		.map_err(|e| WasmError::Other(format!("cannot create the engine: {}", e)))?;
+		.map_err(|e| WasmError::Other(format!("cannot create the engine: {:#}", e)))?;
 
 	engine
 		.precompile_module(&blob.serialize())
-		.map_err(|e| WasmError::Other(format!("cannot precompile module: {}", e)))
+		.map_err(|e| WasmError::Other(format!("cannot precompile module: {:#}", e)))
 }
 
 fn perform_call(


### PR DESCRIPTION
Fixes https://github.com/paritytech/substrate/issues/11848

`wasmtime` uses `anyhow` for its errors which are not fully printed out by default when stringified using `Display`; instead we have to [use `{:#}` to make it display the full error](https://docs.rs/anyhow/1.0.26/anyhow/struct.Error.html#display-representations).