### PR TITLE
Clean up the logging output

### DIFF
--- a/client/tracing/src/logging/mod.rs
+++ b/client/tracing/src/logging/mod.rs
@@ -133,7 +133,13 @@ where
 		.add_directive(
 			parse_default_directive("cranelift_wasm=warn").expect("provided directive is valid"),
 		)
-		.add_directive(parse_default_directive("hyper=warn").expect("provided directive is valid"));
+		.add_directive(parse_default_directive("hyper=warn").expect("provided directive is valid"))
+		.add_directive(
+			parse_default_directive("trust_dns_proto=off").expect("provided directive is valid"),
+		)
+		.add_directive(
+			parse_default_directive("libp2p_mdns::behaviour::iface=off").expect("provided directive is valid"),
+		);
 
 	if let Ok(lvl) = std::env::var("RUST_LOG") {
 		if lvl != "" {

--- a/client/tracing/src/logging/mod.rs
+++ b/client/tracing/src/logging/mod.rs
@@ -138,7 +138,8 @@ where
 			parse_default_directive("trust_dns_proto=off").expect("provided directive is valid"),
 		)
 		.add_directive(
-			parse_default_directive("libp2p_mdns::behaviour::iface=off").expect("provided directive is valid"),
+			parse_default_directive("libp2p_mdns::behaviour::iface=off")
+				.expect("provided directive is valid"),
 		);
 
 	if let Ok(lvl) = std::env::var("RUST_LOG") {


### PR DESCRIPTION
Sadly `trust-dns` and `libp2p::iface` are printing stuff that isn't very informative and just confuses the user. So, we just disable logging output from both of these crates as we already have done this for other crates as well.

