### PR TITLE
extract some grandpa types to Primitives crate

### DIFF
--- a/client/finality-grandpa/src/aux_schema.rs
+++ b/client/finality-grandpa/src/aux_schema.rs
@@ -500,8 +500,7 @@ mod test {
 	use super::*;
 	use sp_core::{crypto::UncheckedFrom, H256};
 	use sp_finality_grandpa::AuthorityId;
-	use substrate_test_runtime_client;
-	use substrate_test_runtime_client::runtime::Block;
+	use substrate_test_runtime_client::{self, runtime::Block};
 
 	fn dummy_id() -> AuthorityId {
 		AuthorityId::unchecked_from([1; 32])

--- a/client/finality-grandpa/src/aux_schema.rs
+++ b/client/finality-grandpa/src/aux_schema.rs
@@ -191,7 +191,7 @@ where
 			"state is for completed round; completed rounds must have a prevote ghost; qed.",
 		);
 
-		let mut current_rounds = CurrentRounds::new();
+		let mut current_rounds = CurrentRounds::<Block>::new();
 		current_rounds.insert(last_round_number + 1, HasVoted::No);
 
 		let set_state = VoterSetState::Live {
@@ -255,7 +255,7 @@ where
 				let base = set_state.prevote_ghost
 					.expect("state is for completed round; completed rounds must have a prevote ghost; qed.");
 
-				let mut current_rounds = CurrentRounds::new();
+				let mut current_rounds = CurrentRounds::<Block>::new();
 				current_rounds.insert(last_round_number + 1, HasVoted::No);
 
 				VoterSetState::Live {
@@ -501,6 +501,7 @@ mod test {
 	use sp_core::{crypto::UncheckedFrom, H256};
 	use sp_finality_grandpa::AuthorityId;
 	use substrate_test_runtime_client;
+	use substrate_test_runtime_client::runtime::Block;
 
 	fn dummy_id() -> AuthorityId {
 		AuthorityId::unchecked_from([1; 32])
@@ -574,7 +575,7 @@ mod test {
 			.unwrap(),
 		);
 
-		let mut current_rounds = CurrentRounds::new();
+		let mut current_rounds = CurrentRounds::<Block>::new();
 		current_rounds.insert(round_number + 1, HasVoted::No);
 
 		assert_eq!(
@@ -667,7 +668,7 @@ mod test {
 			.unwrap(),
 		);
 
-		let mut current_rounds = CurrentRounds::new();
+		let mut current_rounds = CurrentRounds::<Block>::new();
 		current_rounds.insert(round_number + 1, HasVoted::No);
 
 		assert_eq!(

--- a/client/finality-grandpa/src/communication/gossip.rs
+++ b/client/finality-grandpa/src/communication/gossip.rs
@@ -350,7 +350,7 @@ pub(super) struct VoteMessage<Block: BlockT> {
 	/// The voter set ID this message is from.
 	pub(super) set_id: SetId,
 	/// The message itself.
-	pub(super) message: SignedMessage<Block>,
+	pub(super) message: SignedMessage<Block::Header>,
 }
 
 /// Network level commit message with topic information.
@@ -361,7 +361,7 @@ pub(super) struct FullCommitMessage<Block: BlockT> {
 	/// The voter set ID this message is from.
 	pub(super) set_id: SetId,
 	/// The compact commit message.
-	pub(super) message: CompactCommit<Block>,
+	pub(super) message: CompactCommit<Block::Header>,
 }
 
 /// V1 neighbor packet. Neighbor packets are sent from nodes to their peers
@@ -406,7 +406,7 @@ pub(super) struct FullCatchUpMessage<Block: BlockT> {
 	/// The voter set ID this message is from.
 	pub(super) set_id: SetId,
 	/// The compact commit message.
-	pub(super) message: CatchUp<Block>,
+	pub(super) message: CatchUp<Block::Header>,
 }
 
 /// Misbehavior that peers can perform.
@@ -1071,7 +1071,7 @@ impl<Block: BlockT> Inner<Block> {
 
 		let (base_hash, base_number) = last_completed_round.base;
 
-		let catch_up = CatchUp::<Block> {
+		let catch_up = CatchUp::<Block::Header> {
 			round_number: last_completed_round.number,
 			prevotes,
 			precommits,
@@ -1651,8 +1651,8 @@ mod tests {
 	use crate::communication;
 	use sc_network::config::Role;
 	use sc_network_gossip::Validator as GossipValidatorT;
-	use sc_network_test::Block;
 	use sp_core::{crypto::UncheckedFrom, H256};
+	use substrate_test_runtime_client::runtime::{Header, Block};
 
 	// some random config (not really needed)
 	fn config() -> crate::Config {
@@ -1856,7 +1856,7 @@ mod tests {
 			&VoteMessage {
 				round: Round(1),
 				set_id: SetId(set_id),
-				message: SignedMessage::<Block> {
+				message: SignedMessage::<Header> {
 					message: finality_grandpa::Message::Prevote(finality_grandpa::Prevote {
 						target_hash: Default::default(),
 						target_number: 10,
@@ -1872,7 +1872,7 @@ mod tests {
 			&VoteMessage {
 				round: Round(1),
 				set_id: SetId(set_id),
-				message: SignedMessage::<Block> {
+				message: SignedMessage::<Header> {
 					message: finality_grandpa::Message::Prevote(finality_grandpa::Prevote {
 						target_hash: Default::default(),
 						target_number: 10,
@@ -1943,7 +1943,7 @@ mod tests {
 				votes: Default::default(),
 			});
 
-			let mut current_rounds = environment::CurrentRounds::new();
+			let mut current_rounds = environment::CurrentRounds::<Block>::new();
 			current_rounds.insert(3, environment::HasVoted::No);
 
 			let set_state =

--- a/client/finality-grandpa/src/communication/gossip.rs
+++ b/client/finality-grandpa/src/communication/gossip.rs
@@ -1652,7 +1652,7 @@ mod tests {
 	use sc_network::config::Role;
 	use sc_network_gossip::Validator as GossipValidatorT;
 	use sp_core::{crypto::UncheckedFrom, H256};
-	use substrate_test_runtime_client::runtime::{Header, Block};
+	use substrate_test_runtime_client::runtime::{Block, Header};
 
 	// some random config (not really needed)
 	fn config() -> crate::Config {

--- a/client/finality-grandpa/src/communication/mod.rs
+++ b/client/finality-grandpa/src/communication/mod.rs
@@ -694,7 +694,10 @@ impl<Block: BlockT> Sink<Message<Block::Header>> for OutgoingMessages<Block> {
 		})
 	}
 
-	fn start_send(mut self: Pin<&mut Self>, mut msg: Message<Block::Header>) -> Result<(), Self::Error> {
+	fn start_send(
+		mut self: Pin<&mut Self>,
+		mut msg: Message<Block::Header>,
+	) -> Result<(), Self::Error> {
 		// if we've voted on this round previously under the same key, send that vote instead
 		match &mut msg {
 			finality_grandpa::Message::PrimaryPropose(ref mut vote) => {

--- a/client/finality-grandpa/src/communication/mod.rs
+++ b/client/finality-grandpa/src/communication/mod.rs
@@ -312,8 +312,8 @@ impl<B: BlockT, N: Network<B>> NetworkBridge<B, N> {
 		round: Round,
 		set_id: SetId,
 		voters: Arc<VoterSet<AuthorityId>>,
-		has_voted: HasVoted<B>,
-	) -> (impl Stream<Item = SignedMessage<B>> + Unpin, OutgoingMessages<B>) {
+		has_voted: HasVoted<B::Header>,
+	) -> (impl Stream<Item = SignedMessage<B::Header>> + Unpin, OutgoingMessages<B>) {
 		self.note_round(round, set_id, &voters);
 
 		let keystore = keystore.and_then(|ks| {
@@ -675,15 +675,15 @@ pub(crate) struct OutgoingMessages<Block: BlockT> {
 	round: RoundNumber,
 	set_id: SetIdNumber,
 	keystore: Option<LocalIdKeystore>,
-	sender: mpsc::Sender<SignedMessage<Block>>,
+	sender: mpsc::Sender<SignedMessage<Block::Header>>,
 	network: Arc<Mutex<GossipEngine<Block>>>,
-	has_voted: HasVoted<Block>,
+	has_voted: HasVoted<Block::Header>,
 	telemetry: Option<TelemetryHandle>,
 }
 
 impl<B: BlockT> Unpin for OutgoingMessages<B> {}
 
-impl<Block: BlockT> Sink<Message<Block>> for OutgoingMessages<Block> {
+impl<Block: BlockT> Sink<Message<Block::Header>> for OutgoingMessages<Block> {
 	type Error = Error;
 
 	fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
@@ -694,7 +694,7 @@ impl<Block: BlockT> Sink<Message<Block>> for OutgoingMessages<Block> {
 		})
 	}
 
-	fn start_send(mut self: Pin<&mut Self>, mut msg: Message<Block>) -> Result<(), Self::Error> {
+	fn start_send(mut self: Pin<&mut Self>, mut msg: Message<Block::Header>) -> Result<(), Self::Error> {
 		// if we've voted on this round previously under the same key, send that vote instead
 		match &mut msg {
 			finality_grandpa::Message::PrimaryPropose(ref mut vote) => {
@@ -784,7 +784,7 @@ impl<Block: BlockT> Sink<Message<Block>> for OutgoingMessages<Block> {
 // checks a compact commit. returns the cost associated with processing it if
 // the commit was bad.
 fn check_compact_commit<Block: BlockT>(
-	msg: &CompactCommit<Block>,
+	msg: &CompactCommit<Block::Header>,
 	voters: &VoterSet<AuthorityId>,
 	round: Round,
 	set_id: SetId,
@@ -852,7 +852,7 @@ fn check_compact_commit<Block: BlockT>(
 // checks a catch up. returns the cost associated with processing it if
 // the catch up was bad.
 fn check_catch_up<Block: BlockT>(
-	msg: &CatchUp<Block>,
+	msg: &CatchUp<Block::Header>,
 	voters: &VoterSet<AuthorityId>,
 	set_id: SetId,
 	telemetry: Option<TelemetryHandle>,
@@ -902,7 +902,7 @@ fn check_catch_up<Block: BlockT>(
 	) -> Result<usize, ReputationChange>
 	where
 		B: BlockT,
-		I: Iterator<Item = (Message<B>, &'a AuthorityId, &'a AuthoritySignature)>,
+		I: Iterator<Item = (Message<B::Header>, &'a AuthorityId, &'a AuthoritySignature)>,
 	{
 		use crate::communication::gossip::Misbehavior;
 
@@ -996,7 +996,7 @@ impl<Block: BlockT> CommitsOut<Block> {
 	}
 }
 
-impl<Block: BlockT> Sink<(RoundNumber, Commit<Block>)> for CommitsOut<Block> {
+impl<Block: BlockT> Sink<(RoundNumber, Commit<Block::Header>)> for CommitsOut<Block> {
 	type Error = Error;
 
 	fn poll_ready(self: Pin<&mut Self>, _: &mut Context) -> Poll<Result<(), Self::Error>> {
@@ -1005,7 +1005,7 @@ impl<Block: BlockT> Sink<(RoundNumber, Commit<Block>)> for CommitsOut<Block> {
 
 	fn start_send(
 		self: Pin<&mut Self>,
-		input: (RoundNumber, Commit<Block>),
+		input: (RoundNumber, Commit<Block::Header>),
 	) -> Result<(), Self::Error> {
 		if !self.is_voter {
 			return Ok(())
@@ -1027,7 +1027,7 @@ impl<Block: BlockT> Sink<(RoundNumber, Commit<Block>)> for CommitsOut<Block> {
 			.map(|signed| (signed.precommit, (signed.signature, signed.id)))
 			.unzip();
 
-		let compact_commit = CompactCommit::<Block> {
+		let compact_commit = CompactCommit::<Block::Header> {
 			target_hash: commit.target_hash,
 			target_number: commit.target_number,
 			precommits,

--- a/client/finality-grandpa/src/environment.rs
+++ b/client/finality-grandpa/src/environment.rs
@@ -50,6 +50,7 @@ use sp_runtime::{
 	generic::BlockId,
 	traits::{Block as BlockT, Header as HeaderT, NumberFor, Zero},
 };
+use sp_runtime::traits::Header;
 
 use crate::{
 	authorities::{AuthoritySet, SharedAuthoritySet},
@@ -81,7 +82,7 @@ pub struct CompletedRound<Block: BlockT> {
 	/// The target block base used for voting in the round.
 	pub base: (Block::Hash, NumberFor<Block>),
 	/// All the votes observed in the round.
-	pub votes: Vec<SignedMessage<Block>>,
+	pub votes: Vec<SignedMessage<Block::Header>>,
 }
 
 // Data about last completed rounds within a single voter set. Stores
@@ -170,7 +171,7 @@ impl<Block: BlockT> CompletedRounds<Block> {
 
 /// A map with voter status information for currently live rounds,
 /// which votes have we cast and what are they.
-pub type CurrentRounds<Block> = BTreeMap<RoundNumber, HasVoted<Block>>;
+pub type CurrentRounds<Block> = BTreeMap<RoundNumber, HasVoted<<Block as BlockT>::Header>>;
 
 /// The state of the current voter set, whether it is currently active or not
 /// and information related to the previously completed rounds. Current round
@@ -214,7 +215,7 @@ impl<Block: BlockT> VoterSetState<Block> {
 			authority_set,
 		);
 
-		let mut current_rounds = CurrentRounds::new();
+		let mut current_rounds = CurrentRounds::<Block>::new();
 		current_rounds.insert(1, HasVoted::No);
 
 		VoterSetState::Live { completed_rounds, current_rounds }
@@ -258,27 +259,27 @@ impl<Block: BlockT> VoterSetState<Block> {
 
 /// Whether we've voted already during a prior run of the program.
 #[derive(Clone, Debug, Decode, Encode, PartialEq)]
-pub enum HasVoted<Block: BlockT> {
+pub enum HasVoted<Header: HeaderT> {
 	/// Has not voted already in this round.
 	No,
 	/// Has voted in this round.
-	Yes(AuthorityId, Vote<Block>),
+	Yes(AuthorityId, Vote<Header>),
 }
 
 /// The votes cast by this voter already during a prior run of the program.
 #[derive(Debug, Clone, Decode, Encode, PartialEq)]
-pub enum Vote<Block: BlockT> {
+pub enum Vote<Header: HeaderT> {
 	/// Has cast a proposal.
-	Propose(PrimaryPropose<Block>),
+	Propose(PrimaryPropose<Header>),
 	/// Has cast a prevote.
-	Prevote(Option<PrimaryPropose<Block>>, Prevote<Block>),
+	Prevote(Option<PrimaryPropose<Header>>, Prevote<Header>),
 	/// Has cast a precommit (implies prevote.)
-	Precommit(Option<PrimaryPropose<Block>>, Prevote<Block>, Precommit<Block>),
+	Precommit(Option<PrimaryPropose<Header>>, Prevote<Header>, Precommit<Header>),
 }
 
-impl<Block: BlockT> HasVoted<Block> {
+impl<Header: HeaderT> HasVoted<Header> {
 	/// Returns the proposal we should vote with (if any.)
-	pub fn propose(&self) -> Option<&PrimaryPropose<Block>> {
+	pub fn propose(&self) -> Option<&PrimaryPropose<Header>> {
 		match self {
 			HasVoted::Yes(_, Vote::Propose(propose)) => Some(propose),
 			HasVoted::Yes(_, Vote::Prevote(propose, _)) |
@@ -288,7 +289,7 @@ impl<Block: BlockT> HasVoted<Block> {
 	}
 
 	/// Returns the prevote we should vote with (if any.)
-	pub fn prevote(&self) -> Option<&Prevote<Block>> {
+	pub fn prevote(&self) -> Option<&Prevote<Header>> {
 		match self {
 			HasVoted::Yes(_, Vote::Prevote(_, prevote)) |
 			HasVoted::Yes(_, Vote::Precommit(_, prevote, _)) => Some(prevote),
@@ -297,7 +298,7 @@ impl<Block: BlockT> HasVoted<Block> {
 	}
 
 	/// Returns the precommit we should vote with (if any.)
-	pub fn precommit(&self) -> Option<&Precommit<Block>> {
+	pub fn precommit(&self) -> Option<&Precommit<Header>> {
 		match self {
 			HasVoted::Yes(_, Vote::Precommit(_, _, precommit)) => Some(precommit),
 			_ => None,
@@ -368,7 +369,7 @@ impl<Block: BlockT> SharedVoterSetState<Block> {
 	}
 
 	/// Return vote status information for the current round.
-	pub(crate) fn has_voted(&self, round: RoundNumber) -> HasVoted<Block> {
+	pub(crate) fn has_voted(&self, round: RoundNumber) -> HasVoted<Block::Header> {
 		match &*self.inner.read() {
 			VoterSetState::Live { current_rounds, .. } => current_rounds
 				.get(&round)
@@ -771,7 +772,7 @@ where
 	fn proposed(
 		&self,
 		round: RoundNumber,
-		propose: PrimaryPropose<Block>,
+		propose: PrimaryPropose<Block::Header>,
 	) -> Result<(), Self::Error> {
 		let local_id = match self.voter_set_state.voting_on(round) {
 			Some(id) => id,
@@ -811,13 +812,13 @@ where
 		Ok(())
 	}
 
-	fn prevoted(&self, round: RoundNumber, prevote: Prevote<Block>) -> Result<(), Self::Error> {
+	fn prevoted(&self, round: RoundNumber, prevote: Prevote<Block::Header>) -> Result<(), Self::Error> {
 		let local_id = match self.voter_set_state.voting_on(round) {
 			Some(id) => id,
 			None => return Ok(()),
 		};
 
-		let report_prevote_metrics = |prevote: &Prevote<Block>| {
+		let report_prevote_metrics = |prevote: &Prevote<Block::Header>| {
 			telemetry!(
 				self.telemetry;
 				CONSENSUS_DEBUG;
@@ -873,14 +874,14 @@ where
 	fn precommitted(
 		&self,
 		round: RoundNumber,
-		precommit: Precommit<Block>,
+		precommit: Precommit<Block::Header>,
 	) -> Result<(), Self::Error> {
 		let local_id = match self.voter_set_state.voting_on(round) {
 			Some(id) => id,
 			None => return Ok(()),
 		};
 
-		let report_precommit_metrics = |precommit: &Precommit<Block>| {
+		let report_precommit_metrics = |precommit: &Precommit<Block::Header>| {
 			telemetry!(
 				self.telemetry;
 				CONSENSUS_DEBUG;
@@ -1065,7 +1066,7 @@ where
 		hash: Block::Hash,
 		number: NumberFor<Block>,
 		round: RoundNumber,
-		commit: Commit<Block>,
+		commit: Commit<Block::Header>,
 	) -> Result<(), Self::Error> {
 		finalize_block(
 			self.client.clone(),
@@ -1092,7 +1093,7 @@ where
 	fn prevote_equivocation(
 		&self,
 		_round: RoundNumber,
-		equivocation: finality_grandpa::Equivocation<Self::Id, Prevote<Block>, Self::Signature>,
+		equivocation: finality_grandpa::Equivocation<Self::Id, Prevote<Block::Header>, Self::Signature>,
 	) {
 		warn!(target: "afg", "Detected prevote equivocation in the finality worker: {:?}", equivocation);
 		if let Err(err) = self.report_equivocation(equivocation.into()) {
@@ -1103,7 +1104,7 @@ where
 	fn precommit_equivocation(
 		&self,
 		_round: RoundNumber,
-		equivocation: finality_grandpa::Equivocation<Self::Id, Precommit<Block>, Self::Signature>,
+		equivocation: finality_grandpa::Equivocation<Self::Id, Precommit<Block::Header>, Self::Signature>,
 	) {
 		warn!(target: "afg", "Detected precommit equivocation in the finality worker: {:?}", equivocation);
 		if let Err(err) = self.report_equivocation(equivocation.into()) {
@@ -1114,11 +1115,11 @@ where
 
 pub(crate) enum JustificationOrCommit<Block: BlockT> {
 	Justification(GrandpaJustification<Block>),
-	Commit((RoundNumber, Commit<Block>)),
+	Commit((RoundNumber, Commit<Block::Header>)),
 }
 
-impl<Block: BlockT> From<(RoundNumber, Commit<Block>)> for JustificationOrCommit<Block> {
-	fn from(commit: (RoundNumber, Commit<Block>)) -> JustificationOrCommit<Block> {
+impl<Block: BlockT> From<(RoundNumber, Commit<Block::Header>)> for JustificationOrCommit<Block> {
+	fn from(commit: (RoundNumber, Commit<Block::Header>)) -> JustificationOrCommit<Block> {
 		JustificationOrCommit::Commit(commit)
 	}
 }

--- a/client/finality-grandpa/src/environment.rs
+++ b/client/finality-grandpa/src/environment.rs
@@ -50,7 +50,6 @@ use sp_runtime::{
 	generic::BlockId,
 	traits::{Block as BlockT, Header as HeaderT, NumberFor, Zero},
 };
-use sp_runtime::traits::Header;
 
 use crate::{
 	authorities::{AuthoritySet, SharedAuthoritySet},
@@ -812,7 +811,11 @@ where
 		Ok(())
 	}
 
-	fn prevoted(&self, round: RoundNumber, prevote: Prevote<Block::Header>) -> Result<(), Self::Error> {
+	fn prevoted(
+		&self,
+		round: RoundNumber,
+		prevote: Prevote<Block::Header>,
+	) -> Result<(), Self::Error> {
 		let local_id = match self.voter_set_state.voting_on(round) {
 			Some(id) => id,
 			None => return Ok(()),
@@ -1093,7 +1096,11 @@ where
 	fn prevote_equivocation(
 		&self,
 		_round: RoundNumber,
-		equivocation: finality_grandpa::Equivocation<Self::Id, Prevote<Block::Header>, Self::Signature>,
+		equivocation: finality_grandpa::Equivocation<
+			Self::Id,
+			Prevote<Block::Header>,
+			Self::Signature,
+		>,
 	) {
 		warn!(target: "afg", "Detected prevote equivocation in the finality worker: {:?}", equivocation);
 		if let Err(err) = self.report_equivocation(equivocation.into()) {
@@ -1104,7 +1111,11 @@ where
 	fn precommit_equivocation(
 		&self,
 		_round: RoundNumber,
-		equivocation: finality_grandpa::Equivocation<Self::Id, Precommit<Block::Header>, Self::Signature>,
+		equivocation: finality_grandpa::Equivocation<
+			Self::Id,
+			Precommit<Block::Header>,
+			Self::Signature,
+		>,
 	) {
 		warn!(target: "afg", "Detected precommit equivocation in the finality worker: {:?}", equivocation);
 		if let Err(err) = self.report_equivocation(equivocation.into()) {

--- a/client/finality-grandpa/src/finality_proof.rs
+++ b/client/finality-grandpa/src/finality_proof.rs
@@ -381,7 +381,12 @@ mod tests {
 		};
 
 		let grandpa_just: GrandpaJustification<Block> =
-			sp_finality_grandpa::GrandpaJustification::<Header> { round: 8, votes_ancestries: Vec::new(), commit }.into();
+			sp_finality_grandpa::GrandpaJustification::<Header> {
+				round: 8,
+				votes_ancestries: Vec::new(),
+				commit,
+			}
+			.into();
 
 		let finality_proof = FinalityProof {
 			block: header(2).hash(),

--- a/client/finality-grandpa/src/finality_proof.rs
+++ b/client/finality-grandpa/src/finality_proof.rs
@@ -380,8 +380,8 @@ mod tests {
 			precommits: Vec::new(),
 		};
 
-		let grandpa_just =
-			GrandpaJustification::<Block> { round: 8, votes_ancestries: Vec::new(), commit };
+		let grandpa_just: GrandpaJustification<Block> =
+			sp_finality_grandpa::GrandpaJustification::<Header> { round: 8, votes_ancestries: Vec::new(), commit }.into();
 
 		let finality_proof = FinalityProof {
 			block: header(2).hash(),

--- a/client/finality-grandpa/src/justification.rs
+++ b/client/finality-grandpa/src/justification.rs
@@ -20,6 +20,7 @@ use std::{
 	collections::{HashMap, HashSet},
 	sync::Arc,
 };
+use std::marker::PhantomData;
 
 use finality_grandpa::{voter_set::VoterSet, Error as GrandpaError};
 use parity_scale_codec::{Decode, Encode};
@@ -42,9 +43,17 @@ use crate::{AuthorityList, Commit, Error};
 /// nodes, and are used by syncing nodes to prove authority set handoffs.
 #[derive(Clone, Encode, Decode, PartialEq, Eq, Debug)]
 pub struct GrandpaJustification<Block: BlockT> {
-	pub(crate) round: u64,
-	pub(crate) commit: Commit<Block>,
-	pub(crate) votes_ancestries: Vec<Block::Header>,
+	pub justification: sp_finality_grandpa::GrandpaJustification<Block::Header>,
+	_block: PhantomData<Block>,
+}
+
+impl<Block: BlockT> From<sp_finality_grandpa::GrandpaJustification<Block::Header>> for GrandpaJustification<Block> {
+	fn from(justification: sp_finality_grandpa::GrandpaJustification<Block::Header>) -> Self {
+		Self {
+			justification,
+			_block: Default::default(),
+		}
+	}
 }
 
 impl<Block: BlockT> GrandpaJustification<Block> {
@@ -53,8 +62,8 @@ impl<Block: BlockT> GrandpaJustification<Block> {
 	pub fn from_commit<C>(
 		client: &Arc<C>,
 		round: u64,
-		commit: Commit<Block>,
-	) -> Result<GrandpaJustification<Block>, Error>
+		commit: Commit<Block::Header>,
+	) -> Result<Self, Error>
 	where
 		C: HeaderBackend<Block>,
 	{
@@ -108,7 +117,7 @@ impl<Block: BlockT> GrandpaJustification<Block> {
 			}
 		}
 
-		Ok(GrandpaJustification { round, commit, votes_ancestries })
+		Ok(sp_finality_grandpa::GrandpaJustification { round, commit, votes_ancestries }.into())
 	}
 
 	/// Decode a GRANDPA justification and validate the commit and the votes'
@@ -118,14 +127,14 @@ impl<Block: BlockT> GrandpaJustification<Block> {
 		finalized_target: (Block::Hash, NumberFor<Block>),
 		set_id: u64,
 		voters: &VoterSet<AuthorityId>,
-	) -> Result<GrandpaJustification<Block>, ClientError>
+	) -> Result<Self, ClientError>
 	where
 		NumberFor<Block>: finality_grandpa::BlockNumberOps,
 	{
 		let justification = GrandpaJustification::<Block>::decode(&mut &*encoded)
 			.map_err(|_| ClientError::JustificationDecode)?;
 
-		if (justification.commit.target_hash, justification.commit.target_number) !=
+		if (justification.justification.commit.target_hash, justification.justification.commit.target_number) !=
 			finalized_target
 		{
 			let msg = "invalid commit target in grandpa justification".to_string();
@@ -157,9 +166,9 @@ impl<Block: BlockT> GrandpaJustification<Block> {
 	{
 		use finality_grandpa::Chain;
 
-		let ancestry_chain = AncestryChain::<Block>::new(&self.votes_ancestries);
+		let ancestry_chain = AncestryChain::<Block>::new(&self.justification.votes_ancestries);
 
-		match finality_grandpa::validate_commit(&self.commit, voters, &ancestry_chain) {
+		match finality_grandpa::validate_commit(&self.justification.commit, voters, &ancestry_chain) {
 			Ok(ref result) if result.is_valid() => {},
 			_ => {
 				let msg = "invalid commit in grandpa justification".to_string();
@@ -171,6 +180,7 @@ impl<Block: BlockT> GrandpaJustification<Block> {
 		// should serve as the root block for populating ancestry (i.e.
 		// collect all headers from all precommit blocks to the base)
 		let base_hash = self
+			.justification
 			.commit
 			.precommits
 			.iter()
@@ -186,12 +196,12 @@ impl<Block: BlockT> GrandpaJustification<Block> {
 
 		let mut buf = Vec::new();
 		let mut visited_hashes = HashSet::new();
-		for signed in self.commit.precommits.iter() {
+		for signed in self.justification.commit.precommits.iter() {
 			if !sp_finality_grandpa::check_message_signature_with_buffer(
 				&finality_grandpa::Message::Precommit(signed.precommit.clone()),
 				&signed.id,
 				&signed.signature,
-				self.round,
+				self.justification.round,
 				set_id,
 				&mut buf,
 			) {
@@ -221,7 +231,7 @@ impl<Block: BlockT> GrandpaJustification<Block> {
 		}
 
 		let ancestry_hashes: HashSet<_> =
-			self.votes_ancestries.iter().map(|h: &Block::Header| h.hash()).collect();
+			self.justification.votes_ancestries.iter().map(|h: &Block::Header| h.hash()).collect();
 
 		if visited_hashes != ancestry_hashes {
 			return Err(ClientError::BadJustification(
@@ -235,7 +245,7 @@ impl<Block: BlockT> GrandpaJustification<Block> {
 
 	/// The target block number and hash that this justifications proves finality for.
 	pub fn target(&self) -> (NumberFor<Block>, Block::Hash) {
-		(self.commit.target_number, self.commit.target_hash)
+		(self.justification.commit.target_number, self.justification.commit.target_hash)
 	}
 }
 

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -71,7 +71,7 @@ use sc_consensus::BlockImport;
 use sc_network_common::protocol::ProtocolName;
 use sc_telemetry::{telemetry, TelemetryHandle, CONSENSUS_DEBUG, CONSENSUS_INFO};
 use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver};
-use sp_api::{ProvideRuntimeApi};
+use sp_api::ProvideRuntimeApi;
 use sp_application_crypto::AppKey;
 use sp_blockchain::{Error as ClientError, HeaderBackend, HeaderMetadata, Result as ClientResult};
 use sp_consensus::SelectChain;
@@ -79,7 +79,7 @@ use sp_core::crypto::ByteArray;
 use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
 use sp_runtime::{
 	generic::BlockId,
-	traits::{Block as BlockT, Header as HeaderT, NumberFor, Zero},
+	traits::{Block as BlockT, NumberFor, Zero},
 };
 
 pub use finality_grandpa::BlockNumberOps;
@@ -144,7 +144,10 @@ use sp_finality_grandpa::{AuthorityList, AuthoritySignature, SetId};
 use until_imported::UntilGlobalMessageBlocksImported;
 
 // Re-export these two because it's just so damn convenient.
-pub use sp_finality_grandpa::{AuthorityId, AuthorityPair, GrandpaApi, ScheduledChange, CompactCommit, Message, SignedMessage, PrimaryPropose, Prevote, Precommit, CatchUp, Commit};
+pub use sp_finality_grandpa::{
+	AuthorityId, AuthorityPair, CatchUp, Commit, CompactCommit, GrandpaApi, Message, Precommit,
+	Prevote, PrimaryPropose, ScheduledChange, SignedMessage,
+};
 use std::marker::PhantomData;
 
 #[cfg(test)]
@@ -162,12 +165,14 @@ type CommunicationIn<Block> = voter::CommunicationIn<
 /// Global communication input stream for commits and catch up messages, with
 /// the hash type not being derived from the block, useful for forcing the hash
 /// to some type (e.g. `H256`) when the compiler can't do the inference.
-type CommunicationInH<Block, H> = voter::CommunicationIn<H, NumberFor<Block>, AuthoritySignature, AuthorityId>;
+type CommunicationInH<Block, H> =
+	voter::CommunicationIn<H, NumberFor<Block>, AuthoritySignature, AuthorityId>;
 
 /// Global communication sink for commits with the hash type not being derived
 /// from the block, useful for forcing the hash to some type (e.g. `H256`) when
 /// the compiler can't do the inference.
-type CommunicationOutH<Block, H> = voter::CommunicationOut<H, NumberFor<Block>, AuthoritySignature, AuthorityId>;
+type CommunicationOutH<Block, H> =
+	voter::CommunicationOut<H, NumberFor<Block>, AuthoritySignature, AuthorityId>;
 
 /// Shared voter state for querying.
 pub struct SharedVoterState {

--- a/client/finality-grandpa/src/tests.rs
+++ b/client/finality-grandpa/src/tests.rs
@@ -450,7 +450,7 @@ fn finalize_3_voters_1_full_observer() {
 		let justification =
 			crate::aux_schema::best_justification::<_, Block>(&*client).unwrap().unwrap();
 
-		assert_eq!(justification.commit.target_number, 20);
+		assert_eq!(justification.justification.commit.target_number, 20);
 	}
 }
 

--- a/client/finality-grandpa/src/until_imported.rs
+++ b/client/finality-grandpa/src/until_imported.rs
@@ -354,7 +354,7 @@ fn warn_authority_wrong_target<H: ::std::fmt::Display>(hash: H, id: AuthorityId)
 	);
 }
 
-impl<Block: BlockT> BlockUntilImported<Block> for SignedMessage<Block> {
+impl<Block: BlockT> BlockUntilImported<Block> for SignedMessage<Block::Header> {
 	type Blocked = Self;
 
 	fn needs_waiting<BlockStatus: BlockStatusT<Block>>(
@@ -390,7 +390,7 @@ impl<Block: BlockT> BlockUntilImported<Block> for SignedMessage<Block> {
 /// Helper type definition for the stream which waits until vote targets for
 /// signed messages are imported.
 pub(crate) type UntilVoteTargetImported<Block, BlockStatus, BlockSyncRequester, I> =
-	UntilImported<Block, BlockStatus, BlockSyncRequester, I, SignedMessage<Block>>;
+	UntilImported<Block, BlockStatus, BlockSyncRequester, I, SignedMessage<<Block as BlockT>::Header>>;
 
 /// This blocks a global message import, i.e. a commit or catch up messages,
 /// until all blocks referenced in its votes are known.
@@ -646,7 +646,7 @@ mod tests {
 
 	// unwrap the commit from `CommunicationIn` returning its fields in a tuple,
 	// panics if the given message isn't a commit
-	fn unapply_commit(msg: CommunicationIn<Block>) -> (u64, CompactCommit<Block>) {
+	fn unapply_commit(msg: CommunicationIn<Block>) -> (u64, CompactCommit<Header>) {
 		match msg {
 			voter::CommunicationIn::Commit(round, commit, ..) => (round, commit),
 			_ => panic!("expected commit"),
@@ -655,7 +655,7 @@ mod tests {
 
 	// unwrap the catch up from `CommunicationIn` returning its inner representation,
 	// panics if the given message isn't a catch up
-	fn unapply_catch_up(msg: CommunicationIn<Block>) -> CatchUp<Block> {
+	fn unapply_catch_up(msg: CommunicationIn<Block>) -> CatchUp<Header> {
 		match msg {
 			voter::CommunicationIn::CatchUp(catch_up, ..) => catch_up,
 			_ => panic!("expected catch up"),
@@ -740,7 +740,7 @@ mod tests {
 		let h2 = make_header(6);
 		let h3 = make_header(7);
 
-		let unknown_commit = CompactCommit::<Block> {
+		let unknown_commit = CompactCommit::<Header> {
 			target_hash: h1.hash(),
 			target_number: 5,
 			precommits: vec![
@@ -768,7 +768,7 @@ mod tests {
 		let h2 = make_header(6);
 		let h3 = make_header(7);
 
-		let known_commit = CompactCommit::<Block> {
+		let known_commit = CompactCommit::<Header> {
 			target_hash: h1.hash(),
 			target_number: 5,
 			precommits: vec![
@@ -910,7 +910,7 @@ mod tests {
 
 		// we create a commit message, with precommits for blocks 6 and 7 which
 		// we haven't imported.
-		let unknown_commit = CompactCommit::<Block> {
+		let unknown_commit = CompactCommit::<Header> {
 			target_hash: h1.hash(),
 			target_number: 5,
 			precommits: vec![

--- a/client/finality-grandpa/src/until_imported.rs
+++ b/client/finality-grandpa/src/until_imported.rs
@@ -389,8 +389,13 @@ impl<Block: BlockT> BlockUntilImported<Block> for SignedMessage<Block::Header> {
 
 /// Helper type definition for the stream which waits until vote targets for
 /// signed messages are imported.
-pub(crate) type UntilVoteTargetImported<Block, BlockStatus, BlockSyncRequester, I> =
-	UntilImported<Block, BlockStatus, BlockSyncRequester, I, SignedMessage<<Block as BlockT>::Header>>;
+pub(crate) type UntilVoteTargetImported<Block, BlockStatus, BlockSyncRequester, I> = UntilImported<
+	Block,
+	BlockStatus,
+	BlockSyncRequester,
+	I,
+	SignedMessage<<Block as BlockT>::Header>,
+>;
 
 /// This blocks a global message import, i.e. a commit or catch up messages,
 /// until all blocks referenced in its votes are known.

--- a/frame/transaction-payment/rpc/src/lib.rs
+++ b/frame/transaction-payment/rpc/src/lib.rs
@@ -81,7 +81,6 @@ impl From<Error> for i32 {
 	}
 }
 
-#[async_trait]
 impl<C, Block, Balance>
 	TransactionPaymentApiServer<<Block as BlockT>::Hash, RuntimeDispatchInfo<Balance>>
 	for TransactionPayment<C, Block>

--- a/frame/transaction-payment/rpc/src/lib.rs
+++ b/frame/transaction-payment/rpc/src/lib.rs
@@ -21,7 +21,7 @@ use std::{convert::TryInto, sync::Arc};
 
 use codec::{Codec, Decode};
 use jsonrpsee::{
-	core::{async_trait, Error as JsonRpseeError, RpcResult},
+	core::{Error as JsonRpseeError, RpcResult},
 	proc_macros::rpc,
 	types::error::{CallError, ErrorCode, ErrorObject},
 };

--- a/primitives/finality-grandpa/src/lib.rs
+++ b/primitives/finality-grandpa/src/lib.rs
@@ -29,7 +29,10 @@ use codec::{Codec, Decode, Encode, Input};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
-use sp_runtime::{traits::{NumberFor, Header as HeaderT}, ConsensusEngineId, RuntimeDebug};
+use sp_runtime::{
+	traits::{Header as HeaderT, NumberFor},
+	ConsensusEngineId, RuntimeDebug,
+};
 use sp_std::{borrow::Cow, vec::Vec};
 
 #[cfg(feature = "std")]
@@ -77,10 +80,7 @@ pub type RoundNumber = u64;
 pub type AuthorityList = Vec<(AuthorityId, AuthorityWeight)>;
 
 /// A GRANDPA message for a substrate chain.
-pub type Message<Header> = grandpa::Message<
-	<Header as HeaderT>::Hash,
-	<Header as HeaderT>::Number,
->;
+pub type Message<Header> = grandpa::Message<<Header as HeaderT>::Hash, <Header as HeaderT>::Number>;
 
 /// A signed message.
 pub type SignedMessage<Header> = grandpa::SignedMessage<
@@ -92,20 +92,12 @@ pub type SignedMessage<Header> = grandpa::SignedMessage<
 
 /// A primary propose message for this chain's block type.
 pub type PrimaryPropose<Header> =
-grandpa::PrimaryPropose<
-	<Header as HeaderT>::Hash,
-	<Header as HeaderT>::Number,
->;
+	grandpa::PrimaryPropose<<Header as HeaderT>::Hash, <Header as HeaderT>::Number>;
 /// A prevote message for this chain's block type.
-pub type Prevote<Header> = grandpa::Prevote<
-	<Header as HeaderT>::Hash,
-	<Header as HeaderT>::Number,
->;
+pub type Prevote<Header> = grandpa::Prevote<<Header as HeaderT>::Hash, <Header as HeaderT>::Number>;
 /// A precommit message for this chain's block type.
-pub type Precommit<Header> = grandpa::Precommit<
-	<Header as HeaderT>::Hash,
-	<Header as HeaderT>::Number,
->;
+pub type Precommit<Header> =
+	grandpa::Precommit<<Header as HeaderT>::Hash, <Header as HeaderT>::Number>;
 /// A catch up message for this chain's block type.
 pub type CatchUp<Header> = grandpa::CatchUp<
 	<Header as HeaderT>::Hash,

--- a/primitives/finality-grandpa/src/lib.rs
+++ b/primitives/finality-grandpa/src/lib.rs
@@ -29,7 +29,7 @@ use codec::{Codec, Decode, Encode, Input};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
-use sp_runtime::{traits::NumberFor, ConsensusEngineId, RuntimeDebug};
+use sp_runtime::{traits::{NumberFor, Header as HeaderT}, ConsensusEngineId, RuntimeDebug};
 use sp_std::{borrow::Cow, vec::Vec};
 
 #[cfg(feature = "std")]
@@ -75,6 +75,74 @@ pub type RoundNumber = u64;
 
 /// A list of Grandpa authorities with associated weights.
 pub type AuthorityList = Vec<(AuthorityId, AuthorityWeight)>;
+
+/// A GRANDPA message for a substrate chain.
+pub type Message<Header> = grandpa::Message<
+	<Header as HeaderT>::Hash,
+	<Header as HeaderT>::Number,
+>;
+
+/// A signed message.
+pub type SignedMessage<Header> = grandpa::SignedMessage<
+	<Header as HeaderT>::Hash,
+	<Header as HeaderT>::Number,
+	AuthoritySignature,
+	AuthorityId,
+>;
+
+/// A primary propose message for this chain's block type.
+pub type PrimaryPropose<Header> =
+grandpa::PrimaryPropose<
+	<Header as HeaderT>::Hash,
+	<Header as HeaderT>::Number,
+>;
+/// A prevote message for this chain's block type.
+pub type Prevote<Header> = grandpa::Prevote<
+	<Header as HeaderT>::Hash,
+	<Header as HeaderT>::Number,
+>;
+/// A precommit message for this chain's block type.
+pub type Precommit<Header> = grandpa::Precommit<
+	<Header as HeaderT>::Hash,
+	<Header as HeaderT>::Number,
+>;
+/// A catch up message for this chain's block type.
+pub type CatchUp<Header> = grandpa::CatchUp<
+	<Header as HeaderT>::Hash,
+	<Header as HeaderT>::Number,
+	AuthoritySignature,
+	AuthorityId,
+>;
+/// A commit message for this chain's block type.
+pub type Commit<Header> = grandpa::Commit<
+	<Header as HeaderT>::Hash,
+	<Header as HeaderT>::Number,
+	AuthoritySignature,
+	AuthorityId,
+>;
+
+/// A compact commit message for this chain's block type.
+pub type CompactCommit<Header> = grandpa::CompactCommit<
+	<Header as HeaderT>::Hash,
+	<Header as HeaderT>::Number,
+	AuthoritySignature,
+	AuthorityId,
+>;
+
+/// A GRANDPA justification for block finality, it includes a commit message and
+/// an ancestry proof including all headers routing all precommit target blocks
+/// to the commit target block. Due to the current voting strategy the precommit
+/// targets should be the same as the commit target, since honest voters don't
+/// vote past authority set change blocks.
+///
+/// This is meant to be stored in the db and passed around the network to other
+/// nodes, and are used by syncing nodes to prove authority set handoffs.
+#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug)]
+pub struct GrandpaJustification<Header: HeaderT> {
+	pub round: u64,
+	pub commit: Commit<Header>,
+	pub votes_ancestries: Vec<Header>,
+}
 
 /// A scheduled change of authority set.
 #[cfg_attr(feature = "std", derive(Serialize))]


### PR DESCRIPTION
- I improve type params since many types only want to use `Header` rather than the `Block` type.
- These types are used by me in both no_std/std. And  I need grandpa justification field be `pub`.