### PR TITLE
Format templates and fix `--steps` default value

### DIFF
--- a/utils/frame/benchmarking-cli/src/overhead/weights.hbs
+++ b/utils/frame/benchmarking-cli/src/overhead/weights.hbs
@@ -39,7 +39,6 @@ parameter_types! {
 
 #[cfg(test)]
 mod test_weights {
-	use super::*;
 	use sp_weights::constants;
 
 	/// Checks that the weight exists and is sane.
@@ -51,14 +50,26 @@ mod test_weights {
 
 		{{#if (eq short_name "block")}}
 		// At least 100 µs.
-		assert!(w.ref_time() >= 100u64 * constants::WEIGHT_PER_MICROS.ref_time(), "Weight should be at least 100 µs.");
+		assert!(
+			w.ref_time() >= 100u64 * constants::WEIGHT_PER_MICROS.ref_time(),
+			"Weight should be at least 100 µs."
+		);
 		// At most 50 ms.
-		assert!(w.ref_time() <= 50u64 * constants::WEIGHT_PER_MILLIS.ref_time(), "Weight should be at most 50 ms.");
+		assert!(
+			w.ref_time() <= 50u64 * constants::WEIGHT_PER_MILLIS.ref_time(),
+			"Weight should be at most 50 ms."
+		);
 		{{else}}
 		// At least 10 µs.
-		assert!(w.ref_time() >= 10u64 * constants::WEIGHT_PER_MICROS.ref_time(), "Weight should be at least 10 µs.");
+		assert!(
+			w.ref_time() >= 10u64 * constants::WEIGHT_PER_MICROS.ref_time(),
+			"Weight should be at least 10 µs."
+		);
 		// At most 1 ms.
-		assert!(w.ref_time() <= constants::WEIGHT_PER_MILLIS.ref_time(), "Weight should be at most 1 ms.");
+		assert!(
+			w.ref_time() <= constants::WEIGHT_PER_MILLIS.ref_time(),
+			"Weight should be at most 1 ms."
+		);
 		{{/if}}
 	}
 }

--- a/utils/frame/benchmarking-cli/src/pallet/mod.rs
+++ b/utils/frame/benchmarking-cli/src/pallet/mod.rs
@@ -43,7 +43,7 @@ pub struct PalletCmd {
 	pub extrinsic: Option<String>,
 
 	/// Select how many samples we should take across the variable components.
-	#[clap(short, long, default_value = "1")]
+	#[clap(short, long, default_value = "2")]
 	pub steps: u32,
 
 	/// Indicates lowest values for each of the component ranges.

--- a/utils/frame/benchmarking-cli/src/pallet/template.hbs
+++ b/utils/frame/benchmarking-cli/src/pallet/template.hbs
@@ -15,7 +15,7 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 
-use frame_support::{traits::Get, weights::{Weight}};
+use frame_support::{traits::Get, weights::Weight};
 use sp_std::marker::PhantomData;
 
 /// Weight functions for `{{pallet}}`.


### PR DESCRIPTION
Changes:
- Manually do what `cargo +nightly fmt` would do to the templates; [example](https://github.com/paritytech/polkadot/blob/28acc786eedd607954a84078f15e6e27ab66d90f/runtime/kusama/constants/src/weights/block_weights.rs#L73).  
 Looks like it slipped through in the Weights V2 update.
- Set the default value of `--steps` for `benchmark pallet` to 2, since it otherwise errors with `steps must be at least 2`.