### PR TITLE
Bump wasmtime default `table_elements`

### DIFF
--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -366,7 +366,7 @@ fn common_config(semantics: &Semantics) -> std::result::Result<wasmtime::Config,
 				//   table_elements: 1249
 				//   memory_pages: 2070
 				size: 64 * 1024,
-				table_elements: 2048,
+				table_elements: 3072,
 				memory_pages,
 
 				// We can only have a single of those.


### PR DESCRIPTION
Some Polkadot tests started failing (https://github.com/paritytech/polkadot/issues/5788) with:  
```pre
Failed to get runtime version: cannot create module: table index 0 has a minimum element size of 2093 which exceeds the limit of 2048
```

Investigation showed that the `--feature=runtime-benchmarks` flag causes the increase of the WASM size.  
Can I just bump this value or do the others need an increase as well?  
The tests work with the increase to `3072`.