### PR TITLE
clone not required as copy.

### DIFF
--- a/frame/support/procedural/src/pallet/parse/storage.rs
+++ b/frame/support/procedural/src/pallet/parse/storage.rs
@@ -775,7 +775,7 @@ impl StorageDef {
 						error.push_value(last);
 
 						Ok(Some(QueryKind::ResultQuery(
-							syn::Path { leading_colon: leading_colon.clone(), segments: error },
+							syn::Path { leading_colon, segments: error },
 							err_variant,
 						)))
 					},


### PR DESCRIPTION
This will have slipped through the net as a PR that was good to merge and passed the clippy tests, but then we extended the rules to include unnecessary clones. This fixes clippy on master.