### PR TITLE
Fix broken link to web3 foundation research

### DIFF
--- a/frame/staking/reward-curve/src/lib.rs
+++ b/frame/staking/reward-curve/src/lib.rs
@@ -28,7 +28,7 @@ use syn::parse::{Parse, ParseStream};
 
 /// Accepts a number of expressions to create a instance of PiecewiseLinear which represents the
 /// NPoS curve (as detailed
-/// [here](https://research.web3.foundation/en/latest/polkadot/Token%20Economics.html#inflation-model))
+/// [here](https://research.web3.foundation/en/latest/polkadot/overview/2-token-economics.html#inflation-model))
 /// for those parameters. Parameters are:
 /// - `min_inflation`: the minimal amount to be rewarded between validators, expressed as a fraction
 ///   of total issuance. Known as `I_0` in the literature. Expressed in millionth, must be between 0


### PR DESCRIPTION
This link is broken because the web3 foundation site was updated and the section structure was altered. I believe this is the link it should be now.