### PR TITLE
Add `--header` to `benchmark overhead + storage`

### DIFF
--- a/utils/frame/benchmarking-cli/src/overhead/README.md
+++ b/utils/frame/benchmarking-cli/src/overhead/README.md
@@ -126,6 +126,7 @@ Minimizing this is important to have a large transaction throughput.
 - [`--add`](../shared/README.md#arguments)
 - [`--metric`](../shared/README.md#arguments)
 - [`--weight-path`](../shared/README.md#arguments)
+- [`--header`](../shared/README.md#arguments)
 
 License: Apache-2.0
 

--- a/utils/frame/benchmarking-cli/src/overhead/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/overhead/cmd.rs
@@ -28,7 +28,7 @@ use sp_runtime::{traits::Block as BlockT, DigestItem, OpaqueExtrinsic};
 use clap::{Args, Parser};
 use log::info;
 use serde::Serialize;
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, path::PathBuf, sync::Arc};
 
 use crate::{
 	extrinsic::{
@@ -69,6 +69,12 @@ pub struct OverheadParams {
 	#[allow(missing_docs)]
 	#[clap(flatten)]
 	pub hostinfo: HostInfoParams,
+
+	/// Add a header to the generated weight output file.
+	///
+	/// Good for adding LICENSE headers.
+	#[clap(long, value_name = "PATH")]
+	pub header: Option<PathBuf>,
 }
 
 /// Type of a benchmark.

--- a/utils/frame/benchmarking-cli/src/overhead/template.rs
+++ b/utils/frame/benchmarking-cli/src/overhead/template.rs
@@ -72,11 +72,7 @@ impl TemplateData {
 		stats: &Stats,
 	) -> Result<Self> {
 		let weight = params.weight.calc_weight(stats)?;
-		let header = if let Some(ref path) = params.header {
-			std::fs::read_to_string(path)?
-		} else {
-			String::new()
-		};
+		let header = params.header.map(|p| std::fs::read_to_string(p)).transpose()?.unwrap_or_default();
 
 		Ok(TemplateData {
 			short_name: t.short_name().into(),

--- a/utils/frame/benchmarking-cli/src/overhead/template.rs
+++ b/utils/frame/benchmarking-cli/src/overhead/template.rs
@@ -51,6 +51,8 @@ pub(crate) struct TemplateData {
 	hostname: String,
 	/// CPU name of the machine that executed the benchmarks.
 	cpuname: String,
+	/// Header for the generated file.
+	header: String,
 	/// Command line arguments that were passed to the CLI.
 	args: Vec<String>,
 	/// Params of the executed command.
@@ -70,6 +72,11 @@ impl TemplateData {
 		stats: &Stats,
 	) -> Result<Self> {
 		let weight = params.weight.calc_weight(stats)?;
+		let header = if let Some(ref path) = params.header {
+			std::fs::read_to_string(path)?
+		} else {
+			String::new()
+		};
 
 		Ok(TemplateData {
 			short_name: t.short_name().into(),
@@ -79,6 +86,7 @@ impl TemplateData {
 			date: chrono::Utc::now().format("%Y-%m-%d (Y/M/D)").to_string(),
 			hostname: params.hostinfo.hostname(),
 			cpuname: params.hostinfo.cpuname(),
+			header,
 			args: env::args().collect::<Vec<String>>(),
 			params: params.clone(),
 			stats: stats.clone(),

--- a/utils/frame/benchmarking-cli/src/overhead/template.rs
+++ b/utils/frame/benchmarking-cli/src/overhead/template.rs
@@ -72,7 +72,12 @@ impl TemplateData {
 		stats: &Stats,
 	) -> Result<Self> {
 		let weight = params.weight.calc_weight(stats)?;
-		let header = params.header.map(|p| std::fs::read_to_string(p)).transpose()?.unwrap_or_default();
+		let header = params
+			.header
+			.as_ref()
+			.map(|p| std::fs::read_to_string(p))
+			.transpose()?
+			.unwrap_or_default();
 
 		Ok(TemplateData {
 			short_name: t.short_name().into(),

--- a/utils/frame/benchmarking-cli/src/overhead/weights.hbs
+++ b/utils/frame/benchmarking-cli/src/overhead/weights.hbs
@@ -1,20 +1,4 @@
-// This file is part of Substrate.
-
-// Copyright (C) 2022 Parity Technologies (UK) Ltd.
-// SPDX-License-Identifier: Apache-2.0
-
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
+{{header}}
 //! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION {{version}}
 //! DATE: {{date}}
 //! HOSTNAME: `{{hostname}}`, CPU: `{{cpuname}}`

--- a/utils/frame/benchmarking-cli/src/shared/README.md
+++ b/utils/frame/benchmarking-cli/src/shared/README.md
@@ -11,5 +11,6 @@ Contains code that is shared among multiple sub-commands.
 - `--db` The database backend to use. This depends on your snapshot.
 - `--pruning` Set the pruning mode of the node. Some benchmarks require you to set this to `archive`.
 - `--base-path` The location on the disk that should be used for the benchmarks. You can try this on different disks or even on a mounted RAM-disk. It is important to use the same location that will later-on be used to store the chain data to get the correct results.
+- `--header` Optional file header which will be prepended to the weight output file. Can be used for adding LICENSE headers.
 
 License: Apache-2.0

--- a/utils/frame/benchmarking-cli/src/storage/README.md
+++ b/utils/frame/benchmarking-cli/src/storage/README.md
@@ -97,6 +97,7 @@ write: 71_347 * constants::WEIGHT_PER_NANOS,
 - [`--weight-path`](../shared/README.md#arguments)
 - `--json-read-path` Write the raw 'read' results to this file or directory.
 - `--json-write-path` Write the raw 'write' results to this file or directory.
+- [`--header`](../shared/README.md#arguments)
 
 License: Apache-2.0
 

--- a/utils/frame/benchmarking-cli/src/storage/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/storage/cmd.rs
@@ -79,6 +79,12 @@ pub struct StorageParams {
 	#[clap(long)]
 	pub template_path: Option<PathBuf>,
 
+	/// Add a header to the generated weight output file.
+	///
+	/// Good for adding LICENSE headers.
+	#[clap(long, value_name = "PATH")]
+	pub header: Option<PathBuf>,
+
 	/// Path to write the raw 'read' results in JSON format to. Can be a file or directory.
 	#[clap(long)]
 	pub json_read_path: Option<PathBuf>,
@@ -122,7 +128,7 @@ impl StorageCmd {
 		Block: BlockT<Hash = DbHash>,
 		C: UsageProvider<Block> + StorageProvider<Block, BA> + HeaderBackend<Block>,
 	{
-		let mut template = TemplateData::new(&cfg, &self.params);
+		let mut template = TemplateData::new(&cfg, &self.params)?;
 
 		let block_id = BlockId::<Block>::Number(client.usage_info().chain.best_number);
 		template.set_block_number(block_id.to_string());

--- a/utils/frame/benchmarking-cli/src/storage/template.rs
+++ b/utils/frame/benchmarking-cli/src/storage/template.rs
@@ -66,7 +66,12 @@ pub(crate) struct TemplateData {
 impl TemplateData {
 	/// Returns a new [`Self`] from the given configuration.
 	pub fn new(cfg: &Configuration, params: &StorageParams) -> Result<Self> {
-		let header = params.header.map(|p| std::fs::read_to_string(p)).transpose()?.unwrap_or_default();
+		let header = params
+			.header
+			.as_ref()
+			.map(|p| std::fs::read_to_string(p))
+			.transpose()?
+			.unwrap_or_default();
 
 		Ok(TemplateData {
 			db_name: format!("{}", cfg.database),

--- a/utils/frame/benchmarking-cli/src/storage/template.rs
+++ b/utils/frame/benchmarking-cli/src/storage/template.rs
@@ -45,6 +45,8 @@ pub(crate) struct TemplateData {
 	hostname: String,
 	/// CPU name of the machine that executed the benchmarks.
 	cpuname: String,
+	/// Header for the generated file.
+	header: String,
 	/// Command line arguments that were passed to the CLI.
 	args: Vec<String>,
 	/// Storage params of the executed command.
@@ -63,18 +65,25 @@ pub(crate) struct TemplateData {
 
 impl TemplateData {
 	/// Returns a new [`Self`] from the given configuration.
-	pub fn new(cfg: &Configuration, params: &StorageParams) -> Self {
-		TemplateData {
+	pub fn new(cfg: &Configuration, params: &StorageParams) -> Result<Self> {
+		let header = if let Some(ref path) = params.header {
+			std::fs::read_to_string(path)?
+		} else {
+			String::new()
+		};
+
+		Ok(TemplateData {
 			db_name: format!("{}", cfg.database),
 			runtime_name: cfg.chain_spec.name().into(),
 			version: VERSION.into(),
 			date: chrono::Utc::now().format("%Y-%m-%d (Y/M/D)").to_string(),
 			hostname: params.hostinfo.hostname(),
 			cpuname: params.hostinfo.cpuname(),
+			header,
 			args: env::args().collect::<Vec<String>>(),
 			params: params.clone(),
 			..Default::default()
-		}
+		})
 	}
 
 	/// Sets the stats and calculates the final weights.

--- a/utils/frame/benchmarking-cli/src/storage/template.rs
+++ b/utils/frame/benchmarking-cli/src/storage/template.rs
@@ -66,11 +66,7 @@ pub(crate) struct TemplateData {
 impl TemplateData {
 	/// Returns a new [`Self`] from the given configuration.
 	pub fn new(cfg: &Configuration, params: &StorageParams) -> Result<Self> {
-		let header = if let Some(ref path) = params.header {
-			std::fs::read_to_string(path)?
-		} else {
-			String::new()
-		};
+		let header = params.header.map(|p| std::fs::read_to_string(p)).transpose()?.unwrap_or_default();
 
 		Ok(TemplateData {
 			db_name: format!("{}", cfg.database),

--- a/utils/frame/benchmarking-cli/src/storage/weights.hbs
+++ b/utils/frame/benchmarking-cli/src/storage/weights.hbs
@@ -1,20 +1,4 @@
-// This file is part of Substrate.
-
-// Copyright (C) 2022 Parity Technologies (UK) Ltd.
-// SPDX-License-Identifier: Apache-2.0
-
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
+{{header}}
 //! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION {{version}}
 //! DATE: {{date}}
 //! HOSTNAME: `{{hostname}}`, CPU: `{{cpuname}}`


### PR DESCRIPTION
Add `--header` to `benchmark overhead + storage` to swap out the Substrate header for something else.  
To be consistent with `benchmark pallet` it now explicitly requires the Substrate header, otherwise there is none.  
Will need a Polkadot follow-up to update the release CI scripts.  

Part of https://github.com/paritytech/substrate/issues/11141, preparation for https://github.com/paritytech/command-bot/issues/102  
Partially supersedes https://github.com/paritytech/substrate/pull/11893