### PR TITLE
pin gha versions

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   label-new-issues:
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     steps:
       - name: Label drafts
-        uses: andymckay/labeler@master
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # 1.0.4
         if: github.event.issue.author_association == 'NONE'
         with:
           add-labels: 'Z0-unconfirmed'

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label drafts
-        uses: andymckay/labeler@master
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # 1.0.4
         if: github.event.pull_request.draft == true
         with:
           add-labels: 'A3-inprogress'
           remove-labels: 'A0-pleasereview'
       - name: Label PRs
-        uses: andymckay/labeler@master
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # 1.0.4
         if: github.event.pull_request.draft == false && ! contains(github.event.pull_request.labels.*.name, 'A2-insubstantial')
         with:
           add-labels: 'A0-pleasereview'

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: gaurav-nelson/github-action-markdown-link-check@9710f0fec812ce0a3b98bef4c9d842fc1f39d976 # v1.0.13
+    - uses: gaurav-nelson/github-action-markdown-link-check@0a51127e9955b855a9bbfa1ff5577f1d1338c9a5 # 1.0.14
       with:
         use-quiet-mode: 'yes'
         config-file: '.github/workflows/mlc_config.json'

--- a/.github/workflows/monthly-tag.yml
+++ b/.github/workflows/monthly-tag.yml
@@ -32,7 +32,7 @@ jobs:
           ./scripts/ci/github/generate_changelog.sh ${{ steps.tags.outputs.old }} >>  Changelog.md
       - name: Release snapshot
         id: release-snapshot
-        uses: actions/create-release@latest
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4 latest version, repo archived
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release-tagging.yml
+++ b/.github/workflows/release-tagging.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Set Git tag
-        uses: s3krit/walking-tag-action@master
+        uses: s3krit/walking-tag-action@d04f7a53b72ceda4e20283736ce3627011275178 # latest version from master
         with:
           TAG_NAME: release
           TAG_MESSAGE: Latest release


### PR DESCRIPTION
In order to improve our security posture with GitHub Actions usage. I've made a version pinning ether to commit hash or to specific version.

Related issues and policy:
https://github.com/paritytech/ci_cd/issues/464
https://github.com/paritytech/ci_cd/wiki/Policies-and-regulations:-GitHub-Actions-usage-policies