### PR TITLE
[pallet-proxy] Making (height, ext_index) optional in kill_pure()

### DIFF
--- a/frame/proxy/src/benchmarking.rs
+++ b/frame/proxy/src/benchmarking.rs
@@ -249,13 +249,11 @@ benchmarks! {
 			T::BlockNumber::zero(),
 			0
 		)?;
-		let height = system::Pallet::<T>::block_number();
-		let ext_index = system::Pallet::<T>::extrinsic_index().unwrap_or(0);
 		let pure_account = Pallet::<T>::pure_account(&caller, &T::ProxyType::default(), 0, None);
 
 		add_proxies::<T>(p, Some(pure_account.clone()))?;
 		ensure!(Proxies::<T>::contains_key(&pure_account), "pure proxy not created");
-	}: _(RawOrigin::Signed(pure_account.clone()), caller_lookup, T::ProxyType::default(), 0, height, ext_index)
+	}: _(RawOrigin::Signed(caller), T::ProxyType::default(), 0, None)
 	verify {
 		assert!(!Proxies::<T>::contains_key(&pure_account));
 	}

--- a/frame/proxy/src/benchmarking.rs
+++ b/frame/proxy/src/benchmarking.rs
@@ -253,7 +253,7 @@ benchmarks! {
 
 		add_proxies::<T>(p, Some(pure_account.clone()))?;
 		ensure!(Proxies::<T>::contains_key(&pure_account), "pure proxy not created");
-	}: _(RawOrigin::Signed(caller), T::ProxyType::default(), 0, None)
+	}: _(RawOrigin::Signed(pure_account.clone()), caller_lookup, T::ProxyType::default(), 0, None)
 	verify {
 		assert!(!Proxies::<T>::contains_key(&pure_account));
 	}

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -24,7 +24,9 @@ use super::*;
 use crate as proxy;
 use codec::{Decode, Encode};
 use frame_support::{
-	assert_noop, assert_ok, parameter_types,
+	assert_noop, assert_ok,
+	dispatch::DispatchError,
+	parameter_types,
 	traits::{ConstU32, ConstU64, Contains},
 	RuntimeDebug,
 };
@@ -565,7 +567,7 @@ fn pure_works() {
 		// other calls to pure allowed as long as they're not exactly the same.
 		assert_ok!(Proxy::create_pure(RuntimeOrigin::signed(1), ProxyType::JustTransfer, 0, 0));
 		assert_ok!(Proxy::create_pure(RuntimeOrigin::signed(1), ProxyType::Any, 0, 1));
-
+		let anon2 = Proxy::pure_account(&2, &ProxyType::Any, 0, None);
 		assert_ok!(Proxy::create_pure(RuntimeOrigin::signed(2), ProxyType::Any, 0, 0));
 		assert_noop!(
 			Proxy::create_pure(RuntimeOrigin::signed(1), ProxyType::Any, 0, 0),
@@ -577,21 +579,28 @@ fn pure_works() {
 
 		let call = Box::new(call_transfer(6, 1));
 		assert_ok!(Balances::transfer(RuntimeOrigin::signed(3), anon, 5));
-		assert_ok!(Proxy::proxy(RuntimeOrigin::signed(1), anon, None, call.clone()));
+		assert_ok!(Proxy::proxy(RuntimeOrigin::signed(1), anon, None, call));
 		System::assert_last_event(ProxyEvent::ProxyExecuted { result: Ok(()) }.into());
 		assert_eq!(Balances::free_balance(6), 1);
 
+		let call = Box::new(RuntimeCall::Proxy(ProxyCall::new_call_variant_kill_pure(
+			1,
+			ProxyType::Any,
+			0,
+			None,
+		)));
+		assert_ok!(Proxy::proxy(RuntimeOrigin::signed(2), anon2, None, call.clone()));
+		let de = DispatchError::from(Error::<Test>::NoPermission).stripped();
+		System::assert_last_event(ProxyEvent::ProxyExecuted { result: Err(de) }.into());
 		assert_noop!(
-			Proxy::kill_pure(RuntimeOrigin::signed(3), ProxyType::Any, 0, None),
-			Error::<Test>::NotFound
+			Proxy::kill_pure(RuntimeOrigin::signed(1), 1, ProxyType::Any, 0, None),
+			Error::<Test>::NoPermission
 		);
-		assert_ok!(Proxy::kill_pure(RuntimeOrigin::signed(2), ProxyType::Any, 0, None));
-
 		assert_eq!(Balances::free_balance(1), 0);
-		assert_ok!(Proxy::kill_pure(RuntimeOrigin::signed(1), ProxyType::Any, 0, None));
+		assert_ok!(Proxy::proxy(RuntimeOrigin::signed(1), anon, None, call.clone()));
 		assert_eq!(Balances::free_balance(1), 2);
 		assert_noop!(
-			Proxy::proxy(RuntimeOrigin::signed(1), anon, None, call),
+			Proxy::proxy(RuntimeOrigin::signed(1), anon, None, call.clone()),
 			Error::<Test>::NotProxy
 		);
 	});


### PR DESCRIPTION
This PR removes the need to set `height` and `ext_index` parameters in the `kill_pure()` extrinsic making it more user friendly.

I've put both parameters in an `Option<(T::BlockNumber, u32)>` to keep it back compatible with the current design.

If this PR lands, the `spawner` (only) will be able to kill a pure proxy by sending its `proxy_type` and `index` (avoiding keep track of when it was created).