### PR TITLE
Backport #11924: Fix slashing migration to v10

### DIFF
--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -882,7 +882,7 @@ enum Releases {
 
 impl Default for Releases {
 	fn default() -> Self {
-		Releases::V8_0_0
+		Releases::V10_0_0
 	}
 }
 

--- a/frame/staking/src/migrations.rs
+++ b/frame/staking/src/migrations.rs
@@ -27,13 +27,29 @@ pub mod v10 {
 	#[storage_alias]
 	type EarliestUnappliedSlash<T: Config> = StorageValue<Pallet<T>, EraIndex>;
 
+	/// Apply any pending slashes that where queued.
+	///
+	/// That means we might slash someone a bit too early, but we will definitely
+	/// won't forget to slash them. The cap of 512 is somewhat randomly taken to
+	/// prevent us from iterating over an arbitrary large number of keys `on_runtime_upgrade`.
 	pub struct MigrateToV10<T>(sp_std::marker::PhantomData<T>);
 	impl<T: Config> OnRuntimeUpgrade for MigrateToV10<T> {
 		fn on_runtime_upgrade() -> frame_support::weights::Weight {
 			if StorageVersion::<T>::get() == Releases::V9_0_0 {
+				let pending_slashes = <Pallet<T> as Store>::UnappliedSlashes::iter().take(512);
+				for (era, slashes) in pending_slashes {
+					for slash in slashes {
+						// in the old slashing scheme, the slash era was the key at which we read
+						// from `UnappliedSlashes`.
+						log!(warn, "prematurely applying a slash ({:?}) for era {:?}", slash, era);
+						slashing::apply_slash::<T>(slash, era);
+					}
+				}
+
 				EarliestUnappliedSlash::<T>::kill();
 				StorageVersion::<T>::put(Releases::V10_0_0);
 
+				log!(info, "MigrateToV10 executed successfully");
 				T::DbWeight::get().reads_writes(1, 1)
 			} else {
 				log!(warn, "MigrateToV10 should be removed.");


### PR DESCRIPTION
Backport of #11924 to the 0.9.27 release branch

* Fix slashing migration to v10

* add some logs

* Fix default version

* fmt

* Move doc to struct

Co-authored-by: Wilfried Kopp <wilfried@parity.io>



✄ -----------------------------------------------------------------------------

Thank you for your Pull Request! 🙏

Before you submit, please check that:

- [x] **Description:** You added a brief description of the PR, e.g.:
  - What does it do?
  - What important points should reviewers know?
  - Is there something left for follow-up PRs?
- [x] **Labels:** You labeled the PR appropriately if you have permissions to do so:
  - [x] `A*` for PR status (**one required**)
  - [x] `B*` for changelog (**one required**)
  - [x] `C*` for release notes (**exactly one required**)
  - [x] `D*` for various implications/requirements
  - [ ] Github project assignment
- [x] **Related Issues:** You mentioned a related issue if this PR is related to it, e.g. `Fixes #228` or `Related #1337`.
- [x] **2 Reviewers:** You asked at least two reviewers to review. If you aren't sure, start with GH suggestions.
- [ ] **Style Guide:** Your PR adheres to [the style guide](https://github.com/paritytech/substrate/blob/master/docs/STYLE_GUIDE.md)
  - In particular, mind the maximal line length of 100 (120 in exceptional circumstances).
  - There is no commented code checked in unless necessary.
  - Any panickers in the runtime have a proof or were removed.
- [x] **Runtime Version:** You bumped the runtime version if there are breaking changes in the **runtime**.
- [x] **Docs:** You updated any rustdocs which may need to change.
- [ ] **Polkadot Companion:** Has the PR altered the external API or interfaces used by Polkadot?
  - [ ] If so, do you have the corresponding Polkadot PR ready?
  - [ ] Optionally: Do you have a corresponding Cumulus PR?

Refer to [the contributing guide](https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc) for details.

After you've read this notice feel free to remove it.
Thank you!

✄ -----------------------------------------------------------------------------
