### PR TITLE
BEEFY: Simplify hashing for pallet-beefy-mmr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,7 +525,7 @@ dependencies = [
  "env_logger",
  "log",
  "sp-api",
- "tiny-keccak",
+ "sp-runtime",
 ]
 
 [[package]]

--- a/frame/beefy-mmr/primitives/Cargo.toml
+++ b/frame/beefy-mmr/primitives/Cargo.toml
@@ -11,10 +11,10 @@ homepage = "https://substrate.io"
 [dependencies]
 array-bytes = { version = "4.1", optional = true }
 log = { version = "0.4", default-features = false, optional = true }
-tiny-keccak = { version = "2.0.2", features = ["keccak"], optional = true }
 
 beefy-primitives = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/beefy" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/api" }
+sp-runtime = { version = "6.0.0", default-features = false, path = "../../../primitives/runtime" }
 
 [dev-dependencies]
 array-bytes = "4.1"
@@ -22,9 +22,9 @@ env_logger = "0.9"
 
 [features]
 debug = ["array-bytes", "log"]
-default = ["debug", "keccak", "std"]
-keccak = ["tiny-keccak"]
+default = ["debug", "std"]
 std = [
 	"beefy-primitives/std",
-	"sp-api/std"
+	"sp-api/std",
+	"sp-runtime/std"
 ]

