### PR TITLE
Implement `Clone` and `Default` for `Config`

### DIFF
--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -567,10 +567,10 @@ pub struct Config {
 // left for the stack; this is, of course, overridable at link time when compiling the runtime)
 // plus the number of pages specified in the `extra_heap_pages` passed to the executor.
 //
-// By default, rustc (or `lld` specifically) should allocate 1 MiB for the shadow stack, or 16 pages.
-// The data section for runtimes are typically rather small and can fit in a single digit number of
-// WASM pages, so let's say an extra 16 pages. Thus let's assume that 32 pages or 2 MiB are used for
-// these needs by default.
+// By default, rustc (or `lld` specifically) should allocate 1 MiB for the shadow stack, or 16
+// pages. The data section for runtimes are typically rather small and can fit in a single digit
+// number of WASM pages, so let's say an extra 16 pages. Thus let's assume that 32 pages or 2 MiB
+// are used for these needs by default.
 const DEFAULT_HEAP_PAGES_ESTIMATE: u64 = 32;
 const EXTRA_HEAP_PAGES: u64 = 2048;
 
@@ -586,34 +586,35 @@ impl Default for Config {
 				extra_heap_pages: EXTRA_HEAP_PAGES,
 
 				// NOTE: This is specified in bytes, so we multiply by WASM page size.
-				max_memory_size: Some(((DEFAULT_HEAP_PAGES_ESTIMATE + EXTRA_HEAP_PAGES) * 65536) as usize),
+				max_memory_size: Some(
+					((DEFAULT_HEAP_PAGES_ESTIMATE + EXTRA_HEAP_PAGES) * 65536) as usize,
+				),
 
-				instantiation_strategy:
-					InstantiationStrategy::RecreateInstanceCopyOnWrite,
+				instantiation_strategy: InstantiationStrategy::RecreateInstanceCopyOnWrite,
 
-				// Enable deterministic stack limit to pin down the exact number of items the wasmtime stack
-				// can contain before it traps with stack overflow.
+				// Enable deterministic stack limit to pin down the exact number of items the
+				// wasmtime stack can contain before it traps with stack overflow.
 				//
 				// Here is how the values below were chosen.
 				//
-				// At the moment of writing, the default native stack size limit is 1 MiB. Assuming a logical item
-				// (see the docs about the field and the instrumentation algorithm) is 8 bytes, 1 MiB can
-				// fit 2x 65536 logical items.
+				// At the moment of writing, the default native stack size limit is 1 MiB. Assuming
+				// a logical item (see the docs about the field and the instrumentation algorithm)
+				// is 8 bytes, 1 MiB can fit 2x 65536 logical items.
 				//
-				// Since reaching the native stack limit is undesirable, we halve the logical item limit and
-				// also increase the native 256x. This hopefully should preclude wasm code from reaching
-				// the stack limit set by the wasmtime.
+				// Since reaching the native stack limit is undesirable, we halve the logical item
+				// limit and also increase the native 256x. This hopefully should preclude wasm code
+				// from reaching the stack limit set by the wasmtime.
 				deterministic_stack_limit: Some(DeterministicStackLimit {
 					logical_max: 65536,
 					native_stack_max: NATIVE_STACK_MAX,
 				}),
 				canonicalize_nans: true,
-				// Rationale for turning the multi-threaded compilation off is to make the preparation time
-				// easily reproducible and as deterministic as possible.
+				// Rationale for turning the multi-threaded compilation off is to make the
+				// preparation time easily reproducible and as deterministic as possible.
 				//
-				// Currently the prepare queue doesn't distinguish between precheck and prepare requests.
-				// On the one hand, it simplifies the code, on the other, however, slows down compile times
-				// for execute requests. This behavior may change in future.
+				// Currently the prepare queue doesn't distinguish between precheck and prepare
+				// requests. On the one hand, it simplifies the code, on the other, however, slows
+				// down compile times for execute requests. This behavior may change in future.
 				parallel_compilation: false,
 			},
 		}

--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -559,68 +559,6 @@ pub struct Config {
 	pub semantics: Semantics,
 }
 
