### PR TITLE
Properly set the max proof size weight on defaults and tests

### DIFF
--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -139,8 +139,11 @@ parameter_types! {
 	pub const BlockHashCount: BlockNumber = 2400;
 	pub const Version: RuntimeVersion = VERSION;
 	/// We allow for 2 seconds of compute with a 6 second average block time.
-	pub BlockWeights: frame_system::limits::BlockWeights = frame_system::limits::BlockWeights
-		::with_sensible_defaults(2u64 * WEIGHT_PER_SECOND, NORMAL_DISPATCH_RATIO);
+	pub BlockWeights: frame_system::limits::BlockWeights =
+		frame_system::limits::BlockWeights::with_sensible_defaults(
+			(2u64 * WEIGHT_PER_SECOND).set_proof_size(u64::MAX),
+			NORMAL_DISPATCH_RATIO,
+		);
 	pub BlockLength: frame_system::limits::BlockLength = frame_system::limits::BlockLength
 		::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
 	pub const SS58Prefix: u8 = 42;

--- a/bin/node/runtime/src/impls.rs
+++ b/bin/node/runtime/src/impls.rs
@@ -224,7 +224,7 @@ mod multiplier_tests {
 	fn multiplier_can_grow_from_zero() {
 		// if the min is too small, then this will not change, and we are doomed forever.
 		// the weight is 1/100th bigger than target.
-		run_with_system_weight(target() * 101 / 100, || {
+		run_with_system_weight(target().set_ref_time(target().ref_time() * 101 / 100), || {
 			let next = runtime_multiplier_update(min_multiplier());
 			assert!(next > min_multiplier(), "{:?} !>= {:?}", next, min_multiplier());
 		})

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -171,8 +171,7 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 /// by  Operational  extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 /// We allow for 2 seconds of compute with a 6 second average block time, with maximum proof size.
-const MAXIMUM_BLOCK_WEIGHT: Weight =
-	WEIGHT_PER_SECOND.saturating_mul(2).set_proof_size(u64::MAX);
+const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND.saturating_mul(2).set_proof_size(u64::MAX);
 
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 2400;

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -170,8 +170,9 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 /// We allow `Normal` extrinsics to fill up the block up to 75%, the rest can be used
 /// by  Operational  extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
-/// We allow for 2 seconds of compute with a 6 second average block time.
-const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND.saturating_mul(2);
+/// We allow for 2 seconds of compute with a 6 second average block time, with maximum proof size.
+const MAXIMUM_BLOCK_WEIGHT: Weight =
+	WEIGHT_PER_SECOND.saturating_mul(2).set_proof_size(u64::MAX);
 
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 2400;

--- a/frame/balances/src/tests_composite.rs
+++ b/frame/balances/src/tests_composite.rs
@@ -47,7 +47,9 @@ frame_support::construct_runtime!(
 
 parameter_types! {
 	pub BlockWeights: frame_system::limits::BlockWeights =
-		frame_system::limits::BlockWeights::simple_max(frame_support::weights::Weight::from_ref_time(1024));
+		frame_system::limits::BlockWeights::simple_max(
+			frame_support::weights::Weight::from_ref_time(1024).set_proof_size(u64::MAX),
+		);
 	pub static ExistentialDeposit: u64 = 0;
 }
 impl frame_system::Config for Test {

--- a/frame/balances/src/tests_local.rs
+++ b/frame/balances/src/tests_local.rs
@@ -48,7 +48,9 @@ frame_support::construct_runtime!(
 
 parameter_types! {
 	pub BlockWeights: frame_system::limits::BlockWeights =
-		frame_system::limits::BlockWeights::simple_max(frame_support::weights::Weight::from_ref_time(1024));
+		frame_system::limits::BlockWeights::simple_max(
+			frame_support::weights::Weight::from_ref_time(1024).set_proof_size(u64::MAX),
+		);
 	pub static ExistentialDeposit: u64 = 0;
 }
 impl frame_system::Config for Test {

--- a/frame/balances/src/tests_reentrancy.rs
+++ b/frame/balances/src/tests_reentrancy.rs
@@ -51,7 +51,9 @@ frame_support::construct_runtime!(
 
 parameter_types! {
 	pub BlockWeights: frame_system::limits::BlockWeights =
-		frame_system::limits::BlockWeights::simple_max(frame_support::weights::Weight::from_ref_time(1024));
+		frame_system::limits::BlockWeights::simple_max(
+			frame_support::weights::Weight::from_ref_time(1024).set_proof_size(u64::MAX),
+		);
 	pub static ExistentialDeposit: u64 = 0;
 }
 impl frame_system::Config for Test {

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -415,7 +415,7 @@ pub const BOB: AccountId32 = AccountId32::new([2u8; 32]);
 pub const CHARLIE: AccountId32 = AccountId32::new([3u8; 32]);
 pub const DJANGO: AccountId32 = AccountId32::new([4u8; 32]);
 
-pub const GAS_LIMIT: Weight = Weight::from_ref_time(100_000_000_000);
+pub const GAS_LIMIT: Weight = Weight::from_ref_time(100_000_000_000).set_proof_size(u64::MAX);
 
 pub struct ExtBuilder {
 	existential_deposit: u64,
@@ -630,7 +630,7 @@ fn deposit_event_max_value_limit() {
 			RuntimeOrigin::signed(ALICE),
 			addr.clone(),
 			0,
-			GAS_LIMIT * 2, // we are copying a huge buffer,
+			GAS_LIMIT.set_ref_time(GAS_LIMIT.ref_time() * 2), // we are copying a huge buffer,
 			None,
 			<Test as Config>::Schedule::get().limits.payload_len.encode(),
 		));
@@ -771,7 +771,7 @@ fn storage_max_value_limit() {
 			RuntimeOrigin::signed(ALICE),
 			addr.clone(),
 			0,
-			GAS_LIMIT * 2, // we are copying a huge buffer
+			GAS_LIMIT.set_ref_time(GAS_LIMIT.ref_time() * 2), // we are copying a huge buffer
 			None,
 			<Test as Config>::Schedule::get().limits.payload_len.encode(),
 		));
@@ -2545,7 +2545,7 @@ fn gas_estimation_nested_call_fixed_limit() {
 				ALICE,
 				addr_caller,
 				0,
-				Weight::from_ref_time(result.gas_required),
+				Weight::from_ref_time(result.gas_required).set_proof_size(u64::MAX),
 				Some(result.storage_deposit.charge_or_zero()),
 				input,
 				false,

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -2615,7 +2615,7 @@ fn gas_estimation_call_runtime() {
 				ALICE,
 				addr_caller,
 				0,
-				Weight::from_ref_time(result.gas_required),
+				Weight::from_ref_time(result.gas_required).set_proof_size(u64::MAX),
 				None,
 				call.encode(),
 				false,

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -279,7 +279,9 @@ impl RegisteredChainExtension<Test> for TempStorageExtension {
 
 parameter_types! {
 	pub BlockWeights: frame_system::limits::BlockWeights =
-		frame_system::limits::BlockWeights::simple_max(2u64 * WEIGHT_PER_SECOND);
+		frame_system::limits::BlockWeights::simple_max(
+			(2u64 * WEIGHT_PER_SECOND).set_proof_size(u64::MAX),
+		);
 	pub static ExistentialDeposit: u64 = 1;
 }
 impl frame_system::Config for Test {

--- a/frame/democracy/src/tests.rs
+++ b/frame/democracy/src/tests.rs
@@ -78,7 +78,9 @@ impl Contains<RuntimeCall> for BaseFilter {
 
 parameter_types! {
 	pub BlockWeights: frame_system::limits::BlockWeights =
-		frame_system::limits::BlockWeights::simple_max(Weight::from_ref_time(1_000_000));
+		frame_system::limits::BlockWeights::simple_max(
+			Weight::from_ref_time(1_000_000).set_proof_size(u64::MAX),
+		);
 }
 impl frame_system::Config for Test {
 	type BaseCallFilter = BaseFilter;

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -1008,10 +1008,8 @@ pub mod pallet {
 			// unlikely to ever return an error: if phase is signed, snapshot will exist.
 			let size = Self::snapshot_metadata().ok_or(Error::<T>::MissingSnapshotMetadata)?;
 
-			// TODO: account for proof size weight
 			ensure!(
-				Self::solution_weight_of(&raw_solution, size).ref_time() <
-					T::SignedMaxWeight::get().ref_time(),
+				Self::solution_weight_of(&raw_solution, size).all_lt(T::SignedMaxWeight::get()),
 				Error::<T>::SignedTooMuchWeight,
 			);
 
@@ -2338,9 +2336,8 @@ mod tests {
 		};
 
 		let mut active = 1;
-		// TODO: account for proof size weight
-		while weight_with(active).ref_time() <=
-			<Runtime as frame_system::Config>::BlockWeights::get().max_block.ref_time() ||
+		while weight_with(active)
+			.all_lte(<Runtime as frame_system::Config>::BlockWeights::get().max_block) ||
 			active == all_voters
 		{
 			active += 1;

--- a/frame/election-provider-multi-phase/src/mock.rs
+++ b/frame/election-provider-multi-phase/src/mock.rs
@@ -26,7 +26,7 @@ pub use frame_support::{assert_noop, assert_ok, pallet_prelude::GetDefault};
 use frame_support::{
 	bounded_vec, parameter_types,
 	traits::{ConstU32, Hooks},
-	weights::Weight,
+	weights::{constants, Weight},
 	BoundedVec,
 };
 use multi_phase::unsigned::{IndexAssignmentOf, VoterOf};
@@ -227,7 +227,10 @@ const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;
 	pub BlockWeights: frame_system::limits::BlockWeights = frame_system::limits::BlockWeights
-		::with_sensible_defaults(2u64 * frame_support::weights::constants::WEIGHT_PER_SECOND, NORMAL_DISPATCH_RATIO);
+		::with_sensible_defaults(
+			Weight::from_components(2u64 * constants::WEIGHT_PER_SECOND.ref_time(), u64::MAX),
+			NORMAL_DISPATCH_RATIO,
+		);
 }
 
 impl pallet_balances::Config for Runtime {

--- a/frame/election-provider-multi-phase/src/signed.rs
+++ b/frame/election-provider-multi-phase/src/signed.rs
@@ -957,7 +957,7 @@ mod tests {
 	#[test]
 	fn cannot_consume_too_much_future_weight() {
 		ExtBuilder::default()
-			.signed_weight(Weight::from_ref_time(40))
+			.signed_weight(Weight::from_ref_time(40).set_proof_size(u64::MAX))
 			.mock_weight_info(MockedWeightInfo::Basic)
 			.build_and_execute(|| {
 				roll_to(15);
@@ -973,11 +973,11 @@ mod tests {
 				// default solution will have 5 edges (5 * 5 + 10)
 				assert_eq!(solution_weight, Weight::from_ref_time(35));
 				assert_eq!(raw.solution.voter_count(), 5);
-				assert_eq!(<Runtime as Config>::SignedMaxWeight::get(), Weight::from_ref_time(40));
+				assert_eq!(<Runtime as Config>::SignedMaxWeight::get(), Weight::from_ref_time(40).set_proof_size(u64::MAX));
 
 				assert_ok!(MultiPhase::submit(RuntimeOrigin::signed(99), Box::new(raw.clone())));
 
-				<SignedMaxWeight>::set(Weight::from_ref_time(30));
+				<SignedMaxWeight>::set(Weight::from_ref_time(30).set_proof_size(u64::MAX));
 
 				// note: resubmitting the same solution is technically okay as long as the queue has
 				// space.

--- a/frame/election-provider-multi-phase/src/signed.rs
+++ b/frame/election-provider-multi-phase/src/signed.rs
@@ -973,7 +973,10 @@ mod tests {
 				// default solution will have 5 edges (5 * 5 + 10)
 				assert_eq!(solution_weight, Weight::from_ref_time(35));
 				assert_eq!(raw.solution.voter_count(), 5);
-				assert_eq!(<Runtime as Config>::SignedMaxWeight::get(), Weight::from_ref_time(40).set_proof_size(u64::MAX));
+				assert_eq!(
+					<Runtime as Config>::SignedMaxWeight::get(),
+					Weight::from_ref_time(40).set_proof_size(u64::MAX)
+				);
 
 				assert_ok!(MultiPhase::submit(RuntimeOrigin::signed(99), Box::new(raw.clone())));
 

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -1174,7 +1174,9 @@ mod tests {
 
 	parameter_types! {
 		pub BlockWeights: frame_system::limits::BlockWeights =
-			frame_system::limits::BlockWeights::simple_max(frame_support::weights::Weight::from_ref_time(1024));
+			frame_system::limits::BlockWeights::simple_max(
+				frame_support::weights::Weight::from_ref_time(1024).set_proof_size(u64::MAX),
+			);
 	}
 
 	impl frame_system::Config for Test {

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -459,8 +459,7 @@ where
 		let max_weight = <System::BlockWeights as frame_support::traits::Get<_>>::get().max_block;
 		let remaining_weight = max_weight.saturating_sub(weight.total());
 
-		// TODO: account for proof size weight
-		if remaining_weight.ref_time() > 0 {
+		if remaining_weight.all_gt(Weight::zero()) {
 			let used_weight = <AllPalletsWithSystem as OnIdle<System::BlockNumber>>::on_idle(
 				block_number,
 				remaining_weight,
@@ -768,7 +767,7 @@ mod tests {
 			frame_system::limits::BlockWeights::builder()
 				.base_block(Weight::from_ref_time(10))
 				.for_class(DispatchClass::all(), |weights| weights.base_extrinsic = Weight::from_ref_time(5))
-				.for_class(DispatchClass::non_mandatory(), |weights| weights.max_total = Weight::from_ref_time(1024).into())
+				.for_class(DispatchClass::non_mandatory(), |weights| weights.max_total = Weight::from_ref_time(1024).set_proof_size(u64::MAX).into())
 				.build_or_panic();
 		pub const DbWeight: RuntimeDbWeight = RuntimeDbWeight {
 			read: 10,

--- a/frame/fast-unstake/src/mock.rs
+++ b/frame/fast-unstake/src/mock.rs
@@ -32,7 +32,9 @@ pub type T = Runtime;
 
 parameter_types! {
 	pub BlockWeights: frame_system::limits::BlockWeights =
-		frame_system::limits::BlockWeights::simple_max(2u64 * WEIGHT_PER_SECOND);
+		frame_system::limits::BlockWeights::simple_max(
+			(2u64 * WEIGHT_PER_SECOND).set_proof_size(u64::MAX),
+		);
 }
 
 impl frame_system::Config for Runtime {

--- a/frame/grandpa/src/tests.rs
+++ b/frame/grandpa/src/tests.rs
@@ -856,8 +856,7 @@ fn valid_equivocation_reports_dont_pay_fees() {
 		.get_dispatch_info();
 
 		// it should have non-zero weight and the fee has to be paid.
-		// TODO: account for proof size weight
-		assert!(info.weight.ref_time() > 0);
+		assert!(info.weight.any_gt(Weight::zero()));
 		assert_eq!(info.pays_fee, Pays::Yes);
 
 		// report the equivocation.

--- a/frame/scheduler/src/mock.rs
+++ b/frame/scheduler/src/mock.rs
@@ -118,7 +118,9 @@ impl Contains<RuntimeCall> for BaseFilter {
 
 parameter_types! {
 	pub BlockWeights: frame_system::limits::BlockWeights =
-		frame_system::limits::BlockWeights::simple_max(Weight::from_ref_time(2_000_000_000_000));
+		frame_system::limits::BlockWeights::simple_max(
+			Weight::from_ref_time(2_000_000_000_000).set_proof_size(u64::MAX),
+		);
 }
 impl system::Config for Test {
 	type BaseCallFilter = BaseFilter;

--- a/frame/system/src/extensions/check_weight.rs
+++ b/frame/system/src/extensions/check_weight.rs
@@ -310,7 +310,7 @@ mod tests {
 		check(|max, len| {
 			assert_ok!(CheckWeight::<Test>::do_pre_dispatch(max, len));
 			assert_eq!(System::block_weight().total(), Weight::MAX);
-			assert!(System::block_weight().total().all_gt(block_weight_limit()));
+			assert!(System::block_weight().total().ref_time() > block_weight_limit().ref_time());
 		});
 		check(|max, len| {
 			assert_ok!(CheckWeight::<Test>::do_validate(max, len));
@@ -367,7 +367,7 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			System::register_extra_weight_unchecked(Weight::MAX, DispatchClass::Normal);
 			assert_eq!(System::block_weight().total(), Weight::MAX);
-			assert!(System::block_weight().total().all_gt(block_weight_limit()));
+			assert!(System::block_weight().total().ref_time() > block_weight_limit().ref_time());
 		});
 	}
 
@@ -392,8 +392,8 @@ mod tests {
 			assert_ok!(CheckWeight::<Test>::do_pre_dispatch(&max_normal, len));
 			assert_eq!(System::block_weight().total(), Weight::from_ref_time(768));
 			assert_ok!(CheckWeight::<Test>::do_pre_dispatch(&rest_operational, len));
-			assert_eq!(block_weight_limit(), Weight::from_ref_time(1024));
-			assert_eq!(System::block_weight().total(), block_weight_limit());
+			assert_eq!(block_weight_limit(), Weight::from_ref_time(1024).set_proof_size(u64::MAX));
+			assert_eq!(System::block_weight().total(), block_weight_limit().set_proof_size(0));
 			// Checking single extrinsic should not take current block weight into account.
 			assert_eq!(CheckWeight::<Test>::check_extrinsic_weight(&rest_operational), Ok(()));
 		});
@@ -669,7 +669,7 @@ mod tests {
 			assert_ok!(CheckWeight::<Test>::do_pre_dispatch(&max_normal, len));
 			assert_eq!(System::block_weight().total(), Weight::from_ref_time(768));
 			assert_ok!(CheckWeight::<Test>::do_pre_dispatch(&mandatory, len));
-			assert_eq!(block_weight_limit(), Weight::from_ref_time(1024));
+			assert_eq!(block_weight_limit(), Weight::from_ref_time(1024).set_proof_size(u64::MAX));
 			assert_eq!(System::block_weight().total(), Weight::from_ref_time(1024 + 768));
 			assert_eq!(CheckWeight::<Test>::check_extrinsic_weight(&mandatory), Ok(()));
 		});

--- a/frame/system/src/extensions/check_weight.rs
+++ b/frame/system/src/extensions/check_weight.rs
@@ -417,8 +417,8 @@ mod tests {
 			// Extra 20 here from block execution + base extrinsic weight
 			assert_eq!(System::block_weight().total(), Weight::from_ref_time(266));
 			assert_ok!(CheckWeight::<Test>::do_pre_dispatch(&max_normal, len));
-			assert_eq!(block_weight_limit(), Weight::from_ref_time(1024));
-			assert_eq!(System::block_weight().total(), block_weight_limit());
+			assert_eq!(block_weight_limit(), Weight::from_ref_time(1024).set_proof_size(u64::MAX));
+			assert_eq!(System::block_weight().total(), block_weight_limit().set_proof_size(0));
 		});
 	}
 
@@ -682,11 +682,11 @@ mod tests {
 			.base_block(Weight::zero())
 			.for_class(DispatchClass::non_mandatory(), |w| {
 				w.base_extrinsic = Weight::zero();
-				w.max_total = Some(Weight::from_ref_time(20));
+				w.max_total = Some(Weight::from_ref_time(20).set_proof_size(u64::MAX));
 			})
 			.for_class(DispatchClass::Mandatory, |w| {
 				w.base_extrinsic = Weight::zero();
-				w.reserved = Some(Weight::from_ref_time(5));
+				w.reserved = Some(Weight::from_ref_time(5).set_proof_size(u64::MAX));
 				w.max_total = None;
 			})
 			.build_or_panic();
@@ -695,7 +695,7 @@ mod tests {
 			DispatchClass::Operational => Weight::from_ref_time(10),
 			DispatchClass::Mandatory => Weight::zero(),
 		});
-		assert_eq!(maximum_weight.max_block, all_weight.total());
+		assert_eq!(maximum_weight.max_block, all_weight.total().set_proof_size(u64::MAX));
 
 		// fits into reserved
 		let mandatory1 = DispatchInfo {

--- a/frame/system/src/mock.rs
+++ b/frame/system/src/mock.rs
@@ -41,7 +41,7 @@ frame_support::construct_runtime!(
 );
 
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
-const MAX_BLOCK_WEIGHT: Weight = Weight::from_ref_time(1024);
+const MAX_BLOCK_WEIGHT: Weight = Weight::from_ref_time(1024).set_proof_size(u64::MAX);
 
 parameter_types! {
 	pub Version: RuntimeVersion = RuntimeVersion {

--- a/frame/transaction-payment/asset-tx-payment/src/tests.rs
+++ b/frame/transaction-payment/asset-tx-payment/src/tests.rs
@@ -71,7 +71,7 @@ impl Get<frame_system::limits::BlockWeights> for BlockWeights {
 				weights.base_extrinsic = ExtrinsicBaseWeight::get().into();
 			})
 			.for_class(DispatchClass::non_mandatory(), |weights| {
-				weights.max_total = Weight::from_ref_time(1024).into();
+				weights.max_total = Weight::from_ref_time(1024).set_proof_size(u64::MAX).into();
 			})
 			.build_or_panic()
 	}

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -889,7 +889,7 @@ mod tests {
 					weights.base_extrinsic = ExtrinsicBaseWeight::get().into();
 				})
 				.for_class(DispatchClass::non_mandatory(), |weights| {
-					weights.max_total = Weight::from_ref_time(1024).into();
+					weights.max_total = Weight::from_ref_time(1024).set_proof_size(u64::MAX).into();
 				})
 				.build_or_panic()
 		}


### PR DESCRIPTION
Part of #12176.

This PR sets the default proof size weight correctly, so that it passes unit tests as intended.

The default max proof size is set at `u64::MAX`, because not all substrate-based chains require submitting PoV blocks to the relay -- standalone sovereign chains can safely ignore this weight component.

For parachains however, the proper parameter to set for the max proof size comes from the relay chain, and is stored a field called `max_pov_size` in this struct: https://github.com/paritytech/cumulus/blob/032540dbf9afc9f5a0d5db7279fc81048f3a168b/pallets/parachain-system/src/lib.rs#L526.