### PR TITLE
Enforce blocks response limit

### DIFF
--- a/client/network/sync/src/block_request_handler.rs
+++ b/client/network/sync/src/block_request_handler.rs
@@ -405,11 +405,20 @@ where
 				indexed_body,
 			};
 
-			total_size += block_data.body.iter().map(|ex| ex.len()).sum::<usize>();
-			total_size += block_data.indexed_body.iter().map(|ex| ex.len()).sum::<usize>();
+			let new_total_size = total_size +
+				block_data.body.iter().map(|ex| ex.len()).sum::<usize>() +
+				block_data.indexed_body.iter().map(|ex| ex.len()).sum::<usize>();
+
+			// Send at least one block, but make sure to not exceed the limit.
+			if !blocks.is_empty() && new_total_size > MAX_BODY_BYTES {
+				break
+			}
+
+			total_size = new_total_size;
+
 			blocks.push(block_data);
 
-			if blocks.len() >= max_blocks as usize || total_size > MAX_BODY_BYTES {
+			if blocks.len() >= max_blocks as usize {
 				break
 			}
 


### PR DESCRIPTION
Previously limit was checked only after block was added to the response, resulting in responses regularly exceeding configured 8MiB limit:
```
2022-08-30 15:40:42.019 DEBUG tokio-runtime-worker sync: [PrimaryChain] Handling block request from 12D3KooWQWX2BvHEVGk6UYVTcknBAXWpTrZ52VdfgP7wUTnDaRAD: Starting at `BlockId::Number(1920)` with maximum blocks of `64`, reputation_change: `None`, small_request `false`, direction `Descending` and attributes `HEADER | BODY | JUSTIFICATION`.    
2022-08-30 15:40:42.027 DEBUG tokio-runtime-worker sync: [PrimaryChain] Sending result of block request from 12D3KooWQWX2BvHEVGk6UYVTcknBAXWpTrZ52VdfgP7wUTnDaRAD starting at `BlockId::Number(1920)`: blocks: Some(6), data: Some(10555707)
```

Now limit is actually enforced except in hypothetical pathological case where single block exceeds the limit, then we have to send at least one block in response regardless.