### PR TITLE
benchmark-cli: add child tree support

### DIFF
--- a/bin/node/cli/tests/benchmark_storage_works.rs
+++ b/bin/node/cli/tests/benchmark_storage_works.rs
@@ -47,6 +47,7 @@ fn benchmark_storage(db: &str, base_path: &Path) -> ExitStatus {
 		.args(["--state-version", "1"])
 		.args(["--warmups", "0"])
 		.args(["--add", "100", "--mul", "1.2", "--metric", "p75"])
+		.arg("--include-child-trees")
 		.status()
 		.unwrap()
 }

--- a/utils/frame/benchmarking-cli/src/storage/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/storage/cmd.rs
@@ -99,6 +99,10 @@ pub struct StorageParams {
 	/// State cache size.
 	#[clap(long, default_value = "0")]
 	pub state_cache_size: usize,
+
+	/// Include child trees in benchmark.
+	#[clap(long)]
+	pub include_child: bool,
 }
 
 impl StorageCmd {
@@ -171,7 +175,7 @@ impl StorageCmd {
 
 		for i in 0..self.params.warmups {
 			info!("Warmup round {}/{}", i + 1, self.params.warmups);
-			for key in keys.clone() {
+			for key in keys.as_slice() {
 				let _ = client
 					.storage(&block, &key)
 					.expect("Checked above to exist")

--- a/utils/frame/benchmarking-cli/src/storage/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/storage/cmd.rs
@@ -24,7 +24,7 @@ use sp_core::storage::StorageKey;
 use sp_database::{ColumnId, Database};
 use sp_runtime::traits::{Block as BlockT, HashFor};
 use sp_state_machine::Storage;
-use sp_storage::StateVersion;
+use sp_storage::{ChildInfo, ChildType, PrefixedStorageKey, StateVersion};
 
 use clap::{Args, Parser};
 use log::info;
@@ -102,7 +102,7 @@ pub struct StorageParams {
 
 	/// Include child trees in benchmark.
 	#[clap(long)]
-	pub include_child: bool,
+	pub include_child_trees: bool,
 }
 
 impl StorageCmd {
@@ -157,6 +157,16 @@ impl StorageCmd {
 			1 => StateVersion::V1,
 			_ => unreachable!("Clap set to only allow 0 and 1"),
 		}
+	}
+
+	/// Returns Some if child node and None if regular
+	pub(crate) fn is_child_key(&self, key: Vec<u8>) -> Option<ChildInfo> {
+		if let Some((ChildType::ParentKeyId, storage_key)) =
+			ChildType::from_prefixed_key(&PrefixedStorageKey::new(key))
+		{
+			return Some(ChildInfo::new_default(storage_key))
+		}
+		None
 	}
 
 	/// Run some rounds of the (read) benchmark as warmup.

--- a/utils/frame/benchmarking-cli/src/storage/write.rs
+++ b/utils/frame/benchmarking-cli/src/storage/write.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 use sc_cli::Result;
-use sc_client_api::UsageProvider;
+use sc_client_api::{Backend as ClientBackend, StorageProvider, UsageProvider};
 use sc_client_db::{DbHash, DbState};
 use sp_api::StateBackend;
 use sp_blockchain::HeaderBackend;
@@ -29,7 +29,12 @@ use sp_trie::PrefixedMemoryDB;
 
 use log::{info, trace};
 use rand::prelude::*;
-use std::{fmt::Debug, sync::Arc, time::Instant};
+use sp_storage::{well_known_keys::DEFAULT_CHILD_STORAGE_KEY_PREFIX, ChildInfo, StateVersion};
+use std::{
+	fmt::Debug,
+	sync::Arc,
+	time::{Duration, Instant},
+};
 
 use super::cmd::StorageCmd;
 use crate::shared::{new_rng, BenchRecord};
@@ -37,7 +42,7 @@ use crate::shared::{new_rng, BenchRecord};
 impl StorageCmd {
 	/// Benchmarks the time it takes to write a single Storage item.
 	/// Uses the latest state that is available for the given client.
-	pub(crate) fn bench_write<Block, H, C>(
+	pub(crate) fn bench_write<Block, BA, H, C>(
 		&self,
 		client: Arc<C>,
 		(db, state_col): (Arc<dyn sp_database::Database<DbHash>>, ColumnId),
@@ -46,7 +51,8 @@ impl StorageCmd {
 	where
 		Block: BlockT<Header = H, Hash = DbHash> + Debug,
 		H: HeaderT<Hash = DbHash>,
-		C: UsageProvider<Block> + HeaderBackend<Block>,
+		BA: ClientBackend<Block>,
+		C: UsageProvider<Block> + HeaderBackend<Block> + StorageProvider<Block, BA>,
 	{
 		// Store the time that it took to write each value.
 		let mut record = BenchRecord::default();
@@ -62,49 +68,102 @@ impl StorageCmd {
 		let (mut rng, _) = new_rng(None);
 		kvs.shuffle(&mut rng);
 
+		let mut child_tries = Vec::new();
+
 		// Generate all random values first; Make sure there are no collisions with existing
 		// db entries, so we can rollback all additions without corrupting existing entries.
 		for (k, original_v) in kvs.iter_mut() {
+			if self.params.include_child && k.starts_with(DEFAULT_CHILD_STORAGE_KEY_PREFIX) {
+				child_tries.push(k.clone());
+			}
+
 			'retry: loop {
 				let mut new_v = vec![0; original_v.len()];
-				// Create a random value to overwrite with.
-				// NOTE: We use a possibly higher entropy than the original value,
-				// could be improved but acts as an over-estimation which is fine for now.
+				// 	// Create a random value to overwrite with.
+				// 	// NOTE: We use a possibly higher entropy than the original value,
+				// 	// could be improved but acts as an over-estimation which is fine for now.
 				rng.fill_bytes(&mut new_v[..]);
-				let new_kv = vec![(k.as_ref(), Some(new_v.as_ref()))];
-				let (_, mut stx) = trie.storage_root(new_kv.iter().cloned(), self.state_version());
-				for (mut k, (_, rc)) in stx.drain().into_iter() {
-					if rc > 0 {
-						db.sanitize_key(&mut k);
-						if db.get(state_col, &k).is_some() {
-							trace!("Benchmark-store key creation: Key collision detected, retry");
-							continue 'retry
-						}
-					}
+				match check_new_value::<Block>(
+					db.clone(),
+					&trie,
+					&k.to_vec(),
+					&new_v,
+					self.state_version(),
+					state_col,
+					None,
+				) {
+					true => {
+						*original_v = new_v;
+						break
+					},
+					false => continue 'retry,
 				}
-				*original_v = new_v;
-				break
 			}
 		}
 
 		info!("Writing {} keys", kvs.len());
 		// Write each value in one commit.
 		for (k, new_v) in kvs.iter() {
-			// Interesting part here:
-			let start = Instant::now();
-			// Create a TX that will modify the Trie in the DB and
-			// calculate the root hash of the Trie after the modification.
-			let replace = vec![(k.as_ref(), Some(new_v.as_ref()))];
-			let (_, stx) = trie.storage_root(replace.iter().cloned(), self.state_version());
-			// Only the keep the insertions, since we do not want to benchmark pruning.
-			let tx = convert_tx::<Block>(db.clone(), stx.clone(), false, state_col);
-			db.commit(tx).map_err(|e| format!("Writing to the Database: {}", e))?;
-			record.append(new_v.len(), start.elapsed())?;
-
-			// Now undo the changes by removing what was added.
-			let tx = convert_tx::<Block>(db.clone(), stx.clone(), true, state_col);
-			db.commit(tx).map_err(|e| format!("Writing to the Database: {}", e))?;
+			let res = calculate_bench::<Block>(
+				db.clone(),
+				&trie,
+				k.to_vec(),
+				new_v.to_vec(),
+				self.state_version(),
+				state_col,
+				None,
+			)?;
+			record.append(res.0, res.1)?;
 		}
+
+		if self.params.include_child {
+			info!("Writing {} child trees", child_tries.len());
+
+			for key in child_tries {
+				let trie_id = key
+					.strip_prefix(DEFAULT_CHILD_STORAGE_KEY_PREFIX)
+					.expect("Checked above to exist");
+				let info = ChildInfo::new_default(trie_id);
+				let child_keys =
+					client.child_storage_keys_iter(&block, info.clone(), None, None)?;
+
+				for ck in child_keys {
+					if let Some(original_v) = client
+						.child_storage(&block, &info.clone(), &ck)
+						.expect("Checked above to exist")
+					{
+						let mut new_v = vec![0; original_v.0.len()];
+						'child_retry: loop {
+							rng.fill_bytes(&mut new_v[..]);
+							match check_new_value::<Block>(
+								db.clone(),
+								&trie,
+								&ck.0,
+								&new_v,
+								self.state_version(),
+								state_col,
+								Some(&info),
+							) {
+								true => break,
+								false => continue 'child_retry,
+							}
+						}
+
+						let res = calculate_bench::<Block>(
+							db.clone(),
+							&trie,
+							ck.0,
+							new_v.to_vec(),
+							self.state_version(),
+							state_col,
+							Some(&info),
+						)?;
+						record.append(res.0, res.1)?;
+					}
+				}
+			}
+		}
+
 		Ok(record)
 	}
 }
@@ -133,4 +192,71 @@ fn convert_tx<B: BlockT>(
 		// 0 means no modification.
 	}
 	ret
+}
+
+/// Calculates and returns benchmark params
+/// if `child_info` exist then it means this is a child tree key
+fn calculate_bench<Block: BlockT>(
+	db: Arc<dyn sp_database::Database<DbHash>>,
+	trie: &DbState<Block>,
+	key: Vec<u8>,
+	new_v: Vec<u8>,
+	version: StateVersion,
+	col: ColumnId,
+	child_info: Option<&ChildInfo>,
+) -> Result<(usize, Duration)> {
+	let start = Instant::now();
+	// Create a TX that will modify the Trie in the DB and
+	// calculate the root hash of the Trie after the modification.
+	let replace = vec![(key.as_ref(), Some(new_v.as_ref()))];
+	let stx;
+	if let Some(info) = child_info {
+		let (_, _, stx1) = trie.child_storage_root(info, replace.iter().cloned(), version);
+		stx = stx1;
+	} else {
+		let (_, stx2) = trie.storage_root(replace.iter().cloned(), version);
+		stx = stx2;
+	}
+	// Only the keep the insertions, since we do not want to benchmark pruning.
+	let tx = convert_tx::<Block>(db.clone(), stx.clone(), false, col);
+	db.commit(tx).map_err(|e| format!("Writing to the Database: {}", e))?;
+	let result = (new_v.len(), start.elapsed());
+
+	// Now undo the changes by removing what was added.
+	let tx = convert_tx::<Block>(db.clone(), stx.clone(), true, col);
+	db.commit(tx).map_err(|e| format!("Writing to the Database: {}", e))?;
+	Ok(result)
+}
+
+/// Checks if a new value causes any collision in tree updates
+/// returns true if there is no collision
+/// if `child_info` exist then it means this is a child tree key
+fn check_new_value<Block: BlockT>(
+	db: Arc<dyn sp_database::Database<DbHash>>,
+	trie: &DbState<Block>,
+	key: &Vec<u8>,
+	new_v: &Vec<u8>,
+	version: StateVersion,
+	col: ColumnId,
+	child_info: Option<&ChildInfo>,
+) -> bool {
+	let new_kv = vec![(key.as_ref(), Some(new_v.as_ref()))];
+	let mut stx;
+	if let Some(info) = child_info {
+		let (_, _, stx1) = trie.child_storage_root(&info, new_kv.iter().cloned(), version);
+		stx = stx1;
+	} else {
+		let (_, stx2) = trie.storage_root(new_kv.iter().cloned(), version);
+		stx = stx2;
+	}
+	for (mut k, (_, rc)) in stx.drain().into_iter() {
+		if rc > 0 {
+			db.sanitize_key(&mut k);
+			if db.get(col, &k).is_some() {
+				trace!("Benchmark-store key creation: Key collision detected, retry");
+				return false
+			}
+		}
+	}
+	true
 }

--- a/utils/frame/benchmarking-cli/src/storage/write.rs
+++ b/utils/frame/benchmarking-cli/src/storage/write.rs
@@ -79,9 +79,9 @@ impl StorageCmd {
 
 			'retry: loop {
 				let mut new_v = vec![0; original_v.len()];
-				// 	// Create a random value to overwrite with.
-				// 	// NOTE: We use a possibly higher entropy than the original value,
-				// 	// could be improved but acts as an over-estimation which is fine for now.
+				// Create a random value to overwrite with.
+				// NOTE: We use a possibly higher entropy than the original value,
+				// could be improved but acts as an over-estimation which is fine for now.
 				rng.fill_bytes(&mut new_v[..]);
 				match check_new_value::<Block>(
 					db.clone(),


### PR DESCRIPTION
We are using child trees extensively in our blockchain (Frequency) and to be able to evaluate feasibility/scalability of some of these implementations we need to have a better understanding in weight calculations for these nodes that are included in child trees.

### What is included?
- added a feature flag `include-child` to include child tree nodes in storage benchmark calculations
- refactored `write.rs`

### Tasks

- [ ]  Modified benchmark-cli storage tool to support child tree nodes 


### Questions
- is there any need for polkadot or cumulus companion PRs?

### Execution example

![Screen Shot 2022-08-11 at 4 50 51 PM](https://user-images.githubusercontent.com/9152501/184425162-3f965378-b828-4754-8d07-b1799d59b00b.png)

