### PR TITLE
Remove Ord impl for Weights V2 and add comparison fns

### DIFF
--- a/frame/babe/src/tests.rs
+++ b/frame/babe/src/tests.rs
@@ -823,7 +823,7 @@ fn report_equivocation_has_valid_weight() {
 		.map(<Test as Config>::WeightInfo::report_equivocation)
 		.collect::<Vec<_>>()
 		.windows(2)
-		.all(|w| w[0] < w[1]));
+		.all(|w| w[0].ref_time() < w[1].ref_time()));
 }
 
 #[test]
@@ -852,7 +852,7 @@ fn valid_equivocation_reports_dont_pay_fees() {
 		.get_dispatch_info();
 
 		// it should have non-zero weight and the fee has to be paid.
-		assert!(info.weight > Weight::zero());
+		assert!(info.weight.all_gt(Weight::zero()));
 		assert_eq!(info.pays_fee, Pays::Yes);
 
 		// report the equivocation.

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -881,7 +881,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		ensure!(proposal_len <= length_bound, Error::<T, I>::WrongProposalLength);
 		let proposal = ProposalOf::<T, I>::get(hash).ok_or(Error::<T, I>::ProposalMissing)?;
 		let proposal_weight = proposal.get_dispatch_info().weight;
-		ensure!(proposal_weight <= weight_bound, Error::<T, I>::WrongProposalWeight);
+		ensure!(proposal_weight.all_lte(weight_bound), Error::<T, I>::WrongProposalWeight);
 		Ok((proposal, proposal_len as usize))
 	}
 

--- a/frame/contracts/src/gas.rs
+++ b/frame/contracts/src/gas.rs
@@ -111,7 +111,7 @@ where
 
 		// NOTE that it is ok to allocate all available gas since it still ensured
 		// by `charge` that it doesn't reach zero.
-		if self.gas_left < amount {
+		if self.gas_left.any_lt(amount) {
 			Err(<Error<T>>::OutOfGas.into())
 		} else {
 			self.gas_left -= amount;

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -1555,8 +1555,8 @@ mod tests {
 
 		let gas_left = Weight::decode(&mut &*output.data).unwrap();
 		let actual_left = ext.gas_meter.gas_left();
-		assert!(gas_left.any_lt(gas_limit), "gas_left must be less than initial");
-		assert!(gas_left.any_gt(actual_left), "gas_left must be greater than final");
+		assert!(gas_left.all_lt(gas_limit), "gas_left must be less than initial");
+		assert!(gas_left.all_gt(actual_left), "gas_left must be greater than final");
 	}
 
 	const CODE_VALUE_TRANSFERRED: &str = r#"

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -1555,8 +1555,8 @@ mod tests {
 
 		let gas_left = Weight::decode(&mut &*output.data).unwrap();
 		let actual_left = ext.gas_meter.gas_left();
-		assert!(gas_left < gas_limit, "gas_left must be less than initial");
-		assert!(gas_left > actual_left, "gas_left must be greater than final");
+		assert!(gas_left.any_lt(gas_limit), "gas_left must be less than initial");
+		assert!(gas_left.any_gt(actual_left), "gas_left must be greater than final");
 	}
 
 	const CODE_VALUE_TRANSFERRED: &str = r#"
@@ -1911,7 +1911,7 @@ mod tests {
 			)]
 		);
 
