### PR TITLE
[Fix] parameter_types! dead code errors

### DIFF
--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -448,6 +448,7 @@ macro_rules! parameter_types_impl_thread_local {
 					}
 
 					/// Mutate the internal value in place.
+					#[allow(unused)]
 					pub fn mutate<R, F: FnOnce(&mut $type) -> R>(mutate: F) -> R{
 						let mut current = Self::get();
 						let result = mutate(&mut current);
@@ -456,6 +457,7 @@ macro_rules! parameter_types_impl_thread_local {
 					}
 
 					/// Get current value and replace with initial value of the parameter type.
+					#[allow(unused)]
 					pub fn take() -> $type {
 						let current = Self::get();
 						Self::set($value);

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -361,9 +361,9 @@ macro_rules! parameter_types {
 		}
 	};
 	(IMPL_STORAGE $name:ident, $type:ty, $value:expr $(, $ty_params:ident)*) => {
+		#[allow(unused)]
 		impl< $($ty_params),* > $name< $($ty_params),* > {
 			/// Returns the key for this parameter type.
-			#[allow(unused)]
 			pub fn key() -> [u8; 16] {
 				$crate::sp_core_hashing_proc_macro::twox_128!(b":", $name, b":")
 			}
@@ -372,7 +372,6 @@ macro_rules! parameter_types {
 			///
 			/// This needs to be executed in an externalities provided
 			/// environment.
-			#[allow(unused)]
 			pub fn set(value: &$type) {
 				$crate::storage::unhashed::put(&Self::key(), value);
 			}


### PR DESCRIPTION
To prevent this from happening:
```
error: associated function is never used: `take`
   --> frame/support/src/lib.rs:459:6
    |
459 |                       pub fn take() -> $type {
    |                       ^^^^^^^^^^^^^^^^^^^^^^
    |
   ::: frame/support/src/traits/hooks.rs:465:9
    |
465 | /         parameter_types! {
466 | |             static Test1Assertions: u8 = 0;
467 | |             static Test2Assertions: u8 = 0;
468 | |             static Test3Assertions: u8 = 0;
469 | |             static EnableSequentialTest: bool = false;
470 | |             static SequentialAssertions: u8 = 0;
471 | |         }
    | |_________- in this macro invocation

```