### PR TITLE
chore: improve runtime executor docs and remove unused error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8188,7 +8188,6 @@ dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
  "sp-sandbox",
- "sp-serializer",
  "sp-wasm-interface",
  "thiserror",
  "wasm-instrument",

--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -23,7 +23,6 @@ wasmi = "0.9.1"
 sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }
 sp-maybe-compressed-blob = { version = "4.1.0-dev", path = "../../../primitives/maybe-compressed-blob" }
 sp-sandbox = { version = "0.10.0-dev", path = "../../../primitives/sandbox" }
-sp-serializer = { version = "4.0.0-dev", path = "../../../primitives/serializer" }
 sp-wasm-interface = { version = "6.0.0", path = "../../../primitives/wasm-interface" }
 
 [features]

--- a/client/executor/common/src/error.rs
+++ b/client/executor/common/src/error.rs
@@ -18,7 +18,6 @@
 
 //! Rust executor possible errors.
 
-use sp_serializer;
 use wasmi;
 
 /// Result type alias.
@@ -28,9 +27,6 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum Error {
-	#[error("Unserializable data encountered")]
-	InvalidData(#[from] sp_serializer::Error),
-
 	#[error(transparent)]
 	Wasmi(#[from] wasmi::Error),
 

--- a/client/executor/src/native_executor.rs
+++ b/client/executor/src/native_executor.rs
@@ -130,14 +130,13 @@ where
 	/// `default_heap_pages` - Number of 64KB pages to allocate for Wasm execution.
 	///   Defaults to `DEFAULT_HEAP_PAGES` if `None` is provided.
 	///
-	/// `host_functions` - The set of host functions to be available for import provided by this
-	///   executor.
-	///
 	/// `max_runtime_instances` - The number of runtime instances to keep in memory ready for reuse.
 	///
 	/// `cache_path` - A path to a directory where the executor can place its files for purposes of
 	///   caching. This may be important in cases when there are many different modules with the
 	///   compiled execution method is used.
+	///
+	/// `runtime_cache_size` - The capacity of runtime cache.
 	pub fn new(
 		method: WasmExecutionMethod,
 		default_heap_pages: Option<u64>,
@@ -209,7 +208,7 @@ where
 	/// The runtime is passed as a [`RuntimeBlob`]. The runtime will be instantiated with the
 	/// parameters this `WasmExecutor` was initialized with.
 	///
-	/// In case of problems with during creation of the runtime or instantation, a `Err` is
+	/// In case of problems with during creation of the runtime or instantiation, a `Err` is
 	/// returned. that describes the message.
 	#[doc(hidden)] // We use this function for tests across multiple crates.
 	pub fn uncached_call(
@@ -405,6 +404,10 @@ impl<D: NativeExecutionDispatch> NativeElseWasmExecutor<D> {
 	///
 	/// `default_heap_pages` - Number of 64KB pages to allocate for Wasm execution.
 	/// 	Defaults to `DEFAULT_HEAP_PAGES` if `None` is provided.
+	///
+	/// `max_runtime_instances` - The number of runtime instances to keep in memory ready for reuse.
+	///
+	/// `runtime_cache_size` - The capacity of runtime cache.
 	pub fn new(
 		fallback_method: WasmExecutionMethod,
 		default_heap_pages: Option<u64>,

--- a/primitives/runtime-interface/src/lib.rs
+++ b/primitives/runtime-interface/src/lib.rs
@@ -308,10 +308,10 @@ pub use sp_std;
 ///
 /// 1. The generated functions are not callable from the native side.
 /// 2. The trait as shown above is not implemented for [`Externalities`] and is instead
-/// implemented for `FunctionExecutor` (from `sp-wasm-interface`).
+/// implemented for `FunctionContext` (from `sp-wasm-interface`).
 ///
 /// # Disable tracing
-/// By addding `no_tracing` to the list of options you can prevent the wasm-side interface from
+/// By adding `no_tracing` to the list of options you can prevent the wasm-side interface from
 /// generating the default `sp-tracing`-calls. Note that this is rarely needed but only meant
 /// for the case when that would create a circular dependency. You usually _do not_ want to add
 /// this flag, as tracing doesn't cost you anything by default anyways (it is added as a no-op)


### PR DESCRIPTION
BTW, the `sp-serializer` now is only used as dev-dep.