### PR TITLE
Fix `cargo-check-benches` job's `rules:`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -131,6 +131,18 @@ default:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 
+# handle the specific case where benches could store incorrect bench data because of the downstream staging runs
+# exclude cargo-check-benches from such runs
+.test-refs-check-benches:
+  rules:
+    - if: $CI_COMMIT_REF_NAME == "master" && $CI_PIPELINE_SOURCE == "parent_pipeline"  && $CI_IMAGE =~ /staging$/ 
+      when: never
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+
 .test-refs-no-trigger:
   rules:
     - if: $CI_PIPELINE_SOURCE == "pipeline"
@@ -144,18 +156,6 @@ default:
 
 .test-refs-no-trigger-prs-only:
   rules:
-    - if: $CI_PIPELINE_SOURCE == "pipeline"
-      when: never
-    - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-
-# handle the specific case where benches could store incorrect bench data because of the downstream staging runs
-# exclude cargo-check-benches from such runs
-.test-refs-no-trigger-prs-only-check-benches:
-  rules:
-    - if: $CI_COMMIT_REF_NAME == "master" && $CI_PIPELINE_SOURCE == "parent_pipeline"  && $CI_IMAGE =~ /staging$/ 
-      when: never
     - if: $CI_PIPELINE_SOURCE == "pipeline"
       when: never
     - if: $CI_PIPELINE_SOURCE == "web"

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -59,7 +59,7 @@ cargo-check-benches:
     CI_JOB_NAME:                   "cargo-check-benches"
   extends:
     - .docker-env
-    - .test-refs-no-trigger-prs-only-check-benches
+    - .test-refs-check-benches
     - .collect-artifacts
     - .pipeline-stopper-artifacts
   before_script:


### PR DESCRIPTION
#12233 introduced a regression where `cargo-check-benches` job stopped to be included in pipelines. This PR fixes that.