### PR TITLE
add negative tests

### DIFF
--- a/frame/alliance/src/tests.rs
+++ b/frame/alliance/src/tests.rs
@@ -463,7 +463,7 @@ fn assert_powerless(user: Origin) {
 
 	assert_noop!(Alliance::retire(user.clone()), Error::<Test, ()>::RetirementNoticeNotGiven);
 
-	assert_noop!(Alliance::retirement_notice(user.clone()), Error::<Test, ()>::NotMember);
+	assert_noop!(Alliance::give_retirement_notice(user.clone()), Error::<Test, ()>::NotMember);
 
 	assert_noop!(Alliance::elevate_ally(user.clone(), 4), BadOrigin);
 
@@ -472,13 +472,6 @@ fn assert_powerless(user: Origin) {
 	assert_noop!(Alliance::nominate_ally(user.clone(), 4),  Error::<Test, ()>::NoVotingRights);
 
 	assert_noop!(Alliance::propose(user.clone(), 5, Box::new(proposal), 1000),  Error::<Test, ()>::NoVotingRights);
-
-	// Currently failing below:
-	assert_noop!(Alliance::add_unscrupulous_items(user.clone(), vec![]), BadOrigin);
-
-	assert_noop!(Alliance::remove_unscrupulous_items(user.clone(), vec![]), BadOrigin);
-
-	assert_noop!(Alliance::announce(user, cid.clone()), Error::<Test, ()>::NotAlly);
 }
 
 #[test]

--- a/frame/alliance/src/tests.rs
+++ b/frame/alliance/src/tests.rs
@@ -441,7 +441,41 @@ fn retire_works() {
 			member: (3),
 			unreserved: None,
 		}));
+
+		// Move time on:
+		System::set_block_number(System::block_number() + RetirementPeriod::get());
+
+		assert_powerless(Origin::signed(3));
 	});
+}
+
+fn assert_powerless(user: Origin) {
+	//vote / veto with a valid propsal
+	let cid = test_cid();
+	let proposal = make_proposal(42);
+	
+	assert_noop!(Alliance::init_members(user.clone(), vec![], vec![], vec![]), BadOrigin);
+
+	assert_noop!(Alliance::set_rule(user.clone(), cid.clone()), BadOrigin);
+
+	assert_noop!(Alliance::retire(user.clone()), Error::<Test, ()>::RetirementNoticeNotGiven);
+
+	assert_noop!(Alliance::retirement_notice(user.clone()), Error::<Test, ()>::NotMember);
+
+	assert_noop!(Alliance::elevate_ally(user.clone(), 4), BadOrigin);
+
+	assert_noop!(Alliance::kick_member(user.clone(), 1), BadOrigin);
+
+	assert_noop!(Alliance::nominate_ally(user.clone(), 4),  Error::<Test, ()>::NoVotingRights);
+
+	assert_noop!(Alliance::propose(user.clone(), 5, Box::new(proposal), 1000),  Error::<Test, ()>::NoVotingRights);
+
+	// Currently failing below:
+	assert_noop!(Alliance::add_unscrupulous_items(user.clone(), vec![]), BadOrigin);
+
+	assert_noop!(Alliance::remove_unscrupulous_items(user.clone(), vec![]), BadOrigin);
+
+	assert_noop!(Alliance::announce(user, cid.clone()), Error::<Test, ()>::NotAlly);
 }
 
 #[test]

--- a/frame/alliance/src/tests.rs
+++ b/frame/alliance/src/tests.rs
@@ -247,6 +247,9 @@ fn set_rule_works() {
 fn announce_works() {
 	new_test_ext().execute_with(|| {
 		let cid = test_cid();
+
+		assert_noop!(Alliance::announce(Origin::signed(2), cid.clone()), BadOrigin);
+
 		assert_ok!(Alliance::announce(Origin::signed(3), cid.clone()));
 		assert_eq!(Alliance::announcements(), vec![cid.clone()]);
 
@@ -456,7 +459,7 @@ fn assert_powerless(user: Origin) {
 	//vote / veto with a valid propsal
 	let cid = test_cid();
 	let proposal = make_proposal(42);
-	
+
 	assert_noop!(Alliance::init_members(user.clone(), vec![], vec![], vec![]), BadOrigin);
 
 	assert_noop!(Alliance::set_rule(user.clone(), cid.clone()), BadOrigin);
@@ -469,9 +472,12 @@ fn assert_powerless(user: Origin) {
 
 	assert_noop!(Alliance::kick_member(user.clone(), 1), BadOrigin);
 
-	assert_noop!(Alliance::nominate_ally(user.clone(), 4),  Error::<Test, ()>::NoVotingRights);
+	assert_noop!(Alliance::nominate_ally(user.clone(), 4), Error::<Test, ()>::NoVotingRights);
 
-	assert_noop!(Alliance::propose(user.clone(), 5, Box::new(proposal), 1000),  Error::<Test, ()>::NoVotingRights);
+	assert_noop!(
+		Alliance::propose(user.clone(), 5, Box::new(proposal), 1000),
+		Error::<Test, ()>::NoVotingRights
+	);
 }
 
 #[test]
@@ -496,6 +502,8 @@ fn kick_member_works() {
 #[test]
 fn add_unscrupulous_items_works() {
 	new_test_ext().execute_with(|| {
+		assert_noop!(Alliance::add_unscrupulous_items(Origin::signed(2), vec![]), BadOrigin);
+
 		assert_ok!(Alliance::add_unscrupulous_items(
 			Origin::signed(3),
 			vec![
@@ -519,6 +527,8 @@ fn add_unscrupulous_items_works() {
 #[test]
 fn remove_unscrupulous_items_works() {
 	new_test_ext().execute_with(|| {
+		assert_noop!(Alliance::remove_unscrupulous_items(Origin::signed(2), vec![]), BadOrigin);
+
 		assert_noop!(
 			Alliance::remove_unscrupulous_items(
 				Origin::signed(3),


### PR DESCRIPTION
Added some more negative tests to make sure a retired person has no special privileges.

The last 3 asserts currently return Ok(()) and thus fail the test. 

We're using 4 and the announcement origin is defined as the following in the mock:

	`type AnnouncementOrigin = EnsureSignedBy<Three, u64>;`

Maybe I have got the test wrong in some way?