-		assert!(mock_ext.gas_meter.gas_left() > Weight::zero());
+		assert!(mock_ext.gas_meter.gas_left().all_gt(Weight::zero()));
 	}
 
 	const CODE_DEPOSIT_EVENT_MAX_TOPICS: &str = r#"

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -985,7 +985,7 @@ pub mod pallet {
 			let size = Self::snapshot_metadata().ok_or(Error::<T>::MissingSnapshotMetadata)?;
 
 			ensure!(
-				Self::solution_weight_of(&raw_solution, size) < T::SignedMaxWeight::get(),
+				Self::solution_weight_of(&raw_solution, size).all_lt(T::SignedMaxWeight::get()),
 				Error::<T>::SignedTooMuchWeight,
 			);
 

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -2299,8 +2299,8 @@ mod tests {
 		};
 
 		let mut active = 1;
-		while weight_with(active) <=
-			<Runtime as frame_system::Config>::BlockWeights::get().max_block ||
+		while weight_with(active)
+			.all_lte(<Runtime as frame_system::Config>::BlockWeights::get().max_block) ||
 			active == all_voters
 		{
 			active += 1;

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -644,7 +644,7 @@ impl<T: MinerConfig> Miner<T> {
 					Some(voters) if voters < max_voters => Ok(voters),
 					_ => Err(()),
 				}
-			} else if current_weight.all_gt(max_weight) {
+			} else if current_weight.any_gt(max_weight) {
 				voters.checked_sub(step).ok_or(())
 			} else {
 				// If any of the constituent weights is equal to the max weight, we're at max

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -650,7 +650,6 @@ impl<T: MinerConfig> Miner<T> {
 				// If any of the constituent weights is equal to the max weight, we're at max
 				Ok(voters)
 			}
-			// TODO: What to do when time weight is greater and size weight is lesser (and vice versa)?
 		};
 
 		// First binary-search the right amount of voters

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -34,7 +34,7 @@ use sp_runtime::{
 	offchain::storage::{MutateStorageError, StorageValueRef},
 	DispatchError, SaturatedConversion,
 };
-use sp_std::{cmp::Ordering, prelude::*};
+use sp_std::prelude::*;
 
 /// Storage key used to store the last block number at which offchain worker ran.
 pub(crate) const OFFCHAIN_LAST_BLOCK: &[u8] = b"parity/multi-phase-unsigned-election";

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -638,17 +638,19 @@ impl<T: MinerConfig> Miner<T> {
 		};
 
 		let next_voters = |current_weight: Weight, voters: u32, step: u32| -> Result<u32, ()> {
-			match current_weight.cmp(&max_weight) {
-				Ordering::Less => {
-					let next_voters = voters.checked_add(step);
-					match next_voters {
-						Some(voters) if voters < max_voters => Ok(voters),
-						_ => Err(()),
-					}
-				},
-				Ordering::Greater => voters.checked_sub(step).ok_or(()),
-				Ordering::Equal => Ok(voters),
+			if current_weight.all_lt(max_weight) {
+				let next_voters = voters.checked_add(step);
+				match next_voters {
+					Some(voters) if voters < max_voters => Ok(voters),
+					_ => Err(()),
+				}
+			} else if current_weight.all_gt(max_weight) {
+				voters.checked_sub(step).ok_or(())
+			} else {
+				// If any of the constituent weights is equal to the max weight, we're at max
+				Ok(voters)
 			}
+			// TODO: What to do when time weight is greater and size weight is lesser (and vice versa)?
 		};
 
 		// First binary-search the right amount of voters
@@ -672,16 +674,16 @@ impl<T: MinerConfig> Miner<T> {
 
 		// Time to finish. We might have reduced less than expected due to rounding error. Increase
 		// one last time if we have any room left, the reduce until we are sure we are below limit.
-		while voters < max_voters && weight_with(voters + 1) < max_weight {
+		while voters < max_voters && weight_with(voters + 1).all_lt(max_weight) {
 			voters += 1;
 		}
-		while voters.checked_sub(1).is_some() && weight_with(voters) > max_weight {
+		while voters.checked_sub(1).is_some() && weight_with(voters).any_gt(max_weight) {
 			voters -= 1;
 		}
 
 		let final_decision = voters.min(size.voters);
 		debug_assert!(
-			weight_with(final_decision) <= max_weight,
+			weight_with(final_decision).all_lte(max_weight),
 			"weight_with({}) <= {}",
 			final_decision,
 			max_weight,

--- a/frame/examples/basic/src/tests.rs
+++ b/frame/examples/basic/src/tests.rs
@@ -190,11 +190,11 @@ fn weights_work() {
 	let default_call = pallet_example_basic::Call::<Test>::accumulate_dummy { increase_by: 10 };
 	let info1 = default_call.get_dispatch_info();
 	// aka. `let info = <Call<Test> as GetDispatchInfo>::get_dispatch_info(&default_call);`
-	assert!(info1.weight > Weight::zero());
+	assert!(info1.weight.all_gt(Weight::zero()));
 
 	// `set_dummy` is simpler than `accumulate_dummy`, and the weight
 	//   should be less.
 	let custom_call = pallet_example_basic::Call::<Test>::set_dummy { new_value: 20 };
 	let info2 = custom_call.get_dispatch_info();
-	assert!(info1.weight > info2.weight);
+	assert!(info1.weight.all_gt(info2.weight));
 }

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -462,7 +462,7 @@ where
 		let max_weight = <System::BlockWeights as frame_support::traits::Get<_>>::get().max_block;
 		let remaining_weight = max_weight.saturating_sub(weight.total());
 
-		if remaining_weight > Weight::zero() {
+		if remaining_weight.all_gt(Weight::zero()) {
 			let used_weight = <AllPalletsWithSystem as OnIdle<System::BlockNumber>>::on_idle(
 				block_number,
 				remaining_weight,

--- a/frame/grandpa/src/tests.rs
+++ b/frame/grandpa/src/tests.rs
@@ -823,7 +823,7 @@ fn report_equivocation_has_valid_weight() {
 		.map(<Test as Config>::WeightInfo::report_equivocation)
 		.collect::<Vec<_>>()
 		.windows(2)
-		.all(|w| w[0] < w[1]));
+		.all(|w| w[0].ref_time() < w[1].ref_time()));
 }
 
 #[test]
@@ -856,7 +856,7 @@ fn valid_equivocation_reports_dont_pay_fees() {
 		.get_dispatch_info();
 
 		// it should have non-zero weight and the fee has to be paid.
-		assert!(info.weight > Weight::zero());
+		assert!(info.weight.all_gt(Weight::zero()));
 		assert_eq!(info.pays_fee, Pays::Yes);
 
 		// report the equivocation.

--- a/frame/multisig/src/lib.rs
+++ b/frame/multisig/src/lib.rs
@@ -563,7 +563,10 @@ impl<T: Config> Pallet<T> {
 
 			if let Some((call, call_len)) = maybe_approved_call {
 				// verify weight
-				ensure!(call.get_dispatch_info().weight.all_lte(max_weight), Error::<T>::MaxWeightTooLow);
+				ensure!(
+					call.get_dispatch_info().weight.all_lte(max_weight),
+					Error::<T>::MaxWeightTooLow
+				);
 
 				// Clean up storage before executing call to avoid an possibility of reentrancy
 				// attack.

--- a/frame/multisig/src/lib.rs
+++ b/frame/multisig/src/lib.rs
@@ -563,7 +563,7 @@ impl<T: Config> Pallet<T> {
 
 			if let Some((call, call_len)) = maybe_approved_call {
 				// verify weight
-				ensure!(call.get_dispatch_info().weight.any_lte(max_weight), Error::<T>::MaxWeightTooLow);
+				ensure!(call.get_dispatch_info().weight.all_lte(max_weight), Error::<T>::MaxWeightTooLow);
 
 				// Clean up storage before executing call to avoid an possibility of reentrancy
 				// attack.

--- a/frame/multisig/src/lib.rs
+++ b/frame/multisig/src/lib.rs
@@ -563,7 +563,7 @@ impl<T: Config> Pallet<T> {
 
 			if let Some((call, call_len)) = maybe_approved_call {
 				// verify weight
-				ensure!(call.get_dispatch_info().weight <= max_weight, Error::<T>::MaxWeightTooLow);
+				ensure!(call.get_dispatch_info().weight.any_lte(max_weight), Error::<T>::MaxWeightTooLow);
 
 				// Clean up storage before executing call to avoid an possibility of reentrancy
 				// attack.

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -368,7 +368,7 @@ pub mod pallet {
 				let hard_deadline = s.priority <= schedule::HARD_DEADLINE;
 				let test_weight =
 					total_weight.saturating_add(call_weight).saturating_add(item_weight);
-				if !hard_deadline && order > 0 && test_weight > limit {
+				if !hard_deadline && order > 0 && test_weight.any_gt(limit) {
 					// Cannot be scheduled this block - postpone until next.
 					total_weight.saturating_accrue(T::WeightInfo::item(false, named, None));
 					if let Some(ref id) = s.maybe_id {

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -1571,10 +1571,10 @@ pub mod pallet {
 		/// to kick people under the new limits, `chill_other` should be called.
 		// We assume the worst case for this call is either: all items are set or all items are
 		// removed.
-		#[pallet::weight(max(
-			T::WeightInfo::set_staking_configs_all_set(),
-			T::WeightInfo::set_staking_configs_all_remove()
-		))]
+		#[pallet::weight(
+			T::WeightInfo::set_staking_configs_all_set()
+				.max(T::WeightInfo::set_staking_configs_all_remove())
+		)]
 		pub fn set_staking_configs(
 			origin: OriginFor<T>,
 			min_nominator_bond: ConfigOp<BalanceOf<T>>,

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -33,7 +33,7 @@ use sp_runtime::{
 	Perbill, Percent,
 };
 use sp_staking::{EraIndex, SessionIndex};
-use sp_std::{cmp::max, prelude::*};
+use sp_std::prelude::*;
 
 mod impls;
 

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -3759,9 +3759,9 @@ fn payout_stakers_handles_weight_refund() {
 		let half_max_nom_rewarded_weight =
 			<Test as Config>::WeightInfo::payout_stakers_alive_staked(half_max_nom_rewarded);
 		let zero_nom_payouts_weight = <Test as Config>::WeightInfo::payout_stakers_alive_staked(0);
-		assert!(zero_nom_payouts_weight > Weight::zero());
-		assert!(half_max_nom_rewarded_weight > zero_nom_payouts_weight);
-		assert!(max_nom_rewarded_weight > half_max_nom_rewarded_weight);
+		assert!(zero_nom_payouts_weight.any_gt(Weight::zero()));
+		assert!(half_max_nom_rewarded_weight.any_gt(zero_nom_payouts_weight));
+		assert!(max_nom_rewarded_weight.any_gt(half_max_nom_rewarded_weight));
 
 		let balance = 1000;
 		bond_validator(11, 10, balance);
@@ -4238,7 +4238,7 @@ fn do_not_die_when_active_is_ed() {
 fn on_finalize_weight_is_nonzero() {
 	ExtBuilder::default().build_and_execute(|| {
 		let on_finalize_weight = <Test as frame_system::Config>::DbWeight::get().reads(1);
-		assert!(<Staking as Hooks<u64>>::on_initialize(1) >= on_finalize_weight);
+		assert!(<Staking as Hooks<u64>>::on_initialize(1).all_gte(on_finalize_weight));
 	})
 }
 
@@ -4249,8 +4249,8 @@ mod election_data_provider {
 	#[test]
 	fn targets_2sec_block() {
 		let mut validators = 1000;
-		while <Test as Config>::WeightInfo::get_npos_targets(validators) <
-			2u64 * frame_support::weights::constants::WEIGHT_PER_SECOND
+		while <Test as Config>::WeightInfo::get_npos_targets(validators)
+			.all_lt(2u64 * frame_support::weights::constants::WEIGHT_PER_SECOND)
 		{
 			validators += 1;
 		}
@@ -4267,8 +4267,8 @@ mod election_data_provider {
 		let slashing_spans = validators;
 		let mut nominators = 1000;
 
-		while <Test as Config>::WeightInfo::get_npos_voters(validators, nominators, slashing_spans) <
-			2u64 * frame_support::weights::constants::WEIGHT_PER_SECOND
+		while <Test as Config>::WeightInfo::get_npos_voters(validators, nominators, slashing_spans)
+			.all_lt(2u64 * frame_support::weights::constants::WEIGHT_PER_SECOND)
 		{
 			nominators += 1;
 		}

--- a/frame/support/src/weights/block_weights.rs
+++ b/frame/support/src/weights/block_weights.rs
@@ -68,8 +68,8 @@ mod test_weights {
 		let w = super::BlockExecutionWeight::get();
 
 		// At least 100 µs.
-		assert!(w >= 100u32 * constants::WEIGHT_PER_MICROS, "Weight should be at least 100 µs.");
+		assert!(w.ref_time() >= 100u64 * constants::WEIGHT_PER_MICROS.ref_time(), "Weight should be at least 100 µs.");
 		// At most 50 ms.
-		assert!(w <= 50u32 * constants::WEIGHT_PER_MILLIS, "Weight should be at most 50 ms.");
+		assert!(w.ref_time() <= 50u64 * constants::WEIGHT_PER_MILLIS.ref_time(), "Weight should be at most 50 ms.");
 	}
 }

--- a/frame/support/src/weights/block_weights.rs
+++ b/frame/support/src/weights/block_weights.rs
@@ -68,8 +68,14 @@ mod test_weights {
 		let w = super::BlockExecutionWeight::get();
 
 		// At least 100 µs.
-		assert!(w.ref_time() >= 100u64 * constants::WEIGHT_PER_MICROS.ref_time(), "Weight should be at least 100 µs.");
+		assert!(
+			w.ref_time() >= 100u64 * constants::WEIGHT_PER_MICROS.ref_time(),
+			"Weight should be at least 100 µs."
+		);
 		// At most 50 ms.
-		assert!(w.ref_time() <= 50u64 * constants::WEIGHT_PER_MILLIS.ref_time(), "Weight should be at most 50 ms.");
+		assert!(
+			w.ref_time() <= 50u64 * constants::WEIGHT_PER_MILLIS.ref_time(),
+			"Weight should be at most 50 ms."
+		);
 	}
 }

--- a/frame/support/src/weights/extrinsic_weights.rs
+++ b/frame/support/src/weights/extrinsic_weights.rs
@@ -68,8 +68,14 @@ mod test_weights {
 		let w = super::ExtrinsicBaseWeight::get();
 
 		// At least 10 µs.
-		assert!(w.ref_time() >= 10u64 * constants::WEIGHT_PER_MICROS.ref_time(), "Weight should be at least 10 µs.");
+		assert!(
+			w.ref_time() >= 10u64 * constants::WEIGHT_PER_MICROS.ref_time(),
+			"Weight should be at least 10 µs."
+		);
 		// At most 1 ms.
-		assert!(w.ref_time() <= constants::WEIGHT_PER_MILLIS.ref_time(), "Weight should be at most 1 ms.");
+		assert!(
+			w.ref_time() <= constants::WEIGHT_PER_MILLIS.ref_time(),
+			"Weight should be at most 1 ms."
+		);
 	}
 }

--- a/frame/support/src/weights/extrinsic_weights.rs
+++ b/frame/support/src/weights/extrinsic_weights.rs
@@ -68,8 +68,8 @@ mod test_weights {
 		let w = super::ExtrinsicBaseWeight::get();
 
 		// At least 10 µs.
-		assert!(w >= 10u32 * constants::WEIGHT_PER_MICROS, "Weight should be at least 10 µs.");
+		assert!(w.ref_time() >= 10u64 * constants::WEIGHT_PER_MICROS.ref_time(), "Weight should be at least 10 µs.");
 		// At most 1 ms.
-		assert!(w <= constants::WEIGHT_PER_MILLIS, "Weight should be at most 1 ms.");
+		assert!(w.ref_time() <= constants::WEIGHT_PER_MILLIS.ref_time(), "Weight should be at most 1 ms.");
 	}
 }

--- a/frame/support/src/weights/paritydb_weights.rs
+++ b/frame/support/src/weights/paritydb_weights.rs
@@ -42,20 +42,20 @@ pub mod constants {
 		fn sane() {
 			// At least 1 µs.
 			assert!(
-				W::get().reads(1) >= constants::WEIGHT_PER_MICROS,
+				W::get().reads(1).ref_time() >= constants::WEIGHT_PER_MICROS.ref_time(),
 				"Read weight should be at least 1 µs."
 			);
 			assert!(
-				W::get().writes(1) >= constants::WEIGHT_PER_MICROS,
+				W::get().writes(1).ref_time() >= constants::WEIGHT_PER_MICROS.ref_time(),
 				"Write weight should be at least 1 µs."
 			);
 			// At most 1 ms.
 			assert!(
-				W::get().reads(1) <= constants::WEIGHT_PER_MILLIS,
+				W::get().reads(1).ref_time() <= constants::WEIGHT_PER_MILLIS.ref_time(),
 				"Read weight should be at most 1 ms."
 			);
 			assert!(
-				W::get().writes(1) <= constants::WEIGHT_PER_MILLIS,
+				W::get().writes(1).ref_time() <= constants::WEIGHT_PER_MILLIS.ref_time(),
 				"Write weight should be at most 1 ms."
 			);
 		}

--- a/frame/support/src/weights/rocksdb_weights.rs
+++ b/frame/support/src/weights/rocksdb_weights.rs
@@ -42,20 +42,20 @@ pub mod constants {
 		fn sane() {
 			// At least 1 µs.
 			assert!(
-				W::get().reads(1) >= constants::WEIGHT_PER_MICROS,
+				W::get().reads(1).ref_time() >= constants::WEIGHT_PER_MICROS.ref_time(),
 				"Read weight should be at least 1 µs."
 			);
 			assert!(
-				W::get().writes(1) >= constants::WEIGHT_PER_MICROS,
+				W::get().writes(1).ref_time() >= constants::WEIGHT_PER_MICROS.ref_time(),
 				"Write weight should be at least 1 µs."
 			);
 			// At most 1 ms.
 			assert!(
-				W::get().reads(1) <= constants::WEIGHT_PER_MILLIS,
+				W::get().reads(1).ref_time() <= constants::WEIGHT_PER_MILLIS.ref_time(),
 				"Read weight should be at most 1 ms."
 			);
 			assert!(
-				W::get().writes(1) <= constants::WEIGHT_PER_MILLIS,
+				W::get().writes(1).ref_time() <= constants::WEIGHT_PER_MILLIS.ref_time(),
 				"Write weight should be at most 1 ms."
 			);
 		}

--- a/frame/support/src/weights/weight_v2.rs
+++ b/frame/support/src/weights/weight_v2.rs
@@ -35,8 +35,6 @@ use super::*;
 	Clone,
 	RuntimeDebug,
 	Default,
-	Ord,
-	PartialOrd,
 	CompactAs,
 )]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
@@ -163,6 +161,62 @@ impl Weight {
 	pub const fn zero() -> Self {
 		Self { ref_time: 0 }
 	}
+
+	/// Returns true if any of `self`'s constituent weights is strictly greater than that of the
+	/// `other`'s, otherwise returns false.
+	pub const fn any_gt(self, other: Self) -> bool {
+		self.ref_time > other.ref_time
+	}
+
+	/// Returns true if all of `self`'s constituent weights is strictly greater than that of the
+	/// `other`'s, otherwise returns false.
+	pub const fn all_gt(self, other: Self) -> bool {
+		self.ref_time > other.ref_time
+	}
+
+	/// Returns true if any of `self`'s constituent weights is strictly less than that of the
+	/// `other`'s, otherwise returns false.
+	pub const fn any_lt(self, other: Self) -> bool {
+		self.ref_time < other.ref_time
+	}
+
+	/// Returns true if all of `self`'s constituent weights is strictly less than that of the
+	/// `other`'s, otherwise returns false.
+	pub const fn all_lt(self, other: Self) -> bool {
+		self.ref_time < other.ref_time
+	}
+
+	/// Returns true if any of `self`'s constituent weights is greater than or equal to that of the
+	/// `other`'s, otherwise returns false.
+	pub const fn any_gte(self, other: Self) -> bool {
+		self.ref_time >= other.ref_time
+	}
+
+	/// Returns true if all of `self`'s constituent weights is greater than or equal to that of the
+	/// `other`'s, otherwise returns false.
+	pub const fn all_gte(self, other: Self) -> bool {
+		self.ref_time >= other.ref_time
+	}
+
+	/// Returns true if any of `self`'s constituent weights is less than or equal to that of the
+	/// `other`'s, otherwise returns false.
+	pub const fn any_lte(self, other: Self) -> bool {
+		self.ref_time <= other.ref_time
+	}
+
+	/// Returns true if all of `self`'s constituent weights is less than or equal to that of the
+	/// `other`'s, otherwise returns false.
+	pub const fn all_lte(self, other: Self) -> bool {
+		self.ref_time <= other.ref_time
+	}
+
+	/// Returns true if any of `self`'s constituent weights is equal to that of the `other`'s,
+	/// otherwise returns false.
+	pub const fn any_eq(self, other: Self) -> bool {
+		self.ref_time == other.ref_time
+	}
+
+	// NOTE: `all_eq` does not exist, as it's simply the `eq` method from the `PartialEq` trait.
 }
 
 impl Zero for Weight {

--- a/frame/system/src/extensions/check_weight.rs
+++ b/frame/system/src/extensions/check_weight.rs
@@ -145,7 +145,8 @@ where
 
 	// Check if we don't exceed per-class allowance
 	match limit_per_class.max_total {
-		Some(max) if per_class.any_gt(max) => return Err(InvalidTransaction::ExhaustsResources.into()),
+		Some(max) if per_class.any_gt(max) =>
+			return Err(InvalidTransaction::ExhaustsResources.into()),
 		// There is no `max_total` limit (`None`),
 		// or we are below the limit.
 		_ => {},

--- a/frame/system/src/extensions/check_weight.rs
+++ b/frame/system/src/extensions/check_weight.rs
@@ -312,7 +312,7 @@ mod tests {
 		check(|max, len| {
 			assert_ok!(CheckWeight::<Test>::do_pre_dispatch(max, len));
 			assert_eq!(System::block_weight().total(), Weight::MAX);
-			assert!(System::block_weight().total() > block_weight_limit());
+			assert!(System::block_weight().total().all_gt(block_weight_limit()));
 		});
 		check(|max, len| {
 			assert_ok!(CheckWeight::<Test>::do_validate(max, len));
@@ -369,7 +369,7 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			System::register_extra_weight_unchecked(Weight::MAX, DispatchClass::Normal);
 			assert_eq!(System::block_weight().total(), Weight::MAX);
-			assert!(System::block_weight().total() > block_weight_limit());
+			assert!(System::block_weight().total().all_gt(block_weight_limit()));
 		});
 	}
 

--- a/frame/whitelist/src/lib.rs
+++ b/frame/whitelist/src/lib.rs
@@ -172,7 +172,7 @@ pub mod pallet {
 			.map_err(|_| Error::<T>::UndecodableCall)?;
 
 			ensure!(
-				call.get_dispatch_info().weight <= call_weight_witness,
+				call.get_dispatch_info().weight.all_lte(call_weight_witness),
 				Error::<T>::InvalidCallWeightWitness
 			);
 

--- a/utils/frame/benchmarking-cli/src/overhead/weights.hbs
+++ b/utils/frame/benchmarking-cli/src/overhead/weights.hbs
@@ -69,14 +69,14 @@ mod test_weights {
 
 		{{#if (eq short_name "block")}}
 		// At least 100 µs.
-		assert!(w >= Weight::from_ref_time(100 * constants::WEIGHT_PER_MICROS), "Weight should be at least 100 µs.");
+		assert!(w.ref_time() >= 100u64 * constants::WEIGHT_PER_MICROS.ref_time(), "Weight should be at least 100 µs.");
 		// At most 50 ms.
-		assert!(w <= Weight::from_ref_time(50 * constants::WEIGHT_PER_MILLIS), "Weight should be at most 50 ms.");
+		assert!(w.ref_time() <= 50u64 * constants::WEIGHT_PER_MILLIS.ref_time(), "Weight should be at most 50 ms.");
 		{{else}}
 		// At least 10 µs.
-		assert!(w >= Weight::from_ref_time(10 * constants::WEIGHT_PER_MICROS), "Weight should be at least 10 µs.");
+		assert!(w.ref_time() >= 10u64 * constants::WEIGHT_PER_MICROS.ref_time(), "Weight should be at least 10 µs.");
 		// At most 1 ms.
-		assert!(w <= Weight::from_ref_time(constants::WEIGHT_PER_MILLIS), "Weight should be at most 1 ms.");
+		assert!(w.ref_time() <= constants::WEIGHT_PER_MILLIS.ref_time(), "Weight should be at most 1 ms.");
 		{{/if}}
 	}
 }

--- a/utils/frame/benchmarking-cli/src/storage/weights.hbs
+++ b/utils/frame/benchmarking-cli/src/storage/weights.hbs
@@ -91,20 +91,20 @@ pub mod constants {
 		fn bound() {
 			// At least 1 µs.
 			assert!(
-				W::get().reads(1) >= constants::WEIGHT_PER_MICROS,
+				W::get().reads(1).ref_time() >= constants::WEIGHT_PER_MICROS.ref_time(),
 				"Read weight should be at least 1 µs."
 			);
 			assert!(
-				W::get().writes(1) >= constants::WEIGHT_PER_MICROS,
+				W::get().writes(1).ref_time() >= constants::WEIGHT_PER_MICROS.ref_time(),
 				"Write weight should be at least 1 µs."
 			);
 			// At most 1 ms.
 			assert!(
-				W::get().reads(1) <= constants::WEIGHT_PER_MILLIS,
+				W::get().reads(1).ref_time() <= constants::WEIGHT_PER_MILLIS.ref_time(),
 				"Read weight should be at most 1 ms."
 			);
 			assert!(
-				W::get().writes(1) <= constants::WEIGHT_PER_MILLIS,
+				W::get().writes(1).ref_time() <= constants::WEIGHT_PER_MILLIS.ref_time(),
 				"Write weight should be at most 1 ms."
 			);
 		}


### PR DESCRIPTION
Part of #12176.

This PR removes the `PartialOrd` and `Ord` derivation for the new `Weight` struct. The intention here is that normal ordering does not quite make sense for a composite `Weight` struct, and instead we need to be more granular -- do we mean that _all_ constituent weights need to be compared, or _any_ one of them would suffice?

As a result of removing `Ord`, there are places in the code which relied on this behaviour, and reviewers will need to properly check that the more granular comparison makes sense in the context around the affected piece of code.

polkadot companion: paritytech/polkadot#5971
cumulus companion: paritytech/cumulus#1601