### PR TITLE
[ci] Improve cancel-pipeline job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -276,7 +276,7 @@ rusty-cachier-notify:
 cancel-pipeline-test-linux-stable:
   extends:                         .cancel-pipeline-template
   needs:
-    - job:                         test-linux-stable
+    - job:                         "test-linux-stable 1/3"
       artifacts:                   false
 
 cancel-pipeline-test-linux-stable-int:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,18 +82,32 @@ default:
   tags:
     - kubernetes-parity-build
 
-.rust-info-script:                 &rust-info-script
+.rust-info-script:
   script:
     - rustup show
     - cargo --version
     - rustup +nightly show
     - cargo +nightly --version
 
+.pipeline-stopper-vars:
+  script:
+    - echo "Collecting env variables for the cancel-pipeline job"
+    - echo "FAILED_JOB_URL=${CI_JOB_URL}" > pipeline-stopper.env
+    - echo "FAILED_JOB_NAME=${CI_JOB_NAME}" >> pipeline-stopper.env
+    - echo "FAILED_JOB_NAME=${CI_JOB_NAME}" >> pipeline-stopper.env
+    - echo "PR_NUM=${CI_COMMIT_REF_NAME}" >> pipeline-stopper.env
+
+.pipeline-stopper-artifacts:
+  artifacts:
+    reports:
+      dotenv: pipeline-stopper.env
+
 .docker-env:
   image:                           "${CI_IMAGE}"
   before_script:
     - !reference [.rust-info-script, script]
     - !reference [.rusty-cachier, before_script]
+    - !reference [.pipeline-stopper-vars, script]
   after_script:
     - !reference [.rusty-cachier, after_script]
   tags:
@@ -239,15 +253,25 @@ rusty-cachier-notify:
 # This job cancels the whole pipeline if any of provided jobs fail.
 # In a DAG, every jobs chain is executed independently of others. The `fail_fast` principle suggests
 # to fail the pipeline as soon as possible to shorten the feedback loop.
-.cancel-pipeline-template:
+.cancel-pipeline:
   stage:                           .post
+  needs:
+    - job:                         test-linux-stable
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       when: on_failure
   variables:
     PROJECT_ID:                    "${CI_PROJECT_ID}"
+    PROJECT_NAME:                  "${CI_PROJECT_NAME}"
     PIPELINE_ID:                   "${CI_PIPELINE_ID}"
-  trigger:                         "parity/infrastructure/ci_cd/pipeline-stopper"
+    FAILED_JOB_URL:                "${FAILED_JOB_URL}"
+    FAILED_JOB_NAME:               "${FAILED_JOB_NAME}"
+    PR_NUM:                        "${PR_NUM}"
+  trigger:
+    project:                       "parity/infrastructure/ci_cd/pipeline-stopper"
+    # remove branch, when pipeline-stopper for substrate and polakdot is updated to the same branch
+    branch:                        "as-improve"
+
 
 cancel-pipeline-test-linux-stable:
   extends:                         .cancel-pipeline-template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -255,8 +255,6 @@ rusty-cachier-notify:
 # to fail the pipeline as soon as possible to shorten the feedback loop.
 .cancel-pipeline-template:
   stage:                           .post
-  needs:
-    - job:                         test-linux-stable
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       when: on_failure
@@ -277,28 +275,23 @@ cancel-pipeline-test-linux-stable:
   extends:                         .cancel-pipeline-template
   needs:
     - job:                         "test-linux-stable 1/3"
-      artifacts:                   false
 
 cancel-pipeline-test-linux-stable-int:
   extends:                         .cancel-pipeline-template
   needs:
     - job:                         test-linux-stable-int
-      artifacts:                   false
 
 cancel-pipeline-cargo-check-subkey:
   extends:                         .cancel-pipeline-template
   needs:
     - job:                         cargo-check-subkey
-      artifacts:                   false
 
 cancel-pipeline-cargo-check-benches:
   extends:                         .cancel-pipeline-template
   needs:
     - job:                         cargo-check-benches
-      artifacts:                   false
 
 cancel-pipeline-check-tracing:
   extends:                         .cancel-pipeline-template
   needs:
     - job:                         check-tracing
-      artifacts:                   false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -94,7 +94,6 @@ default:
     - echo "Collecting env variables for the cancel-pipeline job"
     - echo "FAILED_JOB_URL=${CI_JOB_URL}" > pipeline-stopper.env
     - echo "FAILED_JOB_NAME=${CI_JOB_NAME}" >> pipeline-stopper.env
-    - echo "FAILED_JOB_NAME=${CI_JOB_NAME}" >> pipeline-stopper.env
     - echo "PR_NUM=${CI_COMMIT_REF_NAME}" >> pipeline-stopper.env
 
 .pipeline-stopper-artifacts:
@@ -270,11 +269,32 @@ rusty-cachier-notify:
     # remove branch, when pipeline-stopper for substrate and polakdot is updated to the same branch
     branch:                        "as-improve"
 
