### PR TITLE
fix: typo in AllPalletsWithSystem deprecated msg

### DIFF
--- a/frame/support/procedural/src/construct_runtime/mod.rs
+++ b/frame/support/procedural/src/construct_runtime/mod.rs
@@ -422,7 +422,7 @@ fn decl_all_pallets<'a>(
 			/// All pallets included in the runtime as a nested tuple of types in reversed order.
 			/// Excludes the System pallet.
 			#[deprecated(note = "Using reverse pallet orders is deprecated. use only \
-			`AllPalletWithSystem or AllPalletsWithoutSystem`")]
+			`AllPalletsWithSystem or AllPalletsWithoutSystem`")]
 			pub type AllPalletsWithoutSystemReversed = ( #(#names,)* );
 		}
 	});
@@ -433,7 +433,7 @@ fn decl_all_pallets<'a>(
 			#attr
 			/// All pallets included in the runtime as a nested tuple of types in reversed order.
 			#[deprecated(note = "Using reverse pallet orders is deprecated. use only \
-			`AllPalletWithSystem or AllPalletsWithoutSystem`")]
+			`AllPalletsWithSystem or AllPalletsWithoutSystem`")]
 			pub type AllPalletsWithSystemReversed = ( #(#names,)* );
 		}
 	});
@@ -447,7 +447,7 @@ fn decl_all_pallets<'a>(
 			/// All pallets included in the runtime as a nested tuple of types in reversed order.
 			/// With the system pallet first.
 			#[deprecated(note = "Using reverse pallet orders is deprecated. use only \
-			`AllPalletWithSystem or AllPalletsWithoutSystem`")]
+			`AllPalletsWithSystem or AllPalletsWithoutSystem`")]
 			pub type AllPalletsReversedWithSystemFirst = ( #(#names,)* );
 		}
 	});


### PR DESCRIPTION
Fix a typo in the deprecated messages.