### PR TITLE
Add batching to fast-unstake pallet

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -582,6 +582,7 @@ impl pallet_staking::Config for Runtime {
 impl pallet_fast_unstake::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type ControlOrigin = frame_system::EnsureRoot<AccountId>;
+	type BatchSize = ConstU32<{ 128 }>;
 	type Deposit = ConstU128<{ DOLLARS }>;
 	type DepositCurrency = Balances;
 	type WeightInfo = ();

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -582,7 +582,7 @@ impl pallet_staking::Config for Runtime {
 impl pallet_fast_unstake::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type ControlOrigin = frame_system::EnsureRoot<AccountId>;
-	type BatchSize = ConstU32<{ 128 }>;
+	type BatchSize = ConstU32<128>;
 	type Deposit = ConstU128<{ DOLLARS }>;
 	type DepositCurrency = Balances;
 	type WeightInfo = ();

--- a/frame/fast-unstake/src/benchmarking.rs
+++ b/frame/fast-unstake/src/benchmarking.rs
@@ -44,11 +44,13 @@ fn l<T: Config>(
 }
 
 fn create_unexposed_nominators<T: Config>() -> Vec<T::AccountId> {
-	(0..T::BatchSize::get()).map(|i| {
-		let account = frame_benchmarking::account::<T::AccountId>("nominator_42", i, USER_SEED);
-		fund_and_bond_account::<T>(&account);
-		account
-	}).collect()
+	(0..T::BatchSize::get())
+		.map(|i| {
+			let account = frame_benchmarking::account::<T::AccountId>("nominator_42", i, USER_SEED);
+			fund_and_bond_account::<T>(&account);
+			account
+		})
+		.collect()
 }
 
 fn fund_and_bond_account<T: Config>(account: &T::AccountId) {

--- a/frame/fast-unstake/src/benchmarking.rs
+++ b/frame/fast-unstake/src/benchmarking.rs
@@ -43,10 +43,12 @@ fn l<T: Config>(
 	T::Lookup::unlookup(who)
 }
 
-fn create_unexposed_nominator<T: Config>() -> T::AccountId {
-	let account = frame_benchmarking::account::<T::AccountId>("nominator_42", 0, USER_SEED);
-	fund_and_bond_account::<T>(&account);
-	account
+fn create_unexposed_nominators<T: Config>() -> Vec<T::AccountId> {
+	(0..T::BatchSize::get()).map(|_| {
+		let account = frame_benchmarking::account::<T::AccountId>("nominator_42", 0, USER_SEED);
+		fund_and_bond_account::<T>(&account);
+		account
+	}).collect()
 }
 
 fn fund_and_bond_account<T: Config>(account: &T::AccountId) {
@@ -108,21 +110,27 @@ fn on_idle_full_block<T: Config>() {
 }
 
 benchmarks! {
-	// on_idle, we we don't check anyone, but fully unbond and move them to another pool.
+	// on_idle, we we don't check anyone, but fully unbond them.
 	on_idle_unstake {
 		ErasToCheckPerBlock::<T>::put(1);
-		let who = create_unexposed_nominator::<T>();
-		assert_ok!(FastUnstake::<T>::register_fast_unstake(
-			RawOrigin::Signed(who.clone()).into(),
-		));
+		for who in create_unexposed_nominators::<T>() {
+			assert_ok!(FastUnstake::<T>::register_fast_unstake(
+				RawOrigin::Signed(who.clone()).into(),
+			));
+		}
 
 		// run on_idle once. This will check era 0.
 		assert_eq!(Head::<T>::get(), None);
 		on_idle_full_block::<T>();
-		assert_eq!(
+
+		assert!(matches!(
 			Head::<T>::get(),
-			Some(UnstakeRequest { stash: who.clone(), checked: vec![0].try_into().unwrap(), deposit: T::Deposit::get() })
-		);
+			Some(UnstakeRequest {
+				checked,
+				stashes,
+				..
+			}) if checked.len() == 1 && stashes.len() as u32 == T::BatchSize::get()
+		));
 	}
 	: {
 		on_idle_full_block::<T>();
@@ -130,7 +138,7 @@ benchmarks! {
 	verify {
 		assert!(matches!(
 			fast_unstake_events::<T>().last(),
-			Some(Event::Unstaked { .. })
+			Some(Event::Terminated)
 		));
 	}
 
@@ -147,10 +155,13 @@ benchmarks! {
 
 		// setup staking with v validators and u eras of data (0..=u)
 		setup_staking::<T>(v, u);
-		let who = create_unexposed_nominator::<T>();
-		assert_ok!(FastUnstake::<T>::register_fast_unstake(
-			RawOrigin::Signed(who.clone()).into(),
-		));
+
+		let stashes = create_unexposed_nominators::<T>().into_iter().map(|s| {
+			assert_ok!(FastUnstake::<T>::register_fast_unstake(
+				RawOrigin::Signed(s.clone()).into(),
+			));
+			(s, T::Deposit::get())
+		}).collect::<Vec<_>>().try_into().unwrap();
 
 		// no one is queued thus far.
 		assert_eq!(Head::<T>::get(), None);
@@ -162,7 +173,7 @@ benchmarks! {
 		let checked: frame_support::BoundedVec<_, _> = (1..=u).rev().collect::<Vec<EraIndex>>().try_into().unwrap();
 		assert_eq!(
 			Head::<T>::get(),
-			Some(UnstakeRequest { stash: who.clone(), checked, deposit: T::Deposit::get() })
+			Some(UnstakeRequest { stashes, checked })
 		);
 		assert!(matches!(
 			fast_unstake_events::<T>().last(),
@@ -172,7 +183,7 @@ benchmarks! {
 
 	register_fast_unstake {
 		ErasToCheckPerBlock::<T>::put(1);
-		let who = create_unexposed_nominator::<T>();
+		let who = create_unexposed_nominators::<T>().get(0).cloned().unwrap();
 		whitelist_account!(who);
 		assert_eq!(Queue::<T>::count(), 0);
 
@@ -184,7 +195,7 @@ benchmarks! {
 
 	deregister {
 		ErasToCheckPerBlock::<T>::put(1);
-		let who = create_unexposed_nominator::<T>();
+		let who = create_unexposed_nominators::<T>().get(0).cloned().unwrap();
 		assert_ok!(FastUnstake::<T>::register_fast_unstake(
 			RawOrigin::Signed(who.clone()).into(),
 		));

--- a/frame/fast-unstake/src/lib.rs
+++ b/frame/fast-unstake/src/lib.rs
@@ -125,14 +125,18 @@ pub mod pallet {
 		/// The origin that can control this pallet.
 		type ControlOrigin: frame_support::traits::EnsureOrigin<Self::RuntimeOrigin>;
 
+		/// Batch size.
+		///
+		/// This many stashes are processed in each unstake request.
+		type BatchSize: Get<u32>;
+
 		/// The weight information of this pallet.
 		type WeightInfo: WeightInfo;
 	}
 
 	/// The current "head of the queue" being unstaked.
 	#[pallet::storage]
-	pub type Head<T: Config> =
-		StorageValue<_, UnstakeRequest<T::AccountId, MaxChecking<T>, BalanceOf<T>>, OptionQuery>;
+	pub type Head<T: Config> = StorageValue<_, UnstakeRequest<T>, OptionQuery>;
 
 	/// The map of all accounts wishing to be unstaked.
 	///
@@ -157,13 +161,18 @@ pub mod pallet {
 		Unstaked { stash: T::AccountId, result: DispatchResult },
 		/// A staker was slashed for requesting fast-unstake whilst being exposed.
 		Slashed { stash: T::AccountId, amount: BalanceOf<T> },
-		/// A staker was partially checked for the given eras, but the process did not finish.
-		Checking { stash: T::AccountId, eras: Vec<EraIndex> },
 		/// Some internal error happened while migrating stash. They are removed as head as a
 		/// consequence.
 		Errored { stash: T::AccountId },
 		/// An internal error happened. Operations will be paused now.
 		InternalError,
+		/// A batch was partially checked for the given eras, but the process did not finish.
+		Checking { eras: Vec<EraIndex> },
+		/// A batch was terminated.
+		///
+		/// This is always follows by a number of `Unstaked` or `Slashed` events, marking the end
+		/// of the batch. A new batch will be created upon next block.
+		Terminated,
 	}
 
 	#[pallet::error]
@@ -225,10 +234,7 @@ pub mod pallet {
 			let ledger =
 				pallet_staking::Ledger::<T>::get(&ctrl).ok_or(Error::<T>::NotController)?;
 			ensure!(!Queue::<T>::contains_key(&ledger.stash), Error::<T>::AlreadyQueued);
-			ensure!(
-				Head::<T>::get().map_or(true, |UnstakeRequest { stash, .. }| stash != ledger.stash),
-				Error::<T>::AlreadyHead
-			);
+			ensure!(!Self::is_head(&ledger.stash), Error::<T>::AlreadyHead);
 			// second part of the && is defensive.
 			ensure!(
 				ledger.active == ledger.total && ledger.unlocking.is_empty(),
@@ -263,10 +269,7 @@ pub mod pallet {
 				.map(|l| l.stash)
 				.ok_or(Error::<T>::NotController)?;
 			ensure!(Queue::<T>::contains_key(&stash), Error::<T>::NotQueued);
-			ensure!(
-				Head::<T>::get().map_or(true, |UnstakeRequest { stash, .. }| stash != stash),
-				Error::<T>::AlreadyHead
-			);
+			ensure!(!Self::is_head(&stash), Error::<T>::AlreadyHead);
 			let deposit = Queue::<T>::take(stash.clone());
 
 			if let Some(deposit) = deposit.defensive() {
@@ -293,6 +296,20 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
+		/// Returns `true` if `staker` is anywhere to be found in the `head`.
+		pub(crate) fn is_head(staker: &T::AccountId) -> bool {
+			Head::<T>::get().map_or(false, |UnstakeRequest { stashes, .. }| {
+				stashes.iter().any(|(stash, _)| stash == staker)
+			})
+		}
+
+		/// Halt the operations of this pallet.
+		pub(crate) fn halt(reason: &'static str) {
+			frame_support::defensive!(reason);
+			ErasToCheckPerBlock::<T>::put(0);
+			Self::deposit_event(Event::<T>::InternalError)
+		}
+
 		/// process up to `remaining_weight`.
 		///
 		/// Returns the actual weight consumed.
@@ -339,28 +356,30 @@ pub mod pallet {
 				return T::DbWeight::get().reads(2)
 			}
 
-			let UnstakeRequest { stash, mut checked, deposit } =
-				match Head::<T>::take().or_else(|| {
-					// NOTE: there is no order guarantees in `Queue`.
-					Queue::<T>::drain()
-						.map(|(stash, deposit)| UnstakeRequest {
-							stash,
-							deposit,
-							checked: Default::default(),
-						})
-						.next()
-				}) {
-					None => {
-						// There's no `Head` and nothing in the `Queue`, nothing to do here.
-						return T::DbWeight::get().reads(4)
-					},
-					Some(head) => head,
-				};
+			let UnstakeRequest { stashes, mut checked } = match Head::<T>::take().or_else(|| {
+				// NOTE: there is no order guarantees in `Queue`.
+				let stashes: BoundedVec<_, T::BatchSize> = Queue::<T>::drain()
+					.take(T::BatchSize::get() as usize)
+					.collect::<Vec<_>>()
+					.try_into()
+					.expect("take ensures bound is met; qed");
+				if stashes.is_empty() {
+					None
+				} else {
+					Some(UnstakeRequest { stashes, checked: Default::default() })
+				}
+			}) {
+				None => {
+					// There's no `Head` and nothing in the `Queue`, nothing to do here.
+					return T::DbWeight::get().reads(4)
+				},
+				Some(head) => head,
+			};
 
 			log!(
 				debug,
 				"checking {:?}, eras_to_check_per_block = {:?}, remaining_weight = {:?}",
-				stash,
+				stashes,
 				eras_to_check_per_block,
 				remaining_weight
 			);
@@ -368,9 +387,11 @@ pub mod pallet {
 			// the range that we're allowed to check in this round.
 			let current_era = pallet_staking::CurrentEra::<T>::get().unwrap_or_default();
 			let bonding_duration = <T as pallet_staking::Config>::BondingDuration::get();
+
 			// prune all the old eras that we don't care about. This will help us keep the bound
 			// of `checked`.
 			checked.retain(|e| *e >= current_era.saturating_sub(bonding_duration));
+
 			let unchecked_eras_to_check = {
 				// get the last available `bonding_duration` eras up to current era in reverse
 				// order.
@@ -400,10 +421,8 @@ pub mod pallet {
 				unchecked_eras_to_check
 			);
 
-			if unchecked_eras_to_check.is_empty() {
-				// `stash` is not exposed in any era now -- we can let go of them now.
+			let unstake_stash = |stash: T::AccountId, deposit| {
 				let num_slashing_spans = Staking::<T>::slashing_spans(&stash).iter().count() as u32;
-
 				let result = pallet_staking::Pallet::<T>::force_unstake(
 					RawOrigin::Root.into(),
 					stash.clone(),
@@ -412,61 +431,71 @@ pub mod pallet {
 
 				let remaining = T::DepositCurrency::unreserve(&stash, deposit);
 				if !remaining.is_zero() {
-					frame_support::defensive!("`not enough balance to unreserve`");
-					ErasToCheckPerBlock::<T>::put(0);
-					Self::deposit_event(Event::<T>::InternalError)
+					Self::halt("not enough balance to unreserve");
 				} else {
 					log!(info, "unstaked {:?}, outcome: {:?}", stash, result);
 					Self::deposit_event(Event::<T>::Unstaked { stash, result });
 				}
+			};
 
-				<T as Config>::WeightInfo::on_idle_unstake()
-			} else {
-				// eras remaining to be checked.
-				let mut eras_checked = 0u32;
+			let check_stash = |stash, deposit, eras_checked: &mut u32| {
 				let is_exposed = unchecked_eras_to_check.iter().any(|e| {
 					eras_checked.saturating_inc();
 					Self::is_exposed_in_era(&stash, e)
 				});
 
-				log!(
-					debug,
-					"checked {:?} eras, exposed? {}, (v: {:?}, u: {:?})",
-					eras_checked,
-					is_exposed,
-					validator_count,
-					unchecked_eras_to_check.len()
-				);
-
-				// NOTE: you can be extremely unlucky and get slashed here: You are not exposed in
-				// the last 28 eras, have registered yourself to be unstaked, midway being checked,
-				// you are exposed.
 				if is_exposed {
 					T::DepositCurrency::slash_reserved(&stash, deposit);
 					log!(info, "slashed {:?} by {:?}", stash, deposit);
 					Self::deposit_event(Event::<T>::Slashed { stash, amount: deposit });
+					false
 				} else {
-					// Not exposed in these eras.
-					match checked.try_extend(unchecked_eras_to_check.clone().into_iter()) {
-						Ok(_) => {
-							Head::<T>::put(UnstakeRequest {
-								stash: stash.clone(),
-								checked,
-								deposit,
-							});
+					true
+				}
+			};
+
+			if unchecked_eras_to_check.is_empty() {
+				// `stash` is not exposed in any era now -- we can let go of them now.
+				stashes.into_iter().for_each(|(stash, deposit)| unstake_stash(stash, deposit));
+				Self::deposit_event(Event::<T>::Terminated);
+				<T as Config>::WeightInfo::on_idle_unstake()
+			} else {
+				// eras checked so far.
+				let mut eras_checked = 0u32;
+
+				let pre_length = stashes.len();
+				let stashes: BoundedVec<(T::AccountId, BalanceOf<T>), T::BatchSize> = stashes
+					.into_iter()
+					.filter(|(stash, deposit)| {
+						check_stash(stash.clone(), *deposit, &mut eras_checked)
+					})
+					.collect::<Vec<_>>()
+					.try_into()
+					.expect("filter can only lesson the length; still in bound; qed");
+				let post_length = stashes.len();
+
+				log!(
+					debug,
+					"checked {:?} eras, pre stashes: {:?}, post: {:?}",
+					eras_checked,
+					pre_length,
+					post_length,
+				);
+
+				match checked.try_extend(unchecked_eras_to_check.clone().into_iter()) {
+					Ok(_) =>
+						if stashes.is_empty() {
+							Self::deposit_event(Event::<T>::Terminated);
+						} else {
+							Head::<T>::put(UnstakeRequest { stashes, checked });
 							Self::deposit_event(Event::<T>::Checking {
-								stash,
 								eras: unchecked_eras_to_check,
 							});
 						},
-						Err(_) => {
-							// don't put the head back in -- there is an internal error in the
-							// pallet.
-							frame_support::defensive!("`checked is pruned via retain above`");
-							ErasToCheckPerBlock::<T>::put(0);
-							Self::deposit_event(Event::<T>::InternalError);
-						},
-					}
+					Err(_) => {
+						// don't put the head back in -- there is an internal error in the pallet.
+						Self::halt("checked is pruned via retain above")
+					},
 				}
 
 				<T as Config>::WeightInfo::on_idle_check(validator_count * eras_checked)

--- a/frame/fast-unstake/src/lib.rs
+++ b/frame/fast-unstake/src/lib.rs
@@ -201,6 +201,29 @@ pub mod pallet {
 				return Weight::from_ref_time(0)
 			}
 
+			// Temporary for migration.
+			if Head::<T>::exists() && Head::<T>::get().is_none() {
+				// Migrate head.
+				let key = Head::<T>::hashed_key();
+				let (stash, deposit) = match frame_support::storage::unhashed::get::<(
+					T::AccountId,
+					Vec<EraIndex>,
+					BalanceOf<T>,
+				)>(&key)
+				.defensive()
+				{
+					Some((stash, _, deposit)) => (stash, deposit),
+					None => {
+						Head::<T>::kill();
+						return T::DbWeight::get().reads_writes(1, 1)
+					},
+				};
+				// insert them back into the queue.
+				Queue::<T>::insert(stash, deposit);
+				Head::<T>::kill();
+				return T::DbWeight::get().reads_writes(1, 2)
+			}
+
 			Self::do_on_idle(remaining_weight)
 		}
 	}

--- a/frame/fast-unstake/src/mock.rs
+++ b/frame/fast-unstake/src/mock.rs
@@ -169,6 +169,7 @@ impl Convert<sp_core::U256, Balance> for U256ToBalance {
 
 parameter_types! {
 	pub static DepositAmount: u128 = 7;
+	pub static BatchSize: u32 = 1;
 }
 
 impl fast_unstake::Config for Runtime {
@@ -176,6 +177,7 @@ impl fast_unstake::Config for Runtime {
 	type Deposit = DepositAmount;
 	type DepositCurrency = Balances;
 	type ControlOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type BatchSize = BatchSize;
 	type WeightInfo = ();
 }
 

--- a/frame/fast-unstake/src/mock.rs
+++ b/frame/fast-unstake/src/mock.rs
@@ -168,13 +168,13 @@ impl Convert<sp_core::U256, Balance> for U256ToBalance {
 }
 
 parameter_types! {
-	pub static DepositAmount: u128 = 7;
+	pub static Deposit: u128 = 7;
 	pub static BatchSize: u32 = 1;
 }
 
 impl fast_unstake::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type Deposit = DepositAmount;
+	type Deposit = Deposit;
 	type DepositCurrency = Balances;
 	type ControlOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BatchSize = BatchSize;

--- a/frame/fast-unstake/src/tests.rs
+++ b/frame/fast-unstake/src/tests.rs
@@ -107,7 +107,7 @@ fn cannot_register_if_head() {
 		ErasToCheckPerBlock::<T>::put(1);
 		// Insert some Head item for stash
 		Head::<T>::put(UnstakeRequest {
-			stashes: bounded_vec![(1, DepositAmount::get())],
+			stashes: bounded_vec![(1, Deposit::get())],
 			checked: bounded_vec![],
 		});
 		// Controller attempts to regsiter
@@ -141,7 +141,7 @@ fn deregister_works() {
 
 		// Controller account registers for fast unstake.
 		assert_ok!(FastUnstake::register_fast_unstake(RuntimeOrigin::signed(2)));
-		assert_eq!(<T as Config>::DepositCurrency::reserved_balance(&1), DepositAmount::get());
+		assert_eq!(<T as Config>::DepositCurrency::reserved_balance(&1), Deposit::get());
 
 		// Controller then changes mind and deregisters.
 		assert_ok!(FastUnstake::deregister(RuntimeOrigin::signed(2)));
@@ -190,7 +190,7 @@ fn cannot_deregister_already_head() {
 		assert_ok!(FastUnstake::register_fast_unstake(RuntimeOrigin::signed(2)));
 		// Insert some Head item for stash.
 		Head::<T>::put(UnstakeRequest {
-			stashes: bounded_vec![(1, DepositAmount::get())],
+			stashes: bounded_vec![(1, Deposit::get())],
 			checked: bounded_vec![],
 		});
 		// Controller attempts to deregister
@@ -225,14 +225,14 @@ mod on_idle {
 
 			// set up Queue item
 			assert_ok!(FastUnstake::register_fast_unstake(RuntimeOrigin::signed(2)));
-			assert_eq!(Queue::<T>::get(1), Some(DepositAmount::get()));
+			assert_eq!(Queue::<T>::get(1), Some(Deposit::get()));
 
 			// call on_idle with no remaining weight
 			FastUnstake::on_idle(System::block_number(), Weight::from_ref_time(0));
 
 			// assert nothing changed in Queue and Head
 			assert_eq!(Head::<T>::get(), None);
-			assert_eq!(Queue::<T>::get(1), Some(DepositAmount::get()));
+			assert_eq!(Queue::<T>::get(1), Some(Deposit::get()));
 		});
 	}
 
@@ -245,7 +245,7 @@ mod on_idle {
 
 			// given
 			assert_ok!(FastUnstake::register_fast_unstake(RuntimeOrigin::signed(2)));
-			assert_eq!(Queue::<T>::get(1), Some(DepositAmount::get()));
+			assert_eq!(Queue::<T>::get(1), Some(Deposit::get()));
 
 			assert_eq!(Queue::<T>::count(), 1);
 			assert_eq!(Head::<T>::get(), None);
@@ -265,7 +265,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3]
 				})
 			);
@@ -284,7 +284,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3, 2]
 				})
 			);
@@ -309,7 +309,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3, 2, 1, 0]
 				})
 			);
@@ -324,7 +324,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3, 2, 1, 0]
 				})
 			);
@@ -365,7 +365,7 @@ mod on_idle {
 			assert_ok!(FastUnstake::register_fast_unstake(RuntimeOrigin::signed(8)));
 			assert_ok!(FastUnstake::register_fast_unstake(RuntimeOrigin::signed(10)));
 
-			assert_eq!(<T as Config>::DepositCurrency::reserved_balance(&1), DepositAmount::get());
+			assert_eq!(<T as Config>::DepositCurrency::reserved_balance(&1), Deposit::get());
 
 			assert_eq!(Queue::<T>::count(), 5);
 			assert_eq!(Head::<T>::get(), None);
@@ -377,7 +377,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3, 2, 1, 0]
 				})
 			);
@@ -397,7 +397,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(5, DepositAmount::get())],
+					stashes: bounded_vec![(5, Deposit::get())],
 					checked: bounded_vec![3, 2, 1, 0]
 				}),
 			);
@@ -425,9 +425,9 @@ mod on_idle {
 
 			// register multi accounts for fast unstake
 			assert_ok!(FastUnstake::register_fast_unstake(RuntimeOrigin::signed(2)));
-			assert_eq!(Queue::<T>::get(1), Some(DepositAmount::get()));
+			assert_eq!(Queue::<T>::get(1), Some(Deposit::get()));
 			assert_ok!(FastUnstake::register_fast_unstake(RuntimeOrigin::signed(4)));
-			assert_eq!(Queue::<T>::get(3), Some(DepositAmount::get()));
+			assert_eq!(Queue::<T>::get(3), Some(Deposit::get()));
 
 			// assert 2 queue items are in Queue & None in Head to start with
 			assert_eq!(Queue::<T>::count(), 2);
@@ -478,7 +478,7 @@ mod on_idle {
 
 			// register for fast unstake
 			assert_ok!(FastUnstake::register_fast_unstake(RuntimeOrigin::signed(2)));
-			assert_eq!(Queue::<T>::get(1), Some(DepositAmount::get()));
+			assert_eq!(Queue::<T>::get(1), Some(Deposit::get()));
 
 			// process on idle
 			next_block(true);
@@ -490,7 +490,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3, 2, 1, 0]
 				})
 			);
@@ -520,7 +520,7 @@ mod on_idle {
 
 			// register for fast unstake
 			assert_ok!(FastUnstake::register_fast_unstake(RuntimeOrigin::signed(2)));
-			assert_eq!(Queue::<T>::get(1), Some(DepositAmount::get()));
+			assert_eq!(Queue::<T>::get(1), Some(Deposit::get()));
 
 			// process on idle
 			next_block(true);
@@ -532,7 +532,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3, 2, 1, 0]
 				})
 			);
@@ -561,7 +561,7 @@ mod on_idle {
 
 			// register for fast unstake
 			assert_ok!(FastUnstake::register_fast_unstake(RuntimeOrigin::signed(2)));
-			assert_eq!(Queue::<T>::get(1), Some(DepositAmount::get()));
+			assert_eq!(Queue::<T>::get(1), Some(Deposit::get()));
 
 			// process on idle
 			next_block(true);
@@ -573,7 +573,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3]
 				})
 			);
