### PR TITLE
Only log when the transaction is actually to be propagated

### DIFF
--- a/client/network/src/transactions.rs
+++ b/client/network/src/transactions.rs
@@ -425,11 +425,11 @@ impl<B: BlockT + 'static, H: ExHashT> TransactionsHandler<B, H> {
 
 	/// Propagate one transaction.
 	pub fn propagate_transaction(&mut self, hash: &H) {
-		debug!(target: "sync", "Propagating transaction [{:?}]", hash);
 		// Accept transactions only when enabled
 		if !self.gossip_enabled.load(Ordering::Relaxed) {
 			return
 		}
+		debug!(target: "sync", "Propagating transaction [{:?}]", hash);
 		if let Some(transaction) = self.transaction_pool.transaction(hash) {
 			let propagated_to = self.do_propagate_transactions(&[(hash.clone(), transaction)]);
 			self.transaction_pool.on_broadcasted(propagated_to);


### PR DESCRIPTION
The logging before is confusing as it says Propagating but it's not in fact when gossip_enabled is
false. Now it's also consistent with `propagate_transactions` below.
