### PR TITLE
Remove references in arithmetic operation arguments for Weights

### DIFF
--- a/frame/contracts/src/gas.rs
+++ b/frame/contracts/src/gas.rs
@@ -121,7 +121,7 @@ where
 				amount.proof_size()
 			},
 		);
-		self.gas_left = self.gas_left.checked_sub(&amount).ok_or_else(|| <Error<T>>::OutOfGas)?;
+		self.gas_left = self.gas_left.checked_sub(amount).ok_or_else(|| <Error<T>>::OutOfGas)?;
 		Ok(GasMeter::new(amount))
 	}
 
@@ -171,7 +171,7 @@ where
 		let amount = token.weight();
 		// It is OK to not charge anything on failure because we always charge _before_ we perform
 		// any action
-		self.gas_left = self.gas_left.checked_sub(&amount).ok_or_else(|| Error::<T>::OutOfGas)?;
+		self.gas_left = self.gas_left.checked_sub(amount).ok_or_else(|| Error::<T>::OutOfGas)?;
 		Ok(ChargedAmount(amount))
 	}
 

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -439,7 +439,7 @@ impl PerDispatchClass<Weight> {
 	/// occur.
 	pub fn checked_add(&mut self, weight: Weight, class: DispatchClass) -> Result<(), ()> {
 		let value = self.get_mut(class);
-		*value = value.checked_add(&weight).ok_or(())?;
+		*value = value.checked_add(weight).ok_or(())?;
 		Ok(())
 	}
 

--- a/primitives/weights/src/weight_v2.rs
+++ b/primitives/weights/src/weight_v2.rs
@@ -93,9 +93,9 @@ impl Weight {
 	}
 
 	/// Try to add some `other` weight while upholding the `limit`.
-	pub fn try_add(&self, other: &Self, limit: &Self) -> Option<Self> {
+	pub fn try_add(&self, other: Self, limit: Self) -> Option<Self> {
 		let total = self.checked_add(other)?;
-		if total.any_gt(*limit) {
+		if total.any_gt(limit) {
 			None
 		} else {
 			Some(total)
@@ -168,7 +168,7 @@ impl Weight {
 	}
 
 	/// Checked [`Weight`] addition. Computes `self + rhs`, returning `None` if overflow occurred.
-	pub const fn checked_add(&self, rhs: &Self) -> Option<Self> {
+	pub const fn checked_add(&self, rhs: Self) -> Option<Self> {
 		let ref_time = match self.ref_time.checked_add(rhs.ref_time) {
 			Some(t) => t,
 			None => return None,
@@ -182,7 +182,7 @@ impl Weight {
 
 	/// Checked [`Weight`] subtraction. Computes `self - rhs`, returning `None` if overflow
 	/// occurred.
-	pub const fn checked_sub(&self, rhs: &Self) -> Option<Self> {
+	pub const fn checked_sub(&self, rhs: Self) -> Option<Self> {
 		let ref_time = match self.ref_time.checked_sub(rhs.ref_time) {
 			Some(t) => t,
 			None => return None,
@@ -405,13 +405,13 @@ where
 
 impl CheckedAdd for Weight {
 	fn checked_add(&self, rhs: &Self) -> Option<Self> {
-		self.checked_add(rhs)
+		self.checked_add(*rhs)
 	}
 }
 
 impl CheckedSub for Weight {
 	fn checked_sub(&self, rhs: &Self) -> Option<Self> {
-		self.checked_sub(rhs)
+		self.checked_sub(*rhs)
 	}
 }
 


### PR DESCRIPTION
Simple PR that removes references to some function arguments in `Weight` v2.

This is because the `Weight` struct itself is already `Copy`, thus it doesn't really need to take references for the sake of performance.

polkadot companion: paritytech/polkadot#6132