### PR TITLE
Add API for block pinning

### DIFF
--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -437,12 +437,24 @@ pub trait StorageProvider<Block: BlockT, B: Backend<Block>> {
 ///
 /// Manages the data layer.
 ///
-/// Note on state pruning: while an object from `state_at` is alive, the state
+/// # State Pruning
+///
+/// While an object from `state_at` is alive, the state
 /// should not be pruned. The backend should internally reference-count
 /// its state objects.
 ///
 /// The same applies for live `BlockImportOperation`s: while an import operation building on a
 /// parent `P` is alive, the state for `P` should not be pruned.
+///
+/// # Block Pruning
+///
+/// Users can prevent a block from being pruned via calling `pin_block`.
+/// After an equal number of `unpin_block` calls, the block can be pruned in
+/// the next pruning window.
+///
+/// While a block is pinned, its state is also preserved.
+///
+/// The backend should internally reference count the number of pin / unpin calls.
 pub trait Backend<Block: BlockT>: AuxStore + Send + Sync {
 	/// Associated block insertion operation type.
 	type BlockImportOperation: BlockImportOperation<Block, State = Self::State>;
@@ -502,6 +514,12 @@ pub trait Backend<Block: BlockT>: AuxStore + Send + Sync {
 
 	/// Returns a handle to offchain storage.
 	fn offchain_storage(&self) -> Option<Self::OffchainStorage>;
+
+	/// Pin the block to prevent pruning.
+	fn pin_block(&self, hash: &Block::Hash) -> sp_blockchain::Result<()>;
+
+	/// Unpin the block to allow pruning.
+	fn unpin_block(&self, hash: &Block::Hash) -> sp_blockchain::Result<()>;
 
 	/// Returns true if state for given block is available.
 	fn have_state_at(&self, hash: &Block::Hash, _number: NumberFor<Block>) -> bool {

--- a/client/api/src/client.rs
+++ b/client/api/src/client.rs
@@ -123,6 +123,12 @@ pub trait BlockBackend<Block: BlockT> {
 		id: &BlockId<Block>,
 	) -> sp_blockchain::Result<Option<Vec<Vec<u8>>>>;
 
+	/// Pin the block to prevent pruning.
+	fn pin_block(&self, hash: &Block::Hash) -> sp_blockchain::Result<()>;
+
+	/// Unpin the block to allow pruning.
+	fn unpin_block(&self, hash: &Block::Hash) -> sp_blockchain::Result<()>;
+
 	/// Get full block by id.
 	fn block(&self, id: &BlockId<Block>) -> sp_blockchain::Result<Option<SignedBlock<Block>>>;
 

--- a/client/api/src/in_mem.rs
+++ b/client/api/src/in_mem.rs
@@ -768,6 +768,14 @@ where
 		None
 	}
 
+	fn pin_block(&self, _hash: &Block::Hash) -> sp_blockchain::Result<()> {
+		Ok(())
+	}
+
+	fn unpin_block(&self, _hash: &Block::Hash) -> sp_blockchain::Result<()> {
+		Ok(())
+	}
+
 	fn state_at(&self, block: BlockId<Block>) -> sp_blockchain::Result<Self::State> {
 		match block {
 			BlockId::Hash(h) if h == Default::default() => return Ok(Self::State::default()),

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -4048,4 +4048,126 @@ pub(crate) mod tests {
 		assert!(bc.body(BlockId::hash(blocks[4])).unwrap().is_none());
 		assert_eq!(Some(vec![5.into()]), bc.body(BlockId::hash(blocks[5])).unwrap());
 	}
+
+	#[test]
+	fn test_pinned_blocks_on_finalize_with_fork() {
+		let backend = Backend::<Block>::new_test_with_tx_storage(BlocksPruning::Some(1), 10);
+		let mut blocks = Vec::new();
+		let mut prev_hash = Default::default();
+
+		// Block tree:
+		//   0 -> 1 -> 2 -> 3 -> 4
+		for i in 0..5 {
+			let hash = insert_block(
+				&backend,
+				i,
+				prev_hash,
+				None,
+				Default::default(),
+				vec![i.into()],
+				None,
+			)
+			.unwrap();
+			blocks.push(hash);
+
+			// Avoid block pruning.
+			backend.pin_block(&blocks[i as usize]).unwrap();
+
+			prev_hash = hash;
+		}
+
+		// Insert a fork at the second block.
+		// Block tree:
+		//   0 -> 1 -> 2 -> 3 -> 4
+		//        1 -> 2 -> 3
+		let fork_hash_root =
+			insert_block(&backend, 2, blocks[1], None, H256::random(), vec![2.into()], None)
+				.unwrap();
+		let fork_hash_3 = insert_block(
+			&backend,
+			3,
+			fork_hash_root,
+			None,
+			H256::random(),
+			vec![3.into(), 11.into()],
+			None,
+		)
+		.unwrap();
+
+		// Do not prune the fork hash.
+		backend.pin_block(&fork_hash_3).unwrap();
+
+		let mut op = backend.begin_operation().unwrap();
+		backend.begin_state_operation(&mut op, BlockId::hash(blocks[4])).unwrap();
+		op.mark_head(BlockId::hash(blocks[4])).unwrap();
+		backend.commit_operation(op).unwrap();
+
+		for i in 1..5 {
+			let mut op = backend.begin_operation().unwrap();
+			backend.begin_state_operation(&mut op, BlockId::hash(blocks[4])).unwrap();
+			op.mark_finalized(BlockId::hash(blocks[i]), None).unwrap();
+			backend.commit_operation(op).unwrap();
+		}
+
+		let bc = backend.blockchain();
+		// Block 0, 1, 2, 3 are pinned and pruning is delayed,
+		// while block 4 is never delayed for pruning as it is finalized.
+		assert_eq!(Some(vec![0.into()]), bc.body(BlockId::hash(blocks[0])).unwrap());
+		assert_eq!(Some(vec![1.into()]), bc.body(BlockId::hash(blocks[1])).unwrap());
+		assert_eq!(Some(vec![2.into()]), bc.body(BlockId::hash(blocks[2])).unwrap());
+		assert_eq!(Some(vec![3.into()]), bc.body(BlockId::hash(blocks[3])).unwrap());
+		assert_eq!(Some(vec![4.into()]), bc.body(BlockId::hash(blocks[4])).unwrap());
+		// Check the fork hashes.
+		assert_eq!(None, bc.body(BlockId::hash(fork_hash_root)).unwrap());
+		assert_eq!(Some(vec![3.into(), 11.into()]), bc.body(BlockId::hash(fork_hash_3)).unwrap());
+
+		// Unpin all blocks, except the forked one.
+		for block in &blocks {
+			backend.unpin_block(&block).unwrap();
+		}
+
+		// Block tree:
+		//   0 -> 1 -> 2 -> 3 -> 4 -> 5
+		//        1 -> ..-> 3
+		let hash =
+			insert_block(&backend, 5, prev_hash, None, Default::default(), vec![5.into()], None)
+				.unwrap();
+		blocks.push(hash);
+
+		// Mark block 5 as finalized.
+		let mut op = backend.begin_operation().unwrap();
+		backend.begin_state_operation(&mut op, BlockId::hash(blocks[5])).unwrap();
+		op.mark_finalized(BlockId::hash(blocks[5]), None).unwrap();
+		backend.commit_operation(op).unwrap();
+
+		assert!(bc.body(BlockId::hash(blocks[0])).unwrap().is_none());
+		assert!(bc.body(BlockId::hash(blocks[1])).unwrap().is_none());
+		assert!(bc.body(BlockId::hash(blocks[2])).unwrap().is_none());
+		assert!(bc.body(BlockId::hash(blocks[3])).unwrap().is_none());
+		// Block 4 was unpinned before pruning, it must also get pruned.
+		assert!(bc.body(BlockId::hash(blocks[4])).unwrap().is_none());
+		assert_eq!(Some(vec![5.into()]), bc.body(BlockId::hash(blocks[5])).unwrap());
+		// Fork 3 was kept around.
+		assert_eq!(Some(vec![3.into(), 11.into()]), bc.body(BlockId::hash(fork_hash_3)).unwrap());
+
+		backend.unpin_block(&fork_hash_3).unwrap();
+
+		// Block tree:
+		//   0 -> 1 -> 2 -> 3 -> 4 -> 5 -> 6
+		//        1 -> ..-> 3
+		let hash =
+			insert_block(&backend, 6, blocks[5], None, Default::default(), vec![6.into()], None)
+				.unwrap();
+		blocks.push(hash);
+
+		// Mark block 6 as finalized.
+		let mut op = backend.begin_operation().unwrap();
+		backend.begin_state_operation(&mut op, BlockId::hash(blocks[6])).unwrap();
+		op.mark_finalized(BlockId::hash(blocks[6]), None).unwrap();
+		backend.commit_operation(op).unwrap();
+
+		// Block 6 must be the only one around.
+		assert!(bc.body(BlockId::hash(fork_hash_3)).unwrap().is_none());
+		assert_eq!(Some(vec![6.into()]), bc.body(BlockId::hash(blocks[6])).unwrap());
+	}
 }

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -1075,7 +1075,8 @@ pub struct Backend<Block: BlockT> {
 	state_usage: Arc<StateUsageStats>,
 	genesis_state: RwLock<Option<Arc<DbGenesisStorage<Block>>>>,
 	shared_trie_cache: Option<sp_trie::cache::SharedTrieCache<HashFor<Block>>>,
-	/// Keep track of the pinned blocks. A block is pinned when calling [`Self::pin_block`].
+	/// Keep track of the pinned blocks. A block is pinned when calling
+	/// [`sc_client_api::backend::Backend::pin_block`].
 	///
 	/// The pruning of these blocks is delayed for as long as their reference count is positive.
 	///

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -2302,6 +2302,14 @@ impl<Block: BlockT> sc_client_api::backend::Backend<Block> for Backend<Block> {
 		&self.blockchain
 	}
 
+	fn pin_block(&self, _hash: &Block::Hash) -> sp_blockchain::Result<()> {
+		Ok(())
+	}
+
+	fn unpin_block(&self, _hash: &Block::Hash) -> sp_blockchain::Result<()> {
+		Ok(())
+	}
+
 	fn state_at(&self, block: BlockId<Block>) -> ClientResult<Self::State> {
 		use sc_client_api::blockchain::HeaderBackend as BcHeaderBackend;
 

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -413,6 +413,16 @@ where
 		&self.finality_notification_sinks
 	}
 
+	/// Pin the block to prevent pruning.
+	fn pin_block(&self, hash: &Block::Hash) -> sp_blockchain::Result<()> {
+		self.backend.pin_block(hash)
+	}
+
+	/// Unpin the block to allow pruning.
+	fn unpin_block(&self, hash: &Block::Hash) -> sp_blockchain::Result<()> {
+		self.backend.unpin_block(hash)
+	}
+
 	/// Get a reference to the state at a given block.
 	pub fn state_at(&self, block: &BlockId<Block>) -> sp_blockchain::Result<B::State> {
 		self.backend.state_at(*block)
@@ -1947,6 +1957,16 @@ where
 		id: &BlockId<Block>,
 	) -> sp_blockchain::Result<Option<Vec<<Block as BlockT>::Extrinsic>>> {
 		self.body(id)
+	}
+
+	/// Pin the block to prevent pruning.
+	fn pin_block(&self, hash: &Block::Hash) -> sp_blockchain::Result<()> {
+		self.pin_block(hash)
+	}
+
+	/// Unpin the block to allow pruning.
+	fn unpin_block(&self, hash: &Block::Hash) -> sp_blockchain::Result<()> {
+		self.unpin_block(hash)
 	}
 
 	fn block(&self, id: &BlockId<Block>) -> sp_blockchain::Result<Option<SignedBlock<Block>>> {


### PR DESCRIPTION
The block pinning is a feature required by the [RPC Spec V2](https://paritytech.github.io/json-rpc-interface-spec/introduction.html).

The [block pinning](https://paritytech.github.io/json-rpc-interface-spec/api/chainHead_unstable_follow.html#pinning) feature should be called for subscribers of the `chainHead_unstable_follow` method.

This PR exposes two methods:
- pin_block - Ensure the given block is never pruned while it has a positive reference count
- unpin_block - Decrease the reference count of the block. When the reference hits zero the block is subject to pruning

When a block is pinned it enters the pinning queue (`Backend::pinned_blocks`) and
increments its reference count. While a block is in the pinning queue will not be
pruned, regardless of the pruning settings.

When a block is unpinned the block can enter the pruning queue (`Backend::pruning_queue`) iff:
- reference count is zero
- pruning was delayed for the block previously

The PR builds upon the  `state_at` function that is not keeping the block's body around.

## Testing Done
- `test_pinned_blocks_on_finalize`
- `test_pinned_blocks_on_finalize_with_fork` 
- custom testing with the new RPC PoC [branch](https://github.com/paritytech/substrate/tree/lexnv/rpc_chainhead_poc) 

Part of #12475.