-
-cancel-pipeline-test-linux-stable:
+# need to copy jobs this way because otherwise gitlab will wait
+# for all 3 jobs to finish instead of cancelling if one fails
+cancel-pipeline-test-linux-stable1:
   extends:                         .cancel-pipeline-template
   needs:
     - job:                         "test-linux-stable 1/3"
+
+cancel-pipeline-test-linux-stable2:
+  extends:                         .cancel-pipeline-template
+  needs:
+    - job:                         "test-linux-stable 2/3"
+
+cancel-pipeline-test-linux-stable3:
+  extends:                         .cancel-pipeline-template
+  needs:
+    - job:                         "test-linux-stable 3/3"
+
+cancel-pipeline-cargo-check-benches1:
+  extends:                         .cancel-pipeline-template
+  needs:
+    - job:                         "cargo-check-benches 1/2"
+
+cancel-pipeline-cargo-check-benches2:
+  extends:                         .cancel-pipeline-template
+  needs:
+    - job:                         "cargo-check-benches 2/2"
 
 cancel-pipeline-test-linux-stable-int:
   extends:                         .cancel-pipeline-template
@@ -285,11 +305,6 @@ cancel-pipeline-cargo-check-subkey:
   extends:                         .cancel-pipeline-template
   needs:
     - job:                         cargo-check-subkey
-
-cancel-pipeline-cargo-check-benches:
-  extends:                         .cancel-pipeline-template
-  needs:
-    - job:                         cargo-check-benches
 
 cancel-pipeline-check-tracing:
   extends:                         .cancel-pipeline-template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -253,7 +253,7 @@ rusty-cachier-notify:
 # This job cancels the whole pipeline if any of provided jobs fail.
 # In a DAG, every jobs chain is executed independently of others. The `fail_fast` principle suggests
 # to fail the pipeline as soon as possible to shorten the feedback loop.
-.cancel-pipeline:
+.cancel-pipeline-template:
   stage:                           .post
   needs:
     - job:                         test-linux-stable

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -266,7 +266,7 @@ rusty-cachier-notify:
     PR_NUM:                        "${PR_NUM}"
   trigger:
     project:                       "parity/infrastructure/ci_cd/pipeline-stopper"
-    # remove branch, when pipeline-stopper for substrate and polakdot is updated to the same branch
+    # remove branch, when pipeline-stopper for polakdot is updated to the same branch
     branch:                        "as-improve"
 
 # need to copy jobs this way because otherwise gitlab will wait

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -61,10 +61,12 @@ cargo-check-benches:
     - .docker-env
     - .test-refs
     - .collect-artifacts
+    - .pipeline-stopper-artifacts
   before_script:
     # perform rusty-cachier operations before any further modifications to the git repo to make cargo feel cheated not so much
     - !reference [.rust-info-script, script]
     - !reference [.rusty-cachier, before_script]
+    - !reference [.pipeline-stopper-vars, script]
     # merges in the master branch on PRs
     - if [ $CI_COMMIT_REF_NAME != "master" ]; then
         git fetch origin +master:master;
@@ -131,6 +133,7 @@ cargo-check-subkey:
   extends:
     - .docker-env
     - .test-refs
+    - .pipeline-stopper-artifacts
   script:
     - rusty-cachier snapshot create
     - cd ./bin/utils/subkey
@@ -199,6 +202,7 @@ test-linux-stable:
   extends:
     - .docker-env
     - .test-refs
+    - .pipeline-stopper-artifacts
   variables:
     # Enable debug assertions since we are running optimized builds for testing
     # but still want to have debug assertions.
@@ -299,6 +303,7 @@ test-linux-stable-int:
   extends:
     - .docker-env
     - .test-refs
+    - .pipeline-stopper-artifacts
   variables:
     # Enable debug assertions since we are running optimized builds for testing
     # but still want to have debug assertions.
@@ -328,6 +333,7 @@ check-tracing:
   extends:
     - .docker-env
     - .test-refs
+    - .pipeline-stopper-artifacts
   script:
     - rusty-cachier snapshot create
     # with-tracing must be explicitly activated, we run a test to ensure this works as expected in both cases

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -335,7 +335,6 @@ check-tracing:
     - .test-refs
     - .pipeline-stopper-artifacts
   script:
-    - exit 1
     - rusty-cachier snapshot create
     # with-tracing must be explicitly activated, we run a test to ensure this works as expected in both cases
     - time cargo +nightly test --manifest-path ./primitives/tracing/Cargo.toml --no-default-features

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -135,6 +135,7 @@ cargo-check-subkey:
     - .test-refs
     - .pipeline-stopper-artifacts
   script:
+    - exit 1
     - rusty-cachier snapshot create
     - cd ./bin/utils/subkey
     - SKIP_WASM_BUILD=1 time cargo check --release
@@ -314,7 +315,6 @@ test-linux-stable-int:
     # Ensure we run the UI tests.
     RUN_UI_TESTS:                  1
   script:
