### PR TITLE
Uniques: Reset approved account after transfer 

### DIFF
--- a/frame/uniques/src/functions.rs
+++ b/frame/uniques/src/functions.rs
@@ -48,6 +48,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Account::<T, I>::insert((&dest, &collection, &item), ());
 		let origin = details.owner;
 		details.owner = dest;
+
+		// The approved account has to be reset to None, because otherwise
+		// pre-approve attack would be possible, where the owner can approve his
+		// second account before making the transaction and then claiming the
+		// item back.
+		details.approved = None;
+
 		Item::<T, I>::insert(&collection, &item, &details);
 		ItemPriceOf::<T, I>::remove(&collection, &item);
 

--- a/frame/uniques/src/functions.rs
+++ b/frame/uniques/src/functions.rs
@@ -49,10 +49,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		let origin = details.owner;
 		details.owner = dest;
 
-		// The approved account has to be reset to None, because otherwise
-		// pre-approve attack would be possible, where the owner can approve his
-		// second account before making the transaction and then claiming the
-		// item back.
+		// The approved account has to be reset to None, because otherwise pre-approve attack would
+		// be possible, where the owner can approve his second account before making the transaction
+		// and then claiming the item back.
 		details.approved = None;
 
 		Item::<T, I>::insert(&collection, &item, &details);

--- a/frame/uniques/src/lib.rs
+++ b/frame/uniques/src/lib.rs
@@ -604,7 +604,7 @@ pub mod pallet {
 			})
 		}
 
-		/// Move an item from the sender account to another. 
+		/// Move an item from the sender account to another.
 		///
 		/// This resets the approved account of the item.
 		///

--- a/frame/uniques/src/lib.rs
+++ b/frame/uniques/src/lib.rs
@@ -916,7 +916,7 @@ pub mod pallet {
 		/// - `item`: The item of the item to be approved for delegated transfer.
 		/// - `delegate`: The account to delegate permission to transfer the item.
 		///
-		/// Important NOTE: The `approved` account gets resest after each transfer.
+		/// Important NOTE: The `approved` account gets reset after each transfer.
 		///
 		/// Emits `ApprovedTransfer` on success.
 		///

--- a/frame/uniques/src/lib.rs
+++ b/frame/uniques/src/lib.rs
@@ -604,7 +604,9 @@ pub mod pallet {
 			})
 		}
 
-		/// Move an item from the sender account to another.
+		/// Move an item from the sender account to another. 
+		///
+		/// This resets the approved account of the item.
 		///
 		/// Origin must be Signed and the signing account must be either:
 		/// - the Admin of the `collection`;

--- a/frame/uniques/src/lib.rs
+++ b/frame/uniques/src/lib.rs
@@ -914,6 +914,8 @@ pub mod pallet {
 		/// - `item`: The item of the item to be approved for delegated transfer.
 		/// - `delegate`: The account to delegate permission to transfer the item.
 		///
+		/// Important NOTE: The `approved` account gets resest after each transfer.
+		///
 		/// Emits `ApprovedTransfer` on success.
 		///
 		/// Weight: `O(1)`

--- a/frame/uniques/src/tests.rs
+++ b/frame/uniques/src/tests.rs
@@ -588,7 +588,7 @@ fn approved_account_gets_reset_after_buy_item() {
 		assert_ok!(Uniques::set_price(Origin::signed(1), 0, item, Some(price), None));
 
 		assert_ok!(Uniques::buy_item(Origin::signed(2), 0, item, price));
-		
+
 		// this shouldn't work because the item has been bough and the approved account should be
 		// reset.
 		assert_noop!(Uniques::transfer(Origin::signed(5), 0, item, 4), Error::<Test>::NoPermission);

--- a/frame/uniques/src/tests.rs
+++ b/frame/uniques/src/tests.rs
@@ -574,6 +574,28 @@ fn approved_account_gets_reset_after_transfer() {
 }
 
 #[test]
+fn approved_account_gets_reset_after_buy_item() {
+	new_test_ext().execute_with(|| {
+		let item = 1;
+		let price = 15;
+
+		Balances::make_free_balance_be(&2, 100);
+
+		assert_ok!(Uniques::force_create(Origin::root(), 0, 1, true));
+		assert_ok!(Uniques::mint(Origin::signed(1), 0, item, 1));
+		assert_ok!(Uniques::approve_transfer(Origin::signed(1), 0, item, 5));
+
+		assert_ok!(Uniques::set_price(Origin::signed(1), 0, item, Some(price), None));
+
+		assert_ok!(Uniques::buy_item(Origin::signed(2), 0, item, price));
+		
+		// this shouldn't work because the item has been bough and the approved account should be
+		// reset.
+		assert_noop!(Uniques::transfer(Origin::signed(5), 0, item, 4), Error::<Test>::NoPermission);
+	});
+}
+
+#[test]
 fn cancel_approval_works() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Uniques::force_create(Origin::root(), 0, 1, true));

--- a/frame/uniques/src/tests.rs
+++ b/frame/uniques/src/tests.rs
@@ -568,6 +568,8 @@ fn approved_account_gets_reset_after_transfer() {
 
 		// this shouldn't work because we have just transfered the item to another account.
 		assert_noop!(Uniques::transfer(Origin::signed(3), 0, 42, 4), Error::<Test>::NoPermission);
+		// The new owner can transfer fine:
+		assert_ok!(Uniques::transfer(Origin::signed(5), 0, 42, 6));
 	});
 }
 

--- a/frame/uniques/src/tests.rs
+++ b/frame/uniques/src/tests.rs
@@ -558,6 +558,20 @@ fn approval_lifecycle_works() {
 }
 
 #[test]
+fn approved_account_gets_reset_after_transfer() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Uniques::force_create(Origin::root(), 0, 1, true));
+		assert_ok!(Uniques::mint(Origin::signed(1), 0, 42, 2));
+
+		assert_ok!(Uniques::approve_transfer(Origin::signed(2), 0, 42, 3));
+		assert_ok!(Uniques::transfer(Origin::signed(2), 0, 42, 5));
+
+		// this shouldn't work because we have just transfered the item to another account.
+		assert_noop!(Uniques::transfer(Origin::signed(3), 0, 42, 4), Error::<Test>::NoPermission);
+	});
+}
+
+#[test]
 fn cancel_approval_works() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Uniques::force_create(Origin::root(), 0, 1, true));


### PR DESCRIPTION
Currently, the `approved` account of an item doesn't get reset to `None` after each transfer. This can cause a problem because it is possible for the owner of the item to approve an item to his other account and after transferring the item he can claim it back.