### PR TITLE
Remove the unused light client requests

### DIFF
--- a/client/network/light/src/light_client_requests/handler.rs
+++ b/client/network/light/src/light_client_requests/handler.rs
@@ -151,12 +151,8 @@ where
 				self.on_remote_call_request(&peer, r)?,
 			Some(schema::v1::light::request::Request::RemoteReadRequest(r)) =>
 				self.on_remote_read_request(&peer, r)?,
-			Some(schema::v1::light::request::Request::RemoteHeaderRequest(_r)) =>
-				return Err(HandleRequestError::BadRequest("Not supported.")),
 			Some(schema::v1::light::request::Request::RemoteReadChildRequest(r)) =>
 				self.on_remote_read_child_request(&peer, r)?,
-			Some(schema::v1::light::request::Request::RemoteChangesRequest(_r)) =>
-				return Err(HandleRequestError::BadRequest("Not supported.")),
 			None =>
 				return Err(HandleRequestError::BadRequest("Remote request without request data.")),
 		};

--- a/client/network/light/src/schema/light.v1.proto
+++ b/client/network/light/src/schema/light.v1.proto
@@ -18,6 +18,7 @@ message Request {
 		RemoteCallRequest remote_call_request = 1;
 		RemoteReadRequest remote_read_request = 2;
 		RemoteReadChildRequest remote_read_child_request = 4;
+		// Note: ids 3 and 5 were used in the past. It would be preferable to not re-use them.
 	}
 }
 
@@ -26,6 +27,7 @@ message Response {
 	oneof response {
 		RemoteCallResponse remote_call_response = 1;
 		RemoteReadResponse remote_read_response = 2;
+		// Note: ids 3 and 4 were used in the past. It would be preferable to not re-use them.
 	}
 }
 

--- a/client/network/light/src/schema/light.v1.proto
+++ b/client/network/light/src/schema/light.v1.proto
@@ -17,9 +17,7 @@ message Request {
 	oneof request {
 		RemoteCallRequest remote_call_request = 1;
 		RemoteReadRequest remote_read_request = 2;
-		RemoteHeaderRequest remote_header_request = 3;
 		RemoteReadChildRequest remote_read_child_request = 4;
-		RemoteChangesRequest remote_changes_request = 5;
 	}
 }
 
@@ -28,8 +26,6 @@ message Response {
 	oneof response {
 		RemoteCallResponse remote_call_response = 1;
 		RemoteReadResponse remote_read_response = 2;
-		RemoteHeaderResponse remote_header_response = 3;
-		RemoteChangesResponse remote_changes_response = 4;
 	}
 }
 
@@ -73,48 +69,3 @@ message RemoteReadChildRequest {
 	// Storage keys.
 	repeated bytes keys = 6;
 }
-
-// Remote header request.
-message RemoteHeaderRequest {
-	// Block number to request header for.
-	bytes block = 2;
-}
-
-// Remote header response.
-message RemoteHeaderResponse {
-	// Header. None if proof generation has failed (e.g. header is unknown).
-	bytes header = 2; // optional
-	// Header proof.
-	bytes proof = 3;
-}
-
-/// Remote changes request.
-message RemoteChangesRequest {
-	// Hash of the first block of the range (including first) where changes are requested.
-	bytes first = 2;
-	// Hash of the last block of the range (including last) where changes are requested.
-	bytes last = 3;
-	// Hash of the first block for which the requester has the changes trie root. All other
-	// affected roots must be proved.
-	bytes min = 4;
-	// Hash of the last block that we can use when querying changes.
-	bytes max = 5;
-	// Storage child node key which changes are requested.
-	bytes storage_key = 6; // optional
-	// Storage key which changes are requested.
-	bytes key = 7;
-}
-
-// Remote changes response.
-message RemoteChangesResponse {
-	// Proof has been generated using block with this number as a max block. Should be
-	// less than or equal to the RemoteChangesRequest::max block number.
-	bytes max = 2;
-	// Changes proof.
-	repeated bytes proof = 3;
-	// Changes tries roots missing on the requester' node.
-	repeated Pair roots = 4;
-	// Missing changes tries roots proof.
-	bytes roots_proof = 5;
-}
-


### PR DESCRIPTION
This removes the light client requests that we never send.

A "header request" is done through a regular blocks request. A "changes request" is not possible to implement due to having deprecated/removed the changes trie.
