### PR TITLE
[ci] Generate rustdocs without dependencies

### DIFF
--- a/scripts/ci/gitlab/pipeline/build.yml
+++ b/scripts/ci/gitlab/pipeline/build.yml
@@ -149,7 +149,7 @@ build-rustdoc:
     - ./crate-docs/
   script:
     - rusty-cachier snapshot create
-    - time cargo +nightly doc --workspace --all-features --verbose
+    - time cargo +nightly doc --workspace --all-features --verbose --no-deps
     - rm -f $CARGO_TARGET_DIR/doc/.lock
     - mv $CARGO_TARGET_DIR/doc ./crate-docs
     # FIXME: remove me after CI image gets nonroot


### PR DESCRIPTION
Currently docs are generated with dependencies and `target/doc/` has 2.4 GB size. Github pages don't support projects > 1GB.
PR removes dependencies from build in `build-rustdoc`

Part of https://github.com/paritytech/ci_cd/issues/503
Part of https://github.com/paritytech/ci_cd/issues/476