### PR TITLE
Update ss58-registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10247,9 +10247,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "ss58-registry"
-version = "1.18.0"
+version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceb8b72a924ccfe7882d0e26144c114503760a4d1248bb5cd06c8ab2d55404cc"
+checksum = "b0837b5d62f42082c9d56cd946495ae273a3c68083b637b9153341d5e465146d"
 dependencies = [
  "Inflector",
  "num-format",

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -57,7 +57,7 @@ hex = { version = "0.4", default-features = false, optional = true }
 libsecp256k1 = { version = "0.7", default-features = false, features = ["static-context"], optional = true }
 merlin = { version = "2.0", default-features = false, optional = true }
 secp256k1 = { version = "0.24.0", default-features = false, features = ["recovery", "alloc"], optional = true }
-ss58-registry = { version = "1.18.0", default-features = false }
+ss58-registry = { version = "1.29.0", default-features = false }
 sp-core-hashing = { version = "4.0.0", path = "./hashing", default-features = false, optional = true }
 sp-runtime-interface = { version = "6.0.0", default-features = false, path = "../runtime-interface" }
 


### PR DESCRIPTION
Update ss58 registry to include the latest additions to the chains list.