### PR TITLE
MMR: Modify `verify_leaves_proof()` signature

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -2044,7 +2044,7 @@ impl_runtime_apis! {
 			proof: mmr::Proof<mmr::Hash>
 		) -> Result<(), mmr::Error> {
 			let node = mmr::DataOrHash::Data(leaf.into_opaque_leaf());
-			pallet_mmr::verify_leaves_proof::<mmr::Hashing, _>(root, vec![node], mmr::Proof::into_batch_proof(proof))
+			pallet_mmr::verify_leaves_proof::<mmr::Hashing, _>(root, vec![node], &mmr::Proof::into_batch_proof(proof))
 		}
 
 		fn mmr_root() -> Result<mmr::Hash, mmr::Error> {
@@ -2098,7 +2098,7 @@ impl_runtime_apis! {
 			proof: mmr::BatchProof<mmr::Hash>
 		) -> Result<(), mmr::Error> {
 			let nodes = leaves.into_iter().map(|leaf|mmr::DataOrHash::Data(leaf.into_opaque_leaf())).collect();
-			pallet_mmr::verify_leaves_proof::<mmr::Hashing, _>(root, nodes, proof)
+			pallet_mmr::verify_leaves_proof::<mmr::Hashing, _>(root, nodes, &proof)
 		}
 	}
 

--- a/frame/merkle-mountain-range/src/lib.rs
+++ b/frame/merkle-mountain-range/src/lib.rs
@@ -271,13 +271,13 @@ pub(crate) type HashingOf<T, I> = <T as Config<I>>::Hashing;
 pub fn verify_leaves_proof<H, L>(
 	root: H::Output,
 	leaves: Vec<mmr::Node<H, L>>,
-	proof: primitives::BatchProof<H::Output>,
+	proof: &primitives::BatchProof<H::Output>,
 ) -> Result<(), primitives::Error>
 where
 	H: traits::Hash,
 	L: primitives::FullLeaf,
 {
-	let is_valid = mmr::verify_leaves_proof::<H, L>(root, leaves, proof)?;
+	let is_valid = mmr::verify_leaves_proof::<H, L>(root, leaves, &proof)?;
 	if is_valid {
 		Ok(())
 	} else {

--- a/frame/merkle-mountain-range/src/mmr/mmr.rs
+++ b/frame/merkle-mountain-range/src/mmr/mmr.rs
@@ -33,7 +33,7 @@ use sp_std::prelude::*;
 pub fn verify_leaves_proof<H, L>(
 	root: H::Output,
 	leaves: Vec<Node<H, L>>,
-	proof: primitives::BatchProof<H::Output>,
+	proof: &primitives::BatchProof<H::Output>,
 ) -> Result<bool, Error>
 where
 	H: sp_runtime::traits::Hash,
@@ -47,14 +47,14 @@ where
 
 	let leaves_and_position_data = proof
 		.leaf_indices
-		.into_iter()
-		.map(|index| mmr_lib::leaf_index_to_pos(index))
+		.iter()
+		.map(|index| mmr_lib::leaf_index_to_pos(*index))
 		.zip(leaves.into_iter())
 		.collect();
 
 	let p = mmr_lib::MerkleProof::<Node<H, L>, Hasher<H, L>>::new(
 		size,
-		proof.items.into_iter().map(Node::Hash).collect(),
+		proof.items.iter().map(|item| Node::Hash(*item)).collect(),
 	);
 	p.verify(Node::Hash(root), leaves_and_position_data)
 		.map_err(|e| Error::Verify.log_debug(e))

--- a/frame/merkle-mountain-range/src/tests.rs
+++ b/frame/merkle-mountain-range/src/tests.rs
@@ -615,7 +615,7 @@ fn verification_should_be_stateless() {
 		crate::verify_leaves_proof::<<Test as Config>::Hashing, _>(
 			root_7,
 			vec![leaf.clone()],
-			proof5
+			&proof5
 		),
 		Ok(())
 	);
@@ -623,7 +623,7 @@ fn verification_should_be_stateless() {
 		crate::verify_leaves_proof::<<Test as Config>::Hashing, _>(
 			root_6,
 			vec![leaf],
-			historical_proof5
+			&historical_proof5
 		),
 		Ok(())
 	);
@@ -665,7 +665,7 @@ fn should_verify_batch_proof_statelessly() {
 				.into_iter()
 				.map(|leaf| crate::primitives::DataOrHash::Data(leaf))
 				.collect(),
-			proof
+			&proof
 		),
 		Ok(())
 	);
@@ -676,7 +676,7 @@ fn should_verify_batch_proof_statelessly() {
 				.into_iter()
 				.map(|leaf| crate::primitives::DataOrHash::Data(leaf))
 				.collect(),
-			historical_proof
+			&historical_proof
 		),
 		Ok(())
 	);


### PR DESCRIPTION
Modify `verify_leaves_proof()` signature in order to receive the proof as a reference.

polkadot companion: https://github.com/paritytech/polkadot/pull/6137