### PR TITLE
Fix flaky service test

### DIFF
--- a/client/network/common/src/config.rs
+++ b/client/network/common/src/config.rs
@@ -244,6 +244,10 @@ pub struct NonDefaultSetConfig {
 	/// `sc_network::protocol::event::Event::NotificationStreamOpened::negotiated_fallback`
 	pub fallback_names: Vec<protocol::ProtocolName>,
 	/// Handshake of the protocol
+	///
+	/// NOTE: Currently custom handshakes are not fully supported. See issue #5685 for more
+	/// details. This field is temporarily used to allow moving the hardcoded block announcement
+	/// protocol out of `protocol.rs`.
 	pub handshake: Option<NotificationHandshake>,
 	/// Maximum allowed size of single notifications.
 	pub max_notification_size: u64,


### PR DESCRIPTION
Sometimes `NotificationStreamOpenened` would be received for the other protocol before `SyncConnected` was received so when the connection was closed, an incorrect event was read from the event stream.

Also added a comment about the `handshake` field in `NonDefaultSetConfig`. I hope that proper handshake support can be added soon so that comment won't stay there for long.
