### PR TITLE
Doc only typo fixes

### DIFF
--- a/frame/assets/src/types.rs
+++ b/frame/assets/src/types.rs
@@ -165,7 +165,7 @@ pub trait FrozenBalance<AssetId, AccountId, Balance> {
 	///
 	/// Under normal behaviour, the account balance should not go below the sum of this (if `Some`)
 	/// and the asset's minimum balance. However, the account balance may reasonably begin below
-	/// this sum (e.g. if less than the sum had ever been transfered into the account).
+	/// this sum (e.g. if less than the sum had ever been transferred into the account).
 	///
 	/// In special cases (privileged intervention) the account balance may also go below the sum.
 	///

--- a/frame/support/src/traits/metadata.rs
+++ b/frame/support/src/traits/metadata.rs
@@ -71,7 +71,7 @@ pub trait PalletsInfoAccess {
 	///
 	/// You probably don't want this function but `infos()` instead.
 	fn count() -> usize {
-		// for backwards compatibility with XCM-3, Mark is deprecated.
+		// for backwards compatibility with XCM-3, Mark as deprecated.
 		Self::infos().len()
 	}
 

--- a/frame/support/src/traits/tokens/fungibles/approvals.rs
+++ b/frame/support/src/traits/tokens/fungibles/approvals.rs
@@ -24,7 +24,7 @@ pub trait Inspect<AccountId>: super::Inspect<AccountId> {
 }
 
 pub trait Mutate<AccountId>: Inspect<AccountId> {
-	// Aprove a delegate account to spend an amount of tokens owned by an owner
+	// Approve a delegate account to spend an amount of tokens owned by an owner
 	fn approve(
 		asset: Self::AssetId,
 		owner: &AccountId,

--- a/frame/support/src/traits/tokens/fungibles/balanced.rs
+++ b/frame/support/src/traits/tokens/fungibles/balanced.rs
@@ -163,7 +163,7 @@ pub trait Balanced<AccountId>: Inspect<AccountId> {
 /// **WARNING**
 /// Do not use this directly unless you want trouble, since it allows you to alter account balances
 /// without keeping the issuance up to date. It has no safeguards against accidentally creating
-/// token imbalances in your system leading to accidental imflation or deflation. It's really just
+/// token imbalances in your system leading to accidental inflation or deflation. It's really just
 /// for the underlying datatype to implement so the user gets the much safer `Balanced` trait to
 /// use.
 pub trait Unbalanced<AccountId>: Inspect<AccountId> {


### PR DESCRIPTION
Have been reading a lot of code recently. These stood out.