### PR TITLE
Fix Origins Used in Runtime Benchmarks

### DIFF
--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -910,7 +910,7 @@ macro_rules! impl_bench_name_tests {
 // Every variant must implement [`BenchmarkingSetup`].
 //
 // ```nocompile
-//
+// 
 // struct Transfer;
 // impl BenchmarkingSetup for Transfer { ... }
 //

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -547,7 +547,7 @@ macro_rules! benchmarks_iter {
 		( $( $names:tt )* )
 		( $( $names_extra:tt )* )
 		( $( $names_skip_meta:tt )* )
-		$name:ident { $( $code:tt )* }: _ ( $origin:expr $( , $arg:expr )* )
+		$name:ident { $( $code:tt )* }: _ $(<$origin_type:ty>)? ( $origin:expr $( , $arg:expr )* )
 		$( $rest:tt )*
 	) => {
 		$crate::benchmarks_iter! {
@@ -557,7 +557,7 @@ macro_rules! benchmarks_iter {
 			( $( $names )* )
 			( $( $names_extra )* )
 			( $( $names_skip_meta )* )
-			$name { $( $code )* }: _ ( $origin $( , $arg )* )
+			$name { $( $code )* }: _ $(<$origin_type>)? ( $origin $( , $arg )* )
 			verify { }
 			$( $rest )*
 		}
@@ -570,7 +570,7 @@ macro_rules! benchmarks_iter {
 		( $( $names:tt )* )
 		( $( $names_extra:tt )* )
 		( $( $names_skip_meta:tt )* )
-		$name:ident { $( $code:tt )* }: $dispatch:ident ( $origin:expr $( , $arg:expr )* )
+		$name:ident { $( $code:tt )* }: $dispatch:ident $(<$origin_type:ty>)? ( $origin:expr $( , $arg:expr )* )
 		$( $rest:tt )*
 	) => {
 		$crate::benchmarks_iter! {
@@ -580,7 +580,7 @@ macro_rules! benchmarks_iter {
 			( $( $names )* )
 			( $( $names_extra )* )
 			( $( $names_skip_meta )* )
-			$name { $( $code )* }: $dispatch ( $origin $( , $arg )* )
+			$name { $( $code )* }: $dispatch $(<$origin_type>)? ( $origin $( , $arg )* )
 			verify { }
 			$( $rest )*
 		}
@@ -593,7 +593,7 @@ macro_rules! benchmarks_iter {
 		( $( $names:tt )* )
 		( $( $names_extra:tt )* )
 		( $( $names_skip_meta:tt )* )
-		$name:ident { $( $code:tt )* }: $eval:block
+		$name:ident { $( $code:tt )* }: $(<$origin_type:ty>)? $eval:block
 		$( $rest:tt )*
 	) => {
 		$crate::benchmarks_iter!(
@@ -603,7 +603,7 @@ macro_rules! benchmarks_iter {
 			( $( $names )* )
 			( $( $names_extra )* )
 			( $( $names_skip_meta )* )
-			$name { $( $code )* }: $eval
+			$name { $( $code )* }: $(<$origin_type>)? $eval
 			verify { }
 			$( $rest )*
 		);
@@ -910,7 +910,7 @@ macro_rules! impl_bench_name_tests {
 // Every variant must implement [`BenchmarkingSetup`].
 //
 // ```nocompile
-// 
+//
 // struct Transfer;
 // impl BenchmarkingSetup for Transfer { ... }
 //

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -617,7 +617,7 @@ macro_rules! to_origin {
 		$origin.into()
 	};
 	($origin:expr, $origin_type:ty) => {
-		<T::Origin as From<$origin_type>>::from($origin)
+		<<T as frame_system::Config>::Origin as From<$origin_type>>::from($origin)
 	};
 }
 

--- a/frame/bounties/src/benchmarking.rs
+++ b/frame/bounties/src/benchmarking.rs
@@ -100,7 +100,8 @@ benchmarks_instance_pallet! {
 		let (caller, curator, fee, value, reason) = setup_bounty::<T, I>(0, T::MaximumReasonLength::get());
 		Bounties::<T, I>::propose_bounty(RawOrigin::Signed(caller).into(), value, reason)?;
 		let bounty_id = BountyCount::<T, I>::get() - 1;
-	}: _(RawOrigin::Root, bounty_id)
+		let approve_origin = T::ApproveOrigin::successful_origin();
+	}: _<T::Origin>(approve_origin, bounty_id)
 
 	propose_curator {
 		setup_pot_account::<T, I>();

--- a/frame/bounties/src/benchmarking.rs
+++ b/frame/bounties/src/benchmarking.rs
@@ -37,7 +37,8 @@ fn create_approved_bounties<T: Config<I>, I: 'static>(n: u32) -> Result<(), &'st
 			setup_bounty::<T, I>(i, T::MaximumReasonLength::get());
 		Bounties::<T, I>::propose_bounty(RawOrigin::Signed(caller).into(), value, reason)?;
 		let bounty_id = BountyCount::<T, I>::get() - 1;
-		Bounties::<T, I>::approve_bounty(RawOrigin::Root.into(), bounty_id)?;
+		let approve_origin = T::ApproveOrigin::successful_origin();
+		Bounties::<T, I>::approve_bounty(approve_origin, bounty_id)?;
 	}
 	ensure!(BountyApprovals::<T, I>::get().len() == n as usize, "Not all bounty approved");
 	Ok(())
@@ -67,14 +68,10 @@ fn create_bounty<T: Config<I>, I: 'static>(
 	let curator_lookup = T::Lookup::unlookup(curator.clone());
 	Bounties::<T, I>::propose_bounty(RawOrigin::Signed(caller).into(), value, reason)?;
 	let bounty_id = BountyCount::<T, I>::get() - 1;
-	Bounties::<T, I>::approve_bounty(RawOrigin::Root.into(), bounty_id)?;
+	let approve_origin = T::ApproveOrigin::successful_origin();
+	Bounties::<T, I>::approve_bounty(approve_origin.clone(), bounty_id)?;
 	Treasury::<T, I>::on_initialize(T::BlockNumber::zero());
-	Bounties::<T, I>::propose_curator(
-		RawOrigin::Root.into(),
-		bounty_id,
-		curator_lookup.clone(),
-		fee,
-	)?;
+	Bounties::<T, I>::propose_curator(approve_origin, bounty_id, curator_lookup.clone(), fee)?;
 	Bounties::<T, I>::accept_curator(RawOrigin::Signed(curator).into(), bounty_id)?;
 	Ok((curator_lookup, bounty_id))
 }
@@ -109,9 +106,11 @@ benchmarks_instance_pallet! {
 		let curator_lookup = T::Lookup::unlookup(curator);
 		Bounties::<T, I>::propose_bounty(RawOrigin::Signed(caller).into(), value, reason)?;
 		let bounty_id = BountyCount::<T, I>::get() - 1;
-		Bounties::<T, I>::approve_bounty(RawOrigin::Root.into(), bounty_id)?;
+		let approve_origin = T::ApproveOrigin::successful_origin();
+		Bounties::<T, I>::approve_bounty(approve_origin, bounty_id)?;
 		Treasury::<T, I>::on_initialize(T::BlockNumber::zero());
-	}: _(RawOrigin::Root, bounty_id, curator_lookup, fee)
+		let approve_origin = T::ApproveOrigin::successful_origin();
+	}: _<T::Origin>(approve_origin, bounty_id, curator_lookup, fee)
 
 	// Worst case when curator is inactive and any sender unassigns the curator.
 	unassign_curator {
@@ -129,9 +128,10 @@ benchmarks_instance_pallet! {
 		let curator_lookup = T::Lookup::unlookup(curator.clone());
 		Bounties::<T, I>::propose_bounty(RawOrigin::Signed(caller).into(), value, reason)?;
 		let bounty_id = BountyCount::<T, I>::get() - 1;
-		Bounties::<T, I>::approve_bounty(RawOrigin::Root.into(), bounty_id)?;
+		let approve_origin = T::ApproveOrigin::successful_origin();
+		Bounties::<T, I>::approve_bounty(approve_origin.clone(), bounty_id)?;
 		Treasury::<T, I>::on_initialize(T::BlockNumber::zero());
-		Bounties::<T, I>::propose_curator(RawOrigin::Root.into(), bounty_id, curator_lookup, fee)?;
+		Bounties::<T, I>::propose_curator(approve_origin, bounty_id, curator_lookup, fee)?;
 	}: _(RawOrigin::Signed(curator), bounty_id)
 
 	award_bounty {
@@ -170,14 +170,16 @@ benchmarks_instance_pallet! {
 		let (caller, curator, fee, value, reason) = setup_bounty::<T, I>(0, 0);
 		Bounties::<T, I>::propose_bounty(RawOrigin::Signed(caller).into(), value, reason)?;
 		let bounty_id = BountyCount::<T, I>::get() - 1;
-	}: close_bounty(RawOrigin::Root, bounty_id)
+		let approve_origin = T::ApproveOrigin::successful_origin();
+	}: close_bounty<T::Origin>(approve_origin, bounty_id)
 
 	close_bounty_active {
 		setup_pot_account::<T, I>();
 		let (curator_lookup, bounty_id) = create_bounty::<T, I>()?;
 		Treasury::<T, I>::on_initialize(T::BlockNumber::zero());
 		let bounty_id = BountyCount::<T, I>::get() - 1;
-	}: close_bounty(RawOrigin::Root, bounty_id)
+		let approve_origin = T::ApproveOrigin::successful_origin();
+	}: close_bounty<T::Origin>(approve_origin, bounty_id)
 	verify {
 		assert_last_event::<T, I>(Event::BountyCanceled { index: bounty_id }.into())
 	}

--- a/frame/democracy/src/benchmarking.rs
+++ b/frame/democracy/src/benchmarking.rs
@@ -318,7 +318,9 @@ benchmarks! {
 		for i in 0 .. p {
 			add_proposal::<T>(i)?;
 		}
-	}: _(RawOrigin::Root, 0)
+
+		let cancel_origin = T::CancelProposalOrigin::successful_origin();
+	}: _<T::Origin>(cancel_origin, 0)
 
 	cancel_referendum {
 		let referendum_index = add_referendum::<T>(0)?;

--- a/frame/scheduler/src/benchmarking.rs
+++ b/frame/scheduler/src/benchmarking.rs
@@ -32,6 +32,8 @@ use frame_system::Pallet as System;
 
 const BLOCK_NUMBER: u32 = 2;
 
+type SystemOrigin<T> = <T as frame_system::Config>::Origin;
+
 /// Add `n` named items to the schedule.
 ///
 /// For `resolved`:
@@ -210,7 +212,8 @@ benchmarks! {
 		let call = Box::new(CallOrHashOf::<T>::Value(inner_call));
 
 		fill_schedule::<T>(when, s, true, true, Some(false))?;
-	}: _(RawOrigin::Root, when, periodic, priority, call)
+		let schedule_origin = T::ScheduleOrigin::successful_origin();
+	}: _<SystemOrigin<T>>(schedule_origin, when, periodic, priority, call)
 	verify {
 		ensure!(
 			Agenda::<T>::get(when).len() == (s + 1) as usize,
@@ -224,7 +227,8 @@ benchmarks! {
 
 		fill_schedule::<T>(when, s, true, true, Some(false))?;
 		assert_eq!(Agenda::<T>::get(when).len(), s as usize);
-	}: _(RawOrigin::Root, when, 0)
+		let schedule_origin = T::ScheduleOrigin::successful_origin();
+	}: _<SystemOrigin<T>>(schedule_origin, when, 0)
 	verify {
 		ensure!(
 			Lookup::<T>::get(0.encode()).is_none(),
@@ -248,7 +252,8 @@ benchmarks! {
 		let call = Box::new(CallOrHashOf::<T>::Value(inner_call));
 
 		fill_schedule::<T>(when, s, true, true, Some(false))?;
-	}: _(RawOrigin::Root, id, when, periodic, priority, call)
+		let schedule_origin = T::ScheduleOrigin::successful_origin();
+	}: _<SystemOrigin<T>>(schedule_origin, id, when, periodic, priority, call)
 	verify {
 		ensure!(
 			Agenda::<T>::get(when).len() == (s + 1) as usize,
@@ -261,7 +266,8 @@ benchmarks! {
 		let when = BLOCK_NUMBER.into();
 
 		fill_schedule::<T>(when, s, true, true, Some(false))?;
-	}: _(RawOrigin::Root, 0.encode())
+		let schedule_origin = T::ScheduleOrigin::successful_origin();
+	}: _<SystemOrigin<T>>(schedule_origin, 0.encode())
 	verify {
 		ensure!(
 			Lookup::<T>::get(0.encode()).is_none(),

--- a/frame/scheduler/src/benchmarking.rs
+++ b/frame/scheduler/src/benchmarking.rs
@@ -23,7 +23,6 @@ use frame_support::{
 	ensure,
 	traits::{OnInitialize, PreimageProvider, PreimageRecipient},
 };
-use frame_system::RawOrigin;
 use sp_runtime::traits::Hash;
 use sp_std::{prelude::*, vec};
 

--- a/frame/staking/Cargo.toml
+++ b/frame/staking/Cargo.toml
@@ -71,6 +71,7 @@ runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-election-provider-support/runtime-benchmarks",
 	"rand_chacha",
-	"sp-staking/runtime-benchmarks"
+	"sp-staking/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/frame/staking/Cargo.toml
+++ b/frame/staking/Cargo.toml
@@ -72,6 +72,5 @@ runtime-benchmarks = [
 	"frame-election-provider-support/runtime-benchmarks",
 	"rand_chacha",
 	"sp-staking/runtime-benchmarks",
-	"frame-support/runtime-benchmarks",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/frame/tips/src/benchmarking.rs
+++ b/frame/tips/src/benchmarking.rs
@@ -190,7 +190,8 @@ benchmarks_instance_pallet! {
 		let reason_hash = T::Hashing::hash(&reason[..]);
 		let hash = T::Hashing::hash_of(&(&reason_hash, &beneficiary));
 		ensure!(Tips::<T, I>::contains_key(hash), "tip does not exist");
-	}: _(RawOrigin::Root, hash)
+		let reject_origin = T::RejectOrigin::successful_origin();
+	}: _<T::Origin>(reject_origin, hash)
 
 	impl_benchmark_test_suite!(TipsMod, crate::tests::new_test_ext(), crate::tests::Test);
 }

--- a/frame/treasury/src/benchmarking.rs
+++ b/frame/treasury/src/benchmarking.rs
@@ -99,7 +99,8 @@ benchmarks_instance_pallet! {
 			beneficiary_lookup
 		)?;
 		let proposal_id = Treasury::<T, _>::proposal_count() - 1;
-	}: _(RawOrigin::Root, proposal_id)
+		let reject_origin = T::RejectOrigin::successful_origin();
+	}: _<T::Origin>(reject_origin, proposal_id)
 
 	approve_proposal {
 		let p in 0 .. T::MaxApprovals::get() - 1;
@@ -111,7 +112,8 @@ benchmarks_instance_pallet! {
 			beneficiary_lookup
 		)?;
 		let proposal_id = Treasury::<T, _>::proposal_count() - 1;
-	}: _(RawOrigin::Root, proposal_id)
+		let approve_origin = T::ApproveOrigin::successful_origin();
+	}: _<T::Origin>(approve_origin, proposal_id)
 
 	remove_approval {
 		let (caller, value, beneficiary_lookup) = setup_proposal::<T, _>(SEED);
@@ -122,7 +124,8 @@ benchmarks_instance_pallet! {
 		)?;
 		let proposal_id = Treasury::<T, _>::proposal_count() - 1;
 		Treasury::<T, I>::approve_proposal(RawOrigin::Root.into(), proposal_id)?;
-	}: _(RawOrigin::Root, proposal_id)
+		let reject_origin = T::RejectOrigin::successful_origin();
+	}: _<T::Origin>(reject_origin, proposal_id)
 
 	on_initialize_proposals {
 		let p in 0 .. T::MaxApprovals::get();


### PR DESCRIPTION
Some benchmarks assume Root origin, instead of calling the appropriate `successful_origin`.

This fixes that.