### PR TITLE
Add `StorageNoopGuard`

### DIFF
--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -93,7 +93,7 @@ pub mod unsigned {
 	};
 }
 
-#[cfg(test)]
+#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
 pub use self::storage::storage_noop_guard::StorageNoopGuard;
 pub use self::{
 	dispatch::{Callable, Parameter},

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -93,6 +93,8 @@ pub mod unsigned {
 	};
 }
 
+#[cfg(test)]
+pub use self::storage::storage_noop_guard::StorageNoopGuard;
 pub use self::{
 	dispatch::{Callable, Parameter},
 	hash::{
@@ -104,7 +106,6 @@ pub use self::{
 		bounded_btree_set::BoundedBTreeSet,
 		bounded_vec::{BoundedSlice, BoundedVec},
 		migration,
-		storage_noop_guard::StorageNoopGuard,
 		weak_bounded_vec::WeakBoundedVec,
 		IterableStorageDoubleMap, IterableStorageMap, IterableStorageNMap, StorageDoubleMap,
 		StorageMap, StorageNMap, StoragePrefixedMap, StorageValue,

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -104,6 +104,7 @@ pub use self::{
 		bounded_btree_set::BoundedBTreeSet,
 		bounded_vec::{BoundedSlice, BoundedVec},
 		migration,
+		storage_noop_guard::StorageNoopGuard,
 		weak_bounded_vec::WeakBoundedVec,
 		IterableStorageDoubleMap, IterableStorageMap, IterableStorageNMap, StorageDoubleMap,
 		StorageMap, StorageNMap, StoragePrefixedMap, StorageValue,

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -46,6 +46,7 @@ pub mod child;
 pub mod generator;
 pub mod hashed;
 pub mod migration;
+pub mod storage_noop_guard;
 pub mod transactional;
 pub mod types;
 pub mod unhashed;

--- a/frame/support/src/storage/storage_noop_guard.rs
+++ b/frame/support/src/storage/storage_noop_guard.rs
@@ -15,7 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(test)] // Testing only since it can panic.
+// Feature gated since it can panic.
+#![cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
 
 //! Contains the [`crate::StorageNoopGuard`] for conveniently asserting
 //! that no storage mutation has been made by a whole code block.
@@ -32,7 +33,7 @@
 /// sp_io::TestExternalities::default().execute_with(|| {
 /// 	let _guard = frame_support::StorageNoopGuard::default();
 /// 	put(b"key", b"value");
-/// 		// Panics since there are storage changes.
+/// 	// Panics since there are storage changes.
 /// });
 /// ```
 #[must_use]

--- a/frame/support/src/storage/storage_noop_guard.rs
+++ b/frame/support/src/storage/storage_noop_guard.rs
@@ -37,7 +37,7 @@
 /// });
 /// ```
 #[must_use]
-pub struct StorageNoopGuard(Vec<u8>);
+pub struct StorageNoopGuard(sp_std::vec::Vec<u8>);
 
 impl Default for StorageNoopGuard {
 	fn default() -> Self {

--- a/frame/support/src/storage/storage_noop_guard.rs
+++ b/frame/support/src/storage/storage_noop_guard.rs
@@ -1,0 +1,113 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(test)] // Testing only since it can panic.
+
+//! Contains the [`crate::StorageNoopGuard`] for conveniently asserting
+//! that no storage mutation has been made by a whole code block.
+
+/// Asserts that no storage changes took place between con- and destruction of [`Self`].
+///
+/// This is easier than wrapping the whole code-block inside a `assert_storage_noop!`.
+///
+/// # Example
+///
+/// ```should_panic
+/// use frame_support::{StorageNoopGuard, storage::unhashed::put};
+///
+/// sp_io::TestExternalities::default().execute_with(|| {
+/// 	let _guard = frame_support::StorageNoopGuard::default();
+/// 	put(b"key", b"value");
+/// 		// Panics since there are storage changes.
+/// });
+/// ```
+#[must_use]
+pub struct StorageNoopGuard(Vec<u8>);
+
+impl Default for StorageNoopGuard {
+	fn default() -> Self {
+		Self(frame_support::storage_root(frame_support::StateVersion::V1))
+	}
+}
+
+impl Drop for StorageNoopGuard {
+	fn drop(&mut self) {
+		// No need to double panic, eg. inside a test assertion failure.
+		if sp_std::thread::panicking() {
+			return
+		}
+		assert_eq!(
+			frame_support::storage_root(frame_support::StateVersion::V1),
+			self.0,
+			"StorageNoopGuard detected wrongful storage changes.",
+		);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use sp_io::TestExternalities;
+
+	#[test]
+	#[should_panic(expected = "StorageNoopGuard detected wrongful storage changes.")]
+	fn storage_noop_guard_panics_on_changed() {
+		TestExternalities::default().execute_with(|| {
+			let _guard = StorageNoopGuard::default();
+			frame_support::storage::unhashed::put(b"key", b"value");
+		});
+	}
+
+	#[test]
+	fn storage_noop_guard_works_on_unchanged() {
+		TestExternalities::default().execute_with(|| {
+			let _guard = StorageNoopGuard::default();
+			frame_support::storage::unhashed::put(b"key", b"value");
+			frame_support::storage::unhashed::kill(b"key");
+		});
+	}
+
+	#[test]
+	#[should_panic(expected = "StorageNoopGuard detected wrongful storage changes.")]
+	fn storage_noop_guard_panics_on_early_drop() {
+		TestExternalities::default().execute_with(|| {
+			let guard = StorageNoopGuard::default();
+			frame_support::storage::unhashed::put(b"key", b"value");
+			sp_std::mem::drop(guard);
+			frame_support::storage::unhashed::kill(b"key");
+		});
+	}
+
+	#[test]
+	fn storage_noop_guard_works_on_changed_forget() {
+		TestExternalities::default().execute_with(|| {
+			let guard = StorageNoopGuard::default();
+			frame_support::storage::unhashed::put(b"key", b"value");
+			sp_std::mem::forget(guard);
+		});
+	}
+
+	#[test]
+	#[should_panic(expected = "Something else")]
+	fn storage_noop_guard_does_not_double_panic() {
+		TestExternalities::default().execute_with(|| {
+			let _guard = StorageNoopGuard::default();
+			frame_support::storage::unhashed::put(b"key", b"value");
+			panic!("Something else");
+		});
+	}
+}


### PR DESCRIPTION
The new struct `StorageNoopGuard` is the guard version of `assert_storage_noop!`.  
Wrapping large code blocks inside a macro is ugly and causes more indentation.  This is useful when writing large zero-sum tests.

### Before:
```rust
fn my_test() {
    new_test_ext().execute_with(|| {
        assert_storage_noop!({
            // The code
        });
    });
}
```

### Now
```rust
fn my_test() {
    new_test_ext().execute_with(|| {
        let _guard = StorageNoopGuard::default();
        // The code
    });
}
```