### PR TITLE
Clarify wrong bootnode peer ID error message

### DIFF
--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -2025,12 +2025,16 @@ where
 
 						if this.boot_node_ids.contains(&peer_id) {
 							if let DialError::WrongPeerId { obtained, endpoint } = &error {
-								error!(
-									"💔 The bootnode you want to connect provided a different peer ID than the one you expect: `{}` with `{}`:`{:?}`.",
-									peer_id,
-									obtained,
-									endpoint,
-								);
+								if let ConnectedPoint::Dialer { address, role_override: _ } =
+									endpoint
+								{
+									error!(
+										"💔 The bootnode you want to connect to at `{}` provided a different peer ID `{}` than the one you expect `{}`.",
+										address,
+										obtained,
+										peer_id,
+									);
+								}
 							}
 						}
 					}


### PR DESCRIPTION
This PR addresses https://github.com/paritytech/substrate/issues/8868

In fact, the error message had been already changed and before this PR was
```
💔 The bootnode you want to connect provided a different peer ID than the one you expect: `12D3KooWM8UexU7U2d8BSmYgpdxu7m27C7xGaTXFn3tB7GxVTQKF` with `12D3KooWRuSueDqdQ1eVRnN2uoUr7r4XF1u9HAMdiSVWDm8Jqmz4`:`Dialer { address: "/ip4/127.0.0.1/tcp/30333/p2p/12D3KooWM8UexU7U2d8BSmYgpdxu7m27C7xGaTXFn3tB7GxVTQKF", role_override: Dialer }`.
```
This PR makes it slightly more clear:
```
💔 The bootnode you want to connect to at `/ip4/127.0.0.1/tcp/30333/p2p/12D3KooWM8UexU7U2d8BSmYgpdxu7m27C7xGaTXFn3tB7GxVTQKF` provided a different peer ID `12D3KooWRuSueDqdQ1eVRnN2uoUr7r4XF1u9HAMdiSVWDm8Jqmz4` than the one you expect `12D3KooWM8UexU7U2d8BSmYgpdxu7m27C7xGaTXFn3tB7GxVTQKF`.
```