### PR TITLE
Add missing metadata specs to crate manifests

### DIFF
--- a/bin/node/bench/Cargo.toml
+++ b/bin/node/bench/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate node integration benchmarks."
 edition = "2021"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+homepage = "https://substrate.io"
+repository = "https://github.com/paritytech/substrate/"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/bin/node/inspect/Cargo.toml
+++ b/bin/node/inspect/Cargo.toml
@@ -2,6 +2,7 @@
 name = "node-inspect"
 version = "0.9.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
+description = "Substrate node block inspection tool."
 edition = "2021"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.io"

--- a/bin/node/primitives/Cargo.toml
+++ b/bin/node/primitives/Cargo.toml
@@ -2,6 +2,7 @@
 name = "node-primitives"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+description = "Substrate node low-level primitives."
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://substrate.io"

--- a/bin/node/rpc/Cargo.toml
+++ b/bin/node/rpc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "node-rpc"
 version = "3.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
+description = "Substrate node rpc methods."
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://substrate.io"

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kitchensink-runtime"
 version = "3.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
+description = "Substrate node kitchensink runtime."
 edition = "2021"
 build = "build.rs"
 license = "Apache-2.0"


### PR DESCRIPTION
Some crates were missing repository or description specs, which are required for publishing crates with cargo unleash.

Related #12209