### PR TITLE
`try-runtime` - support all state versions

### DIFF
--- a/utils/frame/try-runtime/cli/src/commands/execute_block.rs
+++ b/utils/frame/try-runtime/cli/src/commands/execute_block.rs
@@ -139,7 +139,8 @@ where
 			.state
 			.builder::<Block>()?
 			// make sure the state is being build with the parent hash, if it is online.
-			.overwrite_online_at(parent_hash.to_owned());
+			.overwrite_online_at(parent_hash.to_owned())
+			.state_version(shared.state_version);
 
 		let builder = if command.overwrite_wasm_code {
 			log::info!(

--- a/utils/frame/try-runtime/cli/src/commands/follow_chain.rs
+++ b/utils/frame/try-runtime/cli/src/commands/follow_chain.rs
@@ -102,11 +102,13 @@ where
 
 		// create an ext at the state of this block, whatever is the first subscription event.
 		if maybe_state_ext.is_none() {
-			let builder = Builder::<Block>::new().mode(Mode::Online(OnlineConfig {
-				transport: command.uri.clone().into(),
-				at: Some(*header.parent_hash()),
-				..Default::default()
-			}));
+			let builder = Builder::<Block>::new()
+				.mode(Mode::Online(OnlineConfig {
+					transport: command.uri.clone().into(),
+					at: Some(*header.parent_hash()),
+					..Default::default()
+				}))
+				.state_version(shared.state_version);
 
 			let new_ext = builder
 				.inject_hashed_key_value(&[(code_key.clone(), code.clone())])

--- a/utils/frame/try-runtime/cli/src/commands/offchain_worker.rs
+++ b/utils/frame/try-runtime/cli/src/commands/offchain_worker.rs
@@ -128,7 +128,7 @@ where
 	);
 
 	let ext = {
-		let builder = command.state.builder::<Block>()?;
+		let builder = command.state.builder::<Block>()?.state_version(shared.state_version);
 
 		let builder = if command.overwrite_wasm_code {
 			log::info!(

--- a/utils/frame/try-runtime/cli/src/commands/on_runtime_upgrade.rs
+++ b/utils/frame/try-runtime/cli/src/commands/on_runtime_upgrade.rs
@@ -52,7 +52,7 @@ where
 	let execution = shared.execution;
 
 	let ext = {
-		let builder = command.state.builder::<Block>()?;
+		let builder = command.state.builder::<Block>()?.state_version(shared.state_version);
 		let (code_key, code) = extract_code(&config.chain_spec)?;
 		builder.inject_hashed_key_value(&[(code_key, code)]).build().await?
 	};

--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -295,6 +295,7 @@ use sp_runtime::{
 };
 use sp_state_machine::{OverlayedChanges, StateMachine, TrieBackendBuilder};
 use std::{fmt::Debug, path::PathBuf, str::FromStr};
+use sp_version::StateVersion;
 
 mod commands;
 pub(crate) mod parse;
@@ -421,6 +422,10 @@ pub struct SharedParams {
 	/// When enabled, the spec name check will not panic, and instead only show a warning.
 	#[clap(long)]
 	pub no_spec_name_check: bool,
+
+	/// State version that is used by the chain.
+	#[clap(long, default_value = "1", parse(try_from_str = parse::state_version))]
+	pub state_version: StateVersion,
 }
 
 /// Our `try-runtime` command.

--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -294,8 +294,8 @@ use sp_runtime::{
 	DeserializeOwned,
 };
 use sp_state_machine::{OverlayedChanges, StateMachine, TrieBackendBuilder};
-use std::{fmt::Debug, path::PathBuf, str::FromStr};
 use sp_version::StateVersion;
+use std::{fmt::Debug, path::PathBuf, str::FromStr};
 
 mod commands;
 pub(crate) mod parse;

--- a/utils/frame/try-runtime/cli/src/parse.rs
+++ b/utils/frame/try-runtime/cli/src/parse.rs
@@ -18,6 +18,7 @@
 //! Utils for parsing user input
 
 use sp_version::StateVersion;
+use std::num::ParseIntError;
 
 pub(crate) fn hash(block_hash: &str) -> Result<String, String> {
 	let (block_hash, offset) = if let Some(block_hash) = block_hash.strip_prefix("0x") {
@@ -46,10 +47,7 @@ pub(crate) fn url(s: &str) -> Result<String, &'static str> {
 }
 
 pub(crate) fn state_version(s: &str) -> Result<StateVersion, &'static str> {
-	match s.parse::<u32>() {
-		Ok(0) => Ok(StateVersion::V0),
-		Ok(1) => Ok(StateVersion::V1),
-		Ok(_) => Err("State version not supported."),
-		_ => Err("Invalid state version."),
-	}
+	s.parse::<u8>()
+		.and_then(StateVersion::try_from)
+		.map_err(|_| "Invalid state version.")
 }

--- a/utils/frame/try-runtime/cli/src/parse.rs
+++ b/utils/frame/try-runtime/cli/src/parse.rs
@@ -50,6 +50,7 @@ pub(crate) fn state_version(s: &str) -> Result<StateVersion, &'static str> {
 	match s.parse::<u32>() {
 		Ok(0) => Ok(StateVersion::V0),
 		Ok(1) => Ok(StateVersion::V1),
+		Ok(_) => Err("State version not supported."),
 		_ => Err("State version couldn't have been parsed.")
 	}
 }

--- a/utils/frame/try-runtime/cli/src/parse.rs
+++ b/utils/frame/try-runtime/cli/src/parse.rs
@@ -17,7 +17,6 @@
 
 //! Utils for parsing user input
 
-use std::num::ParseIntError;
 use sp_version::StateVersion;
 
 pub(crate) fn hash(block_hash: &str) -> Result<String, String> {
@@ -51,6 +50,6 @@ pub(crate) fn state_version(s: &str) -> Result<StateVersion, &'static str> {
 		Ok(0) => Ok(StateVersion::V0),
 		Ok(1) => Ok(StateVersion::V1),
 		Ok(_) => Err("State version not supported."),
-		_ => Err("State version couldn't have been parsed.")
+		_ => Err("State version couldn't have been parsed."),
 	}
 }

--- a/utils/frame/try-runtime/cli/src/parse.rs
+++ b/utils/frame/try-runtime/cli/src/parse.rs
@@ -17,6 +17,9 @@
 
 //! Utils for parsing user input
 
+use std::num::ParseIntError;
+use sp_version::StateVersion;
+
 pub(crate) fn hash(block_hash: &str) -> Result<String, String> {
 	let (block_hash, offset) = if let Some(block_hash) = block_hash.strip_prefix("0x") {
 		(block_hash, 2)
@@ -40,5 +43,13 @@ pub(crate) fn url(s: &str) -> Result<String, &'static str> {
 		Ok(s.to_string())
 	} else {
 		Err("not a valid WS(S) url: must start with 'ws://' or 'wss://'")
+	}
+}
+
+pub(crate) fn state_version(s: &str) -> Result<StateVersion, &'static str> {
+	match s.parse::<u32>() {
+		Ok(0) => Ok(StateVersion::V0),
+		Ok(1) => Ok(StateVersion::V1),
+		_ => Err("State version couldn't have been parsed.")
 	}
 }

--- a/utils/frame/try-runtime/cli/src/parse.rs
+++ b/utils/frame/try-runtime/cli/src/parse.rs
@@ -18,7 +18,6 @@
 //! Utils for parsing user input
 
 use sp_version::StateVersion;
-use std::num::ParseIntError;
 
 pub(crate) fn hash(block_hash: &str) -> Result<String, String> {
 	let (block_hash, offset) = if let Some(block_hash) = block_hash.strip_prefix("0x") {
@@ -48,6 +47,7 @@ pub(crate) fn url(s: &str) -> Result<String, &'static str> {
 
 pub(crate) fn state_version(s: &str) -> Result<StateVersion, &'static str> {
 	s.parse::<u8>()
+		.map_err(|_| ())
 		.and_then(StateVersion::try_from)
 		.map_err(|_| "Invalid state version.")
 }

--- a/utils/frame/try-runtime/cli/src/parse.rs
+++ b/utils/frame/try-runtime/cli/src/parse.rs
@@ -50,6 +50,6 @@ pub(crate) fn state_version(s: &str) -> Result<StateVersion, &'static str> {
 		Ok(0) => Ok(StateVersion::V0),
 		Ok(1) => Ok(StateVersion::V1),
 		Ok(_) => Err("State version not supported."),
-		_ => Err("State version couldn't have been parsed."),
+		_ => Err("Invalid state version."),
 	}
 }


### PR DESCRIPTION
Currently, every subcommand of `try-runtime` operates on externalities with `StateVersion(1)` (which is the default for `RemoteExternalities` - https://github.com/paritytech/substrate/blob/master/utils/frame/remote-externalities/src/lib.rs#L269). Although it will work with any remote chain without any warning or check, some problems may rise if chain uses another state version. For example, Polkadot (afaik) and AlephZero use `StateVersion(0)`.

This PR introduces new CLI option which enables user to specify target state version. By default it is `StateVersion::1`.

cc: @kianenigma 