### PR TITLE
implement exponential decay curve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,7 +1398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array 0.14.4",
- "typenum",
+ "typenum 1.15.0",
 ]
 
 [[package]]
@@ -2610,7 +2610,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
- "typenum",
+ "typenum 1.15.0",
 ]
 
 [[package]]
@@ -2619,7 +2619,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
- "typenum",
+ "typenum 1.15.0",
  "version_check",
 ]
 
@@ -4083,7 +4083,7 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "sha2 0.9.8",
- "typenum",
+ "typenum 1.15.0",
 ]
 
 [[package]]
@@ -4515,7 +4515,7 @@ dependencies = [
  "rand 0.8.4",
  "rand_distr",
  "simba",
- "typenum",
+ "typenum 1.15.0",
 ]
 
 [[package]]
@@ -6126,6 +6126,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "substrate-fixed",
 ]
 
 [[package]]
@@ -9502,6 +9503,7 @@ dependencies = [
  "sp-debug-derive",
  "sp-std",
  "static_assertions",
+ "substrate-fixed",
 ]
 
 [[package]]
@@ -10353,6 +10355,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-fixed"
+version = "0.5.9"
+source = "git+https://github.com/encointer/substrate-fixed?tag=v0.5.9#a4fb461aae6205ffc55bed51254a40c52be04e5d"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "typenum 1.16.0",
+]
+
+[[package]]
 name = "substrate-frame-cli"
 version = "4.0.0-dev"
 dependencies = [
@@ -11159,6 +11172,15 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "git+https://github.com/encointer/typenum?tag=v1.16.0#4c8dddaa8bdd13130149e43b4085ad14e960617f"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+]
 
 [[package]]
 name = "ucd-trie"

--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -463,7 +463,7 @@ where
 				// If there are more than `MAJOR_SYNC_BLOCKS` in the import queue then we have
 				// enough to do in the import queue that it's not worth kicking off
 				// an ancestor search, which is what we do in the next match case below.
