### PR TITLE
Add @koute to `docs/CODEOWNERS` and update stale paths

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -24,8 +24,19 @@
 /.gitlab-ci.yml @paritytech/ci
 
 # Sandboxing capability of Substrate Runtime
-/primitives/sr-sandbox/ @pepyakin
-/primitives/core/src/sandbox.rs @pepyakin
+/primitives/sandbox/ @pepyakin @koute
+
+# WASM executor, low-level client <-> WASM interface and other WASM-related code
+/client/executor/ @koute
+/client/allocator/ @koute
+/primitives/wasm-interface/ @koute
+/primitives/runtime-interface/ @koute
+/primitives/panic-handler/ @koute
+/utils/wasm-builder/ @koute
+
+# Systems-related bits and bobs on the client side
+/client/sysinfo/ @koute
+/client/tracing/ @koute
 
 # GRANDPA, BABE, consensus stuff
 /frame/babe/ @andresilva


### PR DESCRIPTION
I saw the other PR (https://github.com/paritytech/substrate/pull/12406) and thought it'd be a good idea to add myself there too.

I also fixed the paths to which @pepyakin was assigned (both don't exist anymore from what I can see).