### PR TITLE
offences: make fn slash_fraction non-static

### DIFF
--- a/frame/babe/src/equivocation.rs
+++ b/frame/babe/src/equivocation.rs
@@ -284,7 +284,8 @@ impl<FullIdentification: Clone> Offence<FullIdentification>
 		self.slot
 	}
 
-	fn slash_fraction(offenders_count: u32, validator_set_count: u32) -> Perbill {
+	fn slash_fraction(&self, offenders_count: u32) -> Perbill {
+		let validator_set_count = self.validator_set_count;
 		// the formula is min((3k / n)^2, 1)
 		let x = Perbill::from_rational(3 * offenders_count, validator_set_count);
 		// _ ^ 2

--- a/frame/babe/src/equivocation.rs
+++ b/frame/babe/src/equivocation.rs
@@ -285,9 +285,8 @@ impl<FullIdentification: Clone> Offence<FullIdentification>
 	}
 
 	fn slash_fraction(&self, offenders_count: u32) -> Perbill {
-		let validator_set_count = self.validator_set_count;
 		// the formula is min((3k / n)^2, 1)
-		let x = Perbill::from_rational(3 * offenders_count, validator_set_count);
+		let x = Perbill::from_rational(3 * offenders_count, self.validator_set_count);
 		// _ ^ 2
 		x.square()
 	}

--- a/frame/grandpa/src/equivocation.rs
+++ b/frame/grandpa/src/equivocation.rs
@@ -353,7 +353,8 @@ impl<FullIdentification: Clone> Offence<FullIdentification>
 		self.time_slot
 	}
 
