### PR TITLE
bounding staking: `BoundedElectionProvider` trait

### DIFF
--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -231,7 +231,7 @@
 
 use codec::{Decode, Encode};
 use frame_election_provider_support::{
-	ElectionDataProvider, ElectionProvider, InstantElectionProvider, NposSolution,
+	ElectionDataProvider, ElectionProviderBase, ElectionProvider, InstantElectionProvider, NposSolution,
 };
 use frame_support::{
 	dispatch::DispatchClass,
@@ -289,7 +289,7 @@ pub type SolutionTargetIndexOf<T> = <SolutionOf<T> as NposSolution>::TargetIndex
 pub type SolutionAccuracyOf<T> =
 	<SolutionOf<<T as crate::Config>::MinerConfig> as NposSolution>::Accuracy;
 /// The fallback election type.
-pub type FallbackErrorOf<T> = <<T as crate::Config>::Fallback as ElectionProvider>::Error;
+pub type FallbackErrorOf<T> = <<T as crate::Config>::Fallback as ElectionProviderBase>::Error;
 
 /// Configuration for the benchmarks of the pallet.
 pub trait BenchmarkingConfig {
@@ -312,7 +312,7 @@ pub trait BenchmarkingConfig {
 /// A fallback implementation that transitions the pallet to the emergency phase.
 pub struct NoFallback<T>(sp_std::marker::PhantomData<T>);
 
-impl<T: Config> ElectionProvider for NoFallback<T> {
+impl<T: Config> ElectionProviderBase for NoFallback<T> {
 	type AccountId = T::AccountId;
 	type BlockNumber = T::BlockNumber;
 	type DataProvider = T::DataProvider;
@@ -321,7 +321,9 @@ impl<T: Config> ElectionProvider for NoFallback<T> {
 	fn ongoing() -> bool {
 		false
 	}
+}
 
+impl<T: Config> ElectionProvider for NoFallback<T> {
 	fn elect() -> Result<Supports<T::AccountId>, Self::Error> {
 		// Do nothing, this will enable the emergency phase.
 		Err("NoFallback.")
@@ -1561,7 +1563,7 @@ impl<T: Config> Pallet<T> {
 		<QueuedSolution<T>>::take()
 			.ok_or(ElectionError::<T>::NothingQueued)
 			.or_else(|_| {
-				T::Fallback::elect()
+				<T::Fallback as ElectionProvider>::elect()
 					.map(|supports| ReadySolution {
 						supports,
 						score: Default::default(),
@@ -1596,7 +1598,7 @@ impl<T: Config> Pallet<T> {
 	}
 }
 
-impl<T: Config> ElectionProvider for Pallet<T> {
+impl<T: Config> ElectionProviderBase for Pallet<T> {
 	type AccountId = T::AccountId;
 	type BlockNumber = T::BlockNumber;
 	type Error = ElectionError<T>;
@@ -1608,7 +1610,9 @@ impl<T: Config> ElectionProvider for Pallet<T> {
 			_ => true,
 		}
 	}
+}
 
+impl<T: Config> ElectionProvider for Pallet<T> {
 	fn elect() -> Result<Supports<T::AccountId>, Self::Error> {
 		match Self::do_elect() {
 			Ok(supports) => {
@@ -1625,7 +1629,6 @@ impl<T: Config> ElectionProvider for Pallet<T> {
 		}
 	}
 }
-
 /// convert a DispatchError to a custom InvalidTransaction with the inner code being the error
 /// number.
 pub fn dispatch_error_to_invalid(error: DispatchError) -> InvalidTransaction {

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -231,7 +231,8 @@
 
 use codec::{Decode, Encode};
 use frame_election_provider_support::{
-	ElectionDataProvider, ElectionProviderBase, ElectionProvider, InstantElectionProvider, NposSolution,
+	ElectionDataProvider, ElectionProvider, ElectionProviderBase, InstantElectionProvider,
+	NposSolution,
 };
 use frame_support::{
 	dispatch::DispatchClass,

--- a/frame/election-provider-multi-phase/src/mock.rs
+++ b/frame/election-provider-multi-phase/src/mock.rs
@@ -297,7 +297,7 @@ impl onchain::Config for OnChainSeqPhragmen {
 }
 
 pub struct MockFallback;
-impl ElectionProvider for MockFallback {
+impl ElectionProviderBase for MockFallback {
 	type AccountId = AccountId;
 	type BlockNumber = u64;
 	type Error = &'static str;
@@ -306,7 +306,8 @@ impl ElectionProvider for MockFallback {
 	fn ongoing() -> bool {
 		false
 	}
-
+}
+impl ElectionProvider for MockFallback {
 	fn elect() -> Result<Supports<AccountId>, Self::Error> {
 		Self::elect_with_bounds(Bounded::max_value(), Bounded::max_value())
 	}

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -370,12 +370,8 @@ pub trait ElectionProviderBase {
 }
 
 pub trait BoundedElectionProvider: ElectionProviderBase {
-	/// The upper bound on election winners. The [`Self::DataProvider`] should
-	/// respect these bounds such that: `desired_targets() <= MaxTargets`.
-	type MaxTargets: Get<u32>;
-
-	/// The upper bound on max voters per target.
-	type MaxVoters: Get<u32>;
+	/// The upper bound on election winners
+	type MaxWinners: Get<u32>;
 
 	/// Elect a new set of winners, without specifying any bounds on the amount of data fetched from
 	/// [`Self::DataProvider`]. An implementation could nonetheless impose its own custom limits.
@@ -385,7 +381,7 @@ pub trait BoundedElectionProvider: ElectionProviderBase {
 	/// This should be implemented as a self-weighing function. The implementor should register its
 	/// appropriate weight at the end of execution with the system pallet directly.
 	fn elect(
-	) -> Result<BoundedSupports<Self::AccountId, Self::MaxVoters, Self::MaxTargets>, Self::Error>;
+	) -> Result<BoundedSupports<Self::AccountId, Self::MaxWinners>, Self::Error>;
 }
 
 pub trait ElectionProvider: ElectionProviderBase {

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -132,12 +132,16 @@
 //!         type DataProvider: ElectionDataProvider<AccountId=AccountId, BlockNumber = BlockNumber>;
 //!     }
 //!
-//!     impl<T: Config> ElectionProvider for GenericElectionProvider<T> {
+//!     impl<T: Config> ElectionProviderBase for GenericElectionProvider<T> {
 //!         type AccountId = AccountId;
 //!         type BlockNumber = BlockNumber;
 //!         type Error = &'static str;
 //!         type DataProvider = T::DataProvider;
 //! 	        fn ongoing() -> bool { false }
+//!        
+//!     }
+//!
+//!     impl<T: Config> ElectionProvider for GenericElectionProvider<T> {
 //!         fn elect() -> Result<Supports<AccountId>, Self::Error> {
 //!             Self::DataProvider::electable_targets(None)
 //!                 .map_err(|_| "failed to elect")

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -23,8 +23,8 @@
 //! Something that will provide the functionality of election will implement
 //! [`ElectionProvider`] and its parent-trait [`ElectionProviderBase`], whilst needing an
 //! associated [`ElectionProviderBase::DataProvider`], which needs to be
-//! fulfilled by an entity implementing [`ElectionDataProvider`]. Most often, *the data provider is* the receiver of
-//! the election, resulting in a diagram as below:
+//! fulfilled by an entity implementing [`ElectionDataProvider`]. Most often, *the data provider is*
+//! the receiver of the election, resulting in a diagram as below:
 //!
 //! ```ignore
 //!                                         ElectionDataProvider
@@ -375,8 +375,9 @@ pub trait BoundedElectionProvider: ElectionProviderBase {
 	type MaxWinners: Get<u32>;
 
 	/// Elect a new set of winners, bounded by `MaxWinners` but an unbounded
-	/// number of backers per winner. [`<Self as ElectionProviderBase>::DataProvider`]. An implementation
-	/// could nonetheless impose its own custom limits.
+	/// number of backers per winner. Data is fetched from
+	/// [`ElectionProviderBase::DataProvider`]. An implementation could
+	/// nonetheless impose its own custom limits.
 	///
 	/// The result is returned in a target major format, namely as *vector of
 	/// supports*.
@@ -388,23 +389,26 @@ pub trait BoundedElectionProvider: ElectionProviderBase {
 }
 
 pub trait ElectionProvider: ElectionProviderBase {
-	/// Elect a new set of winners, without specifying any bounds on the amount of data fetched from
-	/// [`<Self as ElectionProviderBase>::DataProvider`]. An implementation could nonetheless impose its own custom limits.
+	/// Elect a new set of winners, without specifying any bounds on the amount
+	/// of data fetched from [`ElectionProviderBase::DataProvider`].
+	/// An implementation could nonetheless impose its own custom limits.
 	///
-	/// The result is returned in a target major format, namely as *vector of supports*.
+	/// The result is returned in a target major format, namely as *vector of
+	/// supports*.
 	///
-	/// This should be implemented as a self-weighing function. The implementor should register its
-	/// appropriate weight at the end of execution with the system pallet directly.
+	/// This should be implemented as a self-weighing function. The implementor
+	/// should register its appropriate weight at the end of execution with the
+	/// system pallet directly.
 	fn elect() -> Result<Supports<Self::AccountId>, Self::Error>;
 }
 
-/// A sub-trait of the [`ElectionProvider`] for cases where we need to be sure an election needs to
-/// happen instantly, not asynchronously.
+/// A sub-trait of the [`ElectionProvider`] for cases where we need to be sure
+/// an election needs to happen instantly, not asynchronously.
 ///
 /// The same `DataProvider` is assumed to be used.
 ///
-/// Consequently, allows for control over the amount of data that is being fetched from the
-/// [`ElectionProviderBase::DataProvider`].
+/// Consequently, allows for control over the amount of data that is being
+/// fetched from the [`ElectionProviderBase::DataProvider`].
 pub trait InstantElectionProvider: ElectionProvider {
 	/// Elect a new set of winners, but unlike [`ElectionProvider::elect`] which cannot enforce
 	/// bounds, this trait method can enforce bounds on the amount of data provided by the

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -370,18 +370,20 @@ pub trait ElectionProviderBase {
 }
 
 pub trait BoundedElectionProvider: ElectionProviderBase {
-	/// The upper bound on election winners
+	/// The upper bound on election winners.
 	type MaxWinners: Get<u32>;
 
-	/// Elect a new set of winners, without specifying any bounds on the amount of data fetched from
-	/// [`Self::DataProvider`]. An implementation could nonetheless impose its own custom limits.
+	/// Elect a new set of winners, bounded by `MaxWinners` but an unbounded
+	/// number of backers per winner. [`Self::DataProvider`]. An implementation
+	/// could nonetheless impose its own custom limits.
 	///
-	/// The result is returned in a target major format, namely as *vector of supports*.
+	/// The result is returned in a target major format, namely as *vector of
+	/// supports*.
 	///
-	/// This should be implemented as a self-weighing function. The implementor should register its
-	/// appropriate weight at the end of execution with the system pallet directly.
-	fn elect(
-	) -> Result<BoundedSupports<Self::AccountId, Self::MaxWinners>, Self::Error>;
+	/// This should be implemented as a self-weighing function. The implementor
+	/// should register its appropriate weight at the end of execution with the
+	/// system pallet directly.
+	fn elect() -> Result<BoundedSupports<Self::AccountId, Self::MaxWinners>, Self::Error>;
 }
 
 pub trait ElectionProvider: ElectionProviderBase {

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -20,10 +20,11 @@
 //! This crate provides two traits that could interact to enable extensible election functionality
 //! within FRAME pallets.
 //!
-//! Something that will provide the functionality of election will implement [`ElectionProvider`],
-//! whilst needing an associated [`ElectionProvider::DataProvider`], which needs to be fulfilled by
-//! an entity implementing [`ElectionDataProvider`]. Most often, *the data provider is* the receiver
-//! of the election, resulting in a diagram as below:
+//! Something that will provide the functionality of election will implement
+//! [`ElectionProvider`] and its parent-trait [`ElectionProviderBase`], whilst needing an
+//! associated [`ElectionProviderBase::DataProvider`], which needs to be
+//! fulfilled by an entity implementing [`ElectionDataProvider`]. Most often, *the data provider is* the receiver of
+//! the election, resulting in a diagram as below:
 //!
 //! ```ignore
 //!                                         ElectionDataProvider
@@ -374,7 +375,7 @@ pub trait BoundedElectionProvider: ElectionProviderBase {
 	type MaxWinners: Get<u32>;
 
 	/// Elect a new set of winners, bounded by `MaxWinners` but an unbounded
-	/// number of backers per winner. [`Self::DataProvider`]. An implementation
+	/// number of backers per winner. [`<Self as ElectionProviderBase>::DataProvider`]. An implementation
 	/// could nonetheless impose its own custom limits.
 	///
 	/// The result is returned in a target major format, namely as *vector of
@@ -388,7 +389,7 @@ pub trait BoundedElectionProvider: ElectionProviderBase {
 
 pub trait ElectionProvider: ElectionProviderBase {
 	/// Elect a new set of winners, without specifying any bounds on the amount of data fetched from
-	/// [`Self::DataProvider`]. An implementation could nonetheless impose its own custom limits.
+	/// [`<Self as ElectionProviderBase>::DataProvider`]. An implementation could nonetheless impose its own custom limits.
 	///
 	/// The result is returned in a target major format, namely as *vector of supports*.
 	///
@@ -403,7 +404,7 @@ pub trait ElectionProvider: ElectionProviderBase {
 /// The same `DataProvider` is assumed to be used.
 ///
 /// Consequently, allows for control over the amount of data that is being fetched from the
-/// [`ElectionProvider::DataProvider`].
+/// [`ElectionProviderBase::DataProvider`].
 pub trait InstantElectionProvider: ElectionProvider {
 	/// Elect a new set of winners, but unlike [`ElectionProvider::elect`] which cannot enforce
 	/// bounds, this trait method can enforce bounds on the amount of data provided by the

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -177,8 +177,8 @@ pub use frame_support::{traits::Get, weights::Weight, BoundedVec, RuntimeDebug};
 /// Re-export some type as they are used in the interface.
 pub use sp_arithmetic::PerThing;
 pub use sp_npos_elections::{
-	Assignment, BalancingConfig, ElectionResult, Error, ExtendedBalance, IdentifierT, PerThing128,
-	Support, Supports, VoteWeight, BoundedSupports,
+	Assignment, BalancingConfig, BoundedSupports, ElectionResult, Error, ExtendedBalance,
+	IdentifierT, PerThing128, Support, Supports, VoteWeight,
 };
 pub use traits::NposSolution;
 
@@ -373,10 +373,10 @@ pub trait BoundedElectionProvider: ElectionProviderBase {
 	/// The upper bound on election winners. The [`Self::DataProvider`] should
 	/// respect these bounds such that: `desired_targets() <= MaxTargets`.
 	type MaxTargets: Get<u32>;
-	
+
 	/// The upper bound on max voters per target.
 	type MaxVoters: Get<u32>;
-	
+
 	/// Elect a new set of winners, without specifying any bounds on the amount of data fetched from
 	/// [`Self::DataProvider`]. An implementation could nonetheless impose its own custom limits.
 	///
@@ -384,7 +384,8 @@ pub trait BoundedElectionProvider: ElectionProviderBase {
 	///
 	/// This should be implemented as a self-weighing function. The implementor should register its
 	/// appropriate weight at the end of execution with the system pallet directly.
-	fn elect() -> Result<BoundedSupports<Self::AccountId, Self::MaxVoters, Self::MaxTargets>, Self::Error>;
+	fn elect(
+	) -> Result<BoundedSupports<Self::AccountId, Self::MaxVoters, Self::MaxTargets>, Self::Error>;
 }
 
 pub trait ElectionProvider: ElectionProviderBase {

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -392,14 +392,14 @@ pub trait BoundedElectionProvider: ElectionProviderBase {
 	fn elect() -> Result<BoundedSupports<Self::AccountId, Self::MaxWinners>, Self::Error>;
 }
 
-/// Elect a new set of winners, without specifying any bounds on the amount
-/// of data fetched from [`ElectionProviderBase::DataProvider`].
-/// An implementation could nonetheless impose its own custom limits.
+/// Same a [`BoundedElectionProvider`], but no bounds are imposed on the number
+/// of winners.
 ///
 /// The result is returned in a target major format, namely as
-/// *Vec<(AccountId, Vec<Support>)>*.
+///*Vec<(AccountId, Vec<Support>)>*.
 pub trait ElectionProvider: ElectionProviderBase {
-	/// Performs the election. This should be implemented as a self-weighing function.
+	/// Performs the election. This should be implemented as a self-weighing
+	/// function, similar to [`BoundedElectionProvider::elect()`].
 	fn elect() -> Result<Supports<Self::AccountId>, Self::Error>;
 }
 

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -383,8 +383,8 @@ pub trait BoundedElectionProvider: ElectionProviderBase {
 	/// [`ElectionProviderBase::DataProvider`]. An implementation could
 	/// nonetheless impose its own custom limits.
 	///
-	/// The result is returned in a target major format, namely as *vector of
-	/// supports*.
+	/// The result is returned in a target major format, namely as *Bounded vector of
+	/// support*.
 	///
 	/// This should be implemented as a self-weighing function. The implementor
 	/// should register its appropriate weight at the end of execution with the
@@ -398,7 +398,7 @@ pub trait ElectionProvider: ElectionProviderBase {
 	/// An implementation could nonetheless impose its own custom limits.
 	///
 	/// The result is returned in a target major format, namely as *vector of
-	/// supports*.
+	/// support*.
 	///
 	/// This should be implemented as a self-weighing function. The implementor
 	/// should register its appropriate weight at the end of execution with the

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -354,6 +354,11 @@ pub trait ElectionDataProvider {
 	fn clear() {}
 }
 
+/// Base trait for [`ElectionProvider`] and [`BoundedElectionProvider`]. It is
+/// meant to be used only with an extension trait that adds an election
+/// functionality.
+///
+/// Data can be bounded or unbounded and is fetched from [`Self::DataProvider`].
 pub trait ElectionProviderBase {
 	/// The account identifier type.
 	type AccountId;
@@ -374,35 +379,27 @@ pub trait ElectionProviderBase {
 	fn ongoing() -> bool;
 }
 
+/// Elect a new set of winners, bounded by `MaxWinners`.
+///
+/// Returns a result in bounded, target major format, namely as
+/// *BoundedVec<(AccountId, Vec<Support>), MaxWinners>*.   
 pub trait BoundedElectionProvider: ElectionProviderBase {
 	/// The upper bound on election winners.
 	type MaxWinners: Get<u32>;
-
-	/// Elect a new set of winners, bounded by `MaxWinners` but an unbounded
-	/// number of backers per winner. Data is fetched from
-	/// [`ElectionProviderBase::DataProvider`]. An implementation could
-	/// nonetheless impose its own custom limits.
-	///
-	/// The result is returned in a target major format, namely as *Bounded vector of
-	/// support*.
-	///
-	/// This should be implemented as a self-weighing function. The implementor
-	/// should register its appropriate weight at the end of execution with the
+	/// Performs the election. This should be implemented as a self-weighing function. The
+	/// implementor should register its appropriate weight at the end of execution with the
 	/// system pallet directly.
 	fn elect() -> Result<BoundedSupports<Self::AccountId, Self::MaxWinners>, Self::Error>;
 }
 
+/// Elect a new set of winners, without specifying any bounds on the amount
+/// of data fetched from [`ElectionProviderBase::DataProvider`].
+/// An implementation could nonetheless impose its own custom limits.
+///
+/// The result is returned in a target major format, namely as
+/// *Vec<(AccountId, Vec<Support>)>*.
 pub trait ElectionProvider: ElectionProviderBase {
-	/// Elect a new set of winners, without specifying any bounds on the amount
-	/// of data fetched from [`ElectionProviderBase::DataProvider`].
-	/// An implementation could nonetheless impose its own custom limits.
-	///
-	/// The result is returned in a target major format, namely as *vector of
-	/// support*.
-	///
-	/// This should be implemented as a self-weighing function. The implementor
-	/// should register its appropriate weight at the end of execution with the
-	/// system pallet directly.
+	/// Performs the election. This should be implemented as a self-weighing function.
 	fn elect() -> Result<Supports<Self::AccountId>, Self::Error>;
 }
 

--- a/frame/election-provider-support/src/onchain.rs
+++ b/frame/election-provider-support/src/onchain.rs
@@ -20,7 +20,8 @@
 //! careful when using it onchain.
 
 use crate::{
-	Debug, ElectionDataProvider, ElectionProviderBase, ElectionProvider, InstantElectionProvider, NposSolver, WeightInfo,
+	Debug, ElectionDataProvider, ElectionProvider, ElectionProviderBase, InstantElectionProvider,
+	NposSolver, WeightInfo,
 };
 use frame_support::{dispatch::DispatchClass, traits::Get};
 use sp_npos_elections::*;

--- a/frame/election-provider-support/src/onchain.rs
+++ b/frame/election-provider-support/src/onchain.rs
@@ -20,7 +20,7 @@
 //! careful when using it onchain.
 
 use crate::{
-	Debug, ElectionDataProvider, ElectionProvider, InstantElectionProvider, NposSolver, WeightInfo,
+	Debug, ElectionDataProvider, ElectionProviderBase, ElectionProvider, InstantElectionProvider, NposSolver, WeightInfo,
 };
 use frame_support::{dispatch::DispatchClass, traits::Get};
 use sp_npos_elections::*;
@@ -133,15 +133,6 @@ fn elect_with<T: Config>(
 }
 
 impl<T: Config> ElectionProvider for UnboundedExecution<T> {
-	type AccountId = <T::System as frame_system::Config>::AccountId;
-	type BlockNumber = <T::System as frame_system::Config>::BlockNumber;
-	type Error = Error;
-	type DataProvider = T::DataProvider;
-
-	fn ongoing() -> bool {
-		false
-	}
-
 	fn elect() -> Result<Supports<Self::AccountId>, Self::Error> {
 		// This should not be called if not in `std` mode (and therefore neither in genesis nor in
 		// testing)
@@ -156,6 +147,17 @@ impl<T: Config> ElectionProvider for UnboundedExecution<T> {
 	}
 }
 
+impl<T: Config> ElectionProviderBase for UnboundedExecution<T> {
+	type AccountId = <T::System as frame_system::Config>::AccountId;
+	type BlockNumber = <T::System as frame_system::Config>::BlockNumber;
+	type Error = Error;
+	type DataProvider = T::DataProvider;
+
+	fn ongoing() -> bool {
+		false
+	}
+}
+
 impl<T: Config> InstantElectionProvider for UnboundedExecution<T> {
 	fn elect_with_bounds(
 		max_voters: usize,
@@ -165,7 +167,7 @@ impl<T: Config> InstantElectionProvider for UnboundedExecution<T> {
 	}
 }
 
-impl<T: BoundedConfig> ElectionProvider for BoundedExecution<T> {
+impl<T: BoundedConfig> ElectionProviderBase for BoundedExecution<T> {
 	type AccountId = <T::System as frame_system::Config>::AccountId;
 	type BlockNumber = <T::System as frame_system::Config>::BlockNumber;
 	type Error = Error;
@@ -174,7 +176,9 @@ impl<T: BoundedConfig> ElectionProvider for BoundedExecution<T> {
 	fn ongoing() -> bool {
 		false
 	}
+}
 
+impl<T: BoundedConfig> ElectionProvider for BoundedExecution<T> {
 	fn elect() -> Result<Supports<Self::AccountId>, Self::Error> {
 		elect_with::<T>(Some(T::VotersBound::get() as usize), Some(T::TargetsBound::get() as usize))
 	}

--- a/frame/fast-unstake/src/lib.rs
+++ b/frame/fast-unstake/src/lib.rs
@@ -80,7 +80,7 @@ macro_rules! log {
 pub mod pallet {
 	use super::*;
 	use crate::types::*;
-	use frame_election_provider_support::{ElectionProviderBase};
+	use frame_election_provider_support::ElectionProviderBase;
 	use frame_support::pallet_prelude::*;
 	use frame_system::{pallet_prelude::*, RawOrigin};
 	use pallet_staking::Pallet as Staking;
@@ -307,7 +307,8 @@ pub mod pallet {
 				}
 			}
 
-			if <<T as pallet_staking::Config>::ElectionProvider as ElectionProviderBase>::ongoing() {
+			if <<T as pallet_staking::Config>::ElectionProvider as ElectionProviderBase>::ongoing()
+			{
 				// NOTE: we assume `ongoing` does not consume any weight.
 				// there is an ongoing election -- we better not do anything. Imagine someone is not
 				// exposed anywhere in the last era, and the snapshot for the election is already

--- a/frame/fast-unstake/src/lib.rs
+++ b/frame/fast-unstake/src/lib.rs
@@ -80,7 +80,7 @@ macro_rules! log {
 pub mod pallet {
 	use super::*;
 	use crate::types::*;
-	use frame_election_provider_support::ElectionProvider;
+	use frame_election_provider_support::{ElectionProviderBase};
 	use frame_support::pallet_prelude::*;
 	use frame_system::{pallet_prelude::*, RawOrigin};
 	use pallet_staking::Pallet as Staking;
@@ -307,7 +307,7 @@ pub mod pallet {
 				}
 			}
 
-			if <T as pallet_staking::Config>::ElectionProvider::ongoing() {
+			if <<T as pallet_staking::Config>::ElectionProvider as ElectionProviderBase>::ongoing() {
 				// NOTE: we assume `ongoing` does not consume any weight.
 				// there is an ongoing election -- we better not do anything. Imagine someone is not
 				// exposed anywhere in the last era, and the snapshot for the election is already

--- a/frame/fast-unstake/src/mock.rs
+++ b/frame/fast-unstake/src/mock.rs
@@ -104,7 +104,7 @@ parameter_types! {
 }
 
 pub struct MockElection;
-impl frame_election_provider_support::ElectionProvider for MockElection {
+impl frame_election_provider_support::ElectionProviderBase for MockElection {
 	type AccountId = AccountId;
 	type BlockNumber = BlockNumber;
 	type DataProvider = Staking;
@@ -113,7 +113,9 @@ impl frame_election_provider_support::ElectionProvider for MockElection {
 	fn ongoing() -> bool {
 		Ongoing::get()
 	}
+}
 
+impl frame_election_provider_support::ElectionProvider for MockElection {
 	fn elect() -> Result<frame_election_provider_support::Supports<AccountId>, Self::Error> {
 		Err(())
 	}

--- a/primitives/npos-elections/src/lib.rs
+++ b/primitives/npos-elections/src/lib.rs
@@ -437,18 +437,6 @@ pub struct Support<AccountId> {
 	pub voters: Vec<(AccountId, ExtendedBalance)>,
 }
 
-/// A Bounded Support.
-///
-/// See also: [`Support`]
-#[derive(RuntimeDebug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct BoundedSupport<AccountId, MaxVoters: sp_core::Get<u32>> {
-	/// Total support.
-	pub total: ExtendedBalance,
-	/// Support from voters.
-	pub voters: BoundedVec<(AccountId, ExtendedBalance), MaxVoters>,
-}
-
 impl<AccountId> Default for Support<AccountId> {
 	fn default() -> Self {
 		Self { total: Default::default(), voters: vec![] }
@@ -462,9 +450,9 @@ impl<AccountId> Default for Support<AccountId> {
 /// The main advantage of this is that it is encodable.
 pub type Supports<A> = Vec<(A, Support<A>)>;
 
-/// A bounded `Supports` with MaxVoters and MaxTargets.
-pub type BoundedSupports<A, MaxVoters, MaxTargets> =
-	BoundedVec<(A, BoundedSupport<A, MaxVoters>), MaxTargets>;
+/// A bounded `Supports` with MaxWinners but unbounded support.
+pub type BoundedSupports<A, MaxWinners> =
+	BoundedVec<(A, Support<A>), MaxWinners>;
 
 /// Linkage from a winner to their [`Support`].
 ///

--- a/primitives/npos-elections/src/lib.rs
+++ b/primitives/npos-elections/src/lib.rs
@@ -450,9 +450,10 @@ impl<AccountId> Default for Support<AccountId> {
 /// The main advantage of this is that it is encodable.
 pub type Supports<A> = Vec<(A, Support<A>)>;
 
-/// A bounded `Supports` with MaxWinners but unbounded support.
-pub type BoundedSupports<A, MaxWinners> =
-	BoundedVec<(A, Support<A>), MaxWinners>;
+/// Same as `Supports` bounded by `MaxWinners`.
+///
+/// To note, the inner `Support` is still unbounded.
+pub type BoundedSupports<A, MaxWinners> = BoundedVec<(A, Support<A>), MaxWinners>;
 
 /// Linkage from a winner to their [`Support`].
 ///

--- a/primitives/npos-elections/src/lib.rs
+++ b/primitives/npos-elections/src/lib.rs
@@ -74,15 +74,15 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
 use sp_arithmetic::{traits::Zero, Normalizable, PerThing, Rational128, ThresholdOrd};
-use sp_core::{RuntimeDebug, bounded::BoundedVec};
+use sp_core::{bounded::BoundedVec, RuntimeDebug};
 use sp_std::{
 	cell::RefCell, cmp::Ordering, collections::btree_map::BTreeMap, prelude::*, rc::Rc, vec,
 };
-use codec::{Decode, Encode, MaxEncodedLen};
-#[cfg(feature = "std")]
-use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 mod mock;
@@ -463,7 +463,8 @@ impl<AccountId> Default for Support<AccountId> {
 pub type Supports<A> = Vec<(A, Support<A>)>;
 
 /// A bounded `Supports` with MaxVoters and MaxTargets.
-pub type BoundedSupports<A, MaxVoters, MaxTargets> = BoundedVec<(A, BoundedSupport<A, MaxVoters>), MaxTargets>;
+pub type BoundedSupports<A, MaxVoters, MaxTargets> =
+	BoundedVec<(A, BoundedSupport<A, MaxVoters>), MaxTargets>;
 
 /// Linkage from a winner to their [`Support`].
 ///

--- a/primitives/npos-elections/src/lib.rs
+++ b/primitives/npos-elections/src/lib.rs
@@ -76,11 +76,10 @@
 
 use scale_info::TypeInfo;
 use sp_arithmetic::{traits::Zero, Normalizable, PerThing, Rational128, ThresholdOrd};
-use sp_core::RuntimeDebug;
+use sp_core::{RuntimeDebug, bounded::BoundedVec};
 use sp_std::{
 	cell::RefCell, cmp::Ordering, collections::btree_map::BTreeMap, prelude::*, rc::Rc, vec,
 };
-
 use codec::{Decode, Encode, MaxEncodedLen};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
@@ -438,6 +437,18 @@ pub struct Support<AccountId> {
 	pub voters: Vec<(AccountId, ExtendedBalance)>,
 }
 
+/// A Bounded Support.
+///
+/// See also: [`Support`]
+#[derive(RuntimeDebug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct BoundedSupport<AccountId, MaxVoters: sp_core::Get<u32>> {
+	/// Total support.
+	pub total: ExtendedBalance,
+	/// Support from voters.
+	pub voters: BoundedVec<(AccountId, ExtendedBalance), MaxVoters>,
+}
+
 impl<AccountId> Default for Support<AccountId> {
 	fn default() -> Self {
 		Self { total: Default::default(), voters: vec![] }
@@ -450,6 +461,9 @@ impl<AccountId> Default for Support<AccountId> {
 ///
 /// The main advantage of this is that it is encodable.
 pub type Supports<A> = Vec<(A, Support<A>)>;
+
+/// A bounded `Supports` with MaxVoters and MaxTargets.
+pub type BoundedSupports<A, MaxVoters, MaxTargets> = BoundedVec<(A, BoundedSupport<A, MaxVoters>), MaxTargets>;
 
 /// Linkage from a winner to their [`Support`].
 ///


### PR DESCRIPTION
This PR is in preparation for bounding the staking pallet by `MaxActiveValidators`. https://github.com/paritytech/substrate/issues/12187

This will split up the trait `ElectionProvider` into bounded and unbounded subtraits. The `BoundedElectionProvider` does not have any implementation yet. The follow up PR for this would be `ElectionProviderMultipPhase` implementing `BoundedElectionProvider`.