### PR TITLE
Update UI tests for Rust 1.64

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ variables:
   CARGO_INCREMENTAL:               0
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  CI_IMAGE:                        "paritytech/ci-linux:production"
+  CI_IMAGE:                        "paritytech/ci-linux:staging"
   RUSTY_CACHIER_SINGLE_BRANCH:     master
   RUSTY_CACHIER_DONT_OPERATE_ON_MAIN_BRANCH: "true"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ variables:
   CARGO_INCREMENTAL:               0
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  CI_IMAGE:                        "paritytech/ci-linux:staging"
+  CI_IMAGE:                        "paritytech/ci-linux:production"
   RUSTY_CACHIER_SINGLE_BRANCH:     master
   RUSTY_CACHIER_DONT_OPERATE_ON_MAIN_BRANCH: "true"
 

--- a/frame/support/test/tests/construct_runtime_ui/no_std_genesis_config.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/no_std_genesis_config.stderr
@@ -10,7 +10,7 @@ error: `Pallet` does not have the std feature enabled, this will cause the `test
 49 | | }
    | |_^
    |
-   = note: this error originates in the macro `test_pallet::__substrate_genesis_config_check::is_std_enabled_for_genesis` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `test_pallet::__substrate_genesis_config_check::is_std_enabled_for_genesis` which comes from the expansion of the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0412]: cannot find type `GenesisConfig` in crate `test_pallet`
   --> tests/construct_runtime_ui/no_std_genesis_config.rs:40:1

--- a/frame/support/test/tests/construct_runtime_ui/pallet_error_too_large.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/pallet_error_too_large.stderr
@@ -10,4 +10,4 @@ error[E0080]: evaluation of constant value failed
 83 | | }
    | |_^ the evaluated program panicked at 'The maximum encoded size of the error type in the `Pallet` pallet exceeds `MAX_MODULE_ERROR_ENCODED_SIZE`', $DIR/tests/construct_runtime_ui/pallet_error_too_large.rs:74:1
    |
-   = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/frame/support/test/tests/construct_runtime_ui/undefined_call_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_call_part.stderr
@@ -13,4 +13,4 @@ error: `Pallet` does not have #[pallet::call] defined, perhaps you should remove
 58 | | }
    | |_- in this macro invocation
    |
-   = note: this error originates in the macro `pallet::__substrate_call_check::is_call_part_defined` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `pallet::__substrate_call_check::is_call_part_defined` which comes from the expansion of the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/frame/support/test/tests/construct_runtime_ui/undefined_event_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_event_part.stderr
@@ -13,7 +13,7 @@ error: `Pallet` does not have #[pallet::event] defined, perhaps you should remov
 58 | | }
    | |_- in this macro invocation
    |
-   = note: this error originates in the macro `pallet::__substrate_event_check::is_event_part_defined` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `pallet::__substrate_event_check::is_event_part_defined` which comes from the expansion of the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0412]: cannot find type `Event` in module `pallet`
   --> tests/construct_runtime_ui/undefined_event_part.rs:49:1

--- a/frame/support/test/tests/construct_runtime_ui/undefined_genesis_config_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_genesis_config_part.stderr
@@ -13,7 +13,7 @@ error: `Pallet` does not have #[pallet::genesis_config] defined, perhaps you sho
 58 | | }
    | |_- in this macro invocation
    |
-   = note: this error originates in the macro `pallet::__substrate_genesis_config_check::is_genesis_config_defined` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `pallet::__substrate_genesis_config_check::is_genesis_config_defined` which comes from the expansion of the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0412]: cannot find type `GenesisConfig` in module `pallet`
   --> tests/construct_runtime_ui/undefined_genesis_config_part.rs:49:1

--- a/frame/support/test/tests/construct_runtime_ui/undefined_inherent_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_inherent_part.stderr
@@ -13,13 +13,13 @@ error: `Pallet` does not have #[pallet::inherent] defined, perhaps you should re
 58 | | }
    | |_- in this macro invocation
    |
-   = note: this error originates in the macro `pallet::__substrate_inherent_check::is_inherent_part_defined` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `pallet::__substrate_inherent_check::is_inherent_part_defined` which comes from the expansion of the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no function or associated item named `create_inherent` found for struct `pallet::Pallet` in the current scope
   --> tests/construct_runtime_ui/undefined_inherent_part.rs:49:1
    |
 11 |       pub struct Pallet<T>(_);
-   |       ------------------------ function or associated item `create_inherent` not found for this
+   |       -------------------- function or associated item `create_inherent` not found for this struct
 ...
 49 | / construct_runtime! {
 50 | |     pub enum Runtime where
@@ -39,7 +39,7 @@ error[E0599]: no function or associated item named `is_inherent` found for struc
   --> tests/construct_runtime_ui/undefined_inherent_part.rs:49:1
    |
 11 |       pub struct Pallet<T>(_);
-   |       ------------------------ function or associated item `is_inherent` not found for this
+   |       -------------------- function or associated item `is_inherent` not found for this struct
 ...
 49 | / construct_runtime! {
 50 | |     pub enum Runtime where
@@ -59,7 +59,7 @@ error[E0599]: no function or associated item named `check_inherent` found for st
   --> tests/construct_runtime_ui/undefined_inherent_part.rs:49:1
    |
 11 |       pub struct Pallet<T>(_);
-   |       ------------------------ function or associated item `check_inherent` not found for this
+   |       -------------------- function or associated item `check_inherent` not found for this struct
 ...
 49 | / construct_runtime! {
 50 | |     pub enum Runtime where
@@ -79,7 +79,7 @@ error[E0599]: no associated item named `INHERENT_IDENTIFIER` found for struct `p
   --> tests/construct_runtime_ui/undefined_inherent_part.rs:49:1
    |
 11 |       pub struct Pallet<T>(_);
