### PR TITLE
Remove `score_update_worst_case` default impl

### DIFF
--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -519,9 +519,7 @@ pub trait SortedListProvider<AccountId> {
 	/// If `who` changes by the returned amount they are guaranteed to have a worst case change
 	/// in their list position.
 	#[cfg(feature = "runtime-benchmarks")]
-	fn score_update_worst_case(_who: &AccountId, _is_increase: bool) -> Self::Score {
-		unimplemented!();
-	}
+	fn score_update_worst_case(_who: &AccountId, _is_increase: bool) -> Self::Score;
 }
 
 /// Something that can provide the `Score` of an account. Similar to [`ElectionProvider`] and

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -519,9 +519,7 @@ pub trait SortedListProvider<AccountId> {
 	/// If `who` changes by the returned amount they are guaranteed to have a worst case change
 	/// in their list position.
 	#[cfg(feature = "runtime-benchmarks")]
-	fn score_update_worst_case(_who: &AccountId, _is_increase: bool) -> Self::Score {
-		Self::Score::max_value()
-	}
+	fn score_update_worst_case(_who: &AccountId, _is_increase: bool) -> Self::Score;
 }
 
 /// Something that can provide the `Score` of an account. Similar to [`ElectionProvider`] and

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -519,7 +519,9 @@ pub trait SortedListProvider<AccountId> {
 	/// If `who` changes by the returned amount they are guaranteed to have a worst case change
 	/// in their list position.
 	#[cfg(feature = "runtime-benchmarks")]
-	fn score_update_worst_case(_who: &AccountId, _is_increase: bool) -> Self::Score;
+	fn score_update_worst_case(_who: &AccountId, _is_increase: bool) -> Self::Score {
+		unimplemented!();
+	}
 }
 
 /// Something that can provide the `Score` of an account. Similar to [`ElectionProvider`] and

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -1381,6 +1381,11 @@ impl<T: Config> SortedListProvider<T::AccountId> for UseNominatorsAndValidatorsM
 		#[allow(deprecated)]
 		Validators::<T>::remove_all();
 	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn score_update_worst_case(_who: &T::AccountId, _is_increase: bool) -> Self::Score {
+		unimplemented!();
+	}
 }
 
 impl<T: Config> StakingInterface for Pallet<T> {


### PR DESCRIPTION
Do not *ever* default impl feature gated trait functions, unless you want very weird stuff to happen.  
Reason being is that someone will forget to enable the feature and you use the default impl without noticing.  

https://github.com/paritytech/substrate/pull/11976 should fix this permanently.