### PR TITLE
Remove `retain_mut` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8877,7 +8877,6 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.12.0",
- "retain_mut",
  "sc-block-builder",
  "sc-client-api",
  "sc-transaction-pool-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7447,12 +7447,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "retain_mut"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "448296241d034b96c11173591deaa1302f2c17b56092106c1f92c1bc0183a8c9"
-
-[[package]]
 name = "rfc6979"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7965,7 +7959,6 @@ dependencies = [
  "parking_lot 0.12.0",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
- "retain_mut",
  "sc-block-builder",
  "sc-client-api",
  "sc-consensus",

--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -26,7 +26,6 @@ num-rational = "0.2.2"
 num-traits = "0.2.8"
 parking_lot = "0.12.0"
 rand = "0.7.2"
-retain_mut = "0.1.4"
 schnorrkel = { version = "0.9.1", features = ["preaudit_deprecated"] }
 serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0"

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -87,7 +87,6 @@ use futures::{
 use log::{debug, info, log, trace, warn};
 use parking_lot::Mutex;
 use prometheus_endpoint::Registry;
-use retain_mut::RetainMut;
 use schnorrkel::SignatureError;
 
 use sc_client_api::{
@@ -835,17 +834,16 @@ where
 		slot: Slot,
 		epoch_descriptor: &ViableEpochDescriptor<B::Hash, NumberFor<B>, Epoch>,
 	) {
-		RetainMut::retain_mut(&mut *self.slot_notification_sinks.lock(), |sink| {
-			match sink.try_send((slot, epoch_descriptor.clone())) {
-				Ok(()) => true,
-				Err(e) =>
-					if e.is_full() {
-						warn!(target: "babe", "Trying to notify a slot but the channel is full");
-						true
-					} else {
-						false
-					},
-			}
+		let sinks = &mut self.slot_notification_sinks.lock();
+		sinks.retain_mut(|sink| match sink.try_send((slot, epoch_descriptor.clone())) {
+			Ok(()) => true,
+			Err(e) =>
+				if e.is_full() {
+					warn!(target: "babe", "Trying to notify a slot but the channel is full");
+					true
+				} else {
+					false
+				},
 		});
 	}
 

--- a/client/transaction-pool/Cargo.toml
+++ b/client/transaction-pool/Cargo.toml
@@ -20,7 +20,6 @@ linked-hash-map = "0.5.4"
 log = "0.4.17"
 parity-util-mem = { version = "0.11.0", default-features = false, features = ["primitive-types"] }
 parking_lot = "0.12.0"
-retain_mut = "0.1.4"
 serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0.30"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", path = "../../utils/prometheus" }


### PR DESCRIPTION
Crate `retain_mut` was throwing errors on CI. Since we are now on 1.62, `retain_mut` is built-in and we can remove the crate.
