### PR TITLE
Try-runtime CLI fix weight decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11356,6 +11356,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-version",
+ "sp-weights",
  "tokio",
  "zstd",
 ]

--- a/utils/frame/try-runtime/cli/Cargo.toml
+++ b/utils/frame/try-runtime/cli/Cargo.toml
@@ -31,6 +31,7 @@ sp-keystore = { version = "0.12.0", path = "../../../../primitives/keystore" }
 sp-runtime = { version = "6.0.0", path = "../../../../primitives/runtime" }
 sp-state-machine = { version = "0.12.0", path = "../../../../primitives/state-machine" }
 sp-version = { version = "5.0.0", path = "../../../../primitives/version" }
+sp-weights = { version = "4.0.0", path = "../../../../primitives/weights" }
 frame-try-runtime = { path = "../../../../frame/try-runtime" }
 
 [dev-dependencies]

--- a/utils/frame/try-runtime/cli/src/commands/follow_chain.rs
+++ b/utils/frame/try-runtime/cli/src/commands/follow_chain.rs
@@ -33,6 +33,7 @@ use sc_service::Configuration;
 use serde::de::DeserializeOwned;
 use sp_core::H256;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
+use sp_weights::Weight;
 use std::{collections::VecDeque, fmt::Debug, str::FromStr};
 
 const SUB: &str = "chain_subscribeFinalizedHeads";
@@ -294,8 +295,8 @@ where
 			full_extensions(),
 		)?;
 
-		let consumed_weight = <u64 as Decode>::decode(&mut &*encoded_result)
-			.map_err(|e| format!("failed to decode output: {:?}", e))?;
+		let consumed_weight = <Weight as Decode>::decode(&mut &*encoded_result)
+			.map_err(|e| format!("failed to decode weight: {:?}", e))?;
 
 		let storage_changes = changes
 			.drain_storage_changes(


### PR DESCRIPTION
Use the correct weight type to prevent decoding errors.  