### PR TITLE
adds EncodeLike Slice for BoundedVec

### DIFF
--- a/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.stderr
+++ b/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.stderr
@@ -28,7 +28,7 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
              <&[(T,)] as EncodeLike<BinaryHeap<LikeT>>>
              <&[(T,)] as EncodeLike<LinkedList<LikeT>>>
              <&[T] as EncodeLike<Vec<U>>>
-           and 278 others
+           and 279 others
    = note: required because of the requirements on the impl of `FullEncode` for `Bar`
    = note: required because of the requirements on the impl of `FullCodec` for `Bar`
    = note: required because of the requirements on the impl of `PartialStorageInfoTrait` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`

--- a/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.stderr
+++ b/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.stderr
@@ -103,7 +103,7 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
              <&[(T,)] as EncodeLike<BinaryHeap<LikeT>>>
              <&[(T,)] as EncodeLike<LinkedList<LikeT>>>
              <&[T] as EncodeLike<Vec<U>>>
-           and 278 others
+           and 279 others
    = note: required because of the requirements on the impl of `FullEncode` for `Bar`
    = note: required because of the requirements on the impl of `FullCodec` for `Bar`
    = note: required because of the requirements on the impl of `StorageEntryMetadataBuilder` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`

--- a/primitives/runtime/src/bounded/bounded_vec.rs
+++ b/primitives/runtime/src/bounded/bounded_vec.rs
@@ -290,10 +290,10 @@ impl<T: Decode, S: Get<u32>> Decode for BoundedVec<T, S> {
 	}
 }
 
-// `BoundedVec`s encode to something which will always decode as a `Vec`.
+// `BoundedVec` encode to something which will always decode as a `Vec`.
 impl<T: Encode + Decode, S: Get<u32>> EncodeLike<Vec<T>> for BoundedVec<T, S> {}
 
-// `BoundedVec encodes to something which will always decode as a `Slice`.
+// `BoundedVec` encodes to something which will always decode as a `Slice`.
 impl<T: Encode + Decode, S: Get<u32>> EncodeLike<&[T]> for BoundedVec<T, S> {}
 
 impl<T, S> BoundedVec<T, S> {

--- a/primitives/runtime/src/bounded/bounded_vec.rs
+++ b/primitives/runtime/src/bounded/bounded_vec.rs
@@ -293,6 +293,9 @@ impl<T: Decode, S: Get<u32>> Decode for BoundedVec<T, S> {
 // `BoundedVec`s encode to something which will always decode as a `Vec`.
 impl<T: Encode + Decode, S: Get<u32>> EncodeLike<Vec<T>> for BoundedVec<T, S> {}
 
+// `BoundedVec encodes to something which will always decode as a `Slice`.
+impl<T: Encode + Decode, S: Get<u32>> EncodeLike<&[T]> for BoundedVec<T, S> {}
+
 impl<T, S> BoundedVec<T, S> {
 	/// Create `Self` from `t` without any checks.
 	fn unchecked_from(t: Vec<T>) -> Self {


### PR DESCRIPTION
Motivation is that it seems like `&[T]` should be able to read storage for key values of `BoundedVec<T, S>`