### PR TITLE
Force `rustix` to use libc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8249,6 +8249,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-wasm 0.42.2",
  "paste 1.0.6",
+ "rustix 0.33.7",
  "rustix 0.35.6",
  "sc-allocator",
  "sc-executor-common",

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -18,6 +18,9 @@ codec = { package = "parity-scale-codec", version = "3.0.0" }
 libc = "0.2.121"
 log = "0.4.17"
 parity-wasm = "0.42.0"
+
+# When bumping wasmtime do not forget to also bump rustix
+# to exactly the same version as used by wasmtime!
 wasmtime = { version = "0.38.0", default-features = false, features = [
 	"cache",
 	"cranelift",
@@ -33,8 +36,15 @@ sp-sandbox = { version = "0.10.0-dev", path = "../../../primitives/sandbox" }
 sp-wasm-interface = { version = "6.0.0", features = ["wasmtime"], path = "../../../primitives/wasm-interface" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rustix = { version = "0.35.6", default-features = false, features = ["std", "mm", "fs", "param"] }
+rustix = { version = "0.35.6", default-features = false, features = ["std", "mm", "fs", "param", "use-libc"] }
 once_cell = "1.12.0"
+
+# Here we include the rustix crate used by wasmtime just to enable its 'use-libc' flag.
+#
+# By default rustix directly calls the appropriate syscalls completely bypassing libc;
+# this doesn't have any actual benefits for us besides making it harder to debug memory
+# problems (since then `mmap` etc. cannot be easily hooked into).
+rustix_wasmtime = { package = "rustix", version = "0.33.7", default-features = false, features = ["std", "use-libc"] }
 
 [dev-dependencies]
 wat = "1.0"


### PR DESCRIPTION
`wasmtime` uses `rustix` to map memory. By default `rustix` uses raw syscalls to call into the OS. This makes it impossible to hook into those calls through conventional means (e.g. through LD_PRELOAD), which makes debugging of memory issues more difficult.

So this PR forces `rustix` to go through `libc` instead of directly calling the appropriate syscalls. Besides making `mmap` etc. hookable this doesn't have any other effects. (We already depend on `libc` anyway, and those calls are heavy enough and not made often enough to make any performance difference at all by having them called directly through a syscall. It's a nice feature when you want to e.g. build a `no_std` program which still can interface with the OS, but in our case it's pointless.)

I've added an extra dependency on an older version of `rustix` since that's what `wasmtime` uses right now (well, the version of `wasmtime` we use). I really didn't want to bother with rolling back the version of `rustix` we use just to have to bump it up again later. We can remove this once we bump `wasmtime` to a newer version so that both versions are in sync.