### PR TITLE
Carry over where clauses defined in Config to Call and Hook

### DIFF
--- a/frame/support/procedural/src/pallet/expand/call.rs
+++ b/frame/support/procedural/src/pallet/expand/call.rs
@@ -32,7 +32,7 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 
 			(span, where_clause, methods, docs)
 		},
-		None => (def.item.span(), None, Vec::new(), Vec::new()),
+		None => (def.item.span(), def.config.where_clause.clone(), Vec::new(), Vec::new()),
 	};
 	let frame_support = &def.frame_support;
 	let frame_system = &def.frame_system;

--- a/frame/support/procedural/src/pallet/expand/hooks.rs
+++ b/frame/support/procedural/src/pallet/expand/hooks.rs
@@ -26,7 +26,7 @@ pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 			let has_runtime_upgrade = hooks.has_runtime_upgrade;
 			(where_clause, span, has_runtime_upgrade)
 		},
-		None => (None, def.pallet_struct.attr_span, false),
+		None => (def.config.where_clause.clone(), def.pallet_struct.attr_span, false),
 	};
 
 	let frame_support = &def.frame_support;


### PR DESCRIPTION
Fixes #12053.

Allows where clauses defined in `Config` to be carried over to the trait impls of `Call` and `Hook` iff they are not defined in the pallet.