### PR TITLE
Adapt `pallet-contracts` to WeightV2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5531,6 +5531,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-runtime",
  "sp-std",
+ "sp-weights",
 ]
 
 [[package]]

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1175,7 +1175,6 @@ impl pallet_contracts::Config for Runtime {
 	type DeletionWeightLimit = DeletionWeightLimit;
 	type Schedule = Schedule;
 	type AddressGenerator = pallet_contracts::DefaultAddressGenerator;
-	type ContractAccessWeight = pallet_contracts::DefaultContractAccessWeight<RuntimeBlockWeights>;
 	type MaxCodeLen = ConstU32<{ 128 * 1024 }>;
 	type MaxStorageKeyLen = ConstU32<128>;
 }

--- a/frame/contracts/primitives/Cargo.toml
+++ b/frame/contracts/primitives/Cargo.toml
@@ -19,6 +19,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 # Substrate Dependencies (This crate should not rely on frame)
 sp-std = { version = "4.0.0", default-features = false, path = "../../../primitives/std" }
 sp-runtime = { version = "6.0.0", default-features = false, path = "../../../primitives/runtime" }
+sp-weights = { version = "4.0.0", default-features = false, path = "../../../primitives/weights" }
 
 [features]
 default = ["std"]

--- a/frame/contracts/primitives/src/lib.rs
+++ b/frame/contracts/primitives/src/lib.rs
@@ -26,25 +26,26 @@ use sp_runtime::{
 	DispatchError, RuntimeDebug,
 };
 use sp_std::prelude::*;
