### PR TITLE
Use saturating add for alliance::disband witness data

### DIFF
--- a/frame/alliance/src/lib.rs
+++ b/frame/alliance/src/lib.rs
@@ -706,7 +706,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::disband(
 			witness.voting_members,
 			witness.ally_members,
-			witness.voting_members + witness.ally_members,
+			witness.voting_members.saturating_add(witness.ally_members),
 		))]
 		pub fn disband(
 			origin: OriginFor<T>,


### PR DESCRIPTION
Overflow is possible.

Fixes https://github.com/paritytech/srlabs_findings/issues/230