-   |       ------------------------ associated item `INHERENT_IDENTIFIER` not found for this
+   |       -------------------- associated item `INHERENT_IDENTIFIER` not found for this struct
 ...
 49 | / construct_runtime! {
 50 | |     pub enum Runtime where
@@ -99,7 +99,7 @@ error[E0599]: no function or associated item named `is_inherent_required` found 
   --> tests/construct_runtime_ui/undefined_inherent_part.rs:49:1
    |
 11 |       pub struct Pallet<T>(_);
-   |       ------------------------ function or associated item `is_inherent_required` not found for this
+   |       -------------------- function or associated item `is_inherent_required` not found for this struct
 ...
 49 | / construct_runtime! {
 50 | |     pub enum Runtime where

--- a/frame/support/test/tests/construct_runtime_ui/undefined_origin_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_origin_part.stderr
@@ -13,7 +13,7 @@ error: `Pallet` does not have #[pallet::origin] defined, perhaps you should remo
 58 | | }
    | |_- in this macro invocation
    |
-   = note: this error originates in the macro `pallet::__substrate_origin_check::is_origin_part_defined` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `pallet::__substrate_origin_check::is_origin_part_defined` which comes from the expansion of the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0412]: cannot find type `Origin` in module `pallet`
   --> tests/construct_runtime_ui/undefined_origin_part.rs:49:1
@@ -56,6 +56,10 @@ error[E0282]: type annotations needed
 ...  |
 57 | |     }
 58 | | }
-   | |_^ cannot infer type for type parameter `AccountId` declared on the enum `RawOrigin`
+   | |_^ cannot infer type of the type parameter `AccountId` declared on the enum `RawOrigin`
    |
    = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider specifying the generic argument
+   |
+58 | }::<AccountId>
+   |  +++++++++++++

--- a/frame/support/test/tests/construct_runtime_ui/undefined_validate_unsigned_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_validate_unsigned_part.stderr
@@ -13,22 +13,27 @@ error: `Pallet` does not have #[pallet::validate_unsigned] defined, perhaps you 
 58 | | }
    | |_- in this macro invocation
    |