@@ -583,7 +583,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3, 2]
 				})
 			);
@@ -593,7 +593,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3, 2, 1]
 				})
 			);
@@ -603,7 +603,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3, 2, 1, 0]
 				})
 			);
@@ -639,13 +639,13 @@ mod on_idle {
 
 			// register for fast unstake
 			assert_ok!(FastUnstake::register_fast_unstake(RuntimeOrigin::signed(2)));
-			assert_eq!(Queue::<T>::get(1), Some(DepositAmount::get()));
+			assert_eq!(Queue::<T>::get(1), Some(Deposit::get()));
 
 			next_block(true);
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3]
 				})
 			);
@@ -654,7 +654,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3, 2]
 				})
 			);
@@ -663,7 +663,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3, 2, 1]
 				})
 			);
@@ -672,7 +672,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3, 2, 1, 0]
 				})
 			);
@@ -686,7 +686,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					// note era 0 is pruned to keep the vector length sane.
 					checked: bounded_vec![3, 2, 1, 4],
 				})
@@ -726,7 +726,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3]
 				})
 			);
@@ -735,7 +735,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3, 2]
 				})
 			);
@@ -748,7 +748,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3, 2]
 				})
 			);
@@ -757,7 +757,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3, 2]
 				})
 			);
@@ -772,7 +772,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3, 2, 4]
 				})
 			);
