### PR TITLE
Removed OuterCall alias & doc fixes

### DIFF
--- a/frame/alliance/src/lib.rs
+++ b/frame/alliance/src/lib.rs
@@ -243,7 +243,7 @@ pub mod pallet {
 		type RuntimeEvent: From<Event<Self, I>>
 			+ IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
-		/// The outer call dispatch type.
+		/// The runtime call dispatch type.
 		type Proposal: Parameter
 			+ Dispatchable<RuntimeOrigin = Self::RuntimeOrigin, PostInfo = PostDispatchInfo>
 			+ From<frame_system::Call<Self>>

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -180,10 +180,10 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config<I: 'static = ()>: frame_system::Config {
-		/// The outer origin type.
+		/// The runtime origin type.
 		type RuntimeOrigin: From<RawOrigin<Self::AccountId, I>>;
 
-		/// The outer call dispatch type.
+		/// The runtime call dispatch type.
 		type Proposal: Parameter
 			+ Dispatchable<
 				RuntimeOrigin = <Self as Config<I>>::RuntimeOrigin,
@@ -191,7 +191,7 @@ pub mod pallet {
 			> + From<frame_system::Call<Self>>
 			+ GetDispatchInfo;
 
-		/// The outer event type.
+		/// The runtime event type.
 		type RuntimeEvent: From<Event<Self, I>>
 			+ IsType<<Self as frame_system::Config>::RuntimeEvent>;
 

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -856,7 +856,7 @@ mod tests {
 	use crate::{
 		mock::{
 			roll_to, roll_to_with_ocw, trim_helpers, witness, BlockNumber, ExtBuilder, Extrinsic,
-			MinerMaxWeight, MultiPhase, Runtime, RuntimeCall as OuterCall, RuntimeOrigin, System,
+			MinerMaxWeight, MultiPhase, Runtime, RuntimeCall, RuntimeOrigin, System,
 			TestNposSolution, TrimHelpers, UnsignedPhase,
 		},
 		CurrentPhase, InvalidTransaction, Phase, QueuedSolution, TransactionSource,
@@ -1070,8 +1070,8 @@ mod tests {
 				raw_solution: Box::new(solution.clone()),
 				witness: witness(),
 			};
-			let outer_call: OuterCall = call.into();
-			let _ = outer_call.dispatch(RuntimeOrigin::none());
+			let runtime_call: RuntimeCall = call.into();
+			let _ = runtime_call.dispatch(RuntimeOrigin::none());
 		})
 	}
 
@@ -1096,8 +1096,8 @@ mod tests {
 				raw_solution: Box::new(solution.clone()),
 				witness: correct_witness,
 			};
-			let outer_call: OuterCall = call.into();
-			let _ = outer_call.dispatch(RuntimeOrigin::none());
+			let runtime_call: RuntimeCall = call.into();
+			let _ = runtime_call.dispatch(RuntimeOrigin::none());
 		})
 	}
 
@@ -1560,7 +1560,7 @@ mod tests {
 			let encoded = pool.read().transactions[0].clone();
 			let extrinsic: Extrinsic = codec::Decode::decode(&mut &*encoded).unwrap();
 			let call = extrinsic.call;
-			assert!(matches!(call, OuterCall::MultiPhase(Call::submit_unsigned { .. })));
+			assert!(matches!(call, RuntimeCall::MultiPhase(Call::submit_unsigned { .. })));
 		})
 	}
 
@@ -1577,7 +1577,7 @@ mod tests {
 			let encoded = pool.read().transactions[0].clone();
 			let extrinsic = Extrinsic::decode(&mut &*encoded).unwrap();
 			let call = match extrinsic.call {
-				OuterCall::MultiPhase(call @ Call::submit_unsigned { .. }) => call,
+				RuntimeCall::MultiPhase(call @ Call::submit_unsigned { .. }) => call,
 				_ => panic!("bad call: unexpected submission"),
 			};
 

--- a/frame/multisig/src/benchmarking.rs
+++ b/frame/multisig/src/benchmarking.rs
@@ -41,7 +41,7 @@ fn setup_multi<T: Config>(
 		signatories.push(signatory);
 	}
 	signatories.sort();
-	// Must first convert to outer call type.
+	// Must first convert to runtime call type.
 	let call: <T as Config>::RuntimeCall =
 		frame_system::Call::<T>::remark { remark: vec![0; z as usize] }.into();
 	let call_data = OpaqueCall::<T>::from_encoded(call.encode());

--- a/frame/ranked-collective/src/lib.rs
+++ b/frame/ranked-collective/src/lib.rs
@@ -361,7 +361,7 @@ pub mod pallet {
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 
-		/// The outer event type.
+		/// The runtime event type.
 		type RuntimeEvent: From<Event<Self, I>>
 			+ IsType<<Self as frame_system::Config>::RuntimeEvent>;
 


### PR DESCRIPTION
Since `Call` got renamed to `RuntimeCall`, we don't need the `OuterCall` alias.