### PR TITLE
Clarify the "direction" field of block requests

### DIFF
--- a/client/network/sync/src/schema/api.v1.proto
+++ b/client/network/sync/src/schema/api.v1.proto
@@ -26,6 +26,7 @@ message BlockRequest {
 	// End at this block. An implementation defined maximum is used when unspecified.
 	bytes to_block = 4; // optional
 	// Sequence direction.
+	// If missing, should be interpreted as "Ascending".
 	Direction direction = 5;
 	// Maximum number of blocks to return. An implementation defined maximum is used when unspecified.
 	uint32 max_blocks = 6; // optional


### PR DESCRIPTION
I've discovered a stupidity: when we send a block request, the "direction" field (i.e. is the starting block of the request the highest block or the lowest block) is either 0 or 1.
However, the protobuf library that we use can't make the difference between "missing field" and "field that contains a 0".
So whenever we send an "ascending" block request, we are in fact not indicating any direction.

For this reason, I'm opening this PR to clarify that the default value should be interpreted as "Ascending".

It could instead be fixable by releasing a version that also interprets "2" as "Ascending", then later a version that sends "2" for "Ascending", but I don't think it's worth the effort.
