### PR TITLE
Require Alliance Initialisation Before Joining

### DIFF
--- a/frame/alliance/src/lib.rs
+++ b/frame/alliance/src/lib.rs
@@ -711,8 +711,8 @@ pub mod pallet {
 		pub fn join_alliance(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
-			// We don't want anyone to join as an Ally before the Founders/Fellows have been
-			// initialized via Root call. The reasons are two-fold:
+			// We don't want anyone to join as an Ally before the Alliance has been initialized via
+			// Root call. The reasons are two-fold:
 			//
 			// 1. There is no `Rule` or admission criteria, so the joiner would be an ally to
 			//    nought, and

--- a/frame/alliance/src/lib.rs
+++ b/frame/alliance/src/lib.rs
@@ -311,7 +311,7 @@ pub mod pallet {
 	#[pallet::error]
 	pub enum Error<T, I = ()> {
 		/// The founders/fellows/allies have already been initialized.
-		MembersAlreadyInitialized,
+		AllianceAlreadyInitialized,
 		/// The Alliance has not been initialized yet, therefore accounts cannot join it.
 		AllianceNotYetInitialized,
 		/// Account is already a member.
@@ -438,7 +438,7 @@ pub mod pallet {
 			if !self.allies.is_empty() {
 				// Only allow Allies if the Alliance is "initialized".
 				assert!(
-					!self.founders.is_empty() || !self.fellows.is_empty(),
+					Pallet::<T, I>::is_initialized(),
 					"Alliance must have Founders or Fellows to have Allies"
 				);
 				let members: BoundedVec<T::AccountId, T::MaxMembersCount> =
@@ -620,7 +620,7 @@ pub mod pallet {
 			ensure_root(origin)?;
 
 			// Cannot be called if the Alliance already has Founders or Fellows.
-			ensure!(!Self::is_initialized(), Error::<T, I>::MembersAlreadyInitialized);
+			ensure!(!Self::is_initialized(), Error::<T, I>::AllianceAlreadyInitialized);
 
 			let mut founders: BoundedVec<T::AccountId, T::MaxMembersCount> =
 				founders.try_into().map_err(|_| Error::<T, I>::TooManyMembers)?;

--- a/frame/alliance/src/lib.rs
+++ b/frame/alliance/src/lib.rs
@@ -620,6 +620,8 @@ pub mod pallet {
 			ensure_root(origin)?;
 
 			// Cannot be called if the Alliance already has Founders or Fellows.
+			// TODO: Remove check and allow Root to set members at any time.
+			// https://github.com/paritytech/substrate/issues/11928
 			ensure!(!Self::is_initialized(), Error::<T, I>::AllianceAlreadyInitialized);
 
 			let mut founders: BoundedVec<T::AccountId, T::MaxMembersCount> =

--- a/frame/alliance/src/mock.rs
+++ b/frame/alliance/src/mock.rs
@@ -291,6 +291,12 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 		assert_ok!(Identity::provide_judgement(Origin::signed(1), 0, 5, Judgement::KnownGood));
 		assert_ok!(Identity::set_identity(Origin::signed(6), Box::new(info.clone())));
 
+		// Joining before init should fail.
+		assert_noop!(
+			Alliance::join_alliance(Origin::signed(1)),
+			Error::<Test, ()>::AllianceNotYetInitialized
+		);
+
 		assert_ok!(Alliance::init_members(Origin::root(), vec![1, 2], vec![3], vec![]));
 
 		System::set_block_number(1);

--- a/frame/alliance/src/mock.rs
+++ b/frame/alliance/src/mock.rs
@@ -26,7 +26,7 @@ pub use sp_runtime::{
 use sp_std::convert::{TryFrom, TryInto};
 
 pub use frame_support::{
-	assert_ok, ord_parameter_types, parameter_types,
+	assert_noop, assert_ok, ord_parameter_types, parameter_types,
 	traits::{EitherOfDiverse, GenesisBuild, SortedMembers},
 	BoundedVec,
 };


### PR DESCRIPTION
Discovered this while testing on Westend: Someone joined the Alliance as an `Ally` before the set was initialized by Root. [This caused](https://github.com/paritytech/substrate/blob/bf467e6e08c0e8297af7fa53d0842a5103833df6/frame/alliance/src/lib.rs#L627) the Root call to fail. This PR prevents accounts from joining as Allies until the Alliance gets initialised.

---

I also considered another implementation option of changing the `init_members` function like so:

```rust
ensure!(
	!Self::has_member(MemberRole::Founder) &&
		!Self::has_member(MemberRole::Fellow) &&
	//	!Self::has_member(MemberRole::Ally), <- remove this line
	Error::<T, I>::MembersAlreadyInitialized
);
for member in founders.iter().chain(fellows.iter()).chain(allies.iter()) {
	Self::has_identity(member)?;
	ensure!(!Self::is_member(&who), Error::<T, I>::AlreadyMember); // add this line, or just set them to the declared position
}
```
I decided against this because joining as an `Ally` does not carry much meaning if the Alliance does not exist.