-				if self.queue_blocks.len() > MAJOR_SYNC_BLOCKS.into() {
+				if self.queue_blocks.len() > MAJOR_SYNC_BLOCKS as usize {
 					debug!(
 						target:"sync",
 						"New peer with unknown best hash {} ({}), assuming common block.",
@@ -695,7 +695,7 @@ where
 			if best_queued.saturating_sub(peer.common_number) > MAX_BLOCKS_TO_LOOK_BACKWARDS.into() &&
 				best_queued < peer.best_number &&
 				peer.common_number < last_finalized &&
-				queue.len() <= MAJOR_SYNC_BLOCKS.into()
+				queue.len() <= MAJOR_SYNC_BLOCKS as usize
 			{
 				trace!(
 					target: "sync",

--- a/frame/merkle-mountain-range/src/mmr/storage.rs
+++ b/frame/merkle-mountain-range/src/mmr/storage.rs
@@ -220,7 +220,7 @@ where
 		// Find out which leaf added node `pos` in the MMR.
 		let ancestor_leaf_idx = NodesUtils::leaf_index_that_added_node(pos);
 
-		let window_size =
+		let window_size: u64 =
 			<T as frame_system::Config>::BlockHashCount::get().unique_saturated_into();
 		// Leaves older than this window should have been canonicalized.
 		if leaves.saturating_sub(ancestor_leaf_idx) > window_size {

--- a/frame/nomination-pools/src/mock.rs
+++ b/frame/nomination-pools/src/mock.rs
@@ -360,7 +360,7 @@ mod test {
 	use super::*;
 	#[test]
 	fn u256_to_balance_convert_works() {
-		assert_eq!(U256ToBalance::convert(0u32.into()), Zero::zero());
+		assert_eq!(U256ToBalance::convert(0u32.into()), Balance::from(0u32));
 		assert_eq!(U256ToBalance::convert(Balance::max_value().into()), Balance::max_value())
 	}
 

--- a/frame/referenda/Cargo.toml
+++ b/frame/referenda/Cargo.toml
@@ -26,6 +26,7 @@ frame-system = { version = "4.0.0-dev", default-features = false, path = "../sys
 sp-io = { version = "6.0.0", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "6.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-std = { version = "4.0.0-dev", default-features = false, path = "../../primitives/std" }
+fixed = {package = "substrate-fixed", tag = "v0.5.9", default-features = false, git = "https://github.com/encointer/substrate-fixed"}
 
 [dev-dependencies]
 assert_matches = { version = "1.5" }
@@ -48,6 +49,7 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"fixed/std"
 ]
 runtime-benchmarks = [
 	"assert_matches",

--- a/frame/referenda/src/types.rs
+++ b/frame/referenda/src/types.rs
@@ -16,15 +16,17 @@
 // limitations under the License.
 
 //! Miscellaneous additional datatypes.
-
 use super::*;
 use codec::{Decode, Encode, EncodeLike, MaxEncodedLen};
+use fixed::{
+	transcendental::{ln, pow},
+	types::I64F64,
+};
 use frame_support::{traits::schedule::Anon, Parameter};
 use scale_info::TypeInfo;
 use sp_arithmetic::{Rounding::*, SignedRounding::*};
 use sp_runtime::{FixedI64, PerThing, RuntimeDebug};
 use sp_std::fmt::Debug;
-
 pub type BalanceOf<T, I = ()> =
 	<<T as Config<I>>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 pub type NegativeImbalanceOf<T, I> = <<T as Config<I>>::Currency as Currency<
@@ -259,6 +261,13 @@ pub enum Curve {
 	SteppedDecreasing { begin: Perbill, end: Perbill, step: Perbill, period: Perbill },
 	/// A recipocal (`K/(x+S)-T`) curve: `factor` is `K` and `x_offset` is `S`, `y_offset` is `T`.
 	Reciprocal { factor: FixedI64, x_offset: FixedI64, y_offset: FixedI64 },
+	/// Exponential decay curve defined by `f(x) = n_0 * (2 ^ -(x / half_time)) + offset`
+	/// https://en.wikipedia.org/wiki/Exponential_decay
+	/// f(0) = n_0
+	/// the function will exponentially decay towards offset
+	/// half_time determines the x value where y = 0.5 * n_0 + offset, ie. the time it takes for
+	/// the curve to drop to half of its range.
+	ExponentialDecay { n_0: I64F64, half_time: I64F64, offset: I64F64 },
 }
 
 /// Calculate the quadratic solution for the given curve.
@@ -336,6 +345,16 @@ impl Curve {
 		Curve::Reciprocal { factor, x_offset, y_offset }
 	}
 
+	/// Create a `Curve::ExponentialDecay` instance from a high-level description.
+	///
+	/// WARNING: This is a `const` function designed for convenient use at build time and
+	/// will panic on overflow. Ensure that any inputs are sensible.
+	pub const fn make_exponential_decay(floor: I64F64, ceil: I64F64, half_time: I64F64) -> Curve {
+		let n_0 = ceil.saturating_sub(floor);
+		let offset = floor;
+		Curve::ExponentialDecay { half_time, n_0, offset }
+	}
+
 	/// Print some info on the curve.
 	#[cfg(feature = "std")]
 	pub fn info(&self, days: u32, name: impl std::fmt::Display) {
@@ -405,6 +424,16 @@ impl Curve {
 				.checked_rounding_div(FixedI64::from(x) + *x_offset, Low)
 				.map(|yp| (yp + *y_offset).into_clamped_perthing())
 				.unwrap_or_else(Perbill::one),
+			Self::ExponentialDecay { n_0, half_time, offset } => {
+				//n_0 * (2 ^ -(x / half_time)) + offset
+				<Perbill as Into<I64F64>>::into(x)
+					.checked_div(*half_time)
+					.and_then(|exponent| pow(I64F64::from(2), -exponent).ok())
+					.and_then(|exponential| n_0.checked_mul(exponential))
+					.and_then(|decay| offset.checked_add(decay))
+					.unwrap_or(I64F64::from_num(1))
+					.into()
+			},
 		}
 	}
 
@@ -460,6 +489,20 @@ impl Curve {
 					.and_then(|term| (term - *x_offset).try_into_perthing().ok())
 					.unwrap_or_else(Perbill::one)
 			},
+			Self::ExponentialDecay { n_0, half_time, offset } => {
+				// x = (half_time * (log(-n_0/(offset-y))))/log(2)
+
+				let ln_2 = || ln(I64F64::from_num(2i32)).expect("ln(2) is valid; qed");
+
+				offset
+					.checked_sub(y.into())
+					.and_then(|offset_minus_y| n_0.checked_div(offset_minus_y))
+					.and_then(|inner_log| ln(-inner_log).ok())
+					.and_then(|log_term| half_time.checked_mul(log_term))
+					.and_then(|numerator| numerator.checked_div(ln_2()))
+					.unwrap_or(I64F64::from_num(1))
+					.into()
+			},
 		}
 	}
 
@@ -492,6 +535,13 @@ impl Debug for Curve {
 					f,
 					"Reciprocal[factor of {:?}, x_offset of {:?}, y_offset of {:?}]",
 					factor, x_offset, y_offset,
+				)
+			},
+			Self::ExponentialDecay { n_0, half_time, offset } => {
+				write!(
+					f,
+					"Exponential Decay[n_0 = {:?}, half_time = {:?}, offset = {:?}]",
+					n_0, half_time, offset,
 				)
 			},
 		}
@@ -644,5 +694,70 @@ mod tests {
 		assert_eq!(c.delay(pc(30)), pc(75));
 		assert_eq!(c.delay(pc(30).less_epsilon()), pc(100));
 		assert_eq!(c.delay(pc(0)), pc(100));
+	}
+
+	#[test]
+	fn exponential_decay_works() {
+		fn pc(x: u32) -> Perbill {
+			Perbill::from_percent(x)
+		}
+		fn abs_diff(a: Perbill, b: Perbill) -> Perbill {
+			if a > b {
+				return a - b
+			}
+			b - a
+		}
+		fn almost_equal(a: Perbill, b: Perbill) -> bool {
+			abs_diff(a, b) < Perbill::from_float(0.0000001)
+		}
+
+		let mut c: Curve = Curve::ExponentialDecay {
+			n_0: I64F64::from_num(0.8),
+			half_time: I64F64::from_num(0.5),
+			offset: I64F64::from_num(0.1),
+		};
+
+		assert!(almost_equal(c.threshold(pc(50)), pc(50)));
+		assert!(almost_equal(c.threshold(pc(30)), Perbill::from_float(0.6278031643091577)));
+		assert!(almost_equal(c.threshold(pc(0)), pc(90)));
+		assert!(almost_equal(c.threshold(pc(100)), pc(30)));
+
+		assert!(almost_equal(c.delay(pc(50)), pc(50)));
+		assert!(almost_equal(c.delay(Perbill::from_float(0.6278031643091577)), pc(30)));
+		assert!(almost_equal(c.delay(pc(90)), pc(0)));
+		assert!(almost_equal(c.delay(pc(30)), pc(100)));
+
+		c = Curve::ExponentialDecay {
+			n_0: I64F64::from_num(1.0),
+			half_time: I64F64::from_num(0.6),
+			offset: I64F64::from_num(0.0),
+		};
+
+		assert!(almost_equal(c.threshold(pc(60)), pc(50)));
+		assert!(almost_equal(c.threshold(pc(70)), Perbill::from_float(0.44544935907016964)));
+		assert!(almost_equal(c.threshold(pc(0)), pc(100)));
+		assert!(almost_equal(c.threshold(pc(100)), Perbill::from_float(0.3149802624737183)));
+
+		assert!(almost_equal(c.delay(pc(50)), pc(60)));
+		assert!(almost_equal(c.delay(Perbill::from_float(0.44544935907016964)), pc(70)));
+		assert!(almost_equal(c.delay(pc(100)), pc(0)));
+		assert!(almost_equal(c.delay(Perbill::from_float(0.3149802624737183)), pc(100)));
+	}
+
+	#[test]
+	fn make_exponential_decay_works() {
+		let c: Curve = Curve::make_exponential_decay(
+			I64F64::from_num(0.1),
+			I64F64::from_num(0.9),
+			I64F64::from_num(0.5),
+		);
+		assert_eq!(
+			c,
+			Curve::ExponentialDecay {
+				half_time: I64F64::from_num(0.5),
+				offset: I64F64::from_num(0.1),
+				n_0: I64F64::from_num(0.9) - I64F64::from_num(0.1)
+			}
+		);
 	}
 }

--- a/frame/referenda/src/types.rs
+++ b/frame/referenda/src/types.rs
@@ -262,7 +262,7 @@ pub enum Curve {
 	/// A recipocal (`K/(x+S)-T`) curve: `factor` is `K` and `x_offset` is `S`, `y_offset` is `T`.
 	Reciprocal { factor: FixedI64, x_offset: FixedI64, y_offset: FixedI64 },
 	/// Exponential decay curve defined by `f(x) = n_0 * (2 ^ -(x / half_time)) + offset`
-	/// https://en.wikipedia.org/wiki/Exponential_decay
+	/// <https://en.wikipedia.org/wiki/Exponential_decay>
 	/// f(0) = n_0
 	/// the function will exponentially decay towards offset
 	/// half_time determines the x value where y = 0.5 * n_0 + offset, ie. the time it takes for

--- a/primitives/arithmetic/Cargo.toml
+++ b/primitives/arithmetic/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0.136", features = ["derive"], optional = true }
 static_assertions = "1.1.0"
 sp-debug-derive = { version = "4.0.0", default-features = false, path = "../debug-derive" }
 sp-std = { version = "4.0.0", default-features = false, path = "../std" }
+fixed = {package = "substrate-fixed", tag = "v0.5.9", default-features = false, git = "https://github.com/encointer/substrate-fixed"}
 
 [dev-dependencies]
 criterion = "0.3"
@@ -41,6 +42,7 @@ std = [
 	"serde",
 	"sp-debug-derive/std",
 	"sp-std/std",
+	"fixed/std"
 ]
 
 [[bench]]

--- a/primitives/npos-elections/src/mock.rs
+++ b/primitives/npos-elections/src/mock.rs
@@ -226,10 +226,10 @@ where
 	if backing_backed_stake.len() > 0 {
 		let max_stake = backing_backed_stake
 			.iter()
-			.max_by(|x, y| x.partial_cmp(&y).unwrap_or(sp_std::cmp::Ordering::Equal))
+			.max_by(|x, y| x.partial_cmp(y).unwrap_or(sp_std::cmp::Ordering::Equal))
 			.expect("vector with positive length will have a max; qed");
 		let min_stake = backed_stakes_iter
-			.min_by(|x, y| x.partial_cmp(&y).unwrap_or(sp_std::cmp::Ordering::Equal))
+			.min_by(|x, y| x.partial_cmp(y).unwrap_or(sp_std::cmp::Ordering::Equal))
 			.expect("iterator with positive length will have a min; qed");
 
 		difference = max_stake - min_stake;
@@ -302,7 +302,7 @@ pub fn check_assignments_sum<T: PerThing>(assignments: &[Assignment<AccountId, T
 		distribution
 			.iter()
 			.for_each(|(_, p)| sum += p.deconstruct().saturated_into::<u128>());
-		assert_eq!(sum, T::ACCURACY.saturated_into(), "Assignment ratio sum is not 100%");
+		assert_eq!(sum, T::ACCURACY.saturated_into::<u128>(), "Assignment ratio sum is not 100%");
 	}
 }
 


### PR DESCRIPTION
This PR introduces a new curve `ExponentialDecay` in the `referenda` pallet. For the implementation we rely on [Encointer's substrate-fixed](https://github.com/encointer/substrate-fixed), which provides efficient fixed point numbers and implements transcendental functions like `exp` and `log`. 

Changes at unrelated locations in the code were necessary because `substrate-fixed` introduces some conflicting impls and  we got errors along the lines of
`type annotations needed`
`multiple impls satisfying usize: PartialOrd<_> found in the following crates: core, substrate_fixed`