### PR TITLE
Enable the `wasmtime`-based WASM executor by default

### DIFF
--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -51,6 +51,6 @@ sp-version = { version = "5.0.0", path = "../../primitives/version" }
 tempfile = "3.1.0"
 
 [features]
-default = ["rocksdb"]
+default = ["rocksdb", "wasmtime"]
 rocksdb = ["sc-client-db/rocksdb"]
 wasmtime = ["sc-service/wasmtime"]


### PR DESCRIPTION
By default the `wasmtime`-based WASM executor is not compiled-in (even though *it is the default*!), and only the interpreted executor is included. This doesn't really make any sense (at least not anymore; this executor is widely used, fast and rock-solid stable), and it can unnecessarily trip up people who are unaware of this (like here: https://github.com/paritytech/substrate/issues/12320). So let's just enable it by default and make it opt-out instead of opt-in.