### PR TITLE
Fix broken links in `polkadot --help`

### DIFF
--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -54,7 +54,7 @@ pub struct RunCmd {
 	///
 	/// Default is local. Note: not all RPC methods are safe to be exposed publicly. Use an RPC
 	/// proxy server to filter out dangerous methods. More details:
-	/// <https://docs.substrate.io/v3/runtime/custom-rpcs/#public-rpcs>.
+	/// <https://docs.substrate.io/main-docs/build/custom-rpc/#public-rpcs>.
 	/// Use `--unsafe-rpc-external` to suppress the warning if you understand the risks.
 	#[clap(long)]
 	pub rpc_external: bool,
@@ -85,7 +85,7 @@ pub struct RunCmd {
 	///
 	/// Default is local. Note: not all RPC methods are safe to be exposed publicly. Use an RPC
 	/// proxy server to filter out dangerous methods. More details:
-	/// <https://docs.substrate.io/v3/runtime/custom-rpcs/#public-rpcs>.
+	/// <https://docs.substrate.io/main-docs/build/custom-rpc/#public-rpcs>.
 	/// Use `--unsafe-ws-external` to suppress the warning if you understand the risks.
 	#[clap(long)]
 	pub ws_external: bool,


### PR DESCRIPTION
https://docs.substrate.io/v3/runtime/custom-rpcs/#public-rpcs is broken, I believe the correct link is now https://docs.substrate.io/main-docs/build/custom-rpc/#public-rpcs