### PR TITLE
`sync` protocol now can have negotiated fallback name

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -1577,8 +1577,6 @@ where
 			} => {
 				// Set number 0 is hardcoded the default set of peers we sync from.
 				if set_id == HARDCODED_PEERSETS_SYNC {
-					debug_assert!(negotiated_fallback.is_none());
-
 					// `received_handshake` can be either a `Status` message if received from the
 					// legacy substream ,or a `BlockAnnouncesHandshake` if received from the block
 					// announces substream.


### PR DESCRIPTION
Hotfix to https://github.com/paritytech/substrate/pull/11938

polkadot companion: https://github.com/paritytech/polkadot/pull/5849
