### PR TITLE
Cleanup light client leftovers

### DIFF
--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -361,11 +361,7 @@ impl CliConfiguration for RunCmd {
 		let keyring = self.get_keyring();
 		let is_authority = self.validator || is_dev || keyring.is_some();
 
-		Ok(if is_authority {
-			sc_service::Role::Authority
-		} else {
-			sc_service::Role::Full
-		})
+		Ok(if is_authority { sc_service::Role::Authority } else { sc_service::Role::Full })
 	}
 
 	fn force_authoring(&self) -> Result<bool> {

--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -50,10 +50,6 @@ pub struct RunCmd {
 	#[clap(long)]
 	pub no_grandpa: bool,
 
-	/// Experimental: Run in light client mode.
-	#[clap(long)]
-	pub light: bool,
-
 	/// Listen to all RPC interfaces.
 	///
 	/// Default is local. Note: not all RPC methods are safe to be exposed publicly. Use an RPC
@@ -337,7 +333,7 @@ impl CliConfiguration for RunCmd {
 
 	fn dev_key_seed(&self, is_dev: bool) -> Result<Option<String>> {
 		Ok(self.get_keyring().map(|a| format!("//{}", a)).or_else(|| {
-			if is_dev && !self.light {
+			if is_dev {
 				Some("//Alice".into())
 			} else {
 				None
@@ -363,12 +359,9 @@ impl CliConfiguration for RunCmd {
 
 	fn role(&self, is_dev: bool) -> Result<Role> {
 		let keyring = self.get_keyring();
-		let is_light = self.light;
-		let is_authority = (self.validator || is_dev || keyring.is_some()) && !is_light;
+		let is_authority = self.validator || is_dev || keyring.is_some();
 
-		Ok(if is_light {
-			sc_service::Role::Light
-		} else if is_authority {
+		Ok(if is_authority {
 			sc_service::Role::Authority
 		} else {
 			sc_service::Role::Full

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -211,12 +211,10 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		base_path: &PathBuf,
 		cache_size: usize,
 		database: Database,
-		role: &Role,
 	) -> Result<DatabaseSource> {
-		let role_dir = match role {
-			Role::Light => "light",
-			Role::Full | Role::Authority => "full",
-		};
+		// FIXME: There used to be `light` role dir.
+		//        May be we should move the directories one level up?
+		let role_dir =  "full";
 		let rocksdb_path = base_path.join("db").join(role_dir);
 		let paritydb_path = base_path.join("paritydb").join(role_dir);
 		Ok(match database {
@@ -536,7 +534,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 			)?,
 			keystore_remote,
 			keystore,
-			database: self.database_config(&config_dir, database_cache_size, database, &role)?,
+			database: self.database_config(&config_dir, database_cache_size, database)?,
 			state_cache_size: self.state_cache_size()?,
 			state_cache_child_ratio: self.state_cache_child_ratio()?,
 			state_pruning: self.state_pruning()?,

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -212,8 +212,6 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		cache_size: usize,
 		database: Database,
 	) -> Result<DatabaseSource> {
-		// FIXME: There used to be `light` role dir.
-		//        May be we should move the directories one level up?
 		let role_dir = "full";
 		let rocksdb_path = base_path.join("db").join(role_dir);
 		let paritydb_path = base_path.join("paritydb").join(role_dir);

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -214,7 +214,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 	) -> Result<DatabaseSource> {
 		// FIXME: There used to be `light` role dir.
 		//        May be we should move the directories one level up?
-		let role_dir =  "full";
+		let role_dir = "full";
 		let rocksdb_path = base_path.join("db").join(role_dir);
 		let paritydb_path = base_path.join("paritydb").join(role_dir);
 		Ok(match database {

--- a/client/finality-grandpa/src/communication/gossip.rs
+++ b/client/finality-grandpa/src/communication/gossip.rs
@@ -728,11 +728,7 @@ type MaybeMessage<Block> = Option<(Vec<PeerId>, NeighborPacket<NumberFor<Block>>
 
 impl<Block: BlockT> Inner<Block> {
 	fn new(config: crate::Config) -> Self {
-		let catch_up_config = if config.local_role.is_light() {
-			// if we are a light client we shouldn't be issuing any catch-up requests
-			// as we don't participate in the full GRANDPA protocol
-			CatchUpConfig::disabled()
-		} else if config.observer_enabled {
+		let catch_up_config = if config.observer_enabled {
 			if config.local_role.is_authority() {
 				// since the observer protocol is enabled, we will only issue
 				// catch-up requests if we are an authority (and only to other
@@ -1231,10 +1227,6 @@ impl<Block: BlockT> Inner<Block> {
 			None => return false,
 		};
 
-		if self.config.local_role.is_light() {
-			return false
-		}
-
 		if round_elapsed < round_duration.mul_f32(PROPAGATION_SOME) {
 			self.peers.first_stage_peers.contains(who)
 		} else if round_elapsed < round_duration.mul_f32(PROPAGATION_ALL) {
@@ -1265,10 +1257,6 @@ impl<Block: BlockT> Inner<Block> {
 			Some(ref local_view) => local_view.round_start.elapsed(),
 			None => return false,
 		};
-
-		if self.config.local_role.is_light() {
-			return false
-		}
 
 		if round_elapsed < round_duration.mul_f32(PROPAGATION_ALL) {
 			self.peers.first_stage_peers.contains(who) ||

--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -147,8 +147,6 @@ where
 pub enum Role {
 	/// Regular full node.
 	Full,
-	/// Regular light node.
-	Light,
 	/// Actual authority.
 	Authority,
 }
@@ -158,18 +156,12 @@ impl Role {
 	pub fn is_authority(&self) -> bool {
 		matches!(self, Self::Authority { .. })
 	}
-
-	/// True for [`Role::Light`].
-	pub fn is_light(&self) -> bool {
-		matches!(self, Self::Light { .. })
-	}
 }
 
 impl fmt::Display for Role {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
 			Self::Full => write!(f, "FULL"),
-			Self::Light => write!(f, "LIGHT"),
 			Self::Authority { .. } => write!(f, "AUTHORITY"),
 		}
 	}

--- a/client/network/src/protocol/message.rs
+++ b/client/network/src/protocol/message.rs
@@ -107,7 +107,6 @@ pub mod generic {
 		fn from(roles: &'a crate::config::Role) -> Self {
 			match roles {
 				crate::config::Role::Full => Self::FULL,
-				crate::config::Role::Light => Self::LIGHT,
 				crate::config::Role::Authority { .. } => Self::AUTHORITY,
 			}
 		}

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -245,15 +245,11 @@ where
 		};
 
 		let chain_sync = (params.create_chain_sync)(
-			if params.role.is_light() {
-				SyncMode::Light
-			} else {
-				match params.network_config.sync_mode {
-					config::SyncMode::Full => SyncMode::Full,
-					config::SyncMode::Fast { skip_proofs, storage_chain_mode } =>
-						SyncMode::LightState { skip_proofs, storage_chain_mode },
-					config::SyncMode::Warp => SyncMode::Warp,
-				}
+			match params.network_config.sync_mode {
+				config::SyncMode::Full => SyncMode::Full,
+				config::SyncMode::Fast { skip_proofs, storage_chain_mode } =>
+					SyncMode::LightState { skip_proofs, storage_chain_mode },
+				config::SyncMode::Warp => SyncMode::Warp,
 			},
 			params.chain.clone(),
 			warp_sync_provider,
@@ -489,7 +485,6 @@ where
 
 		let (tx_handler, tx_handler_controller) = transactions_handler_proto.build(
 			service.clone(),
-			params.role,
 			params.transaction_pool,
 			params.metrics_registry.as_ref(),
 		)?;

--- a/client/rpc-api/src/system/helpers.rs
+++ b/client/rpc-api/src/system/helpers.rs
@@ -76,8 +76,6 @@ pub struct PeerInfo<Hash, Number> {
 pub enum NodeRole {
 	/// The node is a full node
 	Full,
-	/// The node is a light client
-	LightClient,
 	/// The node is an authority
 	Authority,
 }

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -37,17 +37,12 @@ use sc_client_db::{Backend, DatabaseSettings};
 use sc_consensus::import_queue::ImportQueue;
 use sc_executor::RuntimeVersionOf;
 use sc_keystore::LocalKeystore;
-use sc_network::{
-	config::SyncMode,
-	NetworkService,
-};
+use sc_network::{config::SyncMode, NetworkService};
 use sc_network_common::sync::warp::WarpSyncProvider;
 use sc_network_light::light_client_requests::handler::LightClientRequestHandler;
 use sc_network_sync::{
-	block_request_handler::BlockRequestHandler,
-	state_request_handler::StateRequestHandler,
-	warp_request_handler::RequestHandler as WarpSyncRequestHandler,
-	ChainSync,
+	block_request_handler::BlockRequestHandler, state_request_handler::StateRequestHandler,
+	warp_request_handler::RequestHandler as WarpSyncRequestHandler, ChainSync,
 };
 use sc_rpc::{
 	author::AuthorApiServer,
@@ -731,10 +726,8 @@ where
 		}
 	}
 
-	let transaction_pool_adapter = Arc::new(TransactionPoolAdapter {
-		pool: transaction_pool,
-		client: client.clone(),
-	});
+	let transaction_pool_adapter =
+		Arc::new(TransactionPoolAdapter { pool: transaction_pool, client: client.clone() });
 
 	let protocol_id = config.protocol_id();
 

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -253,7 +253,7 @@ async fn build_network_future<
 
 						let node_role = match role {
 							Role::Authority { .. } => NodeRole::Authority,
-							Role::Light => NodeRole::LightClient,
+							// Role::Light => NodeRole::LightClient,
 							Role::Full => NodeRole::Full,
 						};
 
@@ -377,7 +377,6 @@ where
 
 /// Transaction pool adapter.
 pub struct TransactionPoolAdapter<C, P> {
-	imports_external_transactions: bool,
 	pool: Arc<P>,
 	client: Arc<C>,
 }
@@ -425,11 +424,6 @@ where
 	}
 
 	fn import(&self, transaction: B::Extrinsic) -> TransactionImportFuture {
-		if !self.imports_external_transactions {
-			debug!("Transaction rejected");
-			return Box::pin(futures::future::ready(TransactionImport::None))
-		}
-
 		let encoded = transaction.encode();
 		let uxt = match Decode::decode(&mut &encoded[..]) {
 			Ok(uxt) => uxt,

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -253,7 +253,6 @@ async fn build_network_future<
 
 						let node_role = match role {
 							Role::Authority { .. } => NodeRole::Authority,
-							// Role::Light => NodeRole::LightClient,
 							Role::Full => NodeRole::Full,
 						};
 

--- a/client/service/src/metrics.rs
+++ b/client/service/src/metrics.rs
@@ -160,7 +160,7 @@ impl MetricsService {
 	) -> Result<Self, PrometheusError> {
 		let role_bits = match config.role {
 			Role::Full => 1u64,
-			Role::Light => 2u64,
+			// Role::Light => 2u64,
 			Role::Authority { .. } => 4u64,
 		};
 

--- a/client/service/src/metrics.rs
+++ b/client/service/src/metrics.rs
@@ -160,7 +160,7 @@ impl MetricsService {
 	) -> Result<Self, PrometheusError> {
 		let role_bits = match config.role {
 			Role::Full => 1u64,
-			// Role::Light => 2u64,
+			// 2u64 used to represent light client role
 			Role::Authority { .. } => 4u64,
 		};
 


### PR DESCRIPTION
This PR removes the `--light` CLI option and cleans up the left-overs of the light client in substrate.

polkadot companion: https://github.com/paritytech/polkadot/pull/5794
cumulus companion: https://github.com/paritytech/cumulus/pull/1456