+use sp_weights::Weight;
 
 /// Result type of a `bare_call` or `bare_instantiate` call.
 ///
 /// It contains the execution result together with some auxiliary information.
 #[derive(Eq, PartialEq, Encode, Decode, RuntimeDebug)]
 pub struct ContractResult<R, Balance> {
-	/// How much gas was consumed during execution.
-	pub gas_consumed: u64,
-	/// How much gas is required as gas limit in order to execute this call.
+	/// How much weight was consumed during execution.
+	pub gas_consumed: Weight,
+	/// How much weight is required as gas limit in order to execute this call.
 	///
-	/// This value should be used to determine the gas limit for on-chain execution.
+	/// This value should be used to determine the weight limit for on-chain execution.
 	///
 	/// # Note
 	///
-	/// This can only different from [`Self::gas_consumed`] when weight pre charging
+	/// This can only different from [`Self::weight_consumed`] when weight pre charging
 	/// is used. Currently, only `seal_call_runtime` makes use of pre charging.
 	/// Additionally, any `seal_call` or `seal_instantiate` makes use of pre-charging
 	/// when a non-zero `gas_limit` argument is supplied.
-	pub gas_required: u64,
+	pub gas_required: Weight,
 	/// How much balance was deposited and reserved during execution in order to pay for storage.
 	///
 	/// The storage deposit is never actually charged from the caller in case of [`Self::result`]

--- a/frame/contracts/primitives/src/lib.rs
+++ b/frame/contracts/primitives/src/lib.rs
@@ -41,7 +41,7 @@ pub struct ContractResult<R, Balance> {
 	///
 	/// # Note
 	///
-	/// This can only different from [`Self::weight_consumed`] when weight pre charging
+	/// This can only different from [`Self::gas_consumed`] when weight pre charging
 	/// is used. Currently, only `seal_call_runtime` makes use of pre charging.
 	/// Additionally, any `seal_call` or `seal_instantiate` makes use of pre-charging
 	/// when a non-zero `gas_limit` argument is supplied.

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -1015,8 +1015,8 @@ where
 		);
 		ContractExecResult {
 			result: output.result.map_err(|r| r.error),
-			gas_consumed: output.gas_meter.gas_consumed().ref_time(),
-			gas_required: output.gas_meter.gas_required().ref_time(),
+			gas_consumed: output.gas_meter.gas_consumed(),
+			gas_required: output.gas_meter.gas_required(),
 			storage_deposit: output.storage_deposit,
 			debug_message: debug_message.unwrap_or_default(),
 		}
@@ -1060,8 +1060,8 @@ where
 				.result
 				.map(|(account_id, result)| InstantiateReturnValue { result, account_id })
 				.map_err(|e| e.error),
-			gas_consumed: output.gas_meter.gas_consumed().ref_time(),
-			gas_required: output.gas_meter.gas_required().ref_time(),
+			gas_consumed: output.gas_meter.gas_consumed(),
+			gas_required: output.gas_meter.gas_required(),
 			storage_deposit: output.storage_deposit,
 			debug_message: debug_message.unwrap_or_default(),
 		}

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -823,8 +823,6 @@ fn deploy_and_call_other_contract() {
 		// Drop previous events
 		initialize_block(2);
 
-		println!("--------------");
-
 		// Call BOB contract, which attempts to instantiate and call the callee contract and
 		// makes various assertions on the results from those calls.
 		assert_ok!(Contracts::call(

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -823,6 +823,8 @@ fn deploy_and_call_other_contract() {
 		// Drop previous events
 		initialize_block(2);
 
+		println!("--------------");
+
 		// Call BOB contract, which attempts to instantiate and call the callee contract and
 		// makes various assertions on the results from those calls.
 		assert_ok!(Contracts::call(
@@ -2411,7 +2413,8 @@ fn reinstrument_does_charge() {
 		assert!(result2.gas_consumed.ref_time() > result1.gas_consumed.ref_time());
 		assert_eq!(
 			result2.gas_consumed.ref_time(),
-			result1.gas_consumed.ref_time() + <Test as Config>::WeightInfo::reinstrument(code_len).ref_time(),
+			result1.gas_consumed.ref_time() +
+				<Test as Config>::WeightInfo::reinstrument(code_len).ref_time(),
 		);
 	});
 }

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -1759,7 +1759,7 @@ fn chain_extension_works() {
 			false,
 		);
 		assert_ok!(result.result);
-		assert_eq!(result.gas_consumed, gas_consumed + 42);
+		assert_eq!(result.gas_consumed.ref_time(), gas_consumed.ref_time() + 42);
 		let result = Contracts::bare_call(
 			ALICE,
 			addr.clone(),
@@ -1770,7 +1770,7 @@ fn chain_extension_works() {
 			false,
 		);
 		assert_ok!(result.result);
-		assert_eq!(result.gas_consumed, gas_consumed + 95);
+		assert_eq!(result.gas_consumed.ref_time(), gas_consumed.ref_time() + 95);
 
 		// 3 = diverging chain extension call that sets flags to 0x1 and returns a fixed buffer
 		let result = Contracts::bare_call(
@@ -2408,10 +2408,10 @@ fn reinstrument_does_charge() {
 		let result2 =
 			Contracts::bare_call(ALICE, addr.clone(), 0, GAS_LIMIT, None, zero.clone(), false);
 		assert!(!result2.result.unwrap().did_revert());
-		assert!(result2.gas_consumed > result1.gas_consumed);
+		assert!(result2.gas_consumed.ref_time() > result1.gas_consumed.ref_time());
 		assert_eq!(
-			result2.gas_consumed,
-			result1.gas_consumed + <Test as Config>::WeightInfo::reinstrument(code_len).ref_time(),
+			result2.gas_consumed.ref_time(),
+			result1.gas_consumed.ref_time() + <Test as Config>::WeightInfo::reinstrument(code_len).ref_time(),
 		);
 	});
 }
@@ -2535,7 +2535,7 @@ fn gas_estimation_nested_call_fixed_limit() {
 		assert_ok!(&result.result);
 
 		// We have a subcall with a fixed gas limit. This constitutes precharging.
-		assert!(result.gas_required > result.gas_consumed);
+		assert!(result.gas_required.ref_time() > result.gas_consumed.ref_time());
 
 		// Make the same call using the estimated gas. Should succeed.
 		assert_ok!(
@@ -2543,7 +2543,7 @@ fn gas_estimation_nested_call_fixed_limit() {
 				ALICE,
 				addr_caller,
 				0,
-				Weight::from_ref_time(result.gas_required).set_proof_size(u64::MAX),
+				result.gas_required,
 				Some(result.storage_deposit.charge_or_zero()),
 				input,
 				false,
@@ -2607,7 +2607,7 @@ fn gas_estimation_call_runtime() {
 		// contract encodes the result of the dispatch runtime
 		let outcome = u32::decode(&mut result.result.unwrap().data.as_ref()).unwrap();
 		assert_eq!(outcome, 0);
-		assert!(result.gas_required > result.gas_consumed);
+		assert!(result.gas_required.ref_time() > result.gas_consumed.ref_time());
 
 		// Make the same call using the required gas. Should succeed.
 		assert_ok!(
@@ -2615,7 +2615,7 @@ fn gas_estimation_call_runtime() {
 				ALICE,
 				addr_caller,
 				0,
-				Weight::from_ref_time(result.gas_required).set_proof_size(u64::MAX),
+				result.gas_required,
 				None,
 				call.encode(),
 				false,

--- a/frame/contracts/src/wasm/code_cache.rs
+++ b/frame/contracts/src/wasm/code_cache.rs
@@ -228,16 +228,11 @@ impl<T: Config> Token<T> for CodeToken {
 		// contract code. This is why we subtract `T::*::(0)`. We need to do this at this
 		// point because when charging the general weight for calling the contract we not know the
 		// size of the contract.
-		let ref_time_weight = match *self {
+		match *self {
 			Reinstrument(len) => T::WeightInfo::reinstrument(len),
-			Load(len) => {
-				let computation = T::WeightInfo::call_with_code_per_byte(len)
-					.saturating_sub(T::WeightInfo::call_with_code_per_byte(0));
-				let bandwidth = T::ContractAccessWeight::get().saturating_mul(len as u64);
-				computation.max(bandwidth)
-			},
-		};
-
-		ref_time_weight
+			Load(len) => T::WeightInfo::call_with_code_per_byte(len)
+				.saturating_sub(T::WeightInfo::call_with_code_per_byte(0))
+				.set_proof_size(len.into()),
+		}
 	}
 }


### PR DESCRIPTION
A few changes were necessary to make `pallet-contracts` compatible with the new weight.

### Remove `ContractAccessWeight`

This was a workaround used to emulate the huge PoV impact generated by loading a contract. This is now replaced by setting the `proof_size` to the size of the loaded contract. This is an underestimation but the whole system is just in place to prevent the worst offenders. Charging for anything else is missing anyways and will come later.

### Return the whole `Weight` struct from dry runs

Dry runs now include the `proof_size` so that clients can use this to learn about how much `proof_size` a transaction will consume.

### Fix inter contract calls

`seal_call` and `seal_instantiate` allow only setting 1D weight. Eventually we need to add new versions of those. But the old versions need fixing, too. Current behavior is to set `proof_size` to `0` which is not a good default. It will prevent the callee to do anything useful. This PR sets the `proof_size` to "inherit" which allows it to use all of the remaining proof size from the overarching limit.

### Fix compatibility extrinsics

When adding the 2D weight we also added `*_old_weight` compat extrinsics to allow in-storage extrinsics to be still decoded. However, they also set `proof_size` to `0` which makes them useless. This PR sets some sensible default so they continue working. We also removed duplication in docs and code from them.

cumulus companion: https://github.com/paritytech/cumulus/pull/1726
Closes https://github.com/paritytech/substrate/issues/12410
