### PR TITLE
benches: disable caching per default

### DIFF
--- a/utils/frame/benchmarking-cli/src/block/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/block/cmd.rs
@@ -67,6 +67,12 @@ pub struct BlockCmd {
 	#[allow(missing_docs)]
 	#[clap(flatten)]
 	pub params: BenchmarkParams,
+
+	/// Enable the Trie cache.
+	///
+	/// This should only be used for performance analysis and not for final results.
+	#[clap(long)]
+	pub enable_trie_cache: bool,
 }
 
 impl BlockCmd {
@@ -97,5 +103,13 @@ impl CliConfiguration for BlockCmd {
 
 	fn import_params(&self) -> Option<&ImportParams> {
 		Some(&self.import_params)
+	}
+
+	fn trie_cache_maximum_size(&self) -> Result<Option<usize>> {
+		if self.enable_trie_cache {
+			Ok(self.import_params().map(|x| x.trie_cache_maximum_size()).unwrap_or_default())
+		} else {
+			Ok(None)
+		}
 	}
 }

--- a/utils/frame/benchmarking-cli/src/extrinsic/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/extrinsic/cmd.rs
@@ -72,6 +72,12 @@ pub struct ExtrinsicParams {
 	/// Extrinsic to benchmark.
 	#[clap(long, value_name = "EXTRINSIC", required_unless_present = "list")]
 	pub extrinsic: Option<String>,
+
+	/// Enable the Trie cache.
+	///
+	/// This should only be used for performance analysis and not for final results.
+	#[clap(long)]
+	pub enable_trie_cache: bool,
 }
 
 impl ExtrinsicCmd {
@@ -131,5 +137,13 @@ impl CliConfiguration for ExtrinsicCmd {
 
 	fn import_params(&self) -> Option<&ImportParams> {
 		Some(&self.import_params)
+	}
+
+	fn trie_cache_maximum_size(&self) -> Result<Option<usize>> {
+		if self.params.enable_trie_cache {
+			Ok(self.import_params().map(|x| x.trie_cache_maximum_size()).unwrap_or_default())
+		} else {
+			Ok(None)
+		}
 	}
 }

--- a/utils/frame/benchmarking-cli/src/overhead/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/overhead/cmd.rs
@@ -75,6 +75,12 @@ pub struct OverheadParams {
 	/// Good for adding LICENSE headers.
 	#[clap(long, value_name = "PATH")]
 	pub header: Option<PathBuf>,
+
+	/// Enable the Trie cache.
+	///
+	/// This should only be used for performance analysis and not for final results.
+	#[clap(long)]
+	pub enable_trie_cache: bool,
 }
 
 /// Type of a benchmark.
@@ -155,5 +161,13 @@ impl CliConfiguration for OverheadCmd {
 
 	fn import_params(&self) -> Option<&ImportParams> {
 		Some(&self.import_params)
+	}
+
+	fn trie_cache_maximum_size(&self) -> Result<Option<usize>> {
+		if self.params.enable_trie_cache {
+			Ok(self.import_params().map(|x| x.trie_cache_maximum_size()).unwrap_or_default())
+		} else {
+			Ok(None)
+		}
 	}
 }

--- a/utils/frame/benchmarking-cli/src/storage/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/storage/cmd.rs
@@ -105,8 +105,14 @@ pub struct StorageParams {
 	/// Trie cache size in bytes.
 	///
 	/// Providing `0` will disable the cache.
-	#[clap(long, default_value = "1024")]
+	#[clap(long, value_name = "Bytes", default_value = "67108864")]
 	pub trie_cache_size: usize,
+
+	/// Enable the Trie cache.
+	///
+	/// This should only be used for performance analysis and not for final results.
+	#[clap(long)]
+	pub enable_trie_cache: bool,
 
 	/// Include child trees in benchmark.
 	#[clap(long)]
@@ -220,10 +226,10 @@ impl CliConfiguration for StorageCmd {
 	}
 
 	fn trie_cache_maximum_size(&self) -> Result<Option<usize>> {
-		if self.params.trie_cache_size == 0 {
-			Ok(None)
-		} else {
+		if self.params.enable_trie_cache && self.params.trie_cache_size > 0 {
 			Ok(Some(self.params.trie_cache_size))
+		} else {
+			Ok(None)
 		}
 	}
 }

--- a/utils/frame/benchmarking-cli/src/storage/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/storage/cmd.rs
@@ -105,7 +105,7 @@ pub struct StorageParams {
 	/// Trie cache size in bytes.
 	///
 	/// Providing `0` will disable the cache.
-	#[clap(long, default_value = "0")]
+	#[clap(long, default_value = "1024")]
 	pub trie_cache_size: usize,
 
 	/// Include child trees in benchmark.

--- a/utils/frame/benchmarking-cli/src/storage/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/storage/cmd.rs
@@ -105,7 +105,7 @@ pub struct StorageParams {
 	/// Trie cache size in bytes.
 	///
 	/// Providing `0` will disable the cache.
-	#[clap(long, default_value = "1024")]
+	#[clap(long, default_value = "0")]
 	pub trie_cache_size: usize,
 
 	/// Include child trees in benchmark.


### PR DESCRIPTION
Spotted some large weight decrease for `BlockExecutionWeight` on the Polkadot release branch v0.9.29 [here](https://github.com/paritytech/polkadot/pull/5988#discussion_r966960674).  
It comes from the new Trie cache https://github.com/paritytech/substrate/pull/11407 feature which has unforeseen influence on the weights here.  

This MR disables caching per default and makes enabling it explicit. 