### PR TITLE
better benchmark log

### DIFF
--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -1054,7 +1054,9 @@ macro_rules! impl_benchmark {
 					// Time the extrinsic logic.
 					$crate::log::trace!(
 						target: "benchmark",
-						"Start Benchmark: {:?}", c
+						"Start Benchmark: {:?} ({:?})",
+						extrinsic,
+						c
 					);
 
 					let start_pov = $crate::benchmarking::proof_size();

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -1054,7 +1054,7 @@ macro_rules! impl_benchmark {
 					// Time the extrinsic logic.
 					$crate::log::trace!(
 						target: "benchmark",
-						"Start Benchmark: {:?} ({:?})",
+						"Start Benchmark: {} ({:?})",
 						extrinsic,
 						c
 					);


### PR DESCRIPTION
Actually adding the name of the benchmark to the log:


For example:

```
2022-08-12 13:27:56.886 TRACE main benchmark: End Benchmark: 930000 ns    
2022-08-12 13:27:56.886 TRACE main benchmark: Read/Write Count (4, 0, 4, 0)    
2022-08-12 13:27:56.968 TRACE main benchmark: Start Benchmark: one_fewer_deciding_failing ([])    
2022-08-12 13:27:56.969 TRACE main benchmark: End Benchmark: 804000 ns    
2022-08-12 13:27:56.969 TRACE main benchmark: Read/Write Count (0, 0, 0, 0)    
2022-08-12 13:27:57.048 TRACE main benchmark: Start Benchmark: one_fewer_deciding_passing ([])
```