### PR TITLE
[WIP] Split CLI commands into node-related and auxiliary

### DIFF
--- a/bin/node-template/node/src/cli.rs
+++ b/bin/node-template/node/src/cli.rs
@@ -2,35 +2,39 @@ use sc_cli::RunCmd;
 use clap::Parser;
 
 #[derive(Debug, Parser)]
-pub struct Cli {
-	#[clap(subcommand)]
-	pub subcommand: Subcommands,
-}
-
-#[derive(Debug, clap::Subcommand)]
-pub enum Subcommands {
+pub enum Cli {
 	#[clap(flatten)]
-	SubcommandA(SubcommandA),
-	SubcommandB(SubcommandB),
+	AuxiliaryCmd(AuxiliaryCmd),
+	#[clap(name = "node")]
+	NodeCmd(NodeCmd),
 }
 
 #[derive(Debug, clap::Subcommand)]
-pub enum SubcommandA {
+pub enum AuxiliaryCmd {
 	#[clap(subcommand)]
 	Key(sc_cli::KeySubcommand),
+
+	/// Try some command against runtime state.
+	#[cfg(feature = "try-runtime")]
+	TryRuntime(try_runtime_cli::TryRuntimeCmd),
+
+	/// Try some command against runtime state. Note: `try-runtime` feature must be enabled.
+	#[cfg(not(feature = "try-runtime"))]
+	TryRuntime,
 }
 
-#[derive(Debug, Parser)]
-pub struct SubcommandB {
+/// Commands related to the node itself.
+#[derive(Debug, clap::Args)]
+pub struct NodeCmd {
 	#[clap(subcommand)]
-	pub subcommand: Option<Subcommand>,
+	pub subcommand: Option<NodeSubcommand>,
 
 	#[clap(flatten)]
 	pub run: RunCmd,
 }
 
 #[derive(Debug, clap::Subcommand)]
-pub enum Subcommand {
+pub enum NodeSubcommand {
 	/// Build a chain specification.
 	BuildSpec(sc_cli::BuildSpecCmd),
 
@@ -55,14 +59,6 @@ pub enum Subcommand {
 	/// Sub-commands concerned with benchmarking.
 	#[clap(subcommand)]
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
-
-	/// Try some command against runtime state.
-	#[cfg(feature = "try-runtime")]
-	TryRuntime(try_runtime_cli::TryRuntimeCmd),
-
-	/// Try some command against runtime state. Note: `try-runtime` feature must be enabled.
-	#[cfg(not(feature = "try-runtime"))]
-	TryRuntime,
 
 	/// Db meta columns information.
 	ChainInfo(sc_cli::ChainInfoCmd),

--- a/bin/node-template/node/src/cli.rs
+++ b/bin/node-template/node/src/cli.rs
@@ -1,7 +1,27 @@
 use sc_cli::RunCmd;
+use clap::Parser;
 
-#[derive(Debug, clap::Parser)]
+#[derive(Debug, Parser)]
 pub struct Cli {
+	#[clap(subcommand)]
+	pub subcommand: Subcommands,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum Subcommands {
+	#[clap(flatten)]
+	SubcommandA(SubcommandA),
+	SubcommandB(SubcommandB),
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum SubcommandA {
+	#[clap(subcommand)]
+	Key(sc_cli::KeySubcommand),
+}
+
+#[derive(Debug, Parser)]
+pub struct SubcommandB {
 	#[clap(subcommand)]
 	pub subcommand: Option<Subcommand>,
 
@@ -11,10 +31,6 @@ pub struct Cli {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Subcommand {
-	/// Key management cli utilities
-	#[clap(subcommand)]
-	Key(sc_cli::KeySubcommand),
-
 	/// Build a chain specification.
 	BuildSpec(sc_cli::BuildSpecCmd),
 

--- a/bin/node-template/node/src/cli.rs
+++ b/bin/node-template/node/src/cli.rs
@@ -1,5 +1,5 @@
-use sc_cli::RunCmd;
 use clap::Parser;
+use sc_cli::RunCmd;
 
 #[derive(Debug, Parser)]
 pub enum Cli {

--- a/bin/node-template/node/src/command.rs
+++ b/bin/node-template/node/src/command.rs
@@ -1,7 +1,7 @@
 use crate::{
 	benchmarking::{inherent_benchmark_data, RemarkBuilder, TransferKeepAliveBuilder},
 	chain_spec,
-	cli::{Cli, NodeSubcommand},
+	cli::{AuxiliaryCmd, Cli, NodeCmd, NodeSubcommand},
 	service,
 };
 use frame_benchmarking_cli::{BenchmarkCmd, ExtrinsicFactory, SUBSTRATE_REFERENCE_HARDWARE};
@@ -54,150 +54,149 @@ pub fn run() -> sc_cli::Result<()> {
 	let cli = Cli::from_args();
 
 	match &cli {
-		Cli::AuxiliaryCmd(suba) => println!("suba {:?}", suba),
-		Cli::NodeCmd(subb) => println!("subb {:?}", subb),
-	};
-	Ok(())
+		Cli::AuxiliaryCmd(cmd) => match cmd {
+			AuxiliaryCmd::Key(cmd) => cmd.run(&cli),
+			#[cfg(feature = "try-runtime")]
+			AuxiliaryCmd::TryRuntime(cmd) => {
+				let runner = cli.create_runner(cmd)?;
+				runner.async_run(|config| {
+					let registry = config.prometheus_config.as_ref().map(|cfg| &cfg.registry);
+					let task_manager =
+						sc_service::TaskManager::new(config.tokio_handle.clone(), registry)
+							.map_err(|e| {
+								sc_cli::Error::Service(sc_service::Error::Prometheus(e))
+							})?;
+					Ok((cmd.run::<Block, service::ExecutorDispatch>(config), task_manager))
+				})
+			},
+			#[cfg(not(feature = "try-runtime"))]
+			AuxiliaryCmd::TryRuntime(cmd) =>
+				Err("TryRuntime wasn't enabled when building the node. You can enable it with `--features try-runtime`.".into()),
+		},
+		Cli::NodeCmd(NodeCmd { subcommand: cmd, run: run_args }) => match cmd {
+			Some(NodeSubcommand::BuildSpec(cmd)) => {
+				let runner = cli.create_runner(cmd)?;
+				runner.sync_run(|config| cmd.run(config.chain_spec, config.network))
+			},
+			Some(NodeSubcommand::CheckBlock(cmd)) => {
+				let runner = cli.create_runner(cmd)?;
+				runner.async_run(|config| {
+					let PartialComponents { client, task_manager, import_queue, .. } =
+						service::new_partial(&config)?;
+					Ok((cmd.run(client, import_queue), task_manager))
+				})
+			},
+			Some(NodeSubcommand::ExportBlocks(cmd)) => {
+				let runner = cli.create_runner(cmd)?;
+				runner.async_run(|config| {
+					let PartialComponents { client, task_manager, .. } =
+						service::new_partial(&config)?;
+					Ok((cmd.run(client, config.database), task_manager))
+				})
+			},
+			Some(NodeSubcommand::ExportState(cmd)) => {
+				let runner = cli.create_runner(cmd)?;
+				runner.async_run(|config| {
+					let PartialComponents { client, task_manager, .. } =
+						service::new_partial(&config)?;
+					Ok((cmd.run(client, config.chain_spec), task_manager))
+				})
+			},
+			Some(NodeSubcommand::ImportBlocks(cmd)) => {
+				let runner = cli.create_runner(cmd)?;
+				runner.async_run(|config| {
+					let PartialComponents { client, task_manager, import_queue, .. } =
+						service::new_partial(&config)?;
+					Ok((cmd.run(client, import_queue), task_manager))
+				})
+			},
+			Some(NodeSubcommand::PurgeChain(cmd)) => {
+				let runner = cli.create_runner(cmd)?;
+				runner.sync_run(|config| cmd.run(config.database))
+			},
+			Some(NodeSubcommand::Revert(cmd)) => {
+				let runner = cli.create_runner(cmd)?;
+				runner.async_run(|config| {
+					let PartialComponents { client, task_manager, backend, .. } =
+						service::new_partial(&config)?;
+					let aux_revert = Box::new(|client, _, blocks| {
+						sc_finality_grandpa::revert(client, blocks)?;
+						Ok(())
+					});
+					Ok((cmd.run(client, backend, Some(aux_revert)), task_manager))
+				})
+			},
+			Some(NodeSubcommand::Benchmark(cmd)) => {
+				let runner = cli.create_runner(cmd)?;
 
-	// match &cli.subcommand {
-	// 	Some(Subcommand::Key(cmd)) => cmd.run(&cli),
-	// 	Some(Subcommand::BuildSpec(cmd)) => {
-	// 		let runner = cli.create_runner(cmd)?;
-	// 		runner.sync_run(|config| cmd.run(config.chain_spec, config.network))
-	// 	},
-	// 	Some(Subcommand::CheckBlock(cmd)) => {
-	// 		let runner = cli.create_runner(cmd)?;
-	// 		runner.async_run(|config| {
-	// 			let PartialComponents { client, task_manager, import_queue, .. } =
-	// 				service::new_partial(&config)?;
-	// 			Ok((cmd.run(client, import_queue), task_manager))
-	// 		})
-	// 	},
-	// 	Some(Subcommand::ExportBlocks(cmd)) => {
-	// 		let runner = cli.create_runner(cmd)?;
-	// 		runner.async_run(|config| {
-	// 			let PartialComponents { client, task_manager, .. } = service::new_partial(&config)?;
-	// 			Ok((cmd.run(client, config.database), task_manager))
-	// 		})
-	// 	},
-	// 	Some(Subcommand::ExportState(cmd)) => {
-	// 		let runner = cli.create_runner(cmd)?;
-	// 		runner.async_run(|config| {
-	// 			let PartialComponents { client, task_manager, .. } = service::new_partial(&config)?;
-	// 			Ok((cmd.run(client, config.chain_spec), task_manager))
-	// 		})
-	// 	},
-	// 	Some(Subcommand::ImportBlocks(cmd)) => {
-	// 		let runner = cli.create_runner(cmd)?;
-	// 		runner.async_run(|config| {
-	// 			let PartialComponents { client, task_manager, import_queue, .. } =
-	// 				service::new_partial(&config)?;
-	// 			Ok((cmd.run(client, import_queue), task_manager))
-	// 		})
-	// 	},
-	// 	Some(Subcommand::PurgeChain(cmd)) => {
-	// 		let runner = cli.create_runner(cmd)?;
-	// 		runner.sync_run(|config| cmd.run(config.database))
-	// 	},
-	// 	Some(Subcommand::Revert(cmd)) => {
-	// 		let runner = cli.create_runner(cmd)?;
-	// 		runner.async_run(|config| {
-	// 			let PartialComponents { client, task_manager, backend, .. } =
-	// 				service::new_partial(&config)?;
-	// 			let aux_revert = Box::new(|client, _, blocks| {
-	// 				sc_finality_grandpa::revert(client, blocks)?;
-	// 				Ok(())
-	// 			});
-	// 			Ok((cmd.run(client, backend, Some(aux_revert)), task_manager))
-	// 		})
-	// 	},
-	// 	Some(Subcommand::Benchmark(cmd)) => {
-	// 		let runner = cli.create_runner(cmd)?;
-	//
-	// 		runner.sync_run(|config| {
-	// 			// This switch needs to be in the client, since the client decides
-	// 			// which sub-commands it wants to support.
-	// 			match cmd {
-	// 				BenchmarkCmd::Pallet(cmd) => {
-	// 					if !cfg!(feature = "runtime-benchmarks") {
-	// 						return Err(
-	// 							"Runtime benchmarking wasn't enabled when building the node. \
-	// 						You can enable it with `--features runtime-benchmarks`."
-	// 								.into(),
-	// 						)
-	// 					}
-	//
-	// 					cmd.run::<Block, service::ExecutorDispatch>(config)
-	// 				},
-	// 				BenchmarkCmd::Block(cmd) => {
-	// 					let PartialComponents { client, .. } = service::new_partial(&config)?;
-	// 					cmd.run(client)
-	// 				},
-	// 				BenchmarkCmd::Storage(cmd) => {
-	// 					let PartialComponents { client, backend, .. } =
-	// 						service::new_partial(&config)?;
-	// 					let db = backend.expose_db();
-	// 					let storage = backend.expose_storage();
-	//
-	// 					cmd.run(config, client, db, storage)
-	// 				},
-	// 				BenchmarkCmd::Overhead(cmd) => {
-	// 					let PartialComponents { client, .. } = service::new_partial(&config)?;
-	// 					let ext_builder = RemarkBuilder::new(client.clone());
-	//
-	// 					cmd.run(
-	// 						config,
-	// 						client,
-	// 						inherent_benchmark_data()?,
-	// 						Vec::new(),
-	// 						&ext_builder,
-	// 					)
-	// 				},
-	// 				BenchmarkCmd::Extrinsic(cmd) => {
-	// 					let PartialComponents { client, .. } = service::new_partial(&config)?;
-	// 					// Register the *Remark* and *TKA* builders.
-	// 					let ext_factory = ExtrinsicFactory(vec![
-	// 						Box::new(RemarkBuilder::new(client.clone())),
-	// 						Box::new(TransferKeepAliveBuilder::new(
-	// 							client.clone(),
-	// 							Sr25519Keyring::Alice.to_account_id(),
-	// 							EXISTENTIAL_DEPOSIT,
-	// 						)),
-	// 					]);
-	//
-	// 					cmd.run(client, inherent_benchmark_data()?, Vec::new(), &ext_factory)
-	// 				},
-	// 				BenchmarkCmd::Machine(cmd) =>
-	// 					cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone()),
-	// 			}
-	// 		})
-	// 	},
-	// 	#[cfg(feature = "try-runtime")]
-	// 	Some(Subcommand::TryRuntime(cmd)) => {
-	// 		let runner = cli.create_runner(cmd)?;
-	// 		runner.async_run(|config| {
-	// 			// we don't need any of the components of new_partial, just a runtime, or a task
-	// 			// manager to do `async_run`.
-	// 			let registry = config.prometheus_config.as_ref().map(|cfg| &cfg.registry);
-	// 			let task_manager =
-	// 				sc_service::TaskManager::new(config.tokio_handle.clone(), registry)
-	// 					.map_err(|e| sc_cli::Error::Service(sc_service::Error::Prometheus(e)))?;
-	// 			Ok((cmd.run::<Block, service::ExecutorDispatch>(config), task_manager))
-	// 		})
-	// 	},
-	// 	#[cfg(not(feature = "try-runtime"))]
-	// 	Some(Subcommand::TryRuntime) => Err("TryRuntime wasn't enabled when building the node. \
-	// 			You can enable it with `--features try-runtime`."
-	// 		.into()),
-	// 	Some(Subcommand::ChainInfo(cmd)) => {
-	// 		let runner = cli.create_runner(cmd)?;
-	// 		runner.sync_run(|config| cmd.run::<Block>(&config))
-	// 	},
-	// 	None => {
-	// 		let runner = cli.create_runner(&cli.run)?;
-	// 		runner.run_node_until_exit(|config| async move {
-	// 			service::new_full(config).map_err(sc_cli::Error::Service)
-	// 		})
-	// 	},
-	// }
+				runner.sync_run(|config| {
+					// This switch needs to be in the client, since the client decides
+					// which sub-commands it wants to support.
+					match cmd {
+						BenchmarkCmd::Pallet(cmd) => {
+							if !cfg!(feature = "runtime-benchmarks") {
+								return Err(
+									"Runtime benchmarking wasn't enabled when building the node. \
+							You can enable it with `--features runtime-benchmarks`."
+										.into(),
+								)
+							}
+
+							cmd.run::<Block, service::ExecutorDispatch>(config)
+						},
+						BenchmarkCmd::Block(cmd) => {
+							let PartialComponents { client, .. } = service::new_partial(&config)?;
+							cmd.run(client)
+						},
+						BenchmarkCmd::Storage(cmd) => {
+							let PartialComponents { client, backend, .. } =
+								service::new_partial(&config)?;
+							let db = backend.expose_db();
+							let storage = backend.expose_storage();
+
+							cmd.run(config, client, db, storage)
+						},
+						BenchmarkCmd::Overhead(cmd) => {
+							let PartialComponents { client, .. } = service::new_partial(&config)?;
+							let ext_builder = RemarkBuilder::new(client.clone());
+
+							cmd.run(
+								config,
+								client,
+								inherent_benchmark_data()?,
+								Vec::new(),
+								&ext_builder,
+							)
+						},
+						BenchmarkCmd::Extrinsic(cmd) => {
+							let PartialComponents { client, .. } = service::new_partial(&config)?;
+							// Register the *Remark* and *TKA* builders.
+							let ext_factory = ExtrinsicFactory(vec![
+								Box::new(RemarkBuilder::new(client.clone())),
+								Box::new(TransferKeepAliveBuilder::new(
+									client.clone(),
+									Sr25519Keyring::Alice.to_account_id(),
+									EXISTENTIAL_DEPOSIT,
+								)),
+							]);
+
+							cmd.run(client, inherent_benchmark_data()?, Vec::new(), &ext_factory)
+						},
+						BenchmarkCmd::Machine(cmd) =>
+							cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone()),
+					}
+				})
+			},
+			Some(NodeSubcommand::ChainInfo(cmd)) => {
+				let runner = cli.create_runner(cmd)?;
+				runner.sync_run(|config| cmd.run::<Block>(&config))
+			},
+			None => {
+				let runner = cli.create_runner(run_args)?;
+				runner.run_node_until_exit(|config| async move {
+					service::new_full(config).map_err(sc_cli::Error::Service)
+				})
+			},
+		},
+	}
 }

--- a/bin/node-template/node/src/command.rs
+++ b/bin/node-template/node/src/command.rs
@@ -1,7 +1,7 @@
 use crate::{
 	benchmarking::{inherent_benchmark_data, RemarkBuilder, TransferKeepAliveBuilder},
 	chain_spec,
-	cli::{Cli, Subcommand},
+	cli::{Cli, NodeSubcommand},
 	service,
 };
 use frame_benchmarking_cli::{BenchmarkCmd, ExtrinsicFactory, SUBSTRATE_REFERENCE_HARDWARE};
@@ -9,7 +9,6 @@ use node_template_runtime::{Block, EXISTENTIAL_DEPOSIT};
 use sc_cli::{ChainSpec, RuntimeVersion, SubstrateCli};
 use sc_service::PartialComponents;
 use sp_keyring::Sr25519Keyring;
-use crate::cli::Subcommands;
 
 impl SubstrateCli for Cli {
 	fn impl_name() -> String {
@@ -54,9 +53,9 @@ impl SubstrateCli for Cli {
 pub fn run() -> sc_cli::Result<()> {
 	let cli = Cli::from_args();
 
-	match &cli.subcommand {
-		Subcommands::SubcommandA(suba) => println!("suba {:?}", suba),
-		Subcommands::SubcommandB(subb) => println!("subb {:?}", subb),
+	match &cli {
+		Cli::AuxiliaryCmd(suba) => println!("suba {:?}", suba),
+		Cli::NodeCmd(subb) => println!("subb {:?}", subb),
 	};
 	Ok(())
 

--- a/bin/node-template/node/src/command.rs
+++ b/bin/node-template/node/src/command.rs
@@ -9,6 +9,7 @@ use node_template_runtime::{Block, EXISTENTIAL_DEPOSIT};
 use sc_cli::{ChainSpec, RuntimeVersion, SubstrateCli};
 use sc_service::PartialComponents;
 use sp_keyring::Sr25519Keyring;
+use crate::cli::Subcommands;
 
 impl SubstrateCli for Cli {
 	fn impl_name() -> String {
@@ -54,144 +55,150 @@ pub fn run() -> sc_cli::Result<()> {
 	let cli = Cli::from_args();
 
 	match &cli.subcommand {
-		Some(Subcommand::Key(cmd)) => cmd.run(&cli),
-		Some(Subcommand::BuildSpec(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			runner.sync_run(|config| cmd.run(config.chain_spec, config.network))
-		},
-		Some(Subcommand::CheckBlock(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			runner.async_run(|config| {
-				let PartialComponents { client, task_manager, import_queue, .. } =
-					service::new_partial(&config)?;
-				Ok((cmd.run(client, import_queue), task_manager))
-			})
-		},
-		Some(Subcommand::ExportBlocks(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			runner.async_run(|config| {
-				let PartialComponents { client, task_manager, .. } = service::new_partial(&config)?;
-				Ok((cmd.run(client, config.database), task_manager))
-			})
-		},
-		Some(Subcommand::ExportState(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			runner.async_run(|config| {
-				let PartialComponents { client, task_manager, .. } = service::new_partial(&config)?;
-				Ok((cmd.run(client, config.chain_spec), task_manager))
-			})
-		},
-		Some(Subcommand::ImportBlocks(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			runner.async_run(|config| {
-				let PartialComponents { client, task_manager, import_queue, .. } =
-					service::new_partial(&config)?;
-				Ok((cmd.run(client, import_queue), task_manager))
-			})
-		},
-		Some(Subcommand::PurgeChain(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			runner.sync_run(|config| cmd.run(config.database))
-		},
-		Some(Subcommand::Revert(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			runner.async_run(|config| {
-				let PartialComponents { client, task_manager, backend, .. } =
-					service::new_partial(&config)?;
-				let aux_revert = Box::new(|client, _, blocks| {
-					sc_finality_grandpa::revert(client, blocks)?;
-					Ok(())
-				});
-				Ok((cmd.run(client, backend, Some(aux_revert)), task_manager))
-			})
-		},
-		Some(Subcommand::Benchmark(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
+		Subcommands::SubcommandA(suba) => println!("suba {:?}", suba),
+		Subcommands::SubcommandB(subb) => println!("subb {:?}", subb),
+	};
+	Ok(())
 
-			runner.sync_run(|config| {
-				// This switch needs to be in the client, since the client decides
-				// which sub-commands it wants to support.
-				match cmd {
-					BenchmarkCmd::Pallet(cmd) => {
-						if !cfg!(feature = "runtime-benchmarks") {
-							return Err(
-								"Runtime benchmarking wasn't enabled when building the node. \
-							You can enable it with `--features runtime-benchmarks`."
-									.into(),
-							)
-						}
-
-						cmd.run::<Block, service::ExecutorDispatch>(config)
-					},
-					BenchmarkCmd::Block(cmd) => {
-						let PartialComponents { client, .. } = service::new_partial(&config)?;
-						cmd.run(client)
-					},
-					BenchmarkCmd::Storage(cmd) => {
-						let PartialComponents { client, backend, .. } =
-							service::new_partial(&config)?;
-						let db = backend.expose_db();
-						let storage = backend.expose_storage();
-
-						cmd.run(config, client, db, storage)
-					},
-					BenchmarkCmd::Overhead(cmd) => {
-						let PartialComponents { client, .. } = service::new_partial(&config)?;
-						let ext_builder = RemarkBuilder::new(client.clone());
-
-						cmd.run(
-							config,
-							client,
-							inherent_benchmark_data()?,
-							Vec::new(),
-							&ext_builder,
-						)
-					},
-					BenchmarkCmd::Extrinsic(cmd) => {
-						let PartialComponents { client, .. } = service::new_partial(&config)?;
-						// Register the *Remark* and *TKA* builders.
-						let ext_factory = ExtrinsicFactory(vec![
-							Box::new(RemarkBuilder::new(client.clone())),
-							Box::new(TransferKeepAliveBuilder::new(
-								client.clone(),
-								Sr25519Keyring::Alice.to_account_id(),
-								EXISTENTIAL_DEPOSIT,
-							)),
-						]);
-
-						cmd.run(client, inherent_benchmark_data()?, Vec::new(), &ext_factory)
-					},
-					BenchmarkCmd::Machine(cmd) =>
-						cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone()),
-				}
-			})
-		},
-		#[cfg(feature = "try-runtime")]
-		Some(Subcommand::TryRuntime(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			runner.async_run(|config| {
-				// we don't need any of the components of new_partial, just a runtime, or a task
-				// manager to do `async_run`.
-				let registry = config.prometheus_config.as_ref().map(|cfg| &cfg.registry);
-				let task_manager =
-					sc_service::TaskManager::new(config.tokio_handle.clone(), registry)
-						.map_err(|e| sc_cli::Error::Service(sc_service::Error::Prometheus(e)))?;
-				Ok((cmd.run::<Block, service::ExecutorDispatch>(config), task_manager))
-			})
-		},
-		#[cfg(not(feature = "try-runtime"))]
-		Some(Subcommand::TryRuntime) => Err("TryRuntime wasn't enabled when building the node. \
-				You can enable it with `--features try-runtime`."
-			.into()),
-		Some(Subcommand::ChainInfo(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			runner.sync_run(|config| cmd.run::<Block>(&config))
-		},
-		None => {
-			let runner = cli.create_runner(&cli.run)?;
-			runner.run_node_until_exit(|config| async move {
-				service::new_full(config).map_err(sc_cli::Error::Service)
-			})
-		},
-	}
+	// match &cli.subcommand {
+	// 	Some(Subcommand::Key(cmd)) => cmd.run(&cli),
+	// 	Some(Subcommand::BuildSpec(cmd)) => {
+	// 		let runner = cli.create_runner(cmd)?;
+	// 		runner.sync_run(|config| cmd.run(config.chain_spec, config.network))
+	// 	},
+	// 	Some(Subcommand::CheckBlock(cmd)) => {
+	// 		let runner = cli.create_runner(cmd)?;
+	// 		runner.async_run(|config| {
+	// 			let PartialComponents { client, task_manager, import_queue, .. } =
+	// 				service::new_partial(&config)?;
+	// 			Ok((cmd.run(client, import_queue), task_manager))
+	// 		})
+	// 	},
+	// 	Some(Subcommand::ExportBlocks(cmd)) => {
+	// 		let runner = cli.create_runner(cmd)?;
+	// 		runner.async_run(|config| {
+	// 			let PartialComponents { client, task_manager, .. } = service::new_partial(&config)?;
+	// 			Ok((cmd.run(client, config.database), task_manager))
+	// 		})
+	// 	},
+	// 	Some(Subcommand::ExportState(cmd)) => {
+	// 		let runner = cli.create_runner(cmd)?;
+	// 		runner.async_run(|config| {
+	// 			let PartialComponents { client, task_manager, .. } = service::new_partial(&config)?;
+	// 			Ok((cmd.run(client, config.chain_spec), task_manager))
+	// 		})
+	// 	},
+	// 	Some(Subcommand::ImportBlocks(cmd)) => {
+	// 		let runner = cli.create_runner(cmd)?;
+	// 		runner.async_run(|config| {
+	// 			let PartialComponents { client, task_manager, import_queue, .. } =
+	// 				service::new_partial(&config)?;
+	// 			Ok((cmd.run(client, import_queue), task_manager))
+	// 		})
+	// 	},
+	// 	Some(Subcommand::PurgeChain(cmd)) => {
+	// 		let runner = cli.create_runner(cmd)?;
+	// 		runner.sync_run(|config| cmd.run(config.database))
+	// 	},
+	// 	Some(Subcommand::Revert(cmd)) => {
+	// 		let runner = cli.create_runner(cmd)?;
+	// 		runner.async_run(|config| {
+	// 			let PartialComponents { client, task_manager, backend, .. } =
+	// 				service::new_partial(&config)?;
+	// 			let aux_revert = Box::new(|client, _, blocks| {
+	// 				sc_finality_grandpa::revert(client, blocks)?;
+	// 				Ok(())
+	// 			});
+	// 			Ok((cmd.run(client, backend, Some(aux_revert)), task_manager))
+	// 		})
+	// 	},
+	// 	Some(Subcommand::Benchmark(cmd)) => {
+	// 		let runner = cli.create_runner(cmd)?;
+	//
+	// 		runner.sync_run(|config| {
+	// 			// This switch needs to be in the client, since the client decides
+	// 			// which sub-commands it wants to support.
+	// 			match cmd {
+	// 				BenchmarkCmd::Pallet(cmd) => {
+	// 					if !cfg!(feature = "runtime-benchmarks") {
+	// 						return Err(
+	// 							"Runtime benchmarking wasn't enabled when building the node. \
+	// 						You can enable it with `--features runtime-benchmarks`."
+	// 								.into(),
+	// 						)
+	// 					}
+	//
+	// 					cmd.run::<Block, service::ExecutorDispatch>(config)
+	// 				},
+	// 				BenchmarkCmd::Block(cmd) => {
+	// 					let PartialComponents { client, .. } = service::new_partial(&config)?;
+	// 					cmd.run(client)
+	// 				},
+	// 				BenchmarkCmd::Storage(cmd) => {
+	// 					let PartialComponents { client, backend, .. } =
+	// 						service::new_partial(&config)?;
+	// 					let db = backend.expose_db();
+	// 					let storage = backend.expose_storage();
+	//
+	// 					cmd.run(config, client, db, storage)
+	// 				},
+	// 				BenchmarkCmd::Overhead(cmd) => {
+	// 					let PartialComponents { client, .. } = service::new_partial(&config)?;
+	// 					let ext_builder = RemarkBuilder::new(client.clone());
+	//
+	// 					cmd.run(
+	// 						config,
+	// 						client,
+	// 						inherent_benchmark_data()?,
+	// 						Vec::new(),
+	// 						&ext_builder,
+	// 					)
+	// 				},
+	// 				BenchmarkCmd::Extrinsic(cmd) => {
+	// 					let PartialComponents { client, .. } = service::new_partial(&config)?;
+	// 					// Register the *Remark* and *TKA* builders.
+	// 					let ext_factory = ExtrinsicFactory(vec![
+	// 						Box::new(RemarkBuilder::new(client.clone())),
+	// 						Box::new(TransferKeepAliveBuilder::new(
+	// 							client.clone(),
+	// 							Sr25519Keyring::Alice.to_account_id(),
+	// 							EXISTENTIAL_DEPOSIT,
+	// 						)),
+	// 					]);
+	//
+	// 					cmd.run(client, inherent_benchmark_data()?, Vec::new(), &ext_factory)
+	// 				},
+	// 				BenchmarkCmd::Machine(cmd) =>
+	// 					cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone()),
+	// 			}
+	// 		})
+	// 	},
+	// 	#[cfg(feature = "try-runtime")]
+	// 	Some(Subcommand::TryRuntime(cmd)) => {
+	// 		let runner = cli.create_runner(cmd)?;
+	// 		runner.async_run(|config| {
+	// 			// we don't need any of the components of new_partial, just a runtime, or a task
+	// 			// manager to do `async_run`.
+	// 			let registry = config.prometheus_config.as_ref().map(|cfg| &cfg.registry);
+	// 			let task_manager =
+	// 				sc_service::TaskManager::new(config.tokio_handle.clone(), registry)
+	// 					.map_err(|e| sc_cli::Error::Service(sc_service::Error::Prometheus(e)))?;
+	// 			Ok((cmd.run::<Block, service::ExecutorDispatch>(config), task_manager))
+	// 		})
+	// 	},
+	// 	#[cfg(not(feature = "try-runtime"))]
+	// 	Some(Subcommand::TryRuntime) => Err("TryRuntime wasn't enabled when building the node. \
+	// 			You can enable it with `--features try-runtime`."
+	// 		.into()),
+	// 	Some(Subcommand::ChainInfo(cmd)) => {
+	// 		let runner = cli.create_runner(cmd)?;
+	// 		runner.sync_run(|config| cmd.run::<Block>(&config))
+	// 	},
+	// 	None => {
+	// 		let runner = cli.create_runner(&cli.run)?;
+	// 		runner.run_node_until_exit(|config| async move {
+	// 			service::new_full(config).map_err(sc_cli::Error::Service)
+	// 		})
+	// 	},
+	// }
 }

--- a/utils/frame/try-runtime/cli/src/commands/execute_block.rs
+++ b/utils/frame/try-runtime/cli/src/commands/execute_block.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 use parity_scale_codec::Encode;
 use remote_externalities::rpc_api;
-use sc_service::{Configuration, NativeExecutionDispatch};
+use sc_service::NativeExecutionDispatch;
 use sp_core::storage::well_known_keys;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
 use std::{fmt::Debug, str::FromStr};
@@ -133,7 +133,6 @@ impl ExecuteBlockCmd {
 pub(crate) async fn execute_block<Block, ExecDispatch>(
 	shared: SharedParams,
 	command: ExecuteBlockCmd,
-	config: Configuration,
 ) -> sc_cli::Result<()>
 where
 	Block: BlockT + serde::de::DeserializeOwned,
@@ -143,7 +142,7 @@ where
 	<NumberFor<Block> as FromStr>::Err: Debug,
 	ExecDispatch: NativeExecutionDispatch + 'static,
 {
-	let executor = build_executor::<ExecDispatch>(&shared, &config);
+	let executor = build_executor::<ExecDispatch>(&shared);
 	let execution = shared.execution;
 
 	let block_ws_uri = command.block_ws_uri::<Block>();
@@ -169,10 +168,9 @@ where
 		let builder = if command.overwrite_wasm_code {
 			log::info!(
 				target: LOG_TARGET,
-				"replacing the in-storage :code: with the local code from {}'s chain_spec (your local repo)",
-				config.chain_spec.name(),
+				"replacing the in-storage :code: with the local code from chain_spec (your local repo)",
 			);
-			let (code_key, code) = extract_code(&config.chain_spec)?;
+			let (code_key, code) = extract_code(&shared)?;
 			builder.inject_hashed_key_value(&[(code_key, code)])
 		} else {
 			builder.inject_hashed_key(well_known_keys::CODE)

--- a/utils/frame/try-runtime/cli/src/commands/follow_chain.rs
+++ b/utils/frame/try-runtime/cli/src/commands/follow_chain.rs
@@ -29,7 +29,6 @@ use jsonrpsee::{
 use parity_scale_codec::{Decode, Encode};
 use remote_externalities::{rpc_api, Builder, Mode, OnlineConfig};
 use sc_executor::NativeExecutionDispatch;
-use sc_service::Configuration;
 use serde::de::DeserializeOwned;
 use sp_core::H256;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
@@ -211,7 +210,6 @@ where
 pub(crate) async fn follow_chain<Block, ExecDispatch>(
 	shared: SharedParams,
 	command: FollowChainCmd,
-	config: Configuration,
 ) -> sc_cli::Result<()>
 where
 	Block: BlockT<Hash = H256> + DeserializeOwned,
@@ -225,8 +223,8 @@ where
 	let mut maybe_state_ext = None;
 	let (_client, subscription) = start_subscribing::<Block::Header>(&command.uri).await?;
 
-	let (code_key, code) = extract_code(&config.chain_spec)?;
-	let executor = build_executor::<ExecDispatch>(&shared, &config);
+	let (code_key, code) = extract_code(&shared)?;
+	let executor = build_executor::<ExecDispatch>(&shared);
 	let execution = shared.execution;
 
 	let header_provider: RpcHeaderProvider<Block> =

--- a/utils/frame/try-runtime/cli/src/commands/offchain_worker.rs
+++ b/utils/frame/try-runtime/cli/src/commands/offchain_worker.rs
@@ -22,7 +22,6 @@ use crate::{
 use parity_scale_codec::Encode;
 use remote_externalities::rpc_api;
 use sc_executor::NativeExecutionDispatch;
-use sc_service::Configuration;
 use sp_core::storage::well_known_keys;
 use sp_runtime::traits::{Block as BlockT, Header, NumberFor};
 use std::{fmt::Debug, str::FromStr};
@@ -102,7 +101,6 @@ impl OffchainWorkerCmd {
 pub(crate) async fn offchain_worker<Block, ExecDispatch>(
 	shared: SharedParams,
 	command: OffchainWorkerCmd,
-	config: Configuration,
 ) -> sc_cli::Result<()>
 where
 	Block: BlockT + serde::de::DeserializeOwned,
@@ -113,7 +111,7 @@ where
 	<NumberFor<Block> as FromStr>::Err: Debug,
 	ExecDispatch: NativeExecutionDispatch + 'static,
 {
-	let executor = build_executor(&shared, &config);
+	let executor = build_executor(&shared);
 	let execution = shared.execution;
 
 	let header_at = command.header_at::<Block>()?;
@@ -133,10 +131,9 @@ where
 		let builder = if command.overwrite_wasm_code {
 			log::info!(
 				target: LOG_TARGET,
-				"replacing the in-storage :code: with the local code from {}'s chain_spec (your local repo)",
-				config.chain_spec.name(),
+				"replacing the in-storage :code: with the local code from chain_spec (your local repo)",
 			);
-			let (code_key, code) = extract_code(&config.chain_spec)?;
+			let (code_key, code) = extract_code(&shared)?;
 			builder.inject_hashed_key_value(&[(code_key, code)])
 		} else {
 			builder.inject_hashed_key(well_known_keys::CODE)

--- a/utils/frame/try-runtime/cli/src/commands/on_runtime_upgrade.rs
+++ b/utils/frame/try-runtime/cli/src/commands/on_runtime_upgrade.rs
@@ -19,7 +19,6 @@ use std::{fmt::Debug, str::FromStr};
 
 use parity_scale_codec::Decode;
 use sc_executor::NativeExecutionDispatch;
-use sc_service::Configuration;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
 
 use crate::{
@@ -38,7 +37,6 @@ pub struct OnRuntimeUpgradeCmd {
 pub(crate) async fn on_runtime_upgrade<Block, ExecDispatch>(
 	shared: SharedParams,
 	command: OnRuntimeUpgradeCmd,
-	config: Configuration,
 ) -> sc_cli::Result<()>
 where
 	Block: BlockT + serde::de::DeserializeOwned,
@@ -48,12 +46,12 @@ where
 	<NumberFor<Block> as FromStr>::Err: Debug,
 	ExecDispatch: NativeExecutionDispatch + 'static,
 {
-	let executor = build_executor(&shared, &config);
+	let executor = build_executor(&shared);
 	let execution = shared.execution;
 
 	let ext = {
 		let builder = command.state.builder::<Block>()?.state_version(shared.state_version);
-		let (code_key, code) = extract_code(&config.chain_spec)?;
+		let (code_key, code) = extract_code(&shared)?;
 		builder.inject_hashed_key_value(&[(code_key, code)]).build().await?
 	};
 


### PR DESCRIPTION
# Description

See: https://github.com/paritytech/substrate/issues/12156

# New CLI interface

Help output of the main binary:
```
node-template 4.0.0-dev-unknown
Substrate DevHub <https://github.com/substrate-developer-hub>
A fresh FRAME-based Substrate node, ready for hacking.

USAGE:
    node-template
    node-template <SUBCOMMAND>

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    help           Print this message or the help of the given subcommand(s)
    key            Key utilities for the cli
    node           Commands related to the node itself
    try-runtime    Try some command against runtime state

```

Help output from `try-runtime` subcommand:
```
node-template-try-runtime 4.0.0-dev-unknown
Try some command against runtime state

USAGE:
    node-template try-runtime [OPTIONS] <SUBCOMMAND>

OPTIONS:
        --execution <STRATEGY>
            The execution strategy that should be used [default: wasm] [possible values: native,
            wasm, both, native-else-wasm]

    -h, --help
            Print help information

        --heap-pages <HEAP_PAGES>
            The number of 64KB pages to allocate for Wasm execution. Defaults to
            [`sc_service::Configuration.default_heap_pages`]

        --no-spec-name-check
            When enabled, the spec name check will not panic, and instead only show a warning

        --state-version <STATE_VERSION>
            State version that is used by the chain [default: 1]

    -V, --version
            Print version information

        --wasm-execution <METHOD>
            Type of wasm execution used [default: compiled] [possible values:
            interpreted-i-know-what-i-do, compiled]

        --wasm-instantiation-strategy <STRATEGY>
            The WASM instantiation method to use [default: pooling-copy-on-write] [possible values:
            pooling-copy-on-write, recreate-instance-copy-on-write, pooling, recreate-instance,
            legacy-instance-reuse]

SUBCOMMANDS:
    execute-block         Executes the given block against some state
    follow-chain          Follow the given chain's finalized blocks and apply all of its
                              extrinsics
    help                  Print this message or the help of the given subcommand(s)
    offchain-worker       Executes *the offchain worker hooks* of a given block against some
                              state
    on-runtime-upgrade    Execute the migrations of the "local runtime"
```


# Notes

I haven't added all the required commands to `try-runtime` command, in particular there is no way of passing any runtime, but this should be now at most easy.