-	fn slash_fraction(offenders_count: u32, validator_set_count: u32) -> Perbill {
+	fn slash_fraction(&self, offenders_count: u32) -> Perbill {
+		let validator_set_count = self.validator_set_count;
 		// the formula is min((3k / n)^2, 1)
 		let x = Perbill::from_rational(3 * offenders_count, validator_set_count);
 		// _ ^ 2

--- a/frame/grandpa/src/equivocation.rs
+++ b/frame/grandpa/src/equivocation.rs
@@ -354,9 +354,8 @@ impl<FullIdentification: Clone> Offence<FullIdentification>
 	}
 
 	fn slash_fraction(&self, offenders_count: u32) -> Perbill {
-		let validator_set_count = self.validator_set_count;
 		// the formula is min((3k / n)^2, 1)
-		let x = Perbill::from_rational(3 * offenders_count, validator_set_count);
+		let x = Perbill::from_rational(3 * offenders_count, self.validator_set_count);
 		// _ ^ 2
 		x.square()
 	}

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -958,7 +958,8 @@ impl<Offender: Clone> Offence<Offender> for UnresponsivenessOffence<Offender> {
 		self.session_index
 	}
 
-	fn slash_fraction(offenders: u32, validator_set_count: u32) -> Perbill {
+	fn slash_fraction(&self, offenders: u32) -> Perbill {
+		let validator_set_count = self.validator_set_count;
 		// the formula is min((3 * (k - (n / 10 + 1))) / n, 1) * 0.07
 		// basically, 10% can be offline with no slash, but after that, it linearly climbs up to 7%
 		// when 13/30 are offline (around 5% when 1/3 are offline).

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -959,12 +959,11 @@ impl<Offender: Clone> Offence<Offender> for UnresponsivenessOffence<Offender> {
 	}
 
 	fn slash_fraction(&self, offenders: u32) -> Perbill {
-		let validator_set_count = self.validator_set_count;
 		// the formula is min((3 * (k - (n / 10 + 1))) / n, 1) * 0.07
 		// basically, 10% can be offline with no slash, but after that, it linearly climbs up to 7%
 		// when 13/30 are offline (around 5% when 1/3 are offline).
-		if let Some(threshold) = offenders.checked_sub(validator_set_count / 10 + 1) {
-			let x = Perbill::from_rational(3 * threshold, validator_set_count);
+		if let Some(threshold) = offenders.checked_sub(self.validator_set_count / 10 + 1) {
+			let x = Perbill::from_rational(3 * threshold, self.validator_set_count);
 			x.saturating_mul(Perbill::from_percent(7))
 		} else {
 			Perbill::default()

--- a/frame/im-online/src/tests.rs
+++ b/frame/im-online/src/tests.rs
@@ -36,22 +36,24 @@ use sp_runtime::{
 
 #[test]
 fn test_unresponsiveness_slash_fraction() {
+	let dummy_offence =
+		UnresponsivenessOffence { session_index: 0, validator_set_count: 50, offenders: vec![()] };
 	// A single case of unresponsiveness is not slashed.
-	assert_eq!(UnresponsivenessOffence::<()>::slash_fraction(1, 50), Perbill::zero());
+	assert_eq!(dummy_offence.slash_fraction(1), Perbill::zero());
 
 	assert_eq!(
-		UnresponsivenessOffence::<()>::slash_fraction(5, 50),
+		dummy_offence.slash_fraction(5),
 		Perbill::zero(), // 0%
 	);
 
 	assert_eq!(
-		UnresponsivenessOffence::<()>::slash_fraction(7, 50),
+		dummy_offence.slash_fraction(7),
 		Perbill::from_parts(4200000), // 0.42%
 	);
 
 	// One third offline should be punished around 5%.
 	assert_eq!(
-		UnresponsivenessOffence::<()>::slash_fraction(17, 50),
+		dummy_offence.slash_fraction(17),
 		Perbill::from_parts(46200000), // 4.62%
 	);
 }

--- a/frame/offences/benchmarking/src/lib.rs
+++ b/frame/offences/benchmarking/src/lib.rs
@@ -288,15 +288,13 @@ benchmarks! {
 		let (offenders, raw_offenders) = make_offenders_im_online::<T>(o, n)?;
 		let keys =  ImOnline::<T>::keys();
 		let validator_set_count = keys.len() as u32;
-
-		let slash_fraction = UnresponsivenessOffence::<T::AccountId>::slash_fraction(
-			offenders.len() as u32, validator_set_count,
-		);
+		let offenders_count = offenders.len() as u32;
 		let offence = UnresponsivenessOffence {
 			session_index: 0,
 			validator_set_count,
 			offenders,
 		};
+		let slash_fraction = offence.slash_fraction(offenders_count);
 		assert_eq!(System::<T>::event_count(), 0);
 	}: {
 		let _ = <T as ImOnlineConfig>::ReportUnresponsiveness::report_offence(

--- a/frame/offences/src/lib.rs
+++ b/frame/offences/src/lib.rs
@@ -120,7 +120,6 @@ where
 	fn report_offence(reporters: Vec<T::AccountId>, offence: O) -> Result<(), OffenceError> {
 		let offenders = offence.offenders();
 		let time_slot = offence.time_slot();
-		let validator_set_count = offence.validator_set_count();
 
 		// Go through all offenders in the offence report and find all offenders that were spotted
 		// in unique reports.
@@ -134,7 +133,7 @@ where
 		let offenders_count = concurrent_offenders.len() as u32;
 
 		// The amount new offenders are slashed
-		let new_fraction = O::slash_fraction(offenders_count, validator_set_count);
+		let new_fraction = offence.slash_fraction(offenders_count);
 
 		let slash_perbill: Vec<_> = (0..concurrent_offenders.len()).map(|_| new_fraction).collect();
 

--- a/frame/offences/src/mock.rs
+++ b/frame/offences/src/mock.rs
@@ -168,7 +168,8 @@ impl<T: Clone> offence::Offence<T> for Offence<T> {
 		1
 	}
 
-	fn slash_fraction(offenders_count: u32, validator_set_count: u32) -> Perbill {
+	fn slash_fraction(&self, offenders_count: u32) -> Perbill {
+		let validator_set_count = self.validator_set_count;
 		Perbill::from_percent(5 + offenders_count * 100 / validator_set_count)
 	}
 }

--- a/frame/offences/src/mock.rs
+++ b/frame/offences/src/mock.rs
@@ -169,8 +169,7 @@ impl<T: Clone> offence::Offence<T> for Offence<T> {
 	}
 
 	fn slash_fraction(&self, offenders_count: u32) -> Perbill {
-		let validator_set_count = self.validator_set_count;
-		Perbill::from_percent(5 + offenders_count * 100 / validator_set_count)
+		Perbill::from_percent(5 + offenders_count * 100 / self.validator_set_count)
 	}
 }
 

--- a/primitives/staking/src/offence.rs
+++ b/primitives/staking/src/offence.rs
@@ -108,11 +108,10 @@ pub trait Offence<Offender> {
 	}
 
 	/// A slash fraction of the total exposure that should be slashed for this
-	/// particular offence kind for the given parameters that happened at a singular `TimeSlot`.
+	/// particular offence for the `offenders_count` that happened at a singular `TimeSlot`.
 	///
-	/// `offenders_count` - the count of unique offending authorities. It is >0.
-	/// `validator_set_count` - the cardinality of the validator set at the time of offence.
-	fn slash_fraction(offenders_count: u32, validator_set_count: u32) -> Perbill;
+	/// `offenders_count` - the count of unique offending authorities for this `TimeSlot`. It is >0.
+	fn slash_fraction(&self, offenders_count: u32) -> Perbill;
 }
 
 /// Errors that may happen on offence reports.


### PR DESCRIPTION
A use-case for this is to be able to have slash_fraction parameters derived from runtime configuration and read this config once and in the right context: https://github.com/paritytech/polkadot/pull/5535#discussion_r933528750.