### PR TITLE
Restore `wasmtime`'s default stack size limit to 1MB

### DIFF
--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -324,13 +324,14 @@ fn common_config(semantics: &Semantics) -> std::result::Result<wasmtime::Config,
 		.profiler(profiler)
 		.map_err(|e| WasmError::Instantiation(format!("fail to set profiler: {:#}", e)))?;
 
-	if let Some(DeterministicStackLimit { native_stack_max, .. }) =
-		semantics.deterministic_stack_limit
-	{
-		config
-			.max_wasm_stack(native_stack_max as usize)
-			.map_err(|e| WasmError::Other(format!("cannot set max wasm stack: {:#}", e)))?;
-	}
+	let native_stack_max = match semantics.deterministic_stack_limit {
+		Some(DeterministicStackLimit { native_stack_max, .. }) => native_stack_max,
+		None => 1024 * 1024,
+	};
+
+	config
+		.max_wasm_stack(native_stack_max as usize)
+		.map_err(|e| WasmError::Other(format!("cannot set max wasm stack: {:#}", e)))?;
 
 	config.parallel_compilation(semantics.parallel_compilation);
 

--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -326,6 +326,11 @@ fn common_config(semantics: &Semantics) -> std::result::Result<wasmtime::Config,
 
 	let native_stack_max = match semantics.deterministic_stack_limit {
 		Some(DeterministicStackLimit { native_stack_max, .. }) => native_stack_max,
+
+		// In `wasmtime` 0.35 the default stack size limit was changed from 1MB to 512KB.
+		//
+		// This broke at least one parachain which depended on the original 1MB limit,
+		// so here we restore it to what it was originally.
 		None => 1024 * 1024,
 	};
 

