### PR TITLE
Remove "to_block" field from BlockRequests

### DIFF
--- a/client/network/common/src/sync/message.rs
+++ b/client/network/common/src/sync/message.rs
@@ -158,8 +158,6 @@ pub mod generic {
 		pub fields: BlockAttributes,
 		/// Start from this block.
 		pub from: FromBlock<Hash, Number>,
-		/// End at this block. An implementation defined maximum is used when unspecified.
-		pub to: Option<Hash>,
 		/// Sequence direction.
 		pub direction: Direction,
 		/// Maximum number of blocks to return. An implementation defined maximum is used when

--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -650,7 +650,6 @@ where
 					id: 0,
 					fields: BlockAttributes::JUSTIFICATION,
 					from: FromBlock::Hash(request.0),
-					to: None,
 					direction: Direction::Ascending,
 					max: Some(1),
 				};
@@ -1608,7 +1607,6 @@ where
 				FromBlock::Number(n) =>
 					Some(schema::v1::block_request::FromBlock::Number(n.encode())),
 			},
-			to_block: request.to.map(|h| h.encode()).unwrap_or_default(),
 			direction: request.direction as i32,
 			max_blocks: request.max.unwrap_or(0),
 			support_multiple_justifications: true,
@@ -2252,7 +2250,6 @@ fn ancestry_request<B: BlockT>(block: NumberFor<B>) -> BlockRequest<B> {
 		id: 0,
 		fields: BlockAttributes::HEADER | BlockAttributes::JUSTIFICATION,
 		from: FromBlock::Number(block),
-		to: None,
 		direction: Direction::Ascending,
 		max: Some(1),
 	}
@@ -2368,7 +2365,6 @@ fn peer_block_request<B: BlockT>(
 		id: 0,
 		fields: attrs,
 		from,
-		to: None,
 		direction: Direction::Descending,
 		max: Some((range.end - range.start).saturated_into::<u32>()),
 	};
@@ -2402,7 +2398,6 @@ fn peer_gap_block_request<B: BlockT>(
 		id: 0,
 		fields: attrs,
 		from,
-		to: None,
 		direction: Direction::Descending,
 		max: Some((range.end - range.start).saturated_into::<u32>()),
 	};
@@ -2452,7 +2447,6 @@ fn fork_sync_request<B: BlockT>(
 					id: 0,
 					fields: attributes,
 					from: FromBlock::Hash(*hash),
-					to: None,
 					direction: Direction::Descending,
 					max: Some(count),
 				},

--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -2696,8 +2696,7 @@ mod test {
 		assert!(sync.justification_requests().any(|(p, r)| {
 			p == peer_id3 &&
 				r.fields == BlockAttributes::JUSTIFICATION &&
-				r.from == FromBlock::Hash(b1_hash) &&
-				r.to == None
+				r.from == FromBlock::Hash(b1_hash)
 		}));
 
 		assert_eq!(

--- a/client/network/sync/src/schema/api.v1.proto
+++ b/client/network/sync/src/schema/api.v1.proto
@@ -23,8 +23,6 @@ message BlockRequest {
 		// Start with given block number.
 		bytes number = 3;
 	}
-	// End at this block. An implementation defined maximum is used when unspecified.
-	bytes to_block = 4; // optional
 	// Sequence direction.
 	Direction direction = 5;
 	// Maximum number of blocks to return. An implementation defined maximum is used when unspecified.

--- a/client/network/sync/src/warp.rs
+++ b/client/network/sync/src/warp.rs
@@ -193,7 +193,6 @@ where
 					fields: BlockAttributes::HEADER |
 						BlockAttributes::BODY | BlockAttributes::JUSTIFICATION,
 					from: FromBlock::Hash(header.hash()),
-					to: Some(header.hash()),
 					direction: Direction::Ascending,
 					max: Some(1),
 				};


### PR DESCRIPTION
On the receiving side, this field is completely ignored when we receive a request.
On the sender side, we always set this field to `None`, with the sole exception of warp syncing where we set it to the same value as the starting block because we want one specific block.

As far as I know, not only this field isn't used right now but has never been used.

Since this field is useless, this PR removes it.

Because we're using protobuf, it's not a problem if a client on an old version sends us a warp sync request where the field is defined. The now-unrecognized field will simply be ignored.

If this is approved, a corresponding issue should be opened in the w3f/specs repo.