-    - exit 1
     - rusty-cachier snapshot create
     - WASM_BUILD_NO_COLOR=1
       RUST_LOG=sync=trace,consensus=trace,client=trace,state-db=trace,db=trace,forks=trace,state_db=trace,storage_cache=trace

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -83,7 +83,6 @@ cargo-check-benches:
     - echo "___Running benchmarks___";
     - case ${CI_NODE_INDEX} in
         1)
-          exit 1
           SKIP_WASM_BUILD=1 time cargo +nightly check --benches --all;
           cargo run --release -p node-bench -- ::trie::read::small --json
             | tee ./artifacts/benches/$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA/::trie::read::small.json;
@@ -91,6 +90,7 @@ cargo-check-benches:
           rusty-cachier cache upload
           ;;
         2)
+          exit 1
           cargo run --release -p node-bench -- ::node::import::native::sr25519::transfer_keep_alive::paritydb::small --json
             | tee ./artifacts/benches/$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA/::node::import::native::sr25519::transfer_keep_alive::paritydb::small.json
           ;;

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -90,7 +90,6 @@ cargo-check-benches:
           rusty-cachier cache upload
           ;;
         2)
-          exit 1
           cargo run --release -p node-bench -- ::node::import::native::sr25519::transfer_keep_alive::paritydb::small --json
             | tee ./artifacts/benches/$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA/::node::import::native::sr25519::transfer_keep_alive::paritydb::small.json
           ;;
@@ -315,6 +314,7 @@ test-linux-stable-int:
     # Ensure we run the UI tests.
     RUN_UI_TESTS:                  1
   script:
+    - exit 1
     - rusty-cachier snapshot create
     - WASM_BUILD_NO_COLOR=1
       RUST_LOG=sync=trace,consensus=trace,client=trace,state-db=trace,db=trace,forks=trace,state_db=trace,storage_cache=trace

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -216,7 +216,7 @@ test-linux-stable:
     CI_JOB_NAME:                   "test-linux-stable"
   parallel: 3
   script:
-    - if [[ ${CI_NODE_INDEX} == "2" ]]; then exit 1; fi
+    - if [[ ${CI_NODE_INDEX} == "3" ]]; then exit 1; fi
     - rusty-cachier snapshot create
     # this job runs all tests in former runtime-benchmarks, frame-staking and wasmtime tests
     # tests are partitioned by nextest and executed in parallel on $CI_NODE_TOTAL runners

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -216,7 +216,7 @@ test-linux-stable:
     CI_JOB_NAME:                   "test-linux-stable"
   parallel: 3
   script:
-    - if [[ ${CI_NODE_INDEX} == "1" ]]; then exit 1; fi
+    - if [[ ${CI_NODE_INDEX} == "2" ]]; then exit 1; fi
     - rusty-cachier snapshot create
     # this job runs all tests in former runtime-benchmarks, frame-staking and wasmtime tests
     # tests are partitioned by nextest and executed in parallel on $CI_NODE_TOTAL runners

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -83,6 +83,7 @@ cargo-check-benches:
     - echo "___Running benchmarks___";
     - case ${CI_NODE_INDEX} in
         1)
+          exit 1
           SKIP_WASM_BUILD=1 time cargo +nightly check --benches --all;
           cargo run --release -p node-bench -- ::trie::read::small --json
             | tee ./artifacts/benches/$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA/::trie::read::small.json;
@@ -216,7 +217,6 @@ test-linux-stable:
     CI_JOB_NAME:                   "test-linux-stable"
   parallel: 3
   script:
-    - if [[ ${CI_NODE_INDEX} == "3" ]]; then exit 1; fi
     - rusty-cachier snapshot create
     # this job runs all tests in former runtime-benchmarks, frame-staking and wasmtime tests
     # tests are partitioned by nextest and executed in parallel on $CI_NODE_TOTAL runners

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -335,6 +335,7 @@ check-tracing:
     - .test-refs
     - .pipeline-stopper-artifacts
   script:
+    - exit 1
     - rusty-cachier snapshot create
     # with-tracing must be explicitly activated, we run a test to ensure this works as expected in both cases
     - time cargo +nightly test --manifest-path ./primitives/tracing/Cargo.toml --no-default-features

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -216,6 +216,7 @@ test-linux-stable:
     CI_JOB_NAME:                   "test-linux-stable"
   parallel: 3
   script:
+    - if [[ ${CI_NODE_INDEX} == "1" ]]; then exit 1; fi
     - rusty-cachier snapshot create
     # this job runs all tests in former runtime-benchmarks, frame-staking and wasmtime tests
     # tests are partitioned by nextest and executed in parallel on $CI_NODE_TOTAL runners

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -135,7 +135,6 @@ cargo-check-subkey:
     - .test-refs
     - .pipeline-stopper-artifacts
   script:
-    - exit 1
     - rusty-cachier snapshot create
     - cd ./bin/utils/subkey
     - SKIP_WASM_BUILD=1 time cargo check --release


### PR DESCRIPTION
The PR improves `cancel-pipeline` job. It posts a message in PR when the one of the `Required` jobs is broken. See examples below. 

cc https://github.com/paritytech/ci_cd/issues/548