--- a/client/executor/wasmtime/src/tests.rs
+++ b/client/executor/wasmtime/src/tests.rs
@@ -224,15 +224,14 @@ fn deep_call_stack_wat(depth: usize) -> String {
 //   d) the new call depth limit may need to be validated to ensure it doesn't prevent any
 //      existing chain from syncing (if it was effectively decreased)
 
-#[cfg(debug_assertions)]
-const CALL_DEPTH_LIMIT: usize = 65478;
-
-#[cfg(not(debug_assertions))]
-const CALL_DEPTH_LIMIT: usize = 65514;
+// We need two limits here since depending on whether the code is compiled in debug
+// or in release mode the maximum call depth is slightly different.
+const CALL_DEPTH_LOWER_LIMIT: usize = 65478;
+const CALL_DEPTH_UPPER_LIMIT: usize = 65514;
 
 test_wasm_execution!(test_consume_under_1mb_of_stack_does_not_trap);
 fn test_consume_under_1mb_of_stack_does_not_trap(instantiation_strategy: InstantiationStrategy) {
-	let wat = deep_call_stack_wat(CALL_DEPTH_LIMIT);
+	let wat = deep_call_stack_wat(CALL_DEPTH_LOWER_LIMIT);
 	let mut builder = RuntimeBuilder::new(instantiation_strategy).use_wat(wat);
 	let runtime = builder.build();
 	let mut instance = runtime.new_instance().expect("failed to instantiate a runtime");
@@ -241,7 +240,7 @@ fn test_consume_under_1mb_of_stack_does_not_trap(instantiation_strategy: Instant
 
 test_wasm_execution!(test_consume_over_1mb_of_stack_does_trap);
 fn test_consume_over_1mb_of_stack_does_trap(instantiation_strategy: InstantiationStrategy) {
-	let wat = deep_call_stack_wat(CALL_DEPTH_LIMIT + 1);
+	let wat = deep_call_stack_wat(CALL_DEPTH_UPPER_LIMIT + 1);
 	let mut builder = RuntimeBuilder::new(instantiation_strategy).use_wat(wat);
 	let runtime = builder.build();
 	let mut instance = runtime.new_instance().expect("failed to instantiate a runtime");

--- a/client/executor/wasmtime/src/tests.rs
+++ b/client/executor/wasmtime/src/tests.rs
@@ -224,9 +224,15 @@ fn deep_call_stack_wat(depth: usize) -> String {
 //   d) the new call depth limit may need to be validated to ensure it doesn't prevent any
 //      existing chain from syncing (if it was effectively decreased)
 
+#[cfg(debug_assertions)]
+const CALL_DEPTH_LIMIT: usize = 65478;
+
+#[cfg(not(debug_assertions))]
+const CALL_DEPTH_LIMIT: usize = 65514;
+
 test_wasm_execution!(test_consume_under_1mb_of_stack_does_not_trap);
 fn test_consume_under_1mb_of_stack_does_not_trap(instantiation_strategy: InstantiationStrategy) {
-	let wat = deep_call_stack_wat(65478);
+	let wat = deep_call_stack_wat(CALL_DEPTH_LIMIT);
 	let mut builder = RuntimeBuilder::new(instantiation_strategy).use_wat(wat);
 	let runtime = builder.build();
 	let mut instance = runtime.new_instance().expect("failed to instantiate a runtime");
@@ -235,7 +241,7 @@ fn test_consume_under_1mb_of_stack_does_not_trap(instantiation_strategy: Instant
 
 test_wasm_execution!(test_consume_over_1mb_of_stack_does_trap);
 fn test_consume_over_1mb_of_stack_does_trap(instantiation_strategy: InstantiationStrategy) {
-	let wat = deep_call_stack_wat(65479);
+	let wat = deep_call_stack_wat(CALL_DEPTH_LIMIT + 1);
 	let mut builder = RuntimeBuilder::new(instantiation_strategy).use_wat(wat);
 	let runtime = builder.build();
 	let mut instance = runtime.new_instance().expect("failed to instantiate a runtime");

--- a/client/executor/wasmtime/src/tests.rs
+++ b/client/executor/wasmtime/src/tests.rs
@@ -210,6 +210,20 @@ fn deep_call_stack_wat(depth: usize) -> String {
 	)
 }
 
+// These two tests ensure that the `wasmtime`'s stack size limit and the amount of
+// stack space used by a single stack frame doesn't suddenly change without us noticing.
+//
+// If they do (e.g. because we've pulled in a new version of `wasmtime`) we want to know
+// that it did, regardless of how small the change was.
+//
+// If these tests starting failing it doesn't necessarily mean that something is broken;
+// what it means is that one (or multiple) of the following has to be done:
+//   a) the tests may need to be updated for the new call depth,
+//   b) the stack limit may need to be changed to maintain backwards compatibility,
+//   c) the root cause of the new call depth limit determined, and potentially fixed,
+//   d) the new call depth limit may need to be validated to ensure it doesn't prevent any
+//      existing chain from syncing (if it was effectively decreased)
+
 test_wasm_execution!(test_consume_under_1mb_of_stack_does_not_trap);
 fn test_consume_under_1mb_of_stack_does_not_trap(instantiation_strategy: InstantiationStrategy) {
 	let wat = deep_call_stack_wat(65478);


### PR DESCRIPTION
Fixes https://github.com/paritytech/substrate/issues/11891

This PR restores `wasmtime`'s default stack size limit to 1MB.

Originally `wasmtime`'s default stack size limit was set to 1MB, however in [version 0.35 it was changed to 512 KB](https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md#0350) for reasons which aren't really relevant to us. This flew under the radar until our friends from the Astar parachain noticed that this broke their ability to sync their parachain from scratch.

So this PR simply restores the original limit.

I've also added two extra tests to more closely enforce this limit. Please note that since they test the exact boundary in theory they may also fail if anything else changes related to how much stack space a single frame takes without us modifying the stack limit. This is intended; we don't want this to change under us without us knowing about it.

(We might have to `#[cfg]`-gate these test by architecture and/or OS, but I didn't want to blindly do it until I'll see a failing CI job and/or someone complaining that it fails on their machine.)