-   = note: this error originates in the macro `pallet::__substrate_validate_unsigned_check::is_validate_unsigned_part_defined` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `pallet::__substrate_validate_unsigned_check::is_validate_unsigned_part_defined` which comes from the expansion of the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no variant or associated item named `Pallet` found for enum `RuntimeCall` in the current scope
   --> tests/construct_runtime_ui/undefined_validate_unsigned_part.rs:56:3
    |
-49 | construct_runtime! {
-   | ------------------ variant or associated item `Pallet` not found here
-...
-56 |         Pallet: pallet::{Pallet, ValidateUnsigned},
-   |         ^^^^^^ variant or associated item not found in `RuntimeCall`
+49 | / construct_runtime! {
+50 | |     pub enum Runtime where
+51 | |         Block = Block,
+52 | |         NodeBlock = Block,
+...  |
+56 | |         Pallet: pallet::{Pallet, ValidateUnsigned},
+   | |         ^^^^^^ variant or associated item not found in `RuntimeCall`
+57 | |     }
+58 | | }
+   | |_- variant or associated item `Pallet` not found for this enum
 
 error[E0599]: no function or associated item named `pre_dispatch` found for struct `pallet::Pallet` in the current scope
   --> tests/construct_runtime_ui/undefined_validate_unsigned_part.rs:49:1
    |
 11 |       pub struct Pallet<T>(_);
