### PR TITLE
Timestamp: `set_timestamp` sets `DidUpdate`

### DIFF
--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -282,6 +282,7 @@ impl<T: Config> Pallet<T> {
 	#[cfg(any(feature = "runtime-benchmarks", feature = "std"))]
 	pub fn set_timestamp(now: T::Moment) {
 		Now::<T>::put(now);
+		DidUpdate::<T>::put(true);
 	}
 }
 

--- a/frame/timestamp/src/tests.rs
+++ b/frame/timestamp/src/tests.rs
@@ -23,7 +23,7 @@ use frame_support::assert_ok;
 #[test]
 fn timestamp_works() {
 	new_test_ext().execute_with(|| {
-		Timestamp::set_timestamp(42);
+		crate::Now::<Test>::put(46);
 		assert_ok!(Timestamp::set(Origin::none(), 69));
 		assert_eq!(Timestamp::now(), 69);
 		assert_eq!(Some(69), get_captured_moment());
@@ -36,7 +36,6 @@ fn double_timestamp_should_fail() {
 	new_test_ext().execute_with(|| {
 		Timestamp::set_timestamp(42);
 		assert_ok!(Timestamp::set(Origin::none(), 69));
-		let _ = Timestamp::set(Origin::none(), 70);
 	});
 }
 
@@ -46,7 +45,7 @@ fn double_timestamp_should_fail() {
 )]
 fn block_period_minimum_enforced() {
 	new_test_ext().execute_with(|| {
-		Timestamp::set_timestamp(42);
+		crate::Now::<Test>::put(44);
 		let _ = Timestamp::set(Origin::none(), 46);
 	});
 }


### PR DESCRIPTION
There exists the `set_timestamp` in the Timestamp pallet for setting the current timestamp. The
problem is that it doesn't set `DidUpdate`. This results in `on_finalize` panicking. There is no
real reason why the function doesn't also set `DidUpdate`.


Close: https://github.com/paritytech/substrate/issues/11958