### PR TITLE
Const impls of base arithmetics for `Weights` with `u64`

### DIFF
--- a/primitives/weights/src/weight_v2.rs
+++ b/primitives/weights/src/weight_v2.rs
@@ -160,22 +160,22 @@ impl Weight {
 		Self { ref_time: 0 }
 	}
 
-	/// Constant version of Add with u64
+	/// Constant version of Add with u64. Is only overflow safe when evaluated at compile-time.
 	pub const fn add(self, scalar: u64) -> Self {
 		Self { ref_time: self.ref_time + scalar }
 	}
 
-	/// Constant version of Sub with u64
+	/// Constant version of Sub with u64. Is only overflow safe when evaluated at compile-time.
 	pub const fn sub(self, scalar: u64) -> Self {
 		Self { ref_time: self.ref_time - scalar }
 	}
 
-	/// Constant version of Div with u64
+	/// Constant version of Div with u64. Is only overflow safe when evaluated at compile-time.
 	pub const fn div(self, scalar: u64) -> Self {
 		Self { ref_time: self.ref_time / scalar }
 	}
 
-	/// Constant version of Mul with u64
+	/// Constant version of Mul with u64. Is only overflow safe when evaluated at compile-time.
 	pub const fn mul(self, scalar: u64) -> Self {
 		Self { ref_time: self.ref_time * scalar }
 	}

--- a/primitives/weights/src/weight_v2.rs
+++ b/primitives/weights/src/weight_v2.rs
@@ -160,7 +160,9 @@ impl Weight {
 		Self { ref_time: 0 }
 	}
 
-	/// Constant version of Add with u64. Is only overflow safe when evaluated at compile-time.
+	/// Constant version of Add with u64.
+	///
+	/// Is only overflow safe when evaluated at compile-time.
 	pub const fn add(self, scalar: u64) -> Self {
 		Self { ref_time: self.ref_time + scalar }
 	}

--- a/primitives/weights/src/weight_v2.rs
+++ b/primitives/weights/src/weight_v2.rs
@@ -165,17 +165,23 @@ impl Weight {
 		Self { ref_time: self.ref_time + scalar }
 	}
 
-	/// Constant version of Sub with u64. Is only overflow safe when evaluated at compile-time.
+	/// Constant version of Sub with u64.
+	///
+	/// Is only overflow safe when evaluated at compile-time.
 	pub const fn sub(self, scalar: u64) -> Self {
 		Self { ref_time: self.ref_time - scalar }
 	}
 
-	/// Constant version of Div with u64. Is only overflow safe when evaluated at compile-time.
+	/// Constant version of Div with u64.
+	///
+	/// Is only overflow safe when evaluated at compile-time.
 	pub const fn div(self, scalar: u64) -> Self {
 		Self { ref_time: self.ref_time / scalar }
 	}
 
-	/// Constant version of Mul with u64. Is only overflow safe when evaluated at compile-time.
+	/// Constant version of Mul with u64.
+	///
+	/// Is only overflow safe when evaluated at compile-time.
 	pub const fn mul(self, scalar: u64) -> Self {
 		Self { ref_time: self.ref_time * scalar }
 	}

--- a/primitives/weights/src/weight_v2.rs
+++ b/primitives/weights/src/weight_v2.rs
@@ -160,6 +160,26 @@ impl Weight {
 		Self { ref_time: 0 }
 	}
 
+	/// Constant version of Add with u64
+	pub const fn add(self, scalar: u64) -> Self {
+		Self { ref_time: self.ref_time + scalar }
+	}
+
+	/// Constant version of Sub with u64
+	pub const fn sub(self, scalar: u64) -> Self {
+		Self { ref_time: self.ref_time - scalar }
+	}
+
+	/// Constant version of Div with u64
+	pub const fn div(self, scalar: u64) -> Self {
+		Self { ref_time: self.ref_time / scalar }
+	}
+
+	/// Constant version of Mul with u64
+	pub const fn mul(self, scalar: u64) -> Self {
+		Self { ref_time: self.ref_time * scalar }
+	}
+
 	/// Returns true if any of `self`'s constituent weights is strictly greater than that of the
 	/// `other`'s, otherwise returns false.
 	pub const fn any_gt(self, other: Self) -> bool {


### PR DESCRIPTION
Not sure, if this is essentially needed, but with respect to `const`s, which will be one of the common usages of `Weights` as runtime parameters, I am not a fan of saturating operations and the checked versions are currently not really usable as `unwrap()` is not available for consts.

The additional methods allow for usage of weights as `const SOME_WEIGHT: Weight = OTHER_WEIGHT.div(2)`

### E.g. 
* `const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND / 2` does not work, which is fine. 
* `const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND.checked_div(2).unwrap()` does not work, which is not so fine, as we don't want an `Option<Weight>`
* `const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND.saturating_add(u64::MAX)` does work, but assuming `WEIGHT_PER_SECOND` is bigger than `u64::MAX ` a compilation error would be prefered .
