### PR TITLE
Rename --pruning and --keep-blocks to be more similar to one another

### DIFF
--- a/bin/node/cli/benches/block_production.rs
+++ b/bin/node/cli/benches/block_production.rs
@@ -28,7 +28,7 @@ use sc_consensus::{
 };
 use sc_service::{
 	config::{
-		DatabaseSource, KeepBlocks, KeystoreConfig, NetworkConfiguration, OffchainWorkerConfig,
+		BlocksPruning, DatabaseSource, KeystoreConfig, NetworkConfiguration, OffchainWorkerConfig,
 		PruningMode, WasmExecutionMethod, WasmtimeInstantiationStrategy,
 	},
 	BasePath, Configuration, Role,
@@ -75,7 +75,7 @@ fn new_node(tokio_handle: Handle) -> node_cli::service::NewFullBase {
 		state_cache_size: 67108864,
 		state_cache_child_ratio: None,
 		state_pruning: Some(PruningMode::ArchiveAll),
-		keep_blocks: KeepBlocks::All,
+		blocks_pruning: BlocksPruning::All,
 		chain_spec: spec,
 		wasm_method: WasmExecutionMethod::Compiled {
 			instantiation_strategy: WasmtimeInstantiationStrategy::PoolingCopyOnWrite,

--- a/bin/node/cli/benches/transaction_pool.rs
+++ b/bin/node/cli/benches/transaction_pool.rs
@@ -26,7 +26,7 @@ use node_runtime::{constants::currency::*, BalancesCall, SudoCall};
 use sc_client_api::execution_extensions::ExecutionStrategies;
 use sc_service::{
 	config::{
-		DatabaseSource, KeepBlocks, KeystoreConfig, NetworkConfiguration, OffchainWorkerConfig,
+		BlocksPruning, DatabaseSource, KeystoreConfig, NetworkConfiguration, OffchainWorkerConfig,
 		PruningMode, TransactionPoolOptions, WasmExecutionMethod,
 	},
 	BasePath, Configuration, Role,
@@ -69,7 +69,7 @@ fn new_node(tokio_handle: Handle) -> node_cli::service::NewFullBase {
 		state_cache_size: 67108864,
 		state_cache_child_ratio: None,
 		state_pruning: Some(PruningMode::ArchiveAll),
-		keep_blocks: KeepBlocks::All,
+		blocks_pruning: BlocksPruning::All,
 		chain_spec: spec,
 		wasm_method: WasmExecutionMethod::Interpreted,
 		// NOTE: we enforce the use of the native runtime to make the errors more debuggable

--- a/bin/node/testing/src/bench.rs
+++ b/bin/node/testing/src/bench.rs
@@ -391,7 +391,7 @@ impl BenchDb {
 			state_cache_child_ratio: Some((0, 100)),
 			state_pruning: Some(PruningMode::ArchiveAll),
 			source: database_type.into_settings(dir.into()),
-			keep_blocks: sc_client_db::KeepBlocks::All,
+			blocks_pruning: sc_client_db::BlocksPruning::All,
 		};
 		let task_executor = TaskExecutor::new();
 

--- a/client/cli/src/commands/chain_info_cmd.rs
+++ b/client/cli/src/commands/chain_info_cmd.rs
@@ -77,7 +77,7 @@ impl ChainInfoCmd {
 			state_cache_child_ratio: config.state_cache_child_ratio.map(|v| (v, 100)),
 			state_pruning: config.state_pruning.clone(),
 			source: config.database.clone(),
-			keep_blocks: config.keep_blocks.clone(),
+			blocks_pruning: config.blocks_pruning.clone(),
 		};
 		let backend = sc_service::new_db_backend::<B>(db_config)?;
 		let info: ChainInfo<B> = backend.blockchain().info().into();

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -31,7 +31,7 @@ use sc_service::{
 		NodeKeyConfig, OffchainWorkerConfig, PrometheusConfig, PruningMode, Role, RpcMethods,
 		TelemetryEndpoints, TransactionPoolOptions, WasmExecutionMethod,
 	},
-	ChainSpec, KeepBlocks, TracingReceiver,
+	BlocksPruning, ChainSpec, TracingReceiver,
 };
 use sc_tracing::logging::LoggerBuilder;
 use std::{net::SocketAddr, path::PathBuf};
@@ -257,11 +257,11 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 	/// Get the block pruning mode.
 	///
 	/// By default this is retrieved from `block_pruning` if it is available. Otherwise its
-	/// `KeepBlocks::All`.
-	fn keep_blocks(&self) -> Result<KeepBlocks> {
+	/// `BlocksPruning::All`.
+	fn blocks_pruning(&self) -> Result<BlocksPruning> {
 		self.pruning_params()
-			.map(|x| x.keep_blocks())
-			.unwrap_or_else(|| Ok(KeepBlocks::All))
+			.map(|x| x.blocks_pruning())
+			.unwrap_or_else(|| Ok(BlocksPruning::All))
 	}
 
 	/// Get the chain ID (string).
@@ -536,7 +536,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 			state_cache_size: self.state_cache_size()?,
 			state_cache_child_ratio: self.state_cache_child_ratio()?,
 			state_pruning: self.state_pruning()?,
-			keep_blocks: self.keep_blocks()?,
+			blocks_pruning: self.blocks_pruning()?,
 			wasm_method: self.wasm_method()?,
 			wasm_runtime_overrides: self.wasm_runtime_overrides(),
 			execution_strategies: self.execution_strategies(is_dev, is_validator)?,

--- a/client/cli/src/params/pruning_params.rs
+++ b/client/cli/src/params/pruning_params.rs
@@ -28,14 +28,14 @@ pub struct PruningParams {
 	/// Default is to keep only the last 256 blocks,
 	/// otherwise, the state can be kept for all of the blocks (i.e 'archive'),
 	/// or for all of the canonical blocks (i.e 'archive-canonical').
-	#[clap(long, value_name = "PRUNING_MODE")]
+	#[clap(long = "state-pruning", value_name = "PRUNING_MODE")]
 	pub pruning: Option<String>,
 	/// Specify the number of finalized blocks to keep in the database.
 	///
 	/// Default is to keep all blocks.
 	///
 	/// NOTE: only finalized blocks are subject for removal!
-	#[clap(long, value_name = "COUNT")]
+	#[clap(long = "blocks-pruning", value_name = "COUNT")]
 	pub keep_blocks: Option<u32>,
 }
 

--- a/client/cli/src/params/pruning_params.rs
+++ b/client/cli/src/params/pruning_params.rs
@@ -18,7 +18,7 @@
 
 use crate::error;
 use clap::Args;
-use sc_service::{KeepBlocks, PruningMode};
+use sc_service::{BlocksPruning, PruningMode};
 
 /// Parameters to define the pruning mode
 #[derive(Debug, Clone, PartialEq, Args)]
@@ -28,37 +28,37 @@ pub struct PruningParams {
 	/// Default is to keep only the last 256 blocks,
 	/// otherwise, the state can be kept for all of the blocks (i.e 'archive'),
 	/// or for all of the canonical blocks (i.e 'archive-canonical').
-	#[clap(alias = "pruning", long = "state-pruning", value_name = "PRUNING_MODE")]
-	pub pruning: Option<String>,
+	#[clap(alias = "pruning", long, value_name = "PRUNING_MODE")]
+	pub state_pruning: Option<String>,
 	/// Specify the number of finalized blocks to keep in the database.
 	///
 	/// Default is to keep all blocks.
 	///
 	/// NOTE: only finalized blocks are subject for removal!
-	#[clap(alias = "keep-blocks", long = "blocks-pruning", value_name = "COUNT")]
-	pub keep_blocks: Option<u32>,
+	#[clap(alias = "keep-blocks", long, value_name = "COUNT")]
+	pub blocks_pruning: Option<u32>,
 }
 
 impl PruningParams {
 	/// Get the pruning value from the parameters
 	pub fn state_pruning(&self) -> error::Result<Option<PruningMode>> {
-		self.pruning
+		self.state_pruning
 			.as_ref()
 			.map(|s| match s.as_str() {
 				"archive" => Ok(PruningMode::ArchiveAll),
 				bc => bc
 					.parse()
 					.map_err(|_| error::Error::Input("Invalid pruning mode specified".to_string()))
-					.map(PruningMode::keep_blocks),
+					.map(PruningMode::blocks_pruning),
 			})
 			.transpose()
 	}
 
 	/// Get the block pruning value from the parameters
-	pub fn keep_blocks(&self) -> error::Result<KeepBlocks> {
-		Ok(match self.keep_blocks {
-			Some(n) => KeepBlocks::Some(n),
-			None => KeepBlocks::All,
+	pub fn blocks_pruning(&self) -> error::Result<BlocksPruning> {
+		Ok(match self.blocks_pruning {
+			Some(n) => BlocksPruning::Some(n),
+			None => BlocksPruning::All,
 		})
 	}
 }

--- a/client/cli/src/params/pruning_params.rs
+++ b/client/cli/src/params/pruning_params.rs
@@ -28,14 +28,14 @@ pub struct PruningParams {
 	/// Default is to keep only the last 256 blocks,
 	/// otherwise, the state can be kept for all of the blocks (i.e 'archive'),
 	/// or for all of the canonical blocks (i.e 'archive-canonical').
-	#[clap(long = "state-pruning", value_name = "PRUNING_MODE")]
+	#[clap(alias = "pruning", long = "state-pruning", value_name = "PRUNING_MODE")]
 	pub pruning: Option<String>,
 	/// Specify the number of finalized blocks to keep in the database.
 	///
 	/// Default is to keep all blocks.
 	///
 	/// NOTE: only finalized blocks are subject for removal!
-	#[clap(long = "blocks-pruning", value_name = "COUNT")]
+	#[clap(alias = "keep-blocks", long = "blocks-pruning", value_name = "COUNT")]
 	pub keep_blocks: Option<u32>,
 }
 

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -300,12 +300,12 @@ pub struct DatabaseSettings {
 	/// Block pruning mode.
 	///
 	/// NOTE: only finalized blocks are subject for removal!
-	pub keep_blocks: KeepBlocks,
+	pub blocks_pruning: BlocksPruning,
 }
 
 /// Block pruning settings.
 #[derive(Debug, Clone, Copy)]
-pub enum KeepBlocks {
+pub enum BlocksPruning {
 	/// Keep full block history.
 	All,
 	/// Keep N recent finalized blocks.
@@ -1012,7 +1012,7 @@ pub struct Backend<Block: BlockT> {
 	shared_cache: SharedCache<Block>,
 	import_lock: Arc<RwLock<()>>,
 	is_archive: bool,
-	keep_blocks: KeepBlocks,
+	blocks_pruning: BlocksPruning,
 	io_stats: FrozenForDuration<(kvdb::IoStats, StateUsageInfo)>,
 	state_usage: Arc<StateUsageStats>,
 	genesis_state: RwLock<Option<Arc<DbGenesisStorage<Block>>>>,
@@ -1043,21 +1043,21 @@ impl<Block: BlockT> Backend<Block> {
 
 	/// Create new memory-backed client backend for tests.
 	#[cfg(any(test, feature = "test-helpers"))]
-	pub fn new_test(keep_blocks: u32, canonicalization_delay: u64) -> Self {
-		Self::new_test_with_tx_storage(keep_blocks, canonicalization_delay)
+	pub fn new_test(blocks_pruning: u32, canonicalization_delay: u64) -> Self {
+		Self::new_test_with_tx_storage(blocks_pruning, canonicalization_delay)
 	}
 
 	/// Create new memory-backed client backend for tests.
 	#[cfg(any(test, feature = "test-helpers"))]
-	pub fn new_test_with_tx_storage(keep_blocks: u32, canonicalization_delay: u64) -> Self {
+	pub fn new_test_with_tx_storage(blocks_pruning: u32, canonicalization_delay: u64) -> Self {
 		let db = kvdb_memorydb::create(crate::utils::NUM_COLUMNS);
 		let db = sp_database::as_database(db);
 		let db_setting = DatabaseSettings {
 			state_cache_size: 16777216,
 			state_cache_child_ratio: Some((50, 100)),
-			state_pruning: Some(PruningMode::keep_blocks(keep_blocks)),
+			state_pruning: Some(PruningMode::blocks_pruning(blocks_pruning)),
 			source: DatabaseSource::Custom { db, require_create_flag: true },
-			keep_blocks: KeepBlocks::Some(keep_blocks),
+			blocks_pruning: BlocksPruning::Some(blocks_pruning),
 		};
 
 		Self::new(db_setting, canonicalization_delay).expect("failed to create test-db")
@@ -1124,7 +1124,7 @@ impl<Block: BlockT> Backend<Block> {
 			is_archive: is_archive_pruning,
 			io_stats: FrozenForDuration::new(std::time::Duration::from_secs(1)),
 			state_usage: Arc::new(StateUsageStats::new()),
-			keep_blocks: config.keep_blocks,
+			blocks_pruning: config.blocks_pruning,
 			genesis_state: RwLock::new(None),
 		};
 
@@ -1691,9 +1691,9 @@ impl<Block: BlockT> Backend<Block> {
 		finalized: NumberFor<Block>,
 		displaced: &FinalizationDisplaced<Block::Hash, NumberFor<Block>>,
 	) -> ClientResult<()> {
-		if let KeepBlocks::Some(keep_blocks) = self.keep_blocks {
+		if let BlocksPruning::Some(blocks_pruning) = self.blocks_pruning {
 			// Always keep the last finalized block
-			let keep = std::cmp::max(keep_blocks, 1);
+			let keep = std::cmp::max(blocks_pruning, 1);
 			if finalized >= keep.into() {
 				let number = finalized.saturating_sub(keep.into());
 				self.prune_block(transaction, BlockId::<Block>::number(number))?;
@@ -2440,9 +2440,9 @@ pub(crate) mod tests {
 			DatabaseSettings {
 				state_cache_size: 16777216,
 				state_cache_child_ratio: Some((50, 100)),
-				state_pruning: Some(PruningMode::keep_blocks(1)),
+				state_pruning: Some(PruningMode::blocks_pruning(1)),
 				source: DatabaseSource::Custom { db: backing, require_create_flag: false },
-				keep_blocks: KeepBlocks::All,
+				blocks_pruning: BlocksPruning::All,
 			},
 			0,
 		)

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -673,7 +673,7 @@ pub struct FullPeerConfig {
 	/// Pruning window size.
 	///
 	/// NOTE: only finalized blocks are subject for removal!
-	pub keep_blocks: Option<u32>,
+	pub blocks_pruning: Option<u32>,
 	/// Block announce validator.
 	pub block_announce_validator: Option<Box<dyn BlockAnnounceValidator<Block> + Send + Sync>>,
 	/// List of notification protocols that the network must support.
@@ -739,10 +739,10 @@ where
 
 	/// Add a full peer.
 	fn add_full_peer_with_config(&mut self, config: FullPeerConfig) {
-		let mut test_client_builder = match (config.keep_blocks, config.storage_chain) {
-			(Some(keep_blocks), true) => TestClientBuilder::with_tx_storage(keep_blocks),
+		let mut test_client_builder = match (config.blocks_pruning, config.storage_chain) {
+			(Some(blocks_pruning), true) => TestClientBuilder::with_tx_storage(blocks_pruning),
 			(None, true) => TestClientBuilder::with_tx_storage(u32::MAX),
-			(Some(keep_blocks), false) => TestClientBuilder::with_pruning_window(keep_blocks),
+			(Some(blocks_pruning), false) => TestClientBuilder::with_pruning_window(blocks_pruning),
 			(None, false) => TestClientBuilder::with_default_backend(),
 		};
 		if let Some(storage) = config.extra_storage {

--- a/client/network/test/src/sync.rs
+++ b/client/network/test/src/sync.rs
@@ -544,7 +544,7 @@ fn syncs_header_only_forks() {
 	sp_tracing::try_init_simple();
 	let mut net = TestNet::new(0);
 	net.add_full_peer_with_config(Default::default());
-	net.add_full_peer_with_config(FullPeerConfig { keep_blocks: Some(3), ..Default::default() });
+	net.add_full_peer_with_config(FullPeerConfig { blocks_pruning: Some(3), ..Default::default() });
 	net.peer(0).push_blocks(2, false);
 	net.peer(1).push_blocks(2, false);
 

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -207,7 +207,7 @@ where
 			state_cache_child_ratio: config.state_cache_child_ratio.map(|v| (v, 100)),
 			state_pruning: config.state_pruning.clone(),
 			source: config.database.clone(),
-			keep_blocks: config.keep_blocks,
+			blocks_pruning: config.blocks_pruning,
 		};
 
 		let backend = new_db_backend(db_config)?;

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -19,7 +19,7 @@
 //! Service configuration.
 
 pub use sc_client_api::execution_extensions::{ExecutionStrategies, ExecutionStrategy};
-pub use sc_client_db::{Database, DatabaseSource, KeepBlocks, PruningMode};
+pub use sc_client_db::{BlocksPruning, Database, DatabaseSource, PruningMode};
 pub use sc_executor::WasmExecutionMethod;
 #[cfg(feature = "wasmtime")]
 pub use sc_executor::WasmtimeInstantiationStrategy;
@@ -79,7 +79,7 @@ pub struct Configuration {
 	/// Number of blocks to keep in the db.
 	///
 	/// NOTE: only finalized blocks are subject for removal!
-	pub keep_blocks: KeepBlocks,
+	pub blocks_pruning: BlocksPruning,
 	/// Chain configuration.
 	pub chain_spec: Box<dyn ChainSpec>,
 	/// Wasm execution method.

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -60,7 +60,7 @@ pub use self::{
 	error::Error,
 };
 pub use config::{
-	BasePath, Configuration, DatabaseSource, KeepBlocks, PruningMode, Role, RpcMethods, TaskType,
+	BasePath, BlocksPruning, Configuration, DatabaseSource, PruningMode, Role, RpcMethods, TaskType,
 };
 pub use sc_chain_spec::{
 	ChainSpec, ChainType, Extension as ChainSpecExtension, GenericChainSpec, NoExtension,

--- a/client/service/test/src/client/mod.rs
+++ b/client/service/test/src/client/mod.rs
@@ -23,7 +23,7 @@ use sc_block_builder::BlockBuilderProvider;
 use sc_client_api::{
 	in_mem, BlockBackend, BlockchainEvents, FinalityNotifications, StorageProvider,
 };
-use sc_client_db::{Backend, DatabaseSettings, DatabaseSource, KeepBlocks, PruningMode};
+use sc_client_db::{Backend, BlocksPruning, DatabaseSettings, DatabaseSource, PruningMode};
 use sc_consensus::{
 	BlockCheckParams, BlockImport, BlockImportParams, ForkChoiceStrategy, ImportResult,
 };
@@ -1200,7 +1200,7 @@ fn doesnt_import_blocks_that_revert_finality() {
 				state_cache_size: 1 << 20,
 				state_cache_child_ratio: None,
 				state_pruning: Some(PruningMode::ArchiveAll),
-				keep_blocks: KeepBlocks::All,
+				blocks_pruning: BlocksPruning::All,
 				source: DatabaseSource::RocksDb { path: tmp.path().into(), cache_size: 1024 },
 			},
 			u64::MAX,
@@ -1426,8 +1426,8 @@ fn returns_status_for_pruned_blocks() {
 			DatabaseSettings {
 				state_cache_size: 1 << 20,
 				state_cache_child_ratio: None,
-				state_pruning: Some(PruningMode::keep_blocks(1)),
-				keep_blocks: KeepBlocks::All,
+				state_pruning: Some(PruningMode::blocks_pruning(1)),
+				blocks_pruning: BlocksPruning::All,
 				source: DatabaseSource::RocksDb { path: tmp.path().into(), cache_size: 1024 },
 			},
 			u64::MAX,

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -29,8 +29,8 @@ use sc_network::{
 use sc_service::{
 	client::Client,
 	config::{BasePath, DatabaseSource, KeystoreConfig},
-	ChainSpecExtension, Configuration, Error, GenericChainSpec, KeepBlocks, Role, RuntimeGenesis,
-	SpawnTaskHandle, TaskManager,
+	BlocksPruning, ChainSpecExtension, Configuration, Error, GenericChainSpec, Role,
+	RuntimeGenesis, SpawnTaskHandle, TaskManager,
 };
 use sc_transaction_pool_api::TransactionPool;
 use sp_api::BlockId;
@@ -234,7 +234,7 @@ fn node_config<
 		state_cache_size: 16777216,
 		state_cache_child_ratio: None,
 		state_pruning: Default::default(),
-		keep_blocks: KeepBlocks::All,
+		blocks_pruning: BlocksPruning::All,
 		chain_spec: Box::new((*spec).clone()),
 		wasm_method: sc_service::config::WasmExecutionMethod::Interpreted,
 		wasm_runtime_overrides: Default::default(),

--- a/client/state-db/src/lib.rs
+++ b/client/state-db/src/lib.rs
@@ -227,7 +227,7 @@ pub enum PruningMode {
 
 impl PruningMode {
 	/// Create a mode that keeps given number of blocks.
-	pub fn keep_blocks(n: u32) -> PruningMode {
+	pub fn blocks_pruning(n: u32) -> PruningMode {
 		PruningMode::Constrained(Constraints { max_blocks: Some(n), max_mem: None })
 	}
 
@@ -835,34 +835,34 @@ mod tests {
 	#[test]
 	fn pruning_mode_compatibility() {
 		for (created, reopened, expected) in [
-			(None, None, Ok(PruningMode::keep_blocks(256))),
-			(None, Some(PruningMode::keep_blocks(256)), Ok(PruningMode::keep_blocks(256))),
-			(None, Some(PruningMode::keep_blocks(128)), Ok(PruningMode::keep_blocks(128))),
-			(None, Some(PruningMode::keep_blocks(512)), Ok(PruningMode::keep_blocks(512))),
+			(None, None, Ok(PruningMode::blocks_pruning(256))),
+			(None, Some(PruningMode::blocks_pruning(256)), Ok(PruningMode::blocks_pruning(256))),
+			(None, Some(PruningMode::blocks_pruning(128)), Ok(PruningMode::blocks_pruning(128))),
+			(None, Some(PruningMode::blocks_pruning(512)), Ok(PruningMode::blocks_pruning(512))),
 			(None, Some(PruningMode::ArchiveAll), Err(())),
 			(None, Some(PruningMode::ArchiveCanonical), Err(())),
-			(Some(PruningMode::keep_blocks(256)), None, Ok(PruningMode::keep_blocks(256))),
+			(Some(PruningMode::blocks_pruning(256)), None, Ok(PruningMode::blocks_pruning(256))),
 			(
-				Some(PruningMode::keep_blocks(256)),
-				Some(PruningMode::keep_blocks(256)),
-				Ok(PruningMode::keep_blocks(256)),
+				Some(PruningMode::blocks_pruning(256)),
+				Some(PruningMode::blocks_pruning(256)),
+				Ok(PruningMode::blocks_pruning(256)),
 			),
 			(
-				Some(PruningMode::keep_blocks(256)),
-				Some(PruningMode::keep_blocks(128)),
-				Ok(PruningMode::keep_blocks(128)),
+				Some(PruningMode::blocks_pruning(256)),
+				Some(PruningMode::blocks_pruning(128)),
+				Ok(PruningMode::blocks_pruning(128)),
 			),
 			(
-				Some(PruningMode::keep_blocks(256)),
-				Some(PruningMode::keep_blocks(512)),
-				Ok(PruningMode::keep_blocks(512)),
+				Some(PruningMode::blocks_pruning(256)),
+				Some(PruningMode::blocks_pruning(512)),
+				Ok(PruningMode::blocks_pruning(512)),
 			),
-			(Some(PruningMode::keep_blocks(256)), Some(PruningMode::ArchiveAll), Err(())),
-			(Some(PruningMode::keep_blocks(256)), Some(PruningMode::ArchiveCanonical), Err(())),
+			(Some(PruningMode::blocks_pruning(256)), Some(PruningMode::ArchiveAll), Err(())),
+			(Some(PruningMode::blocks_pruning(256)), Some(PruningMode::ArchiveCanonical), Err(())),
 			(Some(PruningMode::ArchiveAll), None, Ok(PruningMode::ArchiveAll)),
-			(Some(PruningMode::ArchiveAll), Some(PruningMode::keep_blocks(256)), Err(())),
-			(Some(PruningMode::ArchiveAll), Some(PruningMode::keep_blocks(128)), Err(())),
-			(Some(PruningMode::ArchiveAll), Some(PruningMode::keep_blocks(512)), Err(())),
+			(Some(PruningMode::ArchiveAll), Some(PruningMode::blocks_pruning(256)), Err(())),
+			(Some(PruningMode::ArchiveAll), Some(PruningMode::blocks_pruning(128)), Err(())),
+			(Some(PruningMode::ArchiveAll), Some(PruningMode::blocks_pruning(512)), Err(())),
 			(
 				Some(PruningMode::ArchiveAll),
 				Some(PruningMode::ArchiveAll),
@@ -870,9 +870,9 @@ mod tests {
 			),
 			(Some(PruningMode::ArchiveAll), Some(PruningMode::ArchiveCanonical), Err(())),
 			(Some(PruningMode::ArchiveCanonical), None, Ok(PruningMode::ArchiveCanonical)),
-			(Some(PruningMode::ArchiveCanonical), Some(PruningMode::keep_blocks(256)), Err(())),
-			(Some(PruningMode::ArchiveCanonical), Some(PruningMode::keep_blocks(128)), Err(())),
-			(Some(PruningMode::ArchiveCanonical), Some(PruningMode::keep_blocks(512)), Err(())),
+			(Some(PruningMode::ArchiveCanonical), Some(PruningMode::blocks_pruning(256)), Err(())),
+			(Some(PruningMode::ArchiveCanonical), Some(PruningMode::blocks_pruning(128)), Err(())),
+			(Some(PruningMode::ArchiveCanonical), Some(PruningMode::blocks_pruning(512)), Err(())),
 			(Some(PruningMode::ArchiveCanonical), Some(PruningMode::ArchiveAll), Err(())),
 			(
 				Some(PruningMode::ArchiveCanonical),

--- a/test-utils/client/src/lib.rs
+++ b/test-utils/client/src/lib.rs
@@ -95,14 +95,14 @@ impl<Block: BlockT, ExecutorDispatch, G: GenesisInit>
 	}
 
 	/// Create new `TestClientBuilder` with default backend and pruning window size
-	pub fn with_pruning_window(keep_blocks: u32) -> Self {
-		let backend = Arc::new(Backend::new_test(keep_blocks, 0));
+	pub fn with_pruning_window(blocks_pruning: u32) -> Self {
+		let backend = Arc::new(Backend::new_test(blocks_pruning, 0));
 		Self::with_backend(backend)
 	}
 
 	/// Create new `TestClientBuilder` with default backend and storage chain mode
-	pub fn with_tx_storage(keep_blocks: u32) -> Self {
-		let backend = Arc::new(Backend::new_test_with_tx_storage(keep_blocks, 0));
+	pub fn with_tx_storage(blocks_pruning: u32) -> Self {
+		let backend = Arc::new(Backend::new_test_with_tx_storage(blocks_pruning, 0));
 		Self::with_backend(backend)
 	}
 }


### PR DESCRIPTION
This PR is renaming flags  `--keep-blocks` and `--prunning` to `--blocks-pruning` and --state-prunning` accordingly. This makes the flags similar to each other and avoids confusion.

Fixes #11907

polkadot companion: https://github.com/paritytech/polkadot/pull/5863
cumulus companion: https://github.com/paritytech/cumulus/pull/1514