### PR TITLE
Upgrade wasm crate dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4372,9 +4372,9 @@ dependencies = [
 
 [[package]]
 name = "memory_units"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
+checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "merlin"
@@ -5004,6 +5004,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5039,7 +5050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
  "autocfg",
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-integer",
  "num-traits",
 ]
@@ -5051,6 +5062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
  "autocfg",
+ "num-bigint 0.4.3",
  "num-integer",
  "num-traits",
 ]
@@ -6617,9 +6629,9 @@ dependencies = [
 
 [[package]]
 name = "parity-wasm"
-version = "0.42.2"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
+checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
 
 [[package]]
 name = "parking"
@@ -8006,7 +8018,7 @@ dependencies = [
  "futures",
  "log",
  "merlin",
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-rational 0.2.4",
  "num-traits",
  "parity-scale-codec",
@@ -8262,7 +8274,7 @@ dependencies = [
  "log",
  "once_cell",
  "parity-scale-codec",
- "parity-wasm 0.42.2",
+ "parity-wasm 0.45.0",
  "paste 1.0.6",
  "rustix 0.33.7",
  "rustix 0.35.6",
@@ -9513,7 +9525,7 @@ name = "sp-arithmetic-fuzzer"
 version = "2.0.0"
 dependencies = [
  "honggfuzz",
- "num-bigint",
+ "num-bigint 0.2.6",
  "primitive-types",
  "sp-arithmetic",
 ]
@@ -10221,7 +10233,7 @@ version = "5.0.0"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
- "parity-wasm 0.42.2",
+ "parity-wasm 0.45.0",
  "scale-info",
  "serde",
  "sp-core-hashing-proc-macro",
@@ -11441,11 +11453,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-instrument"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962e5b0401bbb6c887f54e69b8c496ea36f704df65db73e81fd5ff8dc3e63a9f"
+checksum = "8bca81f5279342b38b17d9acbf007a46ddeb73144e2bd5f0a21bfa9fc5d4ab3e"
 dependencies = [
- "parity-wasm 0.42.2",
+ "parity-wasm 0.45.0",
 ]
 
 [[package]]
@@ -11678,28 +11690,35 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.9.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca00c5147c319a8ec91ec1a0edbec31e566ce2c9cc93b3f9bb86a9efd0eb795d"
+checksum = "fc13b3c219ca9aafeec59150d80d89851df02e0061bc357b4d66fc55a8d38787"
 dependencies = [
- "downcast-rs",
- "errno",
- "libc",
- "libm",
- "memory_units",
- "num-rational 0.2.4",
- "num-traits",
- "parity-wasm 0.42.2",
+ "parity-wasm 0.45.0",
  "wasmi-validation",
+ "wasmi_core",
 ]
 
 [[package]]
 name = "wasmi-validation"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb8e860796d8be48efef530b60eebf84e74a88bce107374fffb0da97d504b8"
+checksum = "91ff416ad1ff0c42e5a926ed5d5fab74c0f098749aa0ad8b2a34b982ce0e867b"
 dependencies = [
- "parity-wasm 0.42.2",
+ "parity-wasm 0.45.0",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a088e8c4c59c6f2b9eae169bf86328adccc477c00b56d3661e3e9fb397b184"
+dependencies = [
+ "downcast-rs",
+ "libm",
+ "memory_units",
+ "num-rational 0.4.0",
+ "num-traits",
 ]
 
 [[package]]

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -149,7 +149,6 @@ pallet-balances = { version = "4.0.0-dev", path = "../../../frame/balances" }
 [features]
 default = ["cli"]
 cli = [
-	"node-executor/wasmi-errno",
 	"node-inspect",
 	"sc-cli",
 	"frame-benchmarking-cli",

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -46,7 +46,6 @@ sp-runtime = { version = "6.0.0", path = "../../../primitives/runtime" }
 
 [features]
 wasmtime = ["sc-executor/wasmtime"]
-wasmi-errno = ["sc-executor/wasmi-errno"]
 stress-test = []
 
 [[bench]]

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = "1.4.0"
 lru = "0.7.5"
 parking_lot = "0.12.1"
 tracing = "0.1.29"
-wasmi = "0.9.1"
+wasmi = "0.13"
 
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 sc-executor-common = { version = "0.10.0-dev", path = "common" }
@@ -63,5 +63,4 @@ default = ["std"]
 std = []
 wasm-extern-trace = []
 wasmtime = ["sc-executor-wasmtime"]
-wasmi-errno = ["wasmi/errno"]
 wasmer-sandbox = ["sc-executor-common/wasmer-sandbox"]

--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -17,9 +17,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 environmental = "1.1.3"
 thiserror = "1.0.30"
-wasm-instrument = "0.1"
+wasm-instrument = "0.2"
 wasmer = { version = "2.2", features = ["singlepass"], optional = true }
-wasmi = "0.9.1"
+wasmi = "0.13"
 sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }
 sp-maybe-compressed-blob = { version = "4.1.0-dev", path = "../../../primitives/maybe-compressed-blob" }
 sp-sandbox = { version = "0.10.0-dev", path = "../../../primitives/sandbox" }

--- a/client/executor/common/src/sandbox/wasmi_backend.rs
+++ b/client/executor/common/src/sandbox/wasmi_backend.rs
@@ -18,14 +18,14 @@
 
 //! Wasmi specific impls for sandbox
 
-use std::rc::Rc;
+use std::{fmt, rc::Rc};
 
 use codec::{Decode, Encode};
 use sp_sandbox::HostError;
 use sp_wasm_interface::{FunctionContext, Pointer, ReturnValue, Value, WordSize};
 use wasmi::{
 	memory_units::Pages, ImportResolver, MemoryInstance, Module, ModuleInstance, RuntimeArgs,
-	RuntimeValue, Trap, TrapKind,
+	RuntimeValue, Trap,
 };
 
 use crate::{
@@ -39,9 +39,20 @@ use crate::{
 
 environmental::environmental!(SandboxContextStore: trait SandboxContext);
 
+#[derive(Debug)]
+struct CustomHostError(String);
+
+impl fmt::Display for CustomHostError {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(f, "HostError: {}", self.0)
+	}
+}
+
+impl wasmi::HostError for CustomHostError {}
+
 /// Construct trap error from specified message
 fn trap(msg: &'static str) -> Trap {
-	TrapKind::Host(Box::new(Error::Other(msg.into()))).into()
+	Trap::host(CustomHostError(msg.into()))
 }
 
 impl ImportResolver for Imports {

--- a/client/executor/wasmi/Cargo.toml
+++ b/client/executor/wasmi/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 log = "0.4.17"
-wasmi = "0.9.1"
+wasmi = "0.13"
 sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }
 sc-executor-common = { version = "0.10.0-dev", path = "../common" }
 sp-runtime-interface = { version = "6.0.0", path = "../../../primitives/runtime-interface" }

--- a/client/executor/wasmi/src/lib.rs
+++ b/client/executor/wasmi/src/lib.rs
@@ -181,6 +181,7 @@ impl Sandbox for FunctionExecutor {
 
 		let len = val_len as usize;
 
+		#[allow(deprecated)]
 		let buffer = match self.memory.get(val_ptr.into(), len) {
 			Err(_) => return Ok(sandbox_env::ERR_OUT_OF_BOUNDS),
 			Ok(buffer) => buffer,
@@ -568,6 +569,7 @@ fn call_in_wasm_module(
 	match result {
 		Ok(Some(I64(r))) => {
 			let (ptr, length) = unpack_ptr_and_len(r as u64);
+			#[allow(deprecated)]
 			memory.get(ptr, length as usize).map_err(|_| Error::Runtime)
 		},
 		Err(e) => {

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -17,7 +17,7 @@ cfg-if = "1.0"
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 libc = "0.2.121"
 log = "0.4.17"
-parity-wasm = "0.42.0"
+parity-wasm = "0.45"
 
 # When bumping wasmtime do not forget to also bump rustix
 # to exactly the same version as used by wasmtime!

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -20,12 +20,12 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 ] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 log = { version = "0.4", default-features = false }
-wasm-instrument = { version = "0.1", default-features = false }
+wasm-instrument = { version = "0.2", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 smallvec = { version = "1", default-features = false, features = [
 	"const_generics",
 ] }
-wasmi-validation = { version = "0.4", default-features = false }
+wasmi-validation = { version = "0.5", default-features = false }
 impl-trait-for-tuples = "0.2"
 
 # Only used in benchmarking to generate random contract code

--- a/frame/contracts/src/benchmarking/code.rs
+++ b/frame/contracts/src/benchmarking/code.rs
@@ -195,7 +195,7 @@ where
 		for func in def.imported_functions {
 			let sig = builder::signature()
 				.with_params(func.params)
-				.with_results(func.return_type.into_iter().collect())
+				.with_results(func.return_type)
 				.build_sig();
 			let sig = contract.push_signature(sig);
 			contract = contract
@@ -254,9 +254,9 @@ where
 			code = inject_stack_metering::<T>(code);
 		}
 
-		let code = code.to_bytes().unwrap();
+		let code = code.into_bytes().unwrap();
 		let hash = T::Hashing::hash(&code);
-		Self { code, hash, memory: def.memory }
+		Self { code: code.into(), hash, memory: def.memory }
 	}
 }
 
@@ -285,11 +285,11 @@ where
 			.find_map(|e| if let External::Memory(mem) = e.external() { Some(mem) } else { None })
 			.unwrap()
 			.limits();
-		let code = module.to_bytes().unwrap();
+		let code = module.into_bytes().unwrap();
 		let hash = T::Hashing::hash(&code);
 		let memory =
 			ImportedMemory { min_pages: limits.initial(), max_pages: limits.maximum().unwrap() };
-		Self { code, hash, memory: Some(memory) }
+		Self { code: code.into(), hash, memory: Some(memory) }
 	}
 
 	/// Creates a wasm module with an empty `call` and `deploy` function and nothing else.

--- a/frame/contracts/src/wasm/prepare.rs
+++ b/frame/contracts/src/wasm/prepare.rs
@@ -54,7 +54,7 @@ impl<'a, T: Config> ContractModule<'a, T> {
 			elements::deserialize_buffer(original_code).map_err(|_| "Can't decode wasm code")?;
 
 		// Make sure that the module is valid.
-		validate_module::<PlainValidator>(&module).map_err(|_| "Module is not valid")?;
+		validate_module::<PlainValidator>(&module, ()).map_err(|_| "Module is not valid")?;
 
 		// Return a `ContractModule` instance with
 		// __valid__ module.

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.136", optional = true, features = ["derive"] }
 byteorder = { version = "1.3.2", default-features = false }
 primitive-types = { version = "0.11.1", default-features = false, features = ["codec", "scale-info"] }
 impl-serde = { version = "0.3.0", optional = true }
-wasmi = { version = "0.9.1", optional = true }
+wasmi = { version = "0.13", optional = true }
 hash-db = { version = "0.15.2", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 base58 = { version = "0.2.0", optional = true }

--- a/primitives/sandbox/Cargo.toml
+++ b/primitives/sandbox/Cargo.toml
@@ -12,16 +12,10 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-wasmi = { version = "0.9.1", default-features = false, features = ["core"] }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-wasmi = "0.9.0"
-
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 log = { version = "0.4", default-features = false }
-wasmi = { version = "0.9.0", optional = true }
+wasmi = { version = "0.13", default-features = false }
 sp-core = { version = "6.0.0", default-features = false, path = "../core" }
 sp-io = { version = "6.0.0", default-features = false, path = "../io" }
 sp-std = { version = "4.0.0", default-features = false, path = "../std" }
@@ -40,7 +34,7 @@ std = [
 	"sp-io/std",
 	"sp-std/std",
 	"sp-wasm-interface/std",
-	"wasmi",
+	"wasmi/std",
 ]
 strict = []
 wasmer-sandbox = []

--- a/primitives/sandbox/src/embedded_executor.rs
+++ b/primitives/sandbox/src/embedded_executor.rs
@@ -22,7 +22,7 @@ use alloc::string::String;
 use wasmi::{
 	memory_units::Pages, Externals, FuncInstance, FuncRef, GlobalDescriptor, GlobalRef,
 	ImportResolver, MemoryDescriptor, MemoryInstance, MemoryRef, Module, ModuleInstance, ModuleRef,
-	RuntimeArgs, RuntimeValue, Signature, TableDescriptor, TableRef, Trap, TrapKind,
+	RuntimeArgs, RuntimeValue, Signature, TableDescriptor, TableRef, Trap,
 };
 
 use sp_std::{
@@ -113,7 +113,7 @@ impl<'a, T> Externals for GuestExternals<'a, T> {
 				ReturnValue::Value(v) => Some(to_wasmi(v)),
 				ReturnValue::Unit => None,
 			}),
-			Err(HostError) => Err(TrapKind::Host(Box::new(DummyHostError)).into()),
+			Err(HostError) => Err(Trap::host(DummyHostError)),
 		}
 	}
 }

--- a/primitives/version/Cargo.toml
+++ b/primitives/version/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 impl-serde = { version = "0.3.1", optional = true }
-parity-wasm = { version = "0.42.2", optional = true }
+parity-wasm = { version = "0.45", optional = true }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.136", features = ["derive"], optional = true }
 thiserror = { version = "1.0.30", optional = true }

--- a/primitives/wasm-interface/Cargo.toml
+++ b/primitives/wasm-interface/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 impl-trait-for-tuples = "0.2.2"
 log = { version = "0.4.17", optional = true }
-wasmi = { version = "0.9.1", optional = true }
+wasmi = { version = "0.13", optional = true }
 wasmtime = { version = "0.38.0", default-features = false, optional = true }
 sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 


### PR DESCRIPTION
This upgrades:

```
parity-wasm 0.42 -> 0.45
wasm-instrument 0.1 -> 0.2
wasmi 0.9 -> 0.13
```

These do not contain big changes but merely big fixes. wasmi is upgraded to the last version before bigger changes were made. We will upgrade only until we did more testing: https://github.com/paritytech/roadmap/issues/9

We should also do a burn in with wasmi as a execution engine.