### PR TITLE
BlockId removal: refactor: Backend::state_at

### DIFF
--- a/bin/node/bench/src/import.rs
+++ b/bin/node/bench/src/import.rs
@@ -34,7 +34,7 @@ use std::borrow::Cow;
 
 use node_primitives::Block;
 use node_testing::bench::{BenchDb, BlockType, DatabaseType, KeyTypes, Profile};
-use sc_client_api::backend::Backend;
+use sc_client_api::{backend::Backend, HeaderBackend};
 use sp_runtime::generic::BlockId;
 use sp_state_machine::InspectState;
 
@@ -127,10 +127,15 @@ impl core::Benchmark for ImportBenchmark {
 		context.import_block(self.block.clone());
 		let elapsed = start.elapsed();
 
+		let hash = context
+			.client
+			.expect_block_hash_from_id(&BlockId::number(1))
+			.expect("Block 1 was imported; qed");
+
 		// Sanity checks.
 		context
 			.client
-			.state_at(&BlockId::number(1))
+			.state_at(&hash)
 			.expect("state_at failed for block#1")
 			.inspect_state(|| {
 				match self.block_type {

--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -505,11 +505,11 @@ pub trait Backend<Block: BlockT>: AuxStore + Send + Sync {
 
 	/// Returns true if state for given block is available.
 	fn have_state_at(&self, hash: &Block::Hash, _number: NumberFor<Block>) -> bool {
-		self.state_at(BlockId::Hash(*hash)).is_ok()
+		self.state_at(hash).is_ok()
 	}
 
 	/// Returns state backend with post-state of given block.
-	fn state_at(&self, block: BlockId<Block>) -> sp_blockchain::Result<Self::State>;
+	fn state_at(&self, hash: &Block::Hash) -> sp_blockchain::Result<Self::State>;
 
 	/// Attempts to revert the chain by `n` blocks. If `revert_finalized` is set it will attempt to
 	/// revert past any finalized block, this is unsafe and can potentially leave the node in an

--- a/client/basic-authorship/src/basic_authorship.rs
+++ b/client/basic-authorship/src/basic_authorship.rs
@@ -736,7 +736,7 @@ mod tests {
 		let api = client.runtime_api();
 		api.execute_block(&block_id, proposal.block).unwrap();
 
-		let state = backend.state_at(block_id).unwrap();
+		let state = backend.state_at(&genesis_hash).unwrap();
 
 		let storage_changes = api.into_storage_changes(&state, genesis_hash).unwrap();
 

--- a/client/block-builder/src/lib.rs
+++ b/client/block-builder/src/lib.rs
@@ -258,12 +258,11 @@ where
 
 		let proof = self.api.extract_proof();
 
-		let state = self.backend.state_at(self.block_id)?;
-		let parent_hash = self.parent_hash;
+		let state = self.backend.state_at(&self.parent_hash)?;
 
 		let storage_changes = self
 			.api
-			.into_storage_changes(&state, parent_hash)
+			.into_storage_changes(&state, self.parent_hash)
 			.map_err(sp_blockchain::Error::StorageChanges)?;
 
 		Ok(BuiltBlock {

--- a/client/db/benches/state_access.rs
+++ b/client/db/benches/state_access.rs
@@ -84,7 +84,7 @@ fn insert_blocks(db: &Backend<Block>, storage: Vec<(Vec<u8>, Vec<u8>)>) -> H256 
 			.map(|(k, v)| (k.clone(), Some(v.clone())))
 			.collect::<Vec<_>>();
 
-		let (state_root, tx) = db.state_at(BlockId::Hash(parent_hash)).unwrap().storage_root(
+		let (state_root, tx) = db.state_at(&parent_hash).unwrap().storage_root(
 			changes.iter().map(|(k, v)| (k.as_slice(), v.as_deref())),
 			StateVersion::V1,
 		);
@@ -176,7 +176,7 @@ fn state_access_benchmarks(c: &mut Criterion) {
 
 		group.bench_function(desc, |b| {
 			b.iter_batched(
-				|| backend.state_at(BlockId::Hash(block_hash)).expect("Creates state"),
+				|| backend.state_at(&block_hash).expect("Creates state"),
 				|state| {
 					for key in keys.iter().cycle().take(keys.len() * multiplier) {
 						let _ = state.storage(&key).expect("Doesn't fail").unwrap();
@@ -214,7 +214,7 @@ fn state_access_benchmarks(c: &mut Criterion) {
 
 		group.bench_function(desc, |b| {
 			b.iter_batched(
-				|| backend.state_at(BlockId::Hash(block_hash)).expect("Creates state"),
+				|| backend.state_at(&block_hash).expect("Creates state"),
 				|state| {
 					for key in keys.iter().take(1).cycle().take(multiplier) {
 						let _ = state.storage(&key).expect("Doesn't fail").unwrap();
@@ -252,7 +252,7 @@ fn state_access_benchmarks(c: &mut Criterion) {
 
 		group.bench_function(desc, |b| {
 			b.iter_batched(
-				|| backend.state_at(BlockId::Hash(block_hash)).expect("Creates state"),
+				|| backend.state_at(&block_hash).expect("Creates state"),
 				|state| {
 					for key in keys.iter().take(1).cycle().take(multiplier) {
 						let _ = state.storage_hash(&key).expect("Doesn't fail").unwrap();
@@ -290,7 +290,7 @@ fn state_access_benchmarks(c: &mut Criterion) {
 
 		group.bench_function(desc, |b| {
 			b.iter_batched(
-				|| backend.state_at(BlockId::Hash(block_hash)).expect("Creates state"),
+				|| backend.state_at(&block_hash).expect("Creates state"),
 				|state| {
 					let _ = state
 						.storage_hash(sp_core::storage::well_known_keys::CODE)

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -414,8 +414,8 @@ where
 	}
 
 	/// Get a reference to the state at a given block.
-	pub fn state_at(&self, block: &BlockId<Block>) -> sp_blockchain::Result<B::State> {
-		self.backend.state_at(*block)
+	pub fn state_at(&self, hash: &Block::Hash) -> sp_blockchain::Result<B::State> {
+		self.backend.state_at(hash)
 	}
 
 	/// Get the code at a given block.
@@ -813,7 +813,7 @@ where
 					Block::new(import_block.header.clone(), body.clone()),
 				)?;
 
-				let state = self.backend.state_at(at)?;
+				let state = self.backend.state_at(parent_hash)?;
 				let gen_storage_changes = runtime_api
 					.into_storage_changes(&state, *parent_hash)
 					.map_err(sp_blockchain::Error::Storage)?;
@@ -1154,7 +1154,8 @@ where
 		id: &BlockId<Block>,
 		keys: &mut dyn Iterator<Item = &[u8]>,
 	) -> sp_blockchain::Result<StorageProof> {
-		self.state_at(id).and_then(|state| prove_read(state, keys).map_err(Into::into))
+		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
+		self.state_at(&hash).and_then(|state| prove_read(state, keys).map_err(Into::into))
 	}
 
 	fn read_child_proof(
@@ -1163,7 +1164,8 @@ where
 		child_info: &ChildInfo,
 		keys: &mut dyn Iterator<Item = &[u8]>,
 	) -> sp_blockchain::Result<StorageProof> {
-		self.state_at(id)
+		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
+		self.state_at(&hash)
 			.and_then(|state| prove_child_read(state, child_info, keys).map_err(Into::into))
 	}
 
@@ -1182,7 +1184,8 @@ where
 		start_key: &[Vec<u8>],
 		size_limit: usize,
 	) -> sp_blockchain::Result<(CompactProof, u32)> {
-		let state = self.state_at(id)?;
+		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
+		let state = self.state_at(&hash)?;
 		// this is a read proof, using version V0 or V1 is equivalent.
 		let root = state.storage_root(std::iter::empty(), StateVersion::V0).0;
 
@@ -1204,7 +1207,8 @@ where
 		if start_key.len() > MAX_NESTED_TRIE_DEPTH {
 			return Err(Error::Backend("Invalid start key.".to_string()))
 		}
-		let state = self.state_at(id)?;
+		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
+		let state = self.state_at(&hash)?;
 		let child_info = |storage_key: &Vec<u8>| -> sp_blockchain::Result<ChildInfo> {
 			let storage_key = PrefixedStorageKey::new_ref(storage_key);
 			match ChildType::from_prefixed_key(storage_key) {
@@ -1400,7 +1404,9 @@ where
 		id: &BlockId<Block>,
 		key_prefix: &StorageKey,
 	) -> sp_blockchain::Result<Vec<StorageKey>> {
-		let keys = self.state_at(id)?.keys(&key_prefix.0).into_iter().map(StorageKey).collect();
+
+		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
+		let keys = self.state_at(&hash)?.keys(&key_prefix.0).into_iter().map(StorageKey).collect();
 		Ok(keys)
 	}
 
@@ -1409,7 +1415,8 @@ where
 		id: &BlockId<Block>,
 		key_prefix: &StorageKey,
 	) -> sp_blockchain::Result<Vec<(StorageKey, StorageData)>> {
-		let state = self.state_at(id)?;
+		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
+		let state = self.state_at(&hash)?;
 		let keys = state
 			.keys(&key_prefix.0)
 			.into_iter()
@@ -1427,7 +1434,8 @@ where
 		prefix: Option<&'a StorageKey>,
 		start_key: Option<&StorageKey>,
 	) -> sp_blockchain::Result<KeyIterator<'a, B::State, Block>> {
-		let state = self.state_at(id)?;
+		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
+		let state = self.state_at(&hash)?;
 		let start_key = start_key.or(prefix).map(|key| key.0.clone()).unwrap_or_else(Vec::new);
 		Ok(KeyIterator::new(state, prefix, start_key))
 	}
@@ -1439,7 +1447,8 @@ where
 		prefix: Option<&'a StorageKey>,
 		start_key: Option<&StorageKey>,
 	) -> sp_blockchain::Result<KeyIterator<'a, B::State, Block>> {
-		let state = self.state_at(id)?;
+		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
+		let state = self.state_at(&hash)?;
 		let start_key = start_key.or(prefix).map(|key| key.0.clone()).unwrap_or_else(Vec::new);
 		Ok(KeyIterator::new_child(state, child_info, prefix, start_key))
 	}
@@ -1449,8 +1458,9 @@ where
 		id: &BlockId<Block>,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<StorageData>> {
+		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
 		Ok(self
-			.state_at(id)?
+			.state_at(&hash)?
 			.storage(&key.0)
 			.map_err(|e| sp_blockchain::Error::from_state(Box::new(e)))?
 			.map(StorageData))
@@ -1461,7 +1471,8 @@ where
 		id: &BlockId<Block>,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<Block::Hash>> {
-		self.state_at(id)?
+		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
+		self.state_at(&hash)?
 			.storage_hash(&key.0)
 			.map_err(|e| sp_blockchain::Error::from_state(Box::new(e)))
 	}
@@ -1472,8 +1483,9 @@ where
 		child_info: &ChildInfo,
 		key_prefix: &StorageKey,
 	) -> sp_blockchain::Result<Vec<StorageKey>> {
+		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
 		let keys = self
-			.state_at(id)?
+			.state_at(&hash)?
 			.child_keys(child_info, &key_prefix.0)
 			.into_iter()
 			.map(StorageKey)
@@ -1487,8 +1499,9 @@ where
 		child_info: &ChildInfo,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<StorageData>> {
+		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
 		Ok(self
-			.state_at(id)?
+			.state_at(&hash)?
 			.child_storage(child_info, &key.0)
 			.map_err(|e| sp_blockchain::Error::from_state(Box::new(e)))?
 			.map(StorageData))
@@ -1500,7 +1513,8 @@ where
 		child_info: &ChildInfo,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<Block::Hash>> {
-		self.state_at(id)?
+		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
+		self.state_at(&hash)?
 			.child_storage_hash(child_info, &key.0)
 			.map_err(|e| sp_blockchain::Error::from_state(Box::new(e)))
 	}
@@ -1681,7 +1695,8 @@ where
 	}
 
 	fn state_at(&self, at: &BlockId<Block>) -> Result<Self::StateBackend, sp_api::ApiError> {
-		self.state_at(at).map_err(Into::into)
+		let hash = self.backend.blockchain().expect_block_hash_from_id(at)?;
+		self.state_at(&hash).map_err(Into::into)
 	}
 }
 

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -1155,7 +1155,8 @@ where
 		keys: &mut dyn Iterator<Item = &[u8]>,
 	) -> sp_blockchain::Result<StorageProof> {
 		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
-		self.state_at(&hash).and_then(|state| prove_read(state, keys).map_err(Into::into))
+		self.state_at(&hash)
+			.and_then(|state| prove_read(state, keys).map_err(Into::into))
 	}
 
 	fn read_child_proof(
@@ -1404,7 +1405,6 @@ where
 		id: &BlockId<Block>,
 		key_prefix: &StorageKey,
 	) -> sp_blockchain::Result<Vec<StorageKey>> {
-
 		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
 		let keys = self.state_at(&hash)?.keys(&key_prefix.0).into_iter().map(StorageKey).collect();
 		Ok(keys)

--- a/client/service/test/src/client/mod.rs
+++ b/client/service/test/src/client/mod.rs
@@ -346,10 +346,7 @@ fn block_builder_works_with_transactions() {
 		.expect("block 1 was just imported. qed");
 
 	assert_eq!(client.chain_info().best_number, 1);
-	assert_ne!(
-		client.state_at(&hash1).unwrap().pairs(),
-		client.state_at(&hash0).unwrap().pairs()
-	);
+	assert_ne!(client.state_at(&hash1).unwrap().pairs(), client.state_at(&hash0).unwrap().pairs());
 	assert_eq!(
 		client
 			.runtime_api()
@@ -407,10 +404,7 @@ fn block_builder_does_not_include_invalid() {
 		.expect("block 1 was just imported. qed");
 
 	assert_eq!(client.chain_info().best_number, 1);
-	assert_ne!(
-		client.state_at(&hash1).unwrap().pairs(),
-		client.state_at(&hash0).unwrap().pairs()
-	);
+	assert_ne!(client.state_at(&hash1).unwrap().pairs(), client.state_at(&hash0).unwrap().pairs());
 	assert_eq!(client.body(&BlockId::Number(1)).unwrap().unwrap().len(), 1)
 }
 

--- a/client/service/test/src/client/mod.rs
+++ b/client/service/test/src/client/mod.rs
@@ -20,7 +20,7 @@ use futures::executor::block_on;
 use parity_scale_codec::{Decode, Encode, Joiner};
 use sc_block_builder::BlockBuilderProvider;
 use sc_client_api::{
-	in_mem, BlockBackend, BlockchainEvents, FinalityNotifications, StorageProvider,
+	in_mem, BlockBackend, BlockchainEvents, FinalityNotifications, HeaderBackend, StorageProvider,
 };
 use sc_client_db::{Backend, BlocksPruning, DatabaseSettings, DatabaseSource, PruningMode};
 use sc_consensus::{
@@ -338,10 +338,17 @@ fn block_builder_works_with_transactions() {
 	let block = builder.build().unwrap().block;
 	block_on(client.import(BlockOrigin::Own, block)).unwrap();
 
+	let hash0 = client
+		.expect_block_hash_from_id(&BlockId::Number(0))
+		.expect("block 0 was just imported. qed");
+	let hash1 = client
+		.expect_block_hash_from_id(&BlockId::Number(1))
+		.expect("block 1 was just imported. qed");
+
 	assert_eq!(client.chain_info().best_number, 1);
 	assert_ne!(
-		client.state_at(&BlockId::Number(1)).unwrap().pairs(),
-		client.state_at(&BlockId::Number(0)).unwrap().pairs()
+		client.state_at(&hash1).unwrap().pairs(),
+		client.state_at(&hash0).unwrap().pairs()
 	);
 	assert_eq!(
 		client
@@ -392,10 +399,17 @@ fn block_builder_does_not_include_invalid() {
 	let block = builder.build().unwrap().block;
 	block_on(client.import(BlockOrigin::Own, block)).unwrap();
 
+	let hash0 = client
+		.expect_block_hash_from_id(&BlockId::Number(0))
+		.expect("block 0 was just imported. qed");
+	let hash1 = client
+		.expect_block_hash_from_id(&BlockId::Number(1))
+		.expect("block 1 was just imported. qed");
+
 	assert_eq!(client.chain_info().best_number, 1);
 	assert_ne!(
-		client.state_at(&BlockId::Number(1)).unwrap().pairs(),
-		client.state_at(&BlockId::Number(0)).unwrap().pairs()
+		client.state_at(&hash1).unwrap().pairs(),
+		client.state_at(&hash0).unwrap().pairs()
 	);
 	assert_eq!(client.body(&BlockId::Number(1)).unwrap().unwrap().len(), 1)
 }

--- a/primitives/blockchain/src/backend.rs
+++ b/primitives/blockchain/src/backend.rs
@@ -78,8 +78,8 @@ pub trait HeaderBackend<Block: BlockT>: Send + Sync {
 	/// Convert an arbitrary block ID into a block hash. Returns `UnknownBlock` error if block is
 	/// not found.
 	fn expect_block_hash_from_id(&self, id: &BlockId<Block>) -> Result<Block::Hash> {
-		self.block_hash_from_id(id).and_then(|n| {
-			n.ok_or_else(|| Error::UnknownBlock(format!("Expect block hash from id: {}", id)))
+		self.block_hash_from_id(id).and_then(|h| {
+			h.ok_or_else(|| Error::UnknownBlock(format!("Expect block hash from id: {}", id)))
 		})
 	}
 }

--- a/utils/frame/rpc/state-trie-migration-rpc/src/lib.rs
+++ b/utils/frame/rpc/state-trie-migration-rpc/src/lib.rs
@@ -24,7 +24,7 @@ use jsonrpsee::{
 };
 use sc_rpc_api::DenyUnsafe;
 use serde::{Deserialize, Serialize};
-use sp_runtime::{generic::BlockId, traits::Block as BlockT};
+use sp_runtime::traits::Block as BlockT;
 use std::sync::Arc;
 
 use sp_core::{
@@ -144,8 +144,8 @@ where
 	fn call(&self, at: Option<<B as BlockT>::Hash>) -> RpcResult<MigrationStatusResult> {
 		self.deny_unsafe.check_if_safe()?;
 
-		let block_id = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
-		let state = self.backend.state_at(block_id).map_err(error_into_rpc_err)?;
+		let hash = at.unwrap_or_else(|| self.client.info().best_hash);
+		let state = self.backend.state_at(&hash).map_err(error_into_rpc_err)?;
 		let (top, child) = migration_status(&state).map_err(error_into_rpc_err)?;
 
 		Ok(MigrationStatusResult {


### PR DESCRIPTION
It changes the argument of `Backend::state_at` from:
`block: BlockId<Block>` to: `hash: &Block::Hash`

This PR is part of `BlockId::Number` refactoring analysis (https://github.com/paritytech/substrate/issues/11292) .

`HeaderBackend::expect_block_hash_from_id` was used to convert `BlockId` to `Block::Hash`.

polkadot companion: paritytech/polkadot#6149
cumulus companion: paritytech/cumulus#1760