### PR TITLE
[ci] Revert cancel-pipeline job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ workflow:
     - if: $CI_COMMIT_TAG
     - if: $CI_COMMIT_BRANCH
 
-variables:                         &default-vars
+variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       100
   CARGO_INCREMENTAL:               0

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -278,8 +278,6 @@ rusty-cachier-notify:
     PR_NUM:                        "${PR_NUM}"
   trigger:
     project:                       "parity/infrastructure/ci_cd/pipeline-stopper"
-    # remove branch, when pipeline-stopper for polakdot is updated to the same branch
-    branch:                        "as-improve"
 
 # need to copy jobs this way because otherwise gitlab will wait
 # for all 3 jobs to finish instead of cancelling if one fails

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -219,6 +219,7 @@ test-linux-stable:
     CI_JOB_NAME:                   "test-linux-stable"
   parallel: 3
   script:
+    - - if [ ${CI_NODE_INDEX} == 1 ]; exit 1; fi
     - rusty-cachier snapshot create
     # this job runs all tests in former runtime-benchmarks, frame-staking and wasmtime tests
     # tests are partitioned by nextest and executed in parallel on $CI_NODE_TOTAL runners

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -219,7 +219,6 @@ test-linux-stable:
     CI_JOB_NAME:                   "test-linux-stable"
   parallel: 3
   script:
-    - - if [ ${CI_NODE_INDEX} == 1 ]; exit 1; fi
     - rusty-cachier snapshot create
     # this job runs all tests in former runtime-benchmarks, frame-staking and wasmtime tests
     # tests are partitioned by nextest and executed in parallel on $CI_NODE_TOTAL runners


### PR DESCRIPTION
PR reverts cancel-pipeline job to an old version in order to change it in the future (more info: https://github.com/paritytech/ci_cd/issues/548#issuecomment-1233436898)