### PR TITLE
MMR: impl `TypeInfo` for some structures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9999,6 +9999,7 @@ dependencies = [
  "array-bytes",
  "log",
  "parity-scale-codec",
+ "scale-info",
  "serde",
  "sp-api",
  "sp-core",

--- a/client/beefy/rpc/src/lib.rs
+++ b/client/beefy/rpc/src/lib.rs
@@ -84,7 +84,7 @@ impl From<Error> for JsonRpseeError {
 // Provides RPC methods for interacting with BEEFY.
 #[rpc(client, server)]
 pub trait BeefyApi<Notification, Hash> {
-	/// Returns the block most recently finalized by BEEFY, alongside side its justification.
+	/// Returns the block most recently finalized by BEEFY, alongside its justification.
 	#[subscription(
 		name = "beefy_subscribeJustifications" => "beefy_justifications",
 		unsubscribe = "beefy_unsubscribeJustifications",

--- a/client/beefy/src/worker.rs
+++ b/client/beefy/src/worker.rs
@@ -508,7 +508,7 @@ where
 
 			if let Err(e) = self.backend.append_justification(
 				BlockId::Number(block_num),
-				(BEEFY_ENGINE_ID, finality_proof.clone().encode()),
+				(BEEFY_ENGINE_ID, finality_proof.encode()),
 			) {
 				error!(target: "beefy", "🥩 Error {:?} on appending justification: {:?}", e, finality_proof);
 			}

--- a/primitives/beefy/src/mmr.rs
+++ b/primitives/beefy/src/mmr.rs
@@ -44,7 +44,7 @@ impl BeefyDataProvider<Vec<u8>> for () {
 }
 
 /// A standard leaf that gets added every block to the MMR constructed by Substrate's `pallet_mmr`.
-#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, TypeInfo)]
 pub struct MmrLeaf<BlockNumber, Hash, MerkleRoot, ExtraData> {
 	/// Version of the leaf format.
 	///
@@ -73,7 +73,7 @@ pub struct MmrLeaf<BlockNumber, Hash, MerkleRoot, ExtraData> {
 /// Given that adding new struct elements in SCALE is backward compatible (i.e. old format can be
 /// still decoded, the new fields will simply be ignored). We expect the major version to be bumped
 /// very rarely (hopefuly never).
-#[derive(Debug, Default, PartialEq, Eq, Clone, Encode, Decode)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Encode, Decode, TypeInfo)]
 pub struct MmrLeafVersion(u8);
 impl MmrLeafVersion {
 	/// Create new version object from `major` and `minor` components.

--- a/primitives/merkle-mountain-range/Cargo.toml
+++ b/primitives/merkle-mountain-range/Cargo.toml
@@ -13,6 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
+scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 serde = { version = "1.0.136", features = ["derive"], optional = true }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }

--- a/primitives/merkle-mountain-range/src/lib.rs
+++ b/primitives/merkle-mountain-range/src/lib.rs
@@ -20,6 +20,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
 
+use scale_info::TypeInfo;
 use sp_debug_derive::RuntimeDebug;
 use sp_runtime::traits;
 #[cfg(not(feature = "std"))]
@@ -69,7 +70,7 @@ impl<Hash> OnNewRoot<Hash> for () {
 }
 
 /// A MMR proof data for one of the leaves.
-#[derive(codec::Encode, codec::Decode, RuntimeDebug, Clone, PartialEq, Eq)]
+#[derive(codec::Encode, codec::Decode, RuntimeDebug, Clone, PartialEq, Eq, TypeInfo)]
 pub struct Proof<Hash> {
 	/// The index of the leaf the proof is for.
 	pub leaf_index: LeafIndex,
@@ -352,7 +353,7 @@ impl_leaf_data_for_tuple!(A:0, B:1, C:2, D:3);
 impl_leaf_data_for_tuple!(A:0, B:1, C:2, D:3, E:4);
 
 /// A MMR proof data for a group of leaves.
-#[derive(codec::Encode, codec::Decode, RuntimeDebug, Clone, PartialEq, Eq)]
+#[derive(codec::Encode, codec::Decode, RuntimeDebug, Clone, PartialEq, Eq, TypeInfo)]
 pub struct BatchProof<Hash> {
 	/// The indices of the leaves the proof is for.
 	pub leaf_indices: Vec<LeafIndex>,


### PR DESCRIPTION
Related to: https://github.com/paritytech/parity-bridges-common/issues/1574

We are working on implementing BEEFY finality in the [bridges](https://github.com/paritytech/parity-bridges-common) project and as part of this we'll need to pass `MmrLeaf` and Mmr `Proof`/`BatchProof` structures as parameters for extrinsics. In order to do this we need them to implement TypeInfo.