### PR TITLE
Make New Storage Layer Truly Default

### DIFF
--- a/frame/nomination-pools/src/tests.rs
+++ b/frame/nomination-pools/src/tests.rs
@@ -2735,7 +2735,7 @@ mod unbond {
 
 			// when: unbonding more than our active: error
 			assert_noop!(
-				frame_support::storage::in_storage_layer(|| Pools::unbond(
+				frame_support::storage::with_storage_layer(|| Pools::unbond(
 					Origin::signed(10),
 					10,
 					5
@@ -2787,7 +2787,7 @@ mod unbond {
 			// when
 			CurrentEra::set(2);
 			assert_noop!(
-				frame_support::storage::in_storage_layer(|| Pools::unbond(
+				frame_support::storage::with_storage_layer(|| Pools::unbond(
 					Origin::signed(20),
 					20,
 					4

--- a/frame/support/procedural/src/construct_runtime/expand/call.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/call.rs
@@ -163,19 +163,6 @@ pub fn expand_outer_dispatch(
 				}
 			}
 		}
-		impl #scrate::traits::DispatchableWithStorageLayer for Call {
-			type Origin = Origin;
-			fn dispatch_with_storage_layer(self, origin: Origin) -> #scrate::dispatch::DispatchResultWithPostInfo {
-				#scrate::storage::with_storage_layer(|| {
-					#scrate::dispatch::Dispatchable::dispatch(self, origin)
-				})
-			}
-			fn dispatch_bypass_filter_with_storage_layer(self, origin: Origin) -> #scrate::dispatch::DispatchResultWithPostInfo {
-				#scrate::storage::with_storage_layer(|| {
-					#scrate::traits::UnfilteredDispatchable::dispatch_bypass_filter(self, origin)
-				})
-			}
-		}
 
 		#(
 			impl #scrate::traits::IsSubType<#scrate::dispatch::CallableCallFor<#pallet_names, #runtime>> for Call {

--- a/frame/support/procedural/src/pallet/expand/call.rs
+++ b/frame/support/procedural/src/pallet/expand/call.rs
@@ -267,9 +267,9 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 							#frame_support::sp_tracing::enter_span!(
 								#frame_support::sp_tracing::trace_span!(stringify!(#fn_name))
 							);
-							// We execute all dispatchable in at least one storage layer, allowing them
+							// We execute all dispatchable in a new storage layer, allowing them
 							// to return an error at any point, and undoing any storage changes.
-							#frame_support::storage::in_storage_layer(|| {
+							#frame_support::storage::with_storage_layer(|| {
 								<#pallet_ident<#type_use_gen>>::#fn_name(origin, #( #args_name, )* )
 									.map(Into::into).map_err(Into::into)
 							})

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -29,7 +29,7 @@ pub use crate::{
 		result,
 	},
 	traits::{
-		CallMetadata, DispatchableWithStorageLayer, GetCallMetadata, GetCallName,
+		CallMetadata, GetCallMetadata, GetCallName,
 		GetStorageVersion, UnfilteredDispatchable,
 	},
 	weights::{
@@ -1473,9 +1473,9 @@ macro_rules! decl_module {
 		$ignore:ident
 		$mod_type:ident<$trait_instance:ident $(, $instance:ident)?> $fn_name:ident $origin:ident $system:ident [ $( $param_name:ident),* ]
 	) => {
-			// We execute all dispatchable in at least one storage layer, allowing them
+			// We execute all dispatchable in a new storage layer, allowing them
 			// to return an error at any point, and undoing any storage changes.
-			$crate::storage::in_storage_layer(|| {
+			$crate::storage::with_storage_layer(|| {
 				<$mod_type<$trait_instance $(, $instance)?>>::$fn_name( $origin $(, $param_name )* ).map(Into::into).map_err(Into::into)
 			})
 	};

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -29,8 +29,7 @@ pub use crate::{
 		result,
 	},
 	traits::{
-		CallMetadata, GetCallMetadata, GetCallName,
-		GetStorageVersion, UnfilteredDispatchable,
+		CallMetadata, GetCallMetadata, GetCallName, GetStorageVersion, UnfilteredDispatchable,
 	},
 	weights::{
 		ClassifyDispatch, DispatchInfo, GetDispatchInfo, PaysFee, PostDispatchInfo,

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -96,9 +96,8 @@ mod dispatch;
 #[allow(deprecated)]
 pub use dispatch::EnsureOneOf;
 pub use dispatch::{
-	AsEnsureOriginWithArg, EitherOf, EitherOfDiverse, EnsureOrigin,
-	EnsureOriginWithArg, MapSuccess, NeverEnsureOrigin, OriginTrait, TryMapSuccess,
-	UnfilteredDispatchable,
+	AsEnsureOriginWithArg, EitherOf, EitherOfDiverse, EnsureOrigin, EnsureOriginWithArg,
+	MapSuccess, NeverEnsureOrigin, OriginTrait, TryMapSuccess, UnfilteredDispatchable,
 };
 
 mod voting;

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -96,7 +96,7 @@ mod dispatch;
 #[allow(deprecated)]
 pub use dispatch::EnsureOneOf;
 pub use dispatch::{
-	AsEnsureOriginWithArg, DispatchableWithStorageLayer, EitherOf, EitherOfDiverse, EnsureOrigin,
+	AsEnsureOriginWithArg, EitherOf, EitherOfDiverse, EnsureOrigin,
 	EnsureOriginWithArg, MapSuccess, NeverEnsureOrigin, OriginTrait, TryMapSuccess,
 	UnfilteredDispatchable,
 };

--- a/frame/support/src/traits/dispatch.rs
+++ b/frame/support/src/traits/dispatch.rs
@@ -236,23 +236,6 @@ pub trait UnfilteredDispatchable {
 	fn dispatch_bypass_filter(self, origin: Self::Origin) -> DispatchResultWithPostInfo;
 }
 
-/// Type that can be dispatched with an additional storage layer which is used to execute the call.
-pub trait DispatchableWithStorageLayer {
-	/// The origin type of the runtime, (i.e. `frame_system::Config::Origin`).
-	type Origin;
-
-	/// Same as `dispatch` from the [`frame_support::dispatch::Dispatchable`] trait, but
-	/// specifically spawns a new storage layer to execute the call inside of.
-	fn dispatch_with_storage_layer(self, origin: Self::Origin) -> DispatchResultWithPostInfo;
-
-	/// Same as `dispatch_bypass_filter` from the [`UnfilteredDispatchable`] trait, but specifically
-	/// spawns a new storage layer to execute the call inside of.
-	fn dispatch_bypass_filter_with_storage_layer(
-		self,
-		origin: Self::Origin,
-	) -> DispatchResultWithPostInfo;
-}
-
 /// Methods available on `frame_system::Config::Origin`.
 pub trait OriginTrait: Sized {
 	/// Runtime call type, as in `frame_system::Config::Call`


### PR DESCRIPTION
This PR simplifies the use of the Transactional Storage APIs introduced in https://github.com/paritytech/substrate/pull/11431

The creation of a new storage layer is trivial enough that it can just be enabled by default, and thus avoid the use of `in_storage_layer`, and the need for a `DispatchWithStorageLayer` traits.

This also makes it more clear exactly what happens when you dispatch a call, no matter if you are already in a dispatchable or not.