@@ -782,7 +782,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(1, DepositAmount::get())],
+					stashes: bounded_vec![(1, Deposit::get())],
 					checked: bounded_vec![3, 2, 4, 1]
 				})
 			);
@@ -836,7 +836,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(exposed, DepositAmount::get())],
+					stashes: bounded_vec![(exposed, Deposit::get())],
 					checked: bounded_vec![3]
 				})
 			);
@@ -844,7 +844,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(exposed, DepositAmount::get())],
+					stashes: bounded_vec![(exposed, Deposit::get())],
 					checked: bounded_vec![3, 2]
 				})
 			);
@@ -856,7 +856,7 @@ mod on_idle {
 				vec![
 					Event::Checking { eras: vec![3] },
 					Event::Checking { eras: vec![2] },
-					Event::Slashed { stash: exposed, amount: DepositAmount::get() },
+					Event::Slashed { stash: exposed, amount: Deposit::get() },
 					Event::Terminated
 				]
 			);
@@ -876,7 +876,7 @@ mod on_idle {
 			pallet_staking::ErasStakers::<T>::mutate(0, VALIDATORS_PER_ERA, |expo| {
 				expo.others.push(IndividualExposure { who: exposed, value: 0 as Balance });
 			});
-			Balances::make_free_balance_be(&exposed, DepositAmount::get() + 100);
+			Balances::make_free_balance_be(&exposed, Deposit::get() + 100);
 			assert_ok!(Staking::bond(
 				RuntimeOrigin::signed(exposed),
 				exposed,
@@ -893,7 +893,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(exposed, DepositAmount::get())],
+					stashes: bounded_vec![(exposed, Deposit::get())],
 					checked: bounded_vec![3, 2]
 				})
 			);