-// Memory configuration
-//
-// When Substrate Runtime is instantiated, a number of WASM pages are allocated for the Substrate
-// Runtime instance's linear memory. The exact number of pages is a sum of whatever the WASM blob
-// itself requests (by default at least enough to hold the data section as well as have some space
-// left for the stack; this is, of course, overridable at link time when compiling the runtime)
-// plus the number of pages specified in the `extra_heap_pages` passed to the executor.
-//
-// By default, rustc (or `lld` specifically) should allocate 1 MiB for the shadow stack, or 16
-// pages. The data section for runtimes are typically rather small and can fit in a single digit
-// number of WASM pages, so let's say an extra 16 pages. Thus let's assume that 32 pages or 2 MiB
-// are used for these needs by default.
-const DEFAULT_HEAP_PAGES_ESTIMATE: u64 = 32;
-const EXTRA_HEAP_PAGES: u64 = 2048;
-
-/// The number of bytes devoted for the stack during wasm execution of a PVF.
-const NATIVE_STACK_MAX: u32 = 256 * 1024 * 1024;
-
-impl Default for Config {
-	fn default() -> Self {
-		Config {
-			allow_missing_func_imports: true,
-			cache_path: None,
-			semantics: Semantics {
-				extra_heap_pages: EXTRA_HEAP_PAGES,
-
-				// NOTE: This is specified in bytes, so we multiply by WASM page size.
-				max_memory_size: Some(
-					((DEFAULT_HEAP_PAGES_ESTIMATE + EXTRA_HEAP_PAGES) * 65536) as usize,
-				),
-
-				instantiation_strategy: InstantiationStrategy::RecreateInstanceCopyOnWrite,
-
-				// Enable deterministic stack limit to pin down the exact number of items the
-				// wasmtime stack can contain before it traps with stack overflow.
-				//
-				// Here is how the values below were chosen.
-				//
-				// At the moment of writing, the default native stack size limit is 1 MiB. Assuming
-				// a logical item (see the docs about the field and the instrumentation algorithm)
-				// is 8 bytes, 1 MiB can fit 2x 65536 logical items.
-				//
-				// Since reaching the native stack limit is undesirable, we halve the logical item
-				// limit and also increase the native 256x. This hopefully should preclude wasm code
-				// from reaching the stack limit set by the wasmtime.
-				deterministic_stack_limit: Some(DeterministicStackLimit {
-					logical_max: 65536,
-					native_stack_max: NATIVE_STACK_MAX,
-				}),
-				canonicalize_nans: true,
-				// Rationale for turning the multi-threaded compilation off is to make the
-				// preparation time easily reproducible and as deterministic as possible.
-				//
-				// Currently the prepare queue doesn't distinguish between precheck and prepare
-				// requests. On the one hand, it simplifies the code, on the other, however, slows
-				// down compile times for execute requests. This behavior may change in future.
-				parallel_compilation: false,
-			},
-		}
-	}
-}
-
 enum CodeSupplyMode<'a> {
 	/// The runtime is instantiated using the given runtime blob.
 	Fresh(RuntimeBlob),

--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -544,6 +544,7 @@ pub struct Semantics {
 	pub max_memory_size: Option<usize>,
 }
 
