### PR TITLE
Fix slashing migration to v10

### DIFF
--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -882,7 +882,7 @@ enum Releases {
 
 impl Default for Releases {
 	fn default() -> Self {
-		Releases::V8_0_0
+		Releases::V10_0_0
 	}
 }
 

--- a/frame/staking/src/migrations.rs
+++ b/frame/staking/src/migrations.rs
@@ -35,8 +35,7 @@ pub mod v10 {
 				// too early, but we will definitely won't forget to slash them. The cap of 512 is
 				// somewhat randomly taken to prevent us from iterating over an arbitrary large
 				// number of keys `on_runtime_upgrade`.
-				let pending_slashes =
-					<Pallet<T> as Store>::UnappliedSlashes::iter().take(512);
+				let pending_slashes = <Pallet<T> as Store>::UnappliedSlashes::iter().take(512);
 				for (era, slashes) in pending_slashes {
 					for slash in slashes {
 						// in the old slashing scheme, the slash era was the key at which we read

--- a/frame/staking/src/migrations.rs
+++ b/frame/staking/src/migrations.rs
@@ -41,6 +41,7 @@ pub mod v10 {
 					for slash in slashes {
 						// in the old slashing scheme, the slash era was the key at which we read
 						// from `UnappliedSlashes`.
+						log!(warn, "prematurely applying a slash ({:?}) for era {:?}", slash, era);
 						slashing::apply_slash::<T>(slash, era);
 					}
 				}
@@ -48,6 +49,7 @@ pub mod v10 {
 				EarliestUnappliedSlash::<T>::kill();
 				StorageVersion::<T>::put(Releases::V10_0_0);
 
+				log!(info, "MigrateToV10 executed successfully");
 				T::DbWeight::get().reads_writes(1, 1)
 			} else {
 				log!(warn, "MigrateToV10 should be removed.");


### PR DESCRIPTION
A small fix to the migration of https://github.com/paritytech/substrate/pull/11823


Problem: If some slashes already exist in `UnappliedSlashes`, they will probably never be triggered in the new logic, since we lookup only a specific key of this map at the beginning of the era.

Solution: Try and apply all pending slashes one last time before going to the new logic. 

What I have written now in code is not ideal, but good enough that under normal conditions we survive. If an attacker wants to create more than 512 slash reports or such, it still needs a manual intervention. 