### PR TITLE
updated MultiplierUpdate trait

### DIFF
--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -254,6 +254,7 @@ impl pallet_balances::Config for Runtime {
 
 parameter_types! {
 	pub FeeMultiplier: Multiplier = Multiplier::one();
+	pub MaxMultiplier: Multiplier = <Multiplier as sp_runtime::traits::Bounded>::max_value();
 }
 
 impl pallet_transaction_payment::Config for Runtime {
@@ -262,7 +263,7 @@ impl pallet_transaction_payment::Config for Runtime {
 	type OperationalFeeMultiplier = ConstU8<5>;
 	type WeightToFee = IdentityFee<Balance>;
 	type LengthToFee = IdentityFee<Balance>;
-	type FeeMultiplierUpdate = ConstFeeMultiplier<FeeMultiplier>;
+	type FeeMultiplierUpdate = ConstFeeMultiplier<FeeMultiplier,MaxMultiplier>;
 }
 
 impl pallet_sudo::Config for Runtime {

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -447,6 +447,7 @@ parameter_types! {
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
 	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(1, 100_000);
 	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000_000u128);
+	pub MaximumMultiplier: Multiplier = <Multiplier as sp_runtime::traits::Bounded>::max_value();
 }
 
 impl pallet_transaction_payment::Config for Runtime {
@@ -456,7 +457,7 @@ impl pallet_transaction_payment::Config for Runtime {
 	type WeightToFee = IdentityFee<Balance>;
 	type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
 	type FeeMultiplierUpdate =
-		TargetedFeeAdjustment<Self, TargetBlockFullness, AdjustmentVariable, MinimumMultiplier>;
+		TargetedFeeAdjustment<Self, TargetBlockFullness, AdjustmentVariable, MinimumMultiplier, MaximumMultiplier>;
 }
 
 impl pallet_asset_tx_payment::Config for Runtime {


### PR DESCRIPTION
This solves #12240, 
Concerning enforcing the returned Multiplier should be less than Next block fees multiplier , I have put that if the returned multiplier is greater than maximum multiplier then return the maximum multiplier.
I have set maximum multiplier to be Bounded::max_value.

Please instruct me If i can improve the above the logic.
@kianenigma 