### PR TITLE
Impl transaction-payment GenesisConfig with NextFeeMultplier support

### DIFF
--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -312,12 +312,16 @@ pub mod pallet {
 	pub(super) type StorageVersion<T: Config> = StorageValue<_, Releases, ValueQuery>;
 
 	#[pallet::genesis_config]
-	pub struct GenesisConfig;
+	pub struct GenesisConfig {
+		multiplier: Multiplier,
+	}
 
 	#[cfg(feature = "std")]
 	impl Default for GenesisConfig {
 		fn default() -> Self {
-			Self
+			Self {
+				multiplier: Multiplier::saturating_from_integer(1),
+			}
 		}
 	}
 
@@ -325,6 +329,7 @@ pub mod pallet {
 	impl<T: Config> GenesisBuild<T> for GenesisConfig {
 		fn build(&self) {
 			StorageVersion::<T>::put(Releases::V2);
+			NextFeeMultiplier::<T>::put(self.multiplier);
 		}
 	}
 

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -319,9 +319,7 @@ pub mod pallet {
 	#[cfg(feature = "std")]
 	impl Default for GenesisConfig {
 		fn default() -> Self {
-			Self {
-				multiplier: Multiplier::saturating_from_integer(1),
-			}
+			Self { multiplier: Multiplier::saturating_from_integer(1) }
 		}
 	}
 

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -970,8 +970,13 @@ mod tests {
 
 	impl Default for ExtBuilder {
 		fn default() -> Self {
-			Self { balance_factor: 1, base_weight: Weight::zero(), byte_fee: 1, weight_to_fee: 1,
-			initial_multiplier: None }
+			Self {
+				balance_factor: 1,
+				base_weight: Weight::zero(),
+				byte_fee: 1,
+				weight_to_fee: 1,
+				initial_multiplier: None,
+			}
 		}
 	}
 
@@ -1022,9 +1027,7 @@ mod tests {
 			.unwrap();
 
 			if let Some(multiplier) = self.initial_multiplier {
-				let genesis = pallet::GenesisConfig {
-					multiplier
-				};
+				let genesis = pallet::GenesisConfig { multiplier };
 				GenesisBuild::<Runtime>::assimilate_storage(&genesis, &mut t).unwrap();
 			}
 
@@ -1757,13 +1760,8 @@ mod tests {
 
 	#[test]
 	fn genesis_default_works() {
-		ExtBuilder::default()
-			.build()
-			.execute_with(|| {
-				assert_eq!(
-					<NextFeeMultiplier<Runtime>>::get(),
-					Multiplier::saturating_from_integer(1)
-				);
-			});
+		ExtBuilder::default().build().execute_with(|| {
+			assert_eq!(<NextFeeMultiplier<Runtime>>::get(), Multiplier::saturating_from_integer(1));
+		});
 	}
 }

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -241,6 +241,10 @@ impl Default for Releases {
 	}
 }
 
+/// Default value for NextFeeMultiplier. This is used in genesis and is also used in
+/// NextFeeMultiplierOnEmpty() to provide a value when none exists in storage.
+const MULTIPLIER_DEFAULT_VALUE: Multiplier = Multiplier::from_u32(1);
+
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
@@ -300,7 +304,7 @@ pub mod pallet {
 
 	#[pallet::type_value]
 	pub fn NextFeeMultiplierOnEmpty() -> Multiplier {
-		Multiplier::saturating_from_integer(1)
+		MULTIPLIER_DEFAULT_VALUE
 	}
 
 	#[pallet::storage]
@@ -319,7 +323,7 @@ pub mod pallet {
 	#[cfg(feature = "std")]
 	impl Default for GenesisConfig {
 		fn default() -> Self {
-			Self { multiplier: Multiplier::saturating_from_integer(1) }
+			Self { multiplier: MULTIPLIER_DEFAULT_VALUE }
 		}
 	}
 


### PR DESCRIPTION
This allows an initial value for `NextFeeMultiplier` to be provided at genesis. 

The current implementation hard-codes the initial value to `FixedU128::saturating_from_integer(1)` when it is absent. While this can be adjusted arbitrarily with `FeeMultiplierUpdate`, this doesn't kick in until the end of block 1.

This means that block 1 fees are impractical on any runtime for which 1 is not a sane value. This is particularly problematic for testing.

An alternative approach would be to add an initial value to the runtime config, but this didn't seem worth the extra bloat to me.