### PR TITLE
Account for missing `HistoryDepth` in staking migration V12

### DIFF
--- a/frame/staking/src/migrations.rs
+++ b/frame/staking/src/migrations.rs
@@ -40,10 +40,14 @@ pub mod v12 {
 				"Expected v11 before upgrading to v12"
 			);
 
-			frame_support::ensure!(
-				T::HistoryDepth::get() == HistoryDepth::<T>::get(),
-				"Provided value of HistoryDepth should be same as the existing storage value"
-			);
+			if HistoryDepth::<T>::exists() {
+				frame_support::ensure!(
+					T::HistoryDepth::get() == HistoryDepth::<T>::get(),
+					"Provided value of HistoryDepth should be same as the existing storage value"
+				);
+			} else {
+				log::info!("No HistoryDepth in storage; nothing to remove");
+			}
 
 			Ok(Default::default())
 		}


### PR DESCRIPTION
The storage alias for the staking V12 migration does not have an OnEmpty as the original code did:  

https://github.com/paritytech/substrate/blob/a47f200eebeb88a5bde6f1ed2be9728b82536dde/frame/staking/src/pallet/mod.rs#L247

The migration assume that the value must be present and errors otherwise. Fixed by doing nothing if the value is not present.  

@coderobe this is the issue I was talking about in chat.
