### PR TITLE
[Uniques V2] Auto-incremental CollectionId

### DIFF
--- a/frame/nfts/src/functions.rs
+++ b/frame/nfts/src/functions.rs
@@ -72,6 +72,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 		T::Currency::reserve(&owner, deposit)?;
 
+		let ref_id = CollectionNextId::<T, I>::get();
 		Collection::<T, I>::insert(
 			collection,
 			CollectionDetails {
@@ -85,11 +86,17 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				item_metadatas: 0,
 				attributes: 0,
 				is_frozen: false,
+				ref_id,
 			},
 		);
 
 		CollectionAccount::<T, I>::insert(&owner, &collection, ());
 		Self::deposit_event(event);
+
+		// update the next ref_id value
+		let next_ref_id = ref_id.saturating_add(1);
+		CollectionNextId::<T, I>::put(next_ref_id);
+
 		Ok(())
 	}
 

--- a/frame/nfts/src/lib.rs
+++ b/frame/nfts/src/lib.rs
@@ -267,6 +267,11 @@ pub mod pallet {
 	pub(super) type CollectionMaxSupply<T: Config<I>, I: 'static = ()> =
 		StorageMap<_, Blake2_128Concat, T::CollectionId, u32, OptionQuery>;
 
+	/// Stores the collection's next id.
+	#[pallet::storage]
+	pub(super) type CollectionNextId<T: Config<I>, I: 'static = ()> =
+		StorageValue<_, u64, ValueQuery>;
+
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config<I>, I: 'static = ()> {

--- a/frame/nfts/src/tests.rs
+++ b/frame/nfts/src/tests.rs
@@ -111,6 +111,7 @@ fn lifecycle_should_work() {
 		assert_ok!(Nfts::create(Origin::signed(1), 0, 1));
 		assert_eq!(Balances::reserved_balance(&1), 2);
 		assert_eq!(collections(), vec![(1, 0)]);
+		assert_eq!(CollectionNextId::<Test>::get(), 1);
 		assert_ok!(Nfts::set_collection_metadata(Origin::signed(1), 0, bvec![0, 0], false));
 		assert_eq!(Balances::reserved_balance(&1), 5);
 		assert!(CollectionMetadataOf::<Test>::contains_key(0));
@@ -122,6 +123,7 @@ fn lifecycle_should_work() {
 		assert_eq!(items(), vec![(10, 0, 42), (20, 0, 69)]);
 		assert_eq!(Collection::<Test>::get(0).unwrap().items, 2);
 		assert_eq!(Collection::<Test>::get(0).unwrap().item_metadatas, 0);
+		assert_eq!(Collection::<Test>::get(0).unwrap().ref_id, 0);
 
 		assert_ok!(Nfts::set_metadata(Origin::signed(1), 0, 42, bvec![42, 42], false));
 		assert_eq!(Balances::reserved_balance(&1), 10);

--- a/frame/nfts/src/types.rs
+++ b/frame/nfts/src/types.rs
@@ -56,6 +56,8 @@ pub struct CollectionDetails<AccountId, DepositBalance> {
 	pub(super) attributes: u32,
 	/// Whether the collection is frozen for non-admin transfers.
 	pub(super) is_frozen: bool,
+	/// Auto-incremental reference id.
+	pub(super) ref_id: u64,
 }
 
 /// Witness data for the destroy transactions.


### PR DESCRIPTION
This PR adds a new field called `ref_id` to Uniques Collections. Since we can't make the CollectionId field itself auto-incremental (as discussed [here](https://github.com/paritytech/substrate/pull/11796#pullrequestreview-1072021100), as a possible solution we can have this internal field, that will be auto-incremented in every collection creation.
This solves the problem when one collection was deleted and then another with the same CollectionId was created. That new `ref_id` field would allow distinguishing between those collections.