+#[derive(Clone)]
 pub struct Config {
 	/// The WebAssembly standard requires all imports of an instantiated module to be resolved,
 	/// otherwise, the instantiation fails. If this option is set to `true`, then this behavior is
@@ -556,6 +557,67 @@ pub struct Config {
 
 	/// Tuning of various semantics of the wasmtime executor.
 	pub semantics: Semantics,
+}
+
+// Memory configuration
+//
+// When Substrate Runtime is instantiated, a number of WASM pages are allocated for the Substrate
+// Runtime instance's linear memory. The exact number of pages is a sum of whatever the WASM blob
+// itself requests (by default at least enough to hold the data section as well as have some space
+// left for the stack; this is, of course, overridable at link time when compiling the runtime)
+// plus the number of pages specified in the `extra_heap_pages` passed to the executor.
+//
+// By default, rustc (or `lld` specifically) should allocate 1 MiB for the shadow stack, or 16 pages.
+// The data section for runtimes are typically rather small and can fit in a single digit number of
+// WASM pages, so let's say an extra 16 pages. Thus let's assume that 32 pages or 2 MiB are used for
+// these needs by default.
+const DEFAULT_HEAP_PAGES_ESTIMATE: u64 = 32;
+const EXTRA_HEAP_PAGES: u64 = 2048;
+
+/// The number of bytes devoted for the stack during wasm execution of a PVF.
+const NATIVE_STACK_MAX: u32 = 256 * 1024 * 1024;
+
+impl Default for Config {
+	fn default() -> Self {
+		Config {
+			allow_missing_func_imports: true,
+			cache_path: None,
+			semantics: Semantics {
+				extra_heap_pages: EXTRA_HEAP_PAGES,
+
+				// NOTE: This is specified in bytes, so we multiply by WASM page size.
+				max_memory_size: Some(((DEFAULT_HEAP_PAGES_ESTIMATE + EXTRA_HEAP_PAGES) * 65536) as usize),
+
+				instantiation_strategy:
+					InstantiationStrategy::RecreateInstanceCopyOnWrite,
+
+				// Enable deterministic stack limit to pin down the exact number of items the wasmtime stack
+				// can contain before it traps with stack overflow.
+				//
+				// Here is how the values below were chosen.
+				//
+				// At the moment of writing, the default native stack size limit is 1 MiB. Assuming a logical item
+				// (see the docs about the field and the instrumentation algorithm) is 8 bytes, 1 MiB can
+				// fit 2x 65536 logical items.
+				//
+				// Since reaching the native stack limit is undesirable, we halve the logical item limit and
+				// also increase the native 256x. This hopefully should preclude wasm code from reaching
+				// the stack limit set by the wasmtime.
+				deterministic_stack_limit: Some(DeterministicStackLimit {
+					logical_max: 65536,
+					native_stack_max: NATIVE_STACK_MAX,
+				}),
+				canonicalize_nans: true,
+				// Rationale for turning the multi-threaded compilation off is to make the preparation time
+				// easily reproducible and as deterministic as possible.
+				//
+				// Currently the prepare queue doesn't distinguish between precheck and prepare requests.
+				// On the one hand, it simplifies the code, on the other, however, slows down compile times
+				// for execute requests. This behavior may change in future.
+				parallel_compilation: false,
+			},
+		}
+	}
 }
 
 enum CodeSupplyMode<'a> {


### PR DESCRIPTION
This is a preparation stage for [polkadot#4212](https://github.com/paritytech/polkadot/issues/4212). It does not affect any existing functionality.

# What?
This PR contains two closely related but separate changes:
1. Derive `Clone` for `Config`;
2. Implement `Default` for `Config` which is returning not just an empty structure but some reasonable fallback defaults.

# Why?
1. `sc_executor_wasmtime` is designed to [consume](https://github.com/paritytech/substrate/blob/s0me0ne/executor-config-fixes/client/executor/wasmtime/src/runtime.rs#L671) the config instead of borrowing it. I believe this is due to the possibility of [replacement](https://github.com/paritytech/substrate/blob/s0me0ne/executor-config-fixes/client/executor/wasmtime/src/runtime.rs#L809) of instantiation strategy inside it in some cases. It works fine while config is set by a [constant value](https://github.com/paritytech/polkadot/blob/master/node/core/pvf/src/executor_intf.rs#L49). The task of execution environment parametrization introduces a need to hold that config as a part of abstract executor structure, owned by that structure. Option are either to rewrite `sc_executor_wasmtime` code  to borrow the config instead of consuming it, or to make it possible to create config clones. By the principle of least impact, the latter approach was chosen.
2. Right now execution environment conifg is set by an external component (in my case by the [PVF executor interface](https://github.com/paritytech/polkadot/blob/master/node/core/pvf/src/executor_intf.rs#L49)) and that is totally correct solution. Nevertheless, it is pretty logical for any execution environment to provide some failsafe default which can be used out-of-the-box. First case where it could be useful is tests. You don't usually want to define a whole config for test unless you're testing with some specific parameters, you just want some safe defaults. Another case is migrations. After execution environment will have been paramertized, we'll get into the situation with older PVFs which haven't ever got a set of parameters bound to them but still need to be executed with some set of parameters. To provide a default set of parameters from the execution environment itself is just more convenient than to define them as a constant in execution environment interface. Config values used in this PR are nothing new by themselves, they are a verbatim copy of values used in [PVF executor interface](https://github.com/paritytech/polkadot/blob/master/node/core/pvf/src/executor_intf.rs#L49).