--- a/frame/beefy-mmr/primitives/src/lib.rs
+++ b/frame/beefy-mmr/primitives/src/lib.rs
@@ -60,7 +60,7 @@ where
 	V: Visitor<H::Output>,
 	I: Iterator<Item = H::Output>,
 {
-	let upper = Vec::with_capacity(leaves.size_hint().1.unwrap());
+	let upper = Vec::with_capacity(leaves.size_hint().0);
 	let mut next = match merkelize_row::<H, _, _>(leaves, upper, visitor) {
 		Ok(root) => return root,
 		Err(next) if next.is_empty() => return H::Output::default(),

--- a/frame/beefy-mmr/primitives/src/lib.rs
+++ b/frame/beefy-mmr/primitives/src/lib.rs
@@ -60,14 +60,14 @@ where
 	V: Visitor<H::Output>,
 	I: Iterator<Item = H::Output>,
 {
-	let upper = Vec::with_capacity(leaves.size_hint().0);
+	let upper = Vec::with_capacity((leaves.size_hint().1.unwrap_or(0).saturating_add(1)) / 2);
 	let mut next = match merkelize_row::<H, _, _>(leaves, upper, visitor) {
 		Ok(root) => return root,
 		Err(next) if next.is_empty() => return H::Output::default(),
 		Err(next) => next,
 	};
 
-	let mut upper = Vec::with_capacity((next.len() + 1) / 2);
+	let mut upper = Vec::with_capacity((next.len().saturating_add(1)) / 2);
 	loop {
 		visitor.move_up();
 

--- a/frame/beefy-mmr/primitives/src/lib.rs
+++ b/frame/beefy-mmr/primitives/src/lib.rs
@@ -25,20 +25,17 @@
 //! compilation targets.
 //!
 //! Merkle Tree is constructed from arbitrary-length leaves, that are initially hashed using the
-//! same [Hasher] as the inner nodes.
+//! same hasher as the inner nodes.
 //! Inner nodes are created by concatenating child hashes and hashing again. The implementation
 //! does not perform any sorting of the input data (leaves) nor when inner nodes are created.
 //!
 //! If the number of leaves is not even, last leave (hash of) is promoted to the upper layer.
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+pub use sp_runtime::traits::Keccak256;
+use sp_runtime::{app_crypto::sp_core, sp_std, traits::Hash as HashT};
+use sp_std::{vec, vec::Vec};
 
 use beefy_primitives::mmr::{BeefyAuthoritySet, BeefyNextAuthoritySet};
-pub use sp_runtime::traits::Keccak256;
-use sp_runtime::{app_crypto::sp_core, traits::Hash as HashT};
 
 /// Construct a root hash of a Binary Merkle Tree created from given leaves.
 ///

--- a/frame/beefy-mmr/primitives/src/lib.rs
+++ b/frame/beefy-mmr/primitives/src/lib.rs
@@ -37,6 +37,8 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use beefy_primitives::mmr::{BeefyAuthoritySet, BeefyNextAuthoritySet};
+use sp_runtime::traits::Hash as HashT;
+pub use sp_runtime::traits::Keccak256;
 
 /// Supported hashing output size.
 ///
@@ -53,30 +55,12 @@ pub trait Hasher {
 	fn hash(data: &[u8]) -> Hash;
 }
 
-#[cfg(feature = "keccak")]
-mod keccak256 {
-	use tiny_keccak::{Hasher as _, Keccak};
-
-	/// Keccak256 hasher implementation.
-	pub struct Keccak256;
-	impl Keccak256 {
-		/// Hash given data.
-		pub fn hash(data: &[u8]) -> super::Hash {
-			<Keccak256 as super::Hasher>::hash(data)
-		}
-	}
-	impl super::Hasher for Keccak256 {
-		fn hash(data: &[u8]) -> super::Hash {
-			let mut keccak = Keccak::v256();
-			keccak.update(data);
-			let mut output = [0_u8; 32];
-			keccak.finalize(&mut output);
-			output
-		}
+/// Keccak256 hasher implementation.
+impl Hasher for Keccak256 {
+	fn hash(data: &[u8]) -> Hash {
+		<Self as HashT>::hash(data).into()
 	}
 }
-#[cfg(feature = "keccak")]
-pub use keccak256::Keccak256;
 
 /// Construct a root hash of a Binary Merkle Tree created from given leaves.
 ///

--- a/frame/beefy-mmr/src/lib.rs
+++ b/frame/beefy-mmr/src/lib.rs
@@ -204,7 +204,7 @@ impl<T: Config> Pallet<T> {
 			.map(T::BeefyAuthorityToMerkleLeaf::convert)
 			.collect::<Vec<_>>();
 		let len = beefy_addresses.len() as u32;
-		let root = beefy_merkle_tree::merkle_root::<<T as pallet_mmr::Config>::Hashing, _, _, _>(
+		let root = beefy_merkle_tree::merkle_root::<<T as pallet_mmr::Config>::Hashing, _>(
 			beefy_addresses,
 		)
 		.into();

--- a/frame/beefy-mmr/src/lib.rs
+++ b/frame/beefy-mmr/src/lib.rs
@@ -163,8 +163,6 @@ impl<T: Config> LeafDataProvider for Pallet<T> {
 impl<T> beefy_primitives::OnNewValidatorSet<<T as pallet_beefy::Config>::BeefyId> for Pallet<T>
 where
 	T: pallet::Config,
-	<T as pallet_mmr::Config>::Hashing: beefy_merkle_tree::Hasher,
-	beefy_merkle_tree::Hash: Into<MerkleRootOf<T>>,
 {
 	/// Compute and cache BEEFY authority sets based on updated BEEFY validator sets.
 	fn on_new_validator_set(
@@ -179,11 +177,7 @@ where
 	}
 }
 
-impl<T: Config> Pallet<T>
-where
-	<T as pallet_mmr::Config>::Hashing: beefy_merkle_tree::Hasher,
-	beefy_merkle_tree::Hash: Into<MerkleRootOf<T>>,
-{
+impl<T: Config> Pallet<T> {
 	/// Return the currently active BEEFY authority set proof.
 	pub fn authority_set_proof() -> BeefyAuthoritySet<MerkleRootOf<T>> {
 		Pallet::<T>::beefy_authorities()
@@ -210,7 +204,7 @@ where
 			.map(T::BeefyAuthorityToMerkleLeaf::convert)
 			.collect::<Vec<_>>();
 		let len = beefy_addresses.len() as u32;
-		let root = beefy_merkle_tree::merkle_root::<<T as pallet_mmr::Config>::Hashing, _, _>(
+		let root = beefy_merkle_tree::merkle_root::<<T as pallet_mmr::Config>::Hashing, _, _, _>(
 			beefy_addresses,
 		)
 		.into();

--- a/frame/beefy-mmr/src/lib.rs
+++ b/frame/beefy-mmr/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 //! and thanks to versioning can be easily updated in the future.
 
-use sp_runtime::traits::{Convert, Hash, Member};
+use sp_runtime::traits::{Convert, Member};
 use sp_std::prelude::*;
 
 use beefy_primitives::{
@@ -142,10 +142,7 @@ pub mod pallet {
 		StorageValue<_, BeefyNextAuthoritySet<MerkleRootOf<T>>, ValueQuery>;
 }
 
-impl<T: Config> LeafDataProvider for Pallet<T>
-where
-	MerkleRootOf<T>: From<beefy_merkle_tree::Hash> + Into<beefy_merkle_tree::Hash>,
-{
+impl<T: Config> LeafDataProvider for Pallet<T> {
 	type LeafData = MmrLeaf<
 		<T as frame_system::Config>::BlockNumber,
 		<T as frame_system::Config>::Hash,
@@ -163,19 +160,11 @@ where
 	}
 }
 
-impl<T: Config> beefy_merkle_tree::Hasher for Pallet<T>
-where
-	MerkleRootOf<T>: Into<beefy_merkle_tree::Hash>,
-{
-	fn hash(data: &[u8]) -> beefy_merkle_tree::Hash {
-		<T as pallet_mmr::Config>::Hashing::hash(data).into()
-	}
-}
-
 impl<T> beefy_primitives::OnNewValidatorSet<<T as pallet_beefy::Config>::BeefyId> for Pallet<T>
 where
 	T: pallet::Config,
-	MerkleRootOf<T>: From<beefy_merkle_tree::Hash> + Into<beefy_merkle_tree::Hash>,
+	<T as pallet_mmr::Config>::Hashing: beefy_merkle_tree::Hasher,
+	beefy_merkle_tree::Hash: Into<MerkleRootOf<T>>,
 {
 	/// Compute and cache BEEFY authority sets based on updated BEEFY validator sets.
 	fn on_new_validator_set(
@@ -192,7 +181,8 @@ where
 
 impl<T: Config> Pallet<T>
 where
-	MerkleRootOf<T>: From<beefy_merkle_tree::Hash> + Into<beefy_merkle_tree::Hash>,
+	<T as pallet_mmr::Config>::Hashing: beefy_merkle_tree::Hasher,
+	beefy_merkle_tree::Hash: Into<MerkleRootOf<T>>,
 {
 	/// Return the currently active BEEFY authority set proof.
 	pub fn authority_set_proof() -> BeefyAuthoritySet<MerkleRootOf<T>> {
@@ -220,7 +210,10 @@ where
 			.map(T::BeefyAuthorityToMerkleLeaf::convert)
 			.collect::<Vec<_>>();
 		let len = beefy_addresses.len() as u32;
-		let root = beefy_merkle_tree::merkle_root::<Self, _, _>(beefy_addresses).into();
+		let root = beefy_merkle_tree::merkle_root::<<T as pallet_mmr::Config>::Hashing, _, _>(
+			beefy_addresses,
+		)
+		.into();
 		BeefyAuthoritySet { id, len, root }
 	}
 }

--- a/frame/beefy-mmr/src/mock.rs
+++ b/frame/beefy-mmr/src/mock.rs
@@ -147,7 +147,7 @@ impl BeefyDataProvider<Vec<u8>> for DummyDataProvider {
 	fn extra_data() -> Vec<u8> {
 		let mut col = vec![(15, vec![1, 2, 3]), (5, vec![4, 5, 6])];
 		col.sort();
-		beefy_merkle_tree::merkle_root::<crate::Pallet<Test>, _, _>(
+		beefy_merkle_tree::merkle_root::<<Test as pallet_mmr::Config>::Hashing, _, _>(
 			col.into_iter().map(|pair| pair.encode()),
 		)
 		.to_vec()

--- a/frame/beefy-mmr/src/mock.rs
+++ b/frame/beefy-mmr/src/mock.rs
@@ -147,7 +147,7 @@ impl BeefyDataProvider<Vec<u8>> for DummyDataProvider {
 	fn extra_data() -> Vec<u8> {
 		let mut col = vec![(15, vec![1, 2, 3]), (5, vec![4, 5, 6])];
 		col.sort();
-		beefy_merkle_tree::merkle_root::<<Test as pallet_mmr::Config>::Hashing, _, _, _>(
+		beefy_merkle_tree::merkle_root::<<Test as pallet_mmr::Config>::Hashing, _>(
 			col.into_iter().map(|pair| pair.encode()),
 		)
 		.as_ref()

--- a/frame/beefy-mmr/src/mock.rs
+++ b/frame/beefy-mmr/src/mock.rs
@@ -147,9 +147,10 @@ impl BeefyDataProvider<Vec<u8>> for DummyDataProvider {
 	fn extra_data() -> Vec<u8> {
 		let mut col = vec![(15, vec![1, 2, 3]), (5, vec![4, 5, 6])];
 		col.sort();
-		beefy_merkle_tree::merkle_root::<<Test as pallet_mmr::Config>::Hashing, _, _>(
+		beefy_merkle_tree::merkle_root::<<Test as pallet_mmr::Config>::Hashing, _, _, _>(
 			col.into_iter().map(|pair| pair.encode()),
 		)
+		.as_ref()
 		.to_vec()
 	}
 }


### PR DESCRIPTION
Reuse `sp_runtime::traits::Hash` instead of defining a new `Hasher` trait for beefy.

Addresses both items in issue #12387 

polkadot companion: https://github.com/paritytech/polkadot/pull/6098