### PR TITLE
Undo removing migration checks

### DIFF
--- a/frame/staking/src/migrations.rs
+++ b/frame/staking/src/migrations.rs
@@ -36,6 +36,11 @@ pub mod v12 {
 		#[cfg(feature = "try-runtime")]
 		fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
 			frame_support::ensure!(
+				StorageVersion::<T>::get() == Releases::V11_0_0,
+				"Expected v11 before upgrading to v12"
+			);
+
+			frame_support::ensure!(
 				T::HistoryDepth::get() == HistoryDepth::<T>::get(),
 				"Provided value of HistoryDepth should be same as the existing storage value"
 			);
@@ -129,6 +134,11 @@ pub mod v11 {
 
 		#[cfg(feature = "try-runtime")]
 		fn post_upgrade(_state: Vec<u8>) -> Result<(), &'static str> {
+			frame_support::ensure!(
+				StorageVersion::<T>::get() == crate::Releases::V11_0_0,
+				"wrong version after the upgrade"
+			);
+
 			let old_pallet_name = N::get();
 			let new_pallet_name = <P as PalletInfoAccess>::name();
 


### PR DESCRIPTION
Re add the migration pre and post checks that was removed for PR https://github.com/paritytech/substrate/pull/12230. 

With @ruseinov's fix for sequential execution of migrate functions https://github.com/paritytech/substrate/pull/12319, we do not need to do this hack anymore.   