### PR TITLE
Replace 'blake2-rfc' with rust-crypto 'blake2' crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9732,7 +9732,7 @@ version = "6.0.0"
 dependencies = [
  "base58",
  "bitflags",
- "blake2-rfc",
+ "blake2",
  "byteorder",
  "criterion",
  "dyn-clonable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,7 +251,6 @@ members = [
 # This list is ordered alphabetically.
 [profile.dev.package]
 blake2 = { opt-level = 3 }
-blake2-rfc = { opt-level = 3 }
 blake2b_simd = { opt-level = 3 }
 chacha20poly1305 = { opt-level = 3 }
 cranelift-codegen = { opt-level = 3 }

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -48,7 +48,7 @@ bitflags = "1.3"
 
 # full crypto
 ed25519-zebra = { version = "3.0.0", default-features = false, optional = true}
-blake2-rfc = { version = "0.2.18", default-features = false, optional = true }
+blake2 = { version = "0.10.2", default-features = false, optional = true }
 schnorrkel = { version = "0.9.1", features = [
 	"preaudit_deprecated",
 	"u64_backend",
@@ -96,7 +96,7 @@ std = [
 	"hash-db/std",
 	"sp-std/std",
 	"serde",
-	"blake2-rfc/std",
+	"blake2/std",
 	"ed25519-zebra",
 	"hex/std",
 	"base58",
@@ -128,7 +128,7 @@ std = [
 # For the regular wasm runtime builds this should not be used.
 full_crypto = [
 	"ed25519-zebra",
-	"blake2-rfc",
+	"blake2",
 	"schnorrkel",
 	"hex",
 	"libsecp256k1",


### PR DESCRIPTION
Closes https://github.com/paritytech/substrate/issues/12260

Added a couple of tests exercising an uncovered code path wrt key derivation (where blake2 was involved)

---

Performances of the two libraries were found to be approximately equal

Results using Substrate startup performance tests (CPU-SCORE MB/s). Bigger Is better.
```
- blake2        : 867, 861, 868
- blake2-rfc    : 868, 867, 862
```

Results using directly criterion: https://github.com/davxy/crypto-benches/tree/main/hash#blake2

---

Blake2-rfc is now pulled in only by parity-db. But I think that can be replaced there as well...