### PR TITLE
[WIP] relax pallet-mmr LeafData requirements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10020,6 +10020,7 @@ dependencies = [
  "array-bytes",
  "log",
  "parity-scale-codec",
+ "scale-info",
  "serde",
  "sp-api",
  "sp-core",

--- a/primitives/merkle-mountain-range/Cargo.toml
+++ b/primitives/merkle-mountain-range/Cargo.toml
@@ -20,6 +20,7 @@ sp-core = { version = "6.0.0", default-features = false, path = "../core" }
 sp-debug-derive = { version = "4.0.0", default-features = false, path = "../debug-derive" }
 sp-runtime = { version = "6.0.0", default-features = false, path = "../runtime" }
 sp-std = { version = "4.0.0", default-features = false, path = "../std" }
+scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 array-bytes = "4.1"


### PR DESCRIPTION
Fixes https://github.com/paritytech/substrate/issues/11799


To-do
- [x] Drops the use of the indexing API 
- [x] Stores the new leaf in a placeholder `NewLeaf` runtime storage item. 
- [x] Use the off-chain worker function to move the leaf to off-chain storage after the block is built.
- [ ] Update pallet tests
