### PR TITLE
Fix sporadic test failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,6 +2107,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "paste 1.0.6",
+ "rusty-fork",
  "scale-info",
  "serde",
  "sp-api",
@@ -7671,6 +7672,17 @@ name = "rustversion"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+]
 
 [[package]]
 name = "rw-stream-sink"

--- a/frame/benchmarking/Cargo.toml
+++ b/frame/benchmarking/Cargo.toml
@@ -32,6 +32,7 @@ sp-storage = { version = "6.0.0", default-features = false, path = "../../primit
 
 [dev-dependencies]
 hex-literal = "0.3.4"
+rusty-fork = { version = "0.3.0", default-features = false }
 sp-keystore = { version = "0.12.0", path = "../../primitives/keystore" }
 
 [features]

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -139,6 +139,7 @@ mod benchmarks {
 	use crate::{account, BenchmarkError, BenchmarkParameter, BenchmarkResult, BenchmarkingSetup};
 	use frame_support::{assert_err, assert_ok, ensure, traits::Get};
 	use frame_system::RawOrigin;
+	use rusty_fork::rusty_fork_test;
 	use sp_std::prelude::*;
 
 	// Additional used internally by the benchmark macro.
@@ -409,24 +410,29 @@ mod benchmarks {
 		});
 	}
 
-	/// Test that the benchmarking uses the correct values for each component and
-	/// that the number of components can be controlled with `VALUES_PER_COMPONENT`.
-	#[test]
-	fn test_values_per_component() {
-		let tests = vec![
-			(Some("1"), Err("`VALUES_PER_COMPONENT` must be at least 2".into())),
-			(Some("asdf"), Err("Could not parse env var `VALUES_PER_COMPONENT` as u32.".into())),
-			(None, Ok(vec![0, 2, 4, 6, 8, 10])),
-			(Some("2"), Ok(vec![0, 10])),
-			(Some("4"), Ok(vec![0, 3, 6, 10])),
-			(Some("6"), Ok(vec![0, 2, 4, 6, 8, 10])),
-			(Some("10"), Ok(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 10])),
-			(Some("11"), Ok(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])),
-			(Some("99"), Ok(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])),
-		];
+	rusty_fork_test! {
+		/// Test that the benchmarking uses the correct values for each component and
+		/// that the number of components can be controlled with `VALUES_PER_COMPONENT`.
+		///
+		/// NOTE: This test needs to run in its own process, since it
+		/// otherwise messes up the env variable for the other tests.
+		#[test]
+		fn test_values_per_component() {
+			let tests = vec![
+				(Some("1"), Err("`VALUES_PER_COMPONENT` must be at least 2".into())),
+				(Some("asdf"), Err("Could not parse env var `VALUES_PER_COMPONENT` as u32.".into())),
+				(None, Ok(vec![0, 2, 4, 6, 8, 10])),
+				(Some("2"), Ok(vec![0, 10])),
+				(Some("4"), Ok(vec![0, 3, 6, 10])),
+				(Some("6"), Ok(vec![0, 2, 4, 6, 8, 10])),
+				(Some("10"), Ok(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 10])),
+				(Some("11"), Ok(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])),
+				(Some("99"), Ok(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])),
+			];
 
-		for (num, expected) in tests {
-			run_test_values_per_component(num, expected);
+			for (num, expected) in tests {
+				run_test_values_per_component(num, expected);
+			}
 		}
 	}
 


### PR DESCRIPTION
`test_values_per_component` does change env variables, which can cause other tests to fail when run concurrently.  
Fixed by using [rusty-fork](https://docs.rs/rusty-fork/latest/rusty_fork/) to fork off the process to isolate the env-var changes.