### PR TITLE
unsafe_pruning flag removed

### DIFF
--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -659,17 +659,6 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 			}
 		}
 
-		if self.import_params().map_or(false, |p| {
-			#[allow(deprecated)]
-			p.unsafe_pruning
-		}) {
-			// according to https://github.com/substrate/issues/8103;
-			warn!(
-				"WARNING: \"--unsafe-pruning\" CLI-flag is deprecated and has no effect. \
-				In future builds it will be removed, and providing this flag will lead to an error."
-			);
-		}
-
 		Ok(())
 	}
 }

--- a/client/cli/src/params/import_params.rs
+++ b/client/cli/src/params/import_params.rs
@@ -41,18 +41,6 @@ pub struct ImportParams {
 	#[clap(flatten)]
 	pub database_params: DatabaseParams,
 
-	/// THIS IS A DEPRECATED CLI-ARGUMENT.
-	///
-	/// It has been preserved in order to not break the compatibility with the existing scripts.
-	/// Enabling this option will lead to a runtime warning.
-	/// In future this option will be removed completely, thus specifying it will lead to a start
-	/// up error.
-	///
-	/// Details: <https://github.com/paritytech/substrate/issues/8103>
-	#[clap(long)]
-	#[deprecated = "According to https://github.com/paritytech/substrate/issues/8103"]
-	pub unsafe_pruning: bool,
-
 	/// Method for executing Wasm runtime code.
 	#[clap(
 		long = "wasm-execution",


### PR DESCRIPTION
Removes deprecated `--unsafe-pruning` flag.
Closes #11380 .
Follow up of #8103
