### PR TITLE
Bug fix of currencies implementation for `pallet-balances`

### DIFF
--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1011,7 +1011,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 		if slashed == beneficiary {
 			return match status {
-				Status::Free => Ok(Self::unreserve(slashed, value)),
+				Status::Free => Ok(value.saturating_sub(Self::unreserve(slashed, value))),
 				Status::Reserved => Ok(value.saturating_sub(Self::reserved_balance(slashed))),
 			}
 		}

--- a/frame/balances/src/tests.rs
+++ b/frame/balances/src/tests.rs
@@ -1179,6 +1179,20 @@ macro_rules! decl_tests {
 		}
 
 		#[test]
+		fn reserved_named_to_yourself_should_work() {
+			<$ext_builder>::default().build().execute_with(|| {
+				let _ = Balances::deposit_creating(&1, 110);
+
+				let id = [1u8; 8];
+
+				assert_ok!(Balances::reserve_named(&id, &1, 50));
+				assert_ok!(Balances::repatriate_reserved_named(&id, &1, &1, 50, Status::Free), 0);
+				assert_eq!(Balances::free_balance(1), 110);
+				assert_eq!(Balances::reserved_balance(1), 0);
+			});
+		}
+
+		#[test]
 		fn ensure_reserved_named_should_work() {
 			<$ext_builder>::default().build().execute_with(|| {
 				let _ = Balances::deposit_creating(&1, 111);

--- a/frame/balances/src/tests.rs
+++ b/frame/balances/src/tests.rs
@@ -529,6 +529,17 @@ macro_rules! decl_tests {
 		}
 
 		#[test]
+		fn transferring_reserved_balance_to_yourself_should_work() {
+			<$ext_builder>::default().build().execute_with(|| {
+				let _ = Balances::deposit_creating(&1, 110);
+				assert_ok!(Balances::reserve(&1, 50));
+				assert_ok!(Balances::repatriate_reserved(&1, &1, 50, Status::Free), 0);
+				assert_eq!(Balances::free_balance(1), 110);
+				assert_eq!(Balances::reserved_balance(1), 0);
+			});
+		}
+
+		#[test]
 		fn transferring_reserved_balance_to_nonexistent_should_fail() {
 			<$ext_builder>::default().build().execute_with(|| {
 				let _ = Balances::deposit_creating(&1, 111);

--- a/frame/balances/src/tests.rs
+++ b/frame/balances/src/tests.rs
@@ -536,6 +536,11 @@ macro_rules! decl_tests {
 				assert_ok!(Balances::repatriate_reserved(&1, &1, 50, Status::Free), 0);
 				assert_eq!(Balances::free_balance(1), 110);
 				assert_eq!(Balances::reserved_balance(1), 0);
+
+				assert_ok!(Balances::reserve(&1, 50));
+				assert_ok!(Balances::repatriate_reserved(&1, &1, 60, Status::Free), 10);
+				assert_eq!(Balances::free_balance(1), 110);
+				assert_eq!(Balances::reserved_balance(1), 0);
 			});
 		}
 


### PR DESCRIPTION
## Explanation:
Currency-family traits with reservation logic (e.g. `ReservableCurrency::unreserve`), affecting reserved funds return balance, that hadn't been able to reveal.

https://github.com/paritytech/substrate/blob/7b81072843e584ef2bee449081aed5c963021ee9/frame/support/src/traits/tokens/currency/reservable.rs#L59-L60

So I found a bug: while using `pallet-balances`'s implementation to `repatriate_reserved` funds for free ones with the same id for `slashed` and `beneficiary` (transferring to yourself), the return value is invalid and equals the requested one due to double subtracting.

## Workflow:
**`Self` means `BalancesPallet<T>`**
- `<Self as ReservableCurrency>::repatriate_reserved` uses `Self::do_transfer_reserved`, calculating unrevealed value afterward:
https://github.com/paritytech/substrate/blob/7b81072843e584ef2bee449081aed5c963021ee9/frame/balances/src/lib.rs#L1877-L1878
- With mentioned conditions, this branch triggers, and `Self::do_transfer_reserved` returns result of `<Self as ReservableCurrency>::unreserve`
https://github.com/paritytech/substrate/blob/7b81072843e584ef2bee449081aed5c963021ee9/frame/balances/src/lib.rs#L1012-L1017
- `<Self as ReservableCurrency>::unreserve` also calculates unrevealed value:
https://github.com/paritytech/substrate/blob/7b81072843e584ef2bee449081aed5c963021ee9/frame/balances/src/lib.rs#L1811-L1812

**In fact we have `assert_ok!(Self::repatriate_reserved(&id, &id, N, Status::Free), N)`**

## Changes:
- Bug fixed with minimal code changes.
- Two tests of such cases for `ReservableCurrency` and `NamedReservableCurrency` implementations added.