@@ -905,7 +905,7 @@ mod on_idle {
 				// we slash them
 				vec![
 					Event::Checking { eras: vec![3, 2] },
-					Event::Slashed { stash: exposed, amount: DepositAmount::get() },
+					Event::Slashed { stash: exposed, amount: Deposit::get() },
 					Event::Terminated
 				]
 			);
@@ -937,7 +937,7 @@ mod on_idle {
 
 			assert_eq!(
 				fast_unstake_events_since_last_call(),
-				vec![Event::Slashed { stash: 100, amount: DepositAmount::get() }, Event::Terminated]
+				vec![Event::Slashed { stash: 100, amount: Deposit::get() }, Event::Terminated]
 			);
 		});
 	}
@@ -949,7 +949,7 @@ mod on_idle {
 			CurrentEra::<T>::put(BondingDuration::get());
 
 			// create a new validator that 100% not exposed.
-			Balances::make_free_balance_be(&42, 100 + DepositAmount::get());
+			Balances::make_free_balance_be(&42, 100 + Deposit::get());
 			assert_ok!(Staking::bond(RuntimeOrigin::signed(42), 42, 10, RewardDestination::Staked));
 			assert_ok!(Staking::validate(RuntimeOrigin::signed(42), Default::default()));
 
@@ -961,7 +961,7 @@ mod on_idle {
 			assert_eq!(
 				Head::<T>::get(),
 				Some(UnstakeRequest {
-					stashes: bounded_vec![(42, DepositAmount::get())],
+					stashes: bounded_vec![(42, Deposit::get())],
 					checked: bounded_vec![3, 2, 1, 0]
 				})
 			);

--- a/frame/fast-unstake/src/types.rs
+++ b/frame/fast-unstake/src/types.rs
@@ -41,5 +41,3 @@ pub struct UnstakeRequest<T: Config> {
 	/// The list of eras for which they have been checked.
 	pub(crate) checked: BoundedVec<EraIndex, MaxChecking<T>>,
 }
-
-// TODO: If we fail at reading the head, we should just remove it.

--- a/frame/fast-unstake/src/types.rs
+++ b/frame/fast-unstake/src/types.rs
@@ -17,14 +17,14 @@
 
 //! Types used in the Fast Unstake pallet.
 
+use crate::{Config, MaxChecking};
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
-	traits::{Currency, Get},
-	BoundedVec, EqNoBound, PartialEqNoBound, RuntimeDebugNoBound,
+	traits::Currency, BoundedVec, EqNoBound, PartialEqNoBound, RuntimeDebugNoBound,
 };
 use scale_info::TypeInfo;
 use sp_staking::EraIndex;
-use sp_std::{fmt::Debug, prelude::*};
+use sp_std::prelude::*;
 
 pub type BalanceOf<T> = <<T as pallet_staking::Config>::Currency as Currency<
 	<T as frame_system::Config>::AccountId,
@@ -34,15 +34,12 @@ pub type BalanceOf<T> = <<T as pallet_staking::Config>::Currency as Currency<
 #[derive(
 	Encode, Decode, EqNoBound, PartialEqNoBound, Clone, TypeInfo, RuntimeDebugNoBound, MaxEncodedLen,
 )]
-pub struct UnstakeRequest<
-	AccountId: Eq + PartialEq + Debug,
-	MaxChecked: Get<u32>,
-	Balance: PartialEq + Debug,
-> {
-	/// Their stash account.
-	pub(crate) stash: AccountId,
+#[scale_info(skip_type_params(T))]
+pub struct UnstakeRequest<T: Config> {
+	/// This list of stashes being processed in this request, and their corresponding deposit.
+	pub(crate) stashes: BoundedVec<(T::AccountId, BalanceOf<T>), T::BatchSize>,
 	/// The list of eras for which they have been checked.
-	pub(crate) checked: BoundedVec<EraIndex, MaxChecked>,
-	/// Deposit to be slashed if the unstake was unsuccessful.
-	pub(crate) deposit: Balance,
+	pub(crate) checked: BoundedVec<EraIndex, MaxChecking<T>>,
 }
+
+// TODO: If we fail at reading the head, we should just remove it.


### PR DESCRIPTION
This will increase the throughput of the fast unstake pallet by an easy 64-128x factor with very little extra resources consumed.