-   |       ------------------------ function or associated item `pre_dispatch` not found for this
+   |       -------------------- function or associated item `pre_dispatch` not found for this struct
 ...
 49 | / construct_runtime! {
 50 | |     pub enum Runtime where
@@ -49,7 +54,7 @@ error[E0599]: no function or associated item named `validate_unsigned` found for
   --> tests/construct_runtime_ui/undefined_validate_unsigned_part.rs:49:1
    |
 11 |       pub struct Pallet<T>(_);
-   |       ------------------------ function or associated item `validate_unsigned` not found for this
+   |       -------------------- function or associated item `validate_unsigned` not found for this struct
 ...
 49 | / construct_runtime! {
 50 | |     pub enum Runtime where

--- a/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_integrity_test.stderr
+++ b/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_integrity_test.stderr
@@ -10,7 +10,7 @@ error: `integrity_test` can only be passed once as input.
 7 | | }
   | |_^
   |
-  = note: this error originates in the macro `$crate::decl_module` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::decl_module` which comes from the expansion of the macro `frame_support::decl_module` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0601]: `main` function not found in crate `$CRATE`
  --> tests/decl_module_ui/reserved_keyword_two_times_integrity_test.rs:7:2

--- a/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_on_initialize.stderr
+++ b/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_on_initialize.stderr
@@ -1,5 +1,5 @@
 error: `on_initialize` can only be passed once as input.
-  --> $DIR/reserved_keyword_two_times_on_initialize.rs:1:1
+  --> tests/decl_module_ui/reserved_keyword_two_times_on_initialize.rs:1:1
    |
 1  | / frame_support::decl_module! {
 2  | |     pub struct Module<T: Config> for enum Call where origin: T::RuntimeOrigin, system=self {
@@ -10,4 +10,4 @@ error: `on_initialize` can only be passed once as input.
 11 | | }
    | |_^
    |
-   = note: this error originates in the macro `$crate::decl_module` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::decl_module` which comes from the expansion of the macro `frame_support::decl_module` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/frame/support/test/tests/derive_no_bound_ui/debug.stderr
+++ b/frame/support/test/tests/derive_no_bound_ui/debug.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `<T as Config>::C` doesn't implement `std::fmt::Debug`
- --> $DIR/debug.rs:7:2
+ --> tests/derive_no_bound_ui/debug.rs:7:2
   |
 7 |     c: T::C,
   |     ^ `<T as Config>::C` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
   |
   = help: the trait `std::fmt::Debug` is not implemented for `<T as Config>::C`
-  = note: required for the cast to the object type `dyn std::fmt::Debug`
+  = note: required for the cast from `<T as Config>::C` to the object type `dyn std::fmt::Debug`

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
@@ -6,7 +6,7 @@ error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
    = note: required because of the requirements on the impl of `std::fmt::Debug` for `&<T as pallet::Config>::Bar`
-   = note: required for the cast to the object type `dyn std::fmt::Debug`
+   = note: required for the cast from `&<T as pallet::Config>::Bar` to the object type `dyn std::fmt::Debug`
 
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: Clone` is not satisfied
   --> tests/pallet_ui/call_argument_invalid_bound.rs:20:36

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
@@ -6,7 +6,7 @@ error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
    = note: required because of the requirements on the impl of `std::fmt::Debug` for `&<T as pallet::Config>::Bar`
-   = note: required for the cast to the object type `dyn std::fmt::Debug`
+   = note: required for the cast from `&<T as pallet::Config>::Bar` to the object type `dyn std::fmt::Debug`
 
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: Clone` is not satisfied
   --> tests/pallet_ui/call_argument_invalid_bound_2.rs:20:36
@@ -21,21 +21,23 @@ error[E0369]: binary operation `==` cannot be applied to type `&<T as pallet::Co
    |                                          ^^^
 
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeEncode` is not satisfied
-  --> tests/pallet_ui/call_argument_invalid_bound_2.rs:20:36
+  --> tests/pallet_ui/call_argument_invalid_bound_2.rs:1:1
    |
-1  | / #[frame_support::pallet]
+1  |   #[frame_support::pallet]
+   |   ^-----------------------
+   |   |
+   |  _in this procedural macro expansion
+   | |
 2  | | mod pallet {
 3  | |     use frame_support::pallet_prelude::{Hooks, DispatchResultWithPostInfo};
 4  | |     use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
 ...  |
 16 | |
 17 | |     #[pallet::call]
-   | |__________________- required by a bound introduced by this call
-...
-20 |           pub fn foo(origin: OriginFor<T>, bar: T::Bar) -> DispatchResultWithPostInfo {
-   |                                            ^^^ the trait `WrapperTypeEncode` is not implemented for `<T as pallet::Config>::Bar`
+   | |__________________^ the trait `WrapperTypeEncode` is not implemented for `<T as pallet::Config>::Bar`
    |
    = note: required because of the requirements on the impl of `Encode` for `<T as pallet::Config>::Bar`
+   = note: this error originates in the derive macro `frame_support::codec::Encode` which comes from the expansion of the attribute macro `frame_support::pallet` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeDecode` is not satisfied
   --> tests/pallet_ui/call_argument_invalid_bound_2.rs:17:12

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.stderr
@@ -7,7 +7,7 @@ error[E0277]: `Bar` doesn't implement `std::fmt::Debug`
    = help: the trait `std::fmt::Debug` is not implemented for `Bar`
    = note: add `#[derive(Debug)]` to `Bar` or manually `impl std::fmt::Debug for Bar`
    = note: required because of the requirements on the impl of `std::fmt::Debug` for `&Bar`
-   = note: required for the cast to the object type `dyn std::fmt::Debug`
+   = note: required for the cast from `&Bar` to the object type `dyn std::fmt::Debug`
 help: consider annotating `Bar` with `#[derive(Debug)]`
    |
 17 |     #[derive(Debug)]

--- a/frame/support/test/tests/pallet_ui/event_field_not_member.stderr
+++ b/frame/support/test/tests/pallet_ui/event_field_not_member.stderr
@@ -18,4 +18,4 @@ error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
    = note: required because of the requirements on the impl of `std::fmt::Debug` for `&<T as pallet::Config>::Bar`
-   = note: required for the cast to the object type `dyn std::fmt::Debug`
+   = note: required for the cast from `&<T as pallet::Config>::Bar` to the object type `dyn std::fmt::Debug`

--- a/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.stderr
+++ b/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.stderr
@@ -28,7 +28,7 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
              <&[(T,)] as EncodeLike<BinaryHeap<LikeT>>>
              <&[(T,)] as EncodeLike<LinkedList<LikeT>>>
              <&[T] as EncodeLike<Vec<U>>>
-           and 280 others
+           and 278 others
    = note: required because of the requirements on the impl of `FullEncode` for `Bar`
    = note: required because of the requirements on the impl of `FullCodec` for `Bar`
    = note: required because of the requirements on the impl of `PartialStorageInfoTrait` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`
@@ -103,7 +103,7 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
              <&[(T,)] as EncodeLike<BinaryHeap<LikeT>>>
              <&[(T,)] as EncodeLike<LinkedList<LikeT>>>
              <&[T] as EncodeLike<Vec<U>>>
-           and 280 others
+           and 278 others
    = note: required because of the requirements on the impl of `FullEncode` for `Bar`
    = note: required because of the requirements on the impl of `FullCodec` for `Bar`
    = note: required because of the requirements on the impl of `StorageEntryMetadataBuilder` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`

--- a/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.stderr
+++ b/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.stderr
@@ -28,7 +28,7 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
              <&[(T,)] as EncodeLike<BinaryHeap<LikeT>>>
              <&[(T,)] as EncodeLike<LinkedList<LikeT>>>
              <&[T] as EncodeLike<Vec<U>>>
-           and 280 others
+           and 278 others
    = note: required because of the requirements on the impl of `FullEncode` for `Bar`
    = note: required because of the requirements on the impl of `FullCodec` for `Bar`
    = note: required because of the requirements on the impl of `PartialStorageInfoTrait` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`
@@ -103,7 +103,7 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
              <&[(T,)] as EncodeLike<BinaryHeap<LikeT>>>
              <&[(T,)] as EncodeLike<LinkedList<LikeT>>>
              <&[T] as EncodeLike<Vec<U>>>
-           and 280 others
+           and 278 others
    = note: required because of the requirements on the impl of `FullEncode` for `Bar`
    = note: required because of the requirements on the impl of `FullCodec` for `Bar`
    = note: required because of the requirements on the impl of `StorageEntryMetadataBuilder` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`

--- a/primitives/api/test/tests/ui/impl_incorrect_method_signature.stderr
+++ b/primitives/api/test/tests/ui/impl_incorrect_method_signature.stderr
@@ -18,5 +18,18 @@ note: type in trait
 error[E0308]: mismatched types
   --> tests/ui/impl_incorrect_method_signature.rs:19:11
    |
-19 |         fn test(data: String) {}
-   |                 ^^^^ expected `u64`, found struct `std::string::String`
+17 | / sp_api::impl_runtime_apis! {
+18 | |     impl self::Api<Block> for Runtime {
+19 | |         fn test(data: String) {}
+   | |                 ^^^^ expected `u64`, found struct `std::string::String`
+20 | |     }
+...  |
+32 | |     }
+33 | | }
+   | |_- arguments to this function are incorrect
+   |
+note: associated function defined here
+  --> tests/ui/impl_incorrect_method_signature.rs:13:6
+   |
+13 |         fn test(data: u64);
+   |            ^^^^

--- a/primitives/api/test/tests/ui/type_reference_in_impl_runtime_apis_call.stderr
+++ b/primitives/api/test/tests/ui/type_reference_in_impl_runtime_apis_call.stderr
@@ -18,9 +18,21 @@ note: type in trait
 error[E0308]: mismatched types
   --> tests/ui/type_reference_in_impl_runtime_apis_call.rs:19:11
    |
-19 |         fn test(data: &u64) {
-   |                 ^^^^^^^ expected `u64`, found `&u64`
+17 | / sp_api::impl_runtime_apis! {
+18 | |     impl self::Api<Block> for Runtime {
+19 | |         fn test(data: &u64) {
+   | |                 ^^^^^^^ expected `u64`, found `&u64`
+20 | |             unimplemented!()
+...  |
+34 | |     }
+35 | | }
+   | |_- arguments to this function are incorrect
    |
+note: associated function defined here
+  --> tests/ui/type_reference_in_impl_runtime_apis_call.rs:13:6
+   |
+13 |         fn test(data: u64);
+   |            ^^^^
 help: consider removing the borrow
    |
 19 -         fn test(data: &u64) {


### PR DESCRIPTION
This PR updates UI tests to make stable 1.64 `rustc` happy. The tests were updated via the machinery using the `/.maintain/update-rust-stable.sh` script.