### PR TITLE
Add base-weight to `System::Extrinsic*` events

### DIFF
--- a/bin/node/executor/tests/basic.rs
+++ b/bin/node/executor/tests/basic.rs
@@ -311,10 +311,19 @@ fn full_native_block_import_works() {
 	let mut alice_last_known_balance: Balance = Default::default();
 	let mut fees = t.execute_with(|| transfer_fee(&xt()));
 
-	let transfer_weight = default_transfer_call().get_dispatch_info().weight;
+	let transfer_weight = default_transfer_call().get_dispatch_info().weight.saturating_add(
+		<Runtime as frame_system::Config>::BlockWeights::get()
+			.get(DispatchClass::Normal)
+			.base_extrinsic,
+	);
 	let timestamp_weight = pallet_timestamp::Call::set::<Runtime> { now: Default::default() }
 		.get_dispatch_info()
-		.weight;
+		.weight
+		.saturating_add(
+			<Runtime as frame_system::Config>::BlockWeights::get()
+				.get(DispatchClass::Mandatory)
+				.base_extrinsic,
+		);
 
 	executor_call(&mut t, "Core_execute_block", &block1.0, true).0.unwrap();
 

--- a/frame/system/src/extensions/check_weight.rs
+++ b/frame/system/src/extensions/check_weight.rs
@@ -342,7 +342,7 @@ mod tests {
 				.get(DispatchClass::Operational)
 				.max_total
 				.unwrap_or_else(|| weights.max_block);
-			let base_weight = weights.get(DispatchClass::Normal).base_extrinsic;
+			let base_weight = weights.get(DispatchClass::Operational).base_extrinsic;
 
 			let weight = operational_limit - base_weight;
 			let okay =
@@ -378,11 +378,11 @@ mod tests {
 			// Max normal is 768 (75%)
 			// 10 is taken for block execution weight
 			// So normal extrinsic can be 758 weight (-5 for base extrinsic weight)
-			// And Operational can be 256 to produce a full block (-5 for base)
+			// And Operational can be 246 to produce a full block (-10 for base)
 			let max_normal =
 				DispatchInfo { weight: Weight::from_ref_time(753), ..Default::default() };
 			let rest_operational = DispatchInfo {
-				weight: Weight::from_ref_time(251),
+				weight: Weight::from_ref_time(246),
 				class: DispatchClass::Operational,
 				..Default::default()
 			};
@@ -406,7 +406,7 @@ mod tests {
 			let max_normal =
 				DispatchInfo { weight: Weight::from_ref_time(753), ..Default::default() };
 			let rest_operational = DispatchInfo {
-				weight: Weight::from_ref_time(251),
+				weight: Weight::from_ref_time(246),
 				class: DispatchClass::Operational,
 				..Default::default()
 			};
@@ -414,7 +414,7 @@ mod tests {
 			let len = 0_usize;
 
 			assert_ok!(CheckWeight::<Test>::do_pre_dispatch(&rest_operational, len));
-			// Extra 15 here from block execution + base extrinsic weight
+			// Extra 20 here from block execution + base extrinsic weight
 			assert_eq!(System::block_weight().total(), Weight::from_ref_time(266));
 			assert_ok!(CheckWeight::<Test>::do_pre_dispatch(&max_normal, len));
 			assert_eq!(block_weight_limit(), Weight::from_ref_time(1024));
@@ -433,7 +433,7 @@ mod tests {
 				..Default::default()
 			};
 			let dispatch_operational = DispatchInfo {
-				weight: Weight::from_ref_time(251),
+				weight: Weight::from_ref_time(246),
 				class: DispatchClass::Operational,
 				..Default::default()
 			};

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1509,9 +1509,15 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// To be called immediately after an extrinsic has been applied.
+	///
+	/// Emits an `ExtrinsicSuccess` or `ExtrinsicFailed` event depending on the outcome.
+	/// The emitted event contains the post-dispatch corrected weight including
+	/// the base-weight for its dispatch class.
 	pub fn note_applied_extrinsic(r: &DispatchResultWithPostInfo, mut info: DispatchInfo) {
-		info.weight = extract_actual_weight(r, &info);
+		info.weight = extract_actual_weight(r, &info)
+			.saturating_add(T::BlockWeights::get().get(info.class).base_extrinsic);
 		info.pays_fee = extract_actual_pays_fee(r, &info);
+
 		Self::deposit_event(match r {
 			Ok(_) => Event::ExtrinsicSuccess { dispatch_info: info },
 			Err(err) => {

--- a/frame/system/src/mock.rs
+++ b/frame/system/src/mock.rs
@@ -67,6 +67,7 @@ parameter_types! {
 			weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAX_BLOCK_WEIGHT);
 		})
 		.for_class(DispatchClass::Operational, |weights| {
+			weights.base_extrinsic = Weight::from_ref_time(10);
 			weights.max_total = Some(MAX_BLOCK_WEIGHT);
 			weights.reserved = Some(
 				MAX_BLOCK_WEIGHT - NORMAL_DISPATCH_RATIO * MAX_BLOCK_WEIGHT

--- a/frame/system/src/tests.rs
+++ b/frame/system/src/tests.rs
@@ -169,6 +169,10 @@ fn deposit_event_should_work() {
 			}]
 		);
 
+		let normal_base = <Test as crate::Config>::BlockWeights::get()
+			.get(DispatchClass::Normal)
+			.base_extrinsic;
+
 		System::reset_events();
 		System::initialize(&2, &[0u8; 32].into(), &Default::default());
 		System::deposit_event(SysEvent::NewAccount { account: 32 });
@@ -194,14 +198,17 @@ fn deposit_event_should_work() {
 				},
 				EventRecord {
 					phase: Phase::ApplyExtrinsic(0),
-					event: SysEvent::ExtrinsicSuccess { dispatch_info: Default::default() }.into(),
+					event: SysEvent::ExtrinsicSuccess {
+						dispatch_info: DispatchInfo { weight: normal_base, ..Default::default() }
+					}
+					.into(),
 					topics: vec![]
 				},
 				EventRecord {
 					phase: Phase::ApplyExtrinsic(1),
 					event: SysEvent::ExtrinsicFailed {
 						dispatch_error: DispatchError::BadOrigin.into(),
-						dispatch_info: Default::default()
+						dispatch_info: DispatchInfo { weight: normal_base, ..Default::default() }
 					}
 					.into(),
 					topics: vec![]
@@ -223,6 +230,9 @@ fn deposit_event_uses_actual_weight_and_pays_fee() {
 		System::initialize(&1, &[0u8; 32].into(), &Default::default());
 		System::note_finished_initialize();
 
+		let normal_base = <Test as crate::Config>::BlockWeights::get()
+			.get(DispatchClass::Normal)
+			.base_extrinsic;
 		let pre_info = DispatchInfo { weight: Weight::from_ref_time(1000), ..Default::default() };
 		System::note_applied_extrinsic(&Ok(Some(300).into()), pre_info);
 		System::note_applied_extrinsic(&Ok(Some(1000).into()), pre_info);
@@ -267,144 +277,168 @@ fn deposit_event_uses_actual_weight_and_pays_fee() {
 			}),
 			pre_info,
 		);
+		// Also works for operational.
+		let operational_base = <Test as crate::Config>::BlockWeights::get()
+			.get(DispatchClass::Operational)
+			.base_extrinsic;
+		assert!(normal_base != operational_base, "Test pre-condition violated");
+		let pre_info = DispatchInfo {
+			weight: Weight::from_ref_time(1000),
+			class: DispatchClass::Operational,
+			..Default::default()
+		};
+		System::note_applied_extrinsic(&Ok(Some(300).into()), pre_info);
 
-		assert_eq!(
-			System::events(),
-			vec![
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: SysEvent::ExtrinsicSuccess {
-						dispatch_info: DispatchInfo {
-							weight: Weight::from_ref_time(300),
-							..Default::default()
-						},
-					}
-					.into(),
-					topics: vec![]
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(1),
-					event: SysEvent::ExtrinsicSuccess {
-						dispatch_info: DispatchInfo {
-							weight: Weight::from_ref_time(1000),
-							..Default::default()
-						},
-					}
-					.into(),
-					topics: vec![]
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(2),
-					event: SysEvent::ExtrinsicSuccess {
-						dispatch_info: DispatchInfo {
-							weight: Weight::from_ref_time(1000),
-							..Default::default()
-						},
-					}
-					.into(),
-					topics: vec![]
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(3),
-					event: SysEvent::ExtrinsicSuccess {
-						dispatch_info: DispatchInfo {
-							weight: Weight::from_ref_time(1000),
-							pays_fee: Pays::Yes,
-							..Default::default()
-						},
-					}
-					.into(),
-					topics: vec![]
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(4),
-					event: SysEvent::ExtrinsicSuccess {
-						dispatch_info: DispatchInfo {
-							weight: Weight::from_ref_time(1000),
-							pays_fee: Pays::No,
-							..Default::default()
-						},
-					}
-					.into(),
-					topics: vec![]
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(5),
-					event: SysEvent::ExtrinsicSuccess {
-						dispatch_info: DispatchInfo {
-							weight: Weight::from_ref_time(1000),
-							pays_fee: Pays::No,
-							..Default::default()
-						},
-					}
-					.into(),
-					topics: vec![]
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(6),
-					event: SysEvent::ExtrinsicSuccess {
-						dispatch_info: DispatchInfo {
-							weight: Weight::from_ref_time(500),
-							pays_fee: Pays::No,
-							..Default::default()
-						},
-					}
-					.into(),
-					topics: vec![]
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(7),
-					event: SysEvent::ExtrinsicFailed {
-						dispatch_error: DispatchError::BadOrigin.into(),
-						dispatch_info: DispatchInfo {
-							weight: Weight::from_ref_time(999),
-							..Default::default()
-						},
-					}
-					.into(),
-					topics: vec![]
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(8),
-					event: SysEvent::ExtrinsicFailed {
-						dispatch_error: DispatchError::BadOrigin.into(),
-						dispatch_info: DispatchInfo {
-							weight: Weight::from_ref_time(1000),
-							pays_fee: Pays::Yes,
-							..Default::default()
-						},
-					}
-					.into(),
-					topics: vec![]
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(9),
-					event: SysEvent::ExtrinsicFailed {
-						dispatch_error: DispatchError::BadOrigin.into(),
-						dispatch_info: DispatchInfo {
-							weight: Weight::from_ref_time(800),
-							pays_fee: Pays::Yes,
-							..Default::default()
-						},
-					}
-					.into(),
-					topics: vec![]
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(10),
-					event: SysEvent::ExtrinsicFailed {
-						dispatch_error: DispatchError::BadOrigin.into(),
-						dispatch_info: DispatchInfo {
-							weight: Weight::from_ref_time(800),
-							pays_fee: Pays::No,
-							..Default::default()
-						},
-					}
-					.into(),
-					topics: vec![]
-				},
-			]
-		);
+		let got = System::events();
+		let want = vec![
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: SysEvent::ExtrinsicSuccess {
+					dispatch_info: DispatchInfo {
+						weight: Weight::from_ref_time(300).saturating_add(normal_base),
+						..Default::default()
+					},
+				}
+				.into(),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(1),
+				event: SysEvent::ExtrinsicSuccess {
+					dispatch_info: DispatchInfo {
+						weight: Weight::from_ref_time(1000).saturating_add(normal_base),
+						..Default::default()
+					},
+				}
+				.into(),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(2),
+				event: SysEvent::ExtrinsicSuccess {
+					dispatch_info: DispatchInfo {
+						weight: Weight::from_ref_time(1000).saturating_add(normal_base),
+						..Default::default()
+					},
+				}
+				.into(),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(3),
+				event: SysEvent::ExtrinsicSuccess {
+					dispatch_info: DispatchInfo {
+						weight: Weight::from_ref_time(1000).saturating_add(normal_base),
+						pays_fee: Pays::Yes,
+						..Default::default()
+					},
+				}
+				.into(),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(4),
+				event: SysEvent::ExtrinsicSuccess {
+					dispatch_info: DispatchInfo {
+						weight: Weight::from_ref_time(1000).saturating_add(normal_base),
+						pays_fee: Pays::No,
+						..Default::default()
+					},
+				}
+				.into(),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(5),
+				event: SysEvent::ExtrinsicSuccess {
+					dispatch_info: DispatchInfo {
+						weight: Weight::from_ref_time(1000).saturating_add(normal_base),
+						pays_fee: Pays::No,
+						..Default::default()
+					},
+				}
+				.into(),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(6),
+				event: SysEvent::ExtrinsicSuccess {
+					dispatch_info: DispatchInfo {
+						weight: Weight::from_ref_time(500).saturating_add(normal_base),
+						pays_fee: Pays::No,
+						..Default::default()
+					},
+				}
+				.into(),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(7),
+				event: SysEvent::ExtrinsicFailed {
+					dispatch_error: DispatchError::BadOrigin.into(),
+					dispatch_info: DispatchInfo {
+						weight: Weight::from_ref_time(999).saturating_add(normal_base),
+						..Default::default()
+					},
+				}
+				.into(),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(8),
+				event: SysEvent::ExtrinsicFailed {
+					dispatch_error: DispatchError::BadOrigin.into(),
+					dispatch_info: DispatchInfo {
+						weight: Weight::from_ref_time(1000).saturating_add(normal_base),
+						pays_fee: Pays::Yes,
+						..Default::default()
+					},
+				}
+				.into(),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(9),
+				event: SysEvent::ExtrinsicFailed {
+					dispatch_error: DispatchError::BadOrigin.into(),
+					dispatch_info: DispatchInfo {
+						weight: Weight::from_ref_time(800).saturating_add(normal_base),
+						pays_fee: Pays::Yes,
+						..Default::default()
+					},
+				}
+				.into(),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(10),
+				event: SysEvent::ExtrinsicFailed {
+					dispatch_error: DispatchError::BadOrigin.into(),
+					dispatch_info: DispatchInfo {
+						weight: Weight::from_ref_time(800).saturating_add(normal_base),
+						pays_fee: Pays::No,
+						..Default::default()
+					},
+				}
+				.into(),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(11),
+				event: SysEvent::ExtrinsicSuccess {
+					dispatch_info: DispatchInfo {
+						weight: Weight::from_ref_time(300).saturating_add(operational_base),
+						class: DispatchClass::Operational,
+						..Default::default()
+					},
+				}
+				.into(),
+				topics: vec![],
+			},
+		];
+		for (i, event) in want.into_iter().enumerate() {
+			assert_eq!(got[i], event, "Event mismatch at index {}", i);
+		}
 	});
 }
 


### PR DESCRIPTION
Closes https://github.com/paritytech/substrate/issues/12252:  
- Adds the base-weight of the respective dispatch class into the event by modifying `note_applied_extrinsic`.  
- Update tests and give the mocked `Operational` class a distinct base weight, to improve testing.

PolkadotJs now also shows the correct weight of a Remark: `87_298_000 = 86_298_000 (base) + 1_000_000 (remark)`.  
This is identical to the result of `System::blockWeight(block_hash)` in that case.  

![Screenshot from 2022-09-22 15-31-37](https://user-images.githubusercontent.com/10380170/191761057-ec49db79-183f-4971-ba01-7b976b67c951.png)  
cc @notlesh 