### PR TITLE
Don't run `cargo-check-benches` for `master` based downstream staging pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,6 +150,18 @@ default:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
 
+# handle the specific case where benches could store incorrect bench data because of the downstream staging runs
+# exclude cargo-check-benches from such runs
+.test-refs-no-trigger-prs-only-check-benches:
+  rules:
+    - if: $CI_COMMIT_REF_NAME == "master" && $CI_PIPELINE_SOURCE == "parent_pipeline"  && $CI_IMAGE =~ /staging$/ 
+      when: never
+    - if: $CI_PIPELINE_SOURCE == "pipeline"
+      when: never
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+
 .test-refs-wasmer-sandbox:
   rules:
     - if: $CI_PIPELINE_SOURCE == "web"

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -59,7 +59,7 @@ cargo-check-benches:
     CI_JOB_NAME:                   "cargo-check-benches"
   extends:
     - .docker-env
-    - .test-refs
+    - .test-refs-no-trigger-prs-only-check-benches
     - .collect-artifacts
     - .pipeline-stopper-artifacts
   before_script:


### PR DESCRIPTION
Running downstream pipelines for `master` with images other than the current production one could result in incorrect `node-bench` results and `node-bench-regression-guard`'s false positives. This behavior could happen because of e.g. different stable Rust toolchains in these images. Any successful `cargo-check-benches` job (i.e. it doesn't matter if it was run with e.g. `ci-linux:staging` or `ci-linux:production`) will upload its results and this can result in incorrect performance regression detections. 