### PR TITLE
pallet-mmr: fix offchain db for sync from zero

### DIFF
--- a/frame/beefy-mmr/src/tests.rs
+++ b/frame/beefy-mmr/src/tests.rs
@@ -100,8 +100,8 @@ fn should_contain_mmr_digest() {
 
 #[test]
 fn should_contain_valid_leaf_data() {
-	fn node_offchain_key(parent_hash: H256, pos: usize) -> Vec<u8> {
-		(<Test as pallet_mmr::Config>::INDEXING_PREFIX, parent_hash, pos as u64).encode()
+	fn node_offchain_key(pos: usize, parent_hash: H256) -> Vec<u8> {
+		(<Test as pallet_mmr::Config>::INDEXING_PREFIX, pos as u64, parent_hash).encode()
 	}
 
 	let mut ext = new_test_ext(vec![1, 2, 3, 4]);
@@ -110,7 +110,7 @@ fn should_contain_valid_leaf_data() {
 		<frame_system::Pallet<Test>>::parent_hash()
 	});
 
-	let mmr_leaf = read_mmr_leaf(&mut ext, node_offchain_key(parent_hash, 0));
+	let mmr_leaf = read_mmr_leaf(&mut ext, node_offchain_key(0, parent_hash));
 	assert_eq!(
 		mmr_leaf,
 		MmrLeaf {
@@ -135,7 +135,7 @@ fn should_contain_valid_leaf_data() {
 		<frame_system::Pallet<Test>>::parent_hash()
 	});
 
-	let mmr_leaf = read_mmr_leaf(&mut ext, node_offchain_key(parent_hash, 1));
+	let mmr_leaf = read_mmr_leaf(&mut ext, node_offchain_key(1, parent_hash));
 	assert_eq!(
 		mmr_leaf,
 		MmrLeaf {

--- a/frame/merkle-mountain-range/src/lib.rs
+++ b/frame/merkle-mountain-range/src/lib.rs
@@ -175,7 +175,7 @@ pub mod pallet {
 		/// Note that the leaf at each block MUST be unique. You may want to include a block hash or
 		/// block number as an easiest way to ensure that.
 		/// Also note that the leaf added by each block is expected to only reference data coming
-		/// from ancestor blocks (leaves are saved offchain using `(parent_hash, pos)` key to be
+		/// from ancestor blocks (leaves are saved offchain using `(pos, parent_hash)` key to be
 		/// fork-resistant, as such conflicts could only happen on 1-block deep forks, which means
 		/// two forks with identical line of ancestors compete to write the same offchain key, but
 		/// that's fine as long as leaves only contain data coming from ancestors - conflicting
@@ -250,7 +250,7 @@ pub mod pallet {
 		fn offchain_worker(n: T::BlockNumber) {
 			use mmr::storage::{OffchainStorage, Storage};
 			// The MMR nodes can be found in offchain db under either:
-			//   - fork-unique keys `(prefix, parent_hash, pos)`, or,
+			//   - fork-unique keys `(prefix, pos, parent_hash)`, or,
 			//   - "canonical" keys `(prefix, pos)`,
 			//   depending on how many blocks in the past the node at position `pos` was
 			//   added to the MMR.
@@ -260,7 +260,7 @@ pub mod pallet {
 			// hashes, so it is limited by `frame_system::BlockHashCount` in terms of how many
 			// historical forks it can track. Nodes added to MMR by block `N` can be found in
 			// offchain db at:
-			//   - fork-unique keys `(prefix, parent_hash, pos)` when (`N` >= `latest_block` -
+			//   - fork-unique keys `(prefix, pos, parent_hash)` when (`N` >= `latest_block` -
 			//     `frame_system::BlockHashCount`);
 			//   - "canonical" keys `(prefix, pos)` when (`N` < `latest_block` -
 			//     `frame_system::BlockHashCount`);
@@ -314,10 +314,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// This combination makes the offchain (key,value) entry resilient to chain forks.
 	fn node_offchain_key(
-		parent_hash: <T as frame_system::Config>::Hash,
 		pos: NodeIndex,
+		parent_hash: <T as frame_system::Config>::Hash,
 	) -> sp_std::prelude::Vec<u8> {
-		(T::INDEXING_PREFIX, parent_hash, pos).encode()
+		(T::INDEXING_PREFIX, pos, parent_hash).encode()
 	}
 
 	/// Build canonical offchain key for node `pos` in MMR.

--- a/frame/merkle-mountain-range/src/mmr/storage.rs
+++ b/frame/merkle-mountain-range/src/mmr/storage.rs
@@ -169,7 +169,7 @@ where
 	fn prune_nodes_for_forks(nodes: &[NodeIndex], forks: Vec<<T as frame_system::Config>::Hash>) {
 		for hash in forks {
 			for pos in nodes {
-				let key = Pallet::<T, I>::node_offchain_key(hash, *pos);
+				let key = Pallet::<T, I>::node_offchain_key(*pos, hash);
 				debug!(
 					target: "runtime::mmr::offchain",
 					"Clear elem at pos {} with key {:?}",
@@ -185,7 +185,7 @@ where
 		to_canon_hash: <T as frame_system::Config>::Hash,
 	) {
 		for pos in to_canon_nodes {
-			let key = Pallet::<T, I>::node_offchain_key(to_canon_hash, *pos);
+			let key = Pallet::<T, I>::node_offchain_key(*pos, to_canon_hash);
 			// Retrieve the element from Off-chain DB under fork-aware key.
 			if let Some(elem) = offchain::local_storage_get(StorageKind::PERSISTENT, &key) {
 				let canon_key = Pallet::<T, I>::node_canon_offchain_key(*pos);
@@ -239,7 +239,7 @@ where
 		let ancestor_parent_block_num =
 			Pallet::<T, I>::leaf_index_to_parent_block_num(ancestor_leaf_idx, leaves);
 		let ancestor_parent_hash = <frame_system::Pallet<T>>::block_hash(ancestor_parent_block_num);
-		let key = Pallet::<T, I>::node_offchain_key(ancestor_parent_hash, pos);
+		let key = Pallet::<T, I>::node_offchain_key(pos, ancestor_parent_hash);
 		debug!(
 			target: "runtime::mmr::offchain", "offchain db get {}: leaf idx {:?}, hash {:?}, key {:?}",
 			pos, ancestor_leaf_idx, ancestor_parent_hash, key
@@ -345,7 +345,7 @@ where
 		// fork-resistant. Offchain worker task will "canonicalize" it
 		// `frame_system::BlockHashCount` blocks later, when we are not worried about forks anymore
 		// (multi-era-deep forks should not happen).
-		let key = Pallet::<T, I>::node_offchain_key(parent_hash, pos);
+		let key = Pallet::<T, I>::node_offchain_key(pos, parent_hash);
 		debug!(
 			target: "runtime::mmr::offchain", "offchain db set: pos {} parent_hash {:?} key {:?}",
 			pos, parent_hash, key

--- a/frame/merkle-mountain-range/src/mmr/storage.rs
+++ b/frame/merkle-mountain-range/src/mmr/storage.rs
@@ -338,9 +338,9 @@ where
 	fn store_to_offchain(
 		pos: NodeIndex,
 		parent_hash: <T as frame_system::Config>::Hash,
-		elem: &NodeOf<T, I, L>,
+		node: &NodeOf<T, I, L>,
 	) {
-		let encoded_node = elem.encode();
+		let encoded_node = node.encode();
 		// We store this leaf offchain keyed by `(parent_hash, node_index)` to make it
 		// fork-resistant. Offchain worker task will "canonicalize" it
 		// `frame_system::BlockHashCount` blocks later, when we are not worried about forks anymore

--- a/frame/merkle-mountain-range/src/mmr/storage.rs
+++ b/frame/merkle-mountain-range/src/mmr/storage.rs
@@ -18,11 +18,10 @@
 //! A MMR storage implementations.
 
 use codec::Encode;
-use frame_support::traits::Get;
+use frame_support::log::{debug, error, trace};
 use mmr_lib::helper;
 use sp_core::offchain::StorageKind;
 use sp_io::{offchain, offchain_index};
-use sp_runtime::traits::UniqueSaturatedInto;
 use sp_std::iter::Peekable;
 #[cfg(not(feature = "std"))]
 use sp_std::prelude::*;
@@ -133,15 +132,14 @@ where
 		// Effectively move a rolling window of fork-unique leaves. Once out of the window, leaves
 		// are "canonicalized" in offchain by moving them under `Pallet::node_canon_offchain_key`.
 		let leaves = NumberOfLeaves::<T, I>::get();
-		let window_size =
-			<T as frame_system::Config>::BlockHashCount::get().unique_saturated_into();
+		let window_size = Pallet::<T, I>::offchain_canonicalization_window();
 		if leaves >= window_size {
 			// Move the rolling window towards the end of `block_num->hash` mappings available
 			// in the runtime: we "canonicalize" the leaf at the end,
 			let to_canon_leaf = leaves.saturating_sub(window_size);
 			// and all the nodes added by that leaf.
 			let to_canon_nodes = NodesUtils::right_branch_ending_in_leaf(to_canon_leaf);
-			frame_support::log::debug!(
+			debug!(
 				target: "runtime::mmr::offchain", "Nodes to canon for leaf {}: {:?}",
 				to_canon_leaf, to_canon_nodes
 			);
@@ -149,7 +147,7 @@ where
 			let to_canon_block_num =
 				Pallet::<T, I>::leaf_index_to_parent_block_num(to_canon_leaf, leaves);
 			// Only entries under this hash (retrieved from state on current canon fork) are to be
-			// persisted. All other entries added by same block number will be cleared.
+			// persisted. All entries added by same block number on other forks will be cleared.
 			let to_canon_hash = <frame_system::Pallet<T>>::block_hash(to_canon_block_num);
 
 			Self::canonicalize_nodes_for_hash(&to_canon_nodes, to_canon_hash);
@@ -159,7 +157,7 @@ where
 					Self::prune_nodes_for_forks(&to_canon_nodes, forks);
 				})
 				.unwrap_or_else(|| {
-					frame_support::log::error!(
+					error!(
 						target: "runtime::mmr::offchain",
 						"Offchain: could not prune: no entry in pruning map for block {:?}",
 						to_canon_block_num
@@ -172,7 +170,7 @@ where
 		for hash in forks {
 			for pos in nodes {
 				let key = Pallet::<T, I>::node_offchain_key(hash, *pos);
-				frame_support::log::debug!(
+				debug!(
 					target: "runtime::mmr::offchain",
 					"Clear elem at pos {} with key {:?}",
 					pos, key
@@ -193,13 +191,13 @@ where
 				let canon_key = Pallet::<T, I>::node_canon_offchain_key(*pos);
 				// Add under new canon key.
 				offchain::local_storage_set(StorageKind::PERSISTENT, &canon_key, &elem);
-				frame_support::log::debug!(
+				debug!(
 					target: "runtime::mmr::offchain",
 					"Moved elem at pos {} from key {:?} to canon key {:?}",
 					pos, key, canon_key
 				);
 			} else {
-				frame_support::log::error!(
+				error!(
 					target: "runtime::mmr::offchain",
 					"Could not canonicalize elem at pos {} using key {:?}",
 					pos, key
@@ -220,21 +218,18 @@ where
 		// Find out which leaf added node `pos` in the MMR.
 		let ancestor_leaf_idx = NodesUtils::leaf_index_that_added_node(pos);
 
-		let window_size =
-			<T as frame_system::Config>::BlockHashCount::get().unique_saturated_into();
+		let window_size = Pallet::<T, I>::offchain_canonicalization_window();
 		// Leaves older than this window should have been canonicalized.
 		if leaves.saturating_sub(ancestor_leaf_idx) > window_size {
 			let key = Pallet::<T, I>::node_canon_offchain_key(pos);
-			frame_support::log::debug!(
+			debug!(
 				target: "runtime::mmr::offchain", "offchain db get {}: leaf idx {:?}, key {:?}",
 				pos, ancestor_leaf_idx, key
 			);
 			// Just for safety, to easily handle runtime upgrades where any of the window params
 			// change and maybe we mess up storage migration,
 			// return _if and only if_ node is found (in normal conditions it's always found),
-			if let Some(elem) =
-				sp_io::offchain::local_storage_get(sp_core::offchain::StorageKind::PERSISTENT, &key)
-			{
+			if let Some(elem) = sp_io::offchain::local_storage_get(StorageKind::PERSISTENT, &key) {
 				return Ok(codec::Decode::decode(&mut &*elem).ok())
 			}
 			// BUT if we DID MESS UP, fall through to searching node using fork-specific key.
@@ -245,19 +240,19 @@ where
 			Pallet::<T, I>::leaf_index_to_parent_block_num(ancestor_leaf_idx, leaves);
 		let ancestor_parent_hash = <frame_system::Pallet<T>>::block_hash(ancestor_parent_block_num);
 		let key = Pallet::<T, I>::node_offchain_key(ancestor_parent_hash, pos);
-		frame_support::log::debug!(
+		debug!(
 			target: "runtime::mmr::offchain", "offchain db get {}: leaf idx {:?}, hash {:?}, key {:?}",
 			pos, ancestor_leaf_idx, ancestor_parent_hash, key
 		);
 		// Retrieve the element from Off-chain DB.
-		Ok(sp_io::offchain::local_storage_get(sp_core::offchain::StorageKind::PERSISTENT, &key)
+		Ok(sp_io::offchain::local_storage_get(StorageKind::PERSISTENT, &key)
 			.or_else(|| {
 				// Again, this is just us being extra paranoid.
 				// We get here only if we mess up a storage migration for a runtime upgrades where
 				// say the window is increased, and for a little while following the upgrade there's
 				// leaves inside new 'window' that had been already canonicalized before upgrade.
 				let key = Pallet::<T, I>::node_canon_offchain_key(pos);
-				sp_io::offchain::local_storage_get(sp_core::offchain::StorageKind::PERSISTENT, &key)
+				sp_io::offchain::local_storage_get(StorageKind::PERSISTENT, &key)
 			})
 			.and_then(|v| codec::Decode::decode(&mut &*v).ok()))
 	}
@@ -282,7 +277,7 @@ where
 			return Ok(())
 		}
 
-		frame_support::log::trace!(
+		trace!(
 			target: "runtime::mmr",
 			"elems: {:?}",
 			elems.iter().map(|elem| elem.hash()).collect::<Vec<_>>()
@@ -317,7 +312,7 @@ where
 			// "Canonicalization" in this case means moving this leaf under a new key based
 			// only on the leaf's `node_index`.
 			let key = Pallet::<T, I>::node_offchain_key(parent_hash, node_index);
-			frame_support::log::debug!(
+			debug!(
 				target: "runtime::mmr::offchain", "offchain db set: pos {} parent_hash {:?} key {:?}",
 				node_index, parent_hash, key
 			);
@@ -356,8 +351,8 @@ fn peaks_to_prune_and_store(
 	// both collections may share a common prefix.
 	let peaks_before = if old_size == 0 { vec![] } else { helper::get_peaks(old_size) };
 	let peaks_after = helper::get_peaks(new_size);
-	frame_support::log::trace!(target: "runtime::mmr", "peaks_before: {:?}", peaks_before);
-	frame_support::log::trace!(target: "runtime::mmr", "peaks_after: {:?}", peaks_after);
+	trace!(target: "runtime::mmr", "peaks_before: {:?}", peaks_before);
+	trace!(target: "runtime::mmr", "peaks_after: {:?}", peaks_after);
 	let mut peaks_before = peaks_before.into_iter().peekable();
 	let mut peaks_after = peaks_after.into_iter().peekable();
 

--- a/frame/merkle-mountain-range/src/tests.rs
+++ b/frame/merkle-mountain-range/src/tests.rs
@@ -169,25 +169,22 @@ fn should_append_to_mmr_when_on_initialize_is_called() {
 	ext.persist_offchain_overlay();
 
 	let offchain_db = ext.offchain_db();
-	assert_eq!(
-		offchain_db.get(&MMR::node_offchain_key(parent_b1, 0)).map(decode_node),
-		Some(mmr::Node::Data(((0, H256::repeat_byte(1)), LeafData::new(1),)))
-	);
-	assert_eq!(
-		offchain_db.get(&MMR::node_offchain_key(parent_b2, 1)).map(decode_node),
-		Some(mmr::Node::Data(((1, H256::repeat_byte(2)), LeafData::new(2),)))
-	);
-	assert_eq!(
-		offchain_db.get(&MMR::node_offchain_key(parent_b2, 2)).map(decode_node),
-		Some(mmr::Node::Hash(hex(
-			"672c04a9cd05a644789d769daa552d35d8de7c33129f8a7cbf49e595234c4854"
-		)))
-	);
-	assert_eq!(offchain_db.get(&MMR::node_offchain_key(parent_b2, 3)), None);
 
-	assert_eq!(offchain_db.get(&MMR::node_canon_offchain_key(0)), None);
-	assert_eq!(offchain_db.get(&MMR::node_canon_offchain_key(1)), None);
-	assert_eq!(offchain_db.get(&MMR::node_canon_offchain_key(2)), None);
+	let expected = Some(mmr::Node::Data(((0, H256::repeat_byte(1)), LeafData::new(1))));
+	assert_eq!(offchain_db.get(&MMR::node_offchain_key(parent_b1, 0)).map(decode_node), expected);
+	assert_eq!(offchain_db.get(&MMR::node_canon_offchain_key(0)).map(decode_node), expected);
+
+	let expected = Some(mmr::Node::Data(((1, H256::repeat_byte(2)), LeafData::new(2))));
+	assert_eq!(offchain_db.get(&MMR::node_offchain_key(parent_b2, 1)).map(decode_node), expected);
+	assert_eq!(offchain_db.get(&MMR::node_canon_offchain_key(1)).map(decode_node), expected);
+
+	let expected = Some(mmr::Node::Hash(hex(
+		"672c04a9cd05a644789d769daa552d35d8de7c33129f8a7cbf49e595234c4854",
+	)));
+	assert_eq!(offchain_db.get(&MMR::node_offchain_key(parent_b2, 2)).map(decode_node), expected);
+	assert_eq!(offchain_db.get(&MMR::node_canon_offchain_key(2)).map(decode_node), expected);
+
+	assert_eq!(offchain_db.get(&MMR::node_offchain_key(parent_b2, 3)), None);
 	assert_eq!(offchain_db.get(&MMR::node_canon_offchain_key(3)), None);
 }
 
@@ -815,16 +812,20 @@ fn should_canonicalize_offchain() {
 			let parent_num: BlockNumber = (block_num - 1).into();
 			let leaf_index = u64::from(block_num - 1);
 			let pos = helper::leaf_index_to_pos(leaf_index.into());
-			// not canon,
-			assert_eq!(offchain_db.get(&MMR::node_canon_offchain_key(pos)), None);
 			let parent_hash = <frame_system::Pallet<Test>>::block_hash(parent_num);
-			// but available in fork-proof storage.
+			// Available in offchain db under both fork-proof key and canon key.
+			// We'll later check it is pruned from fork-proof key.
+			let expected = Some(mmr::Node::Data((
+				(leaf_index, H256::repeat_byte(u8::try_from(block_num).unwrap())),
+				LeafData::new(block_num.into()),
+			)));
+			assert_eq!(
+				offchain_db.get(&MMR::node_canon_offchain_key(pos)).map(decode_node),
+				expected
+			);
 			assert_eq!(
 				offchain_db.get(&MMR::node_offchain_key(parent_hash, pos)).map(decode_node),
-				Some(mmr::Node::Data((
-					(leaf_index, H256::repeat_byte(u8::try_from(block_num).unwrap())),
-					LeafData::new(block_num.into()),
-				)))
+				expected
 			);
 		}
 
@@ -835,12 +836,16 @@ fn should_canonicalize_offchain() {
 		let verify = |pos: NodeIndex, leaf_index: LeafIndex, expected: H256| {
 			let parent_num: BlockNumber = leaf_index.try_into().unwrap();
 			let parent_hash = <frame_system::Pallet<Test>>::block_hash(parent_num);
-			// not canon,
-			assert_eq!(offchain_db.get(&MMR::node_canon_offchain_key(pos)), None);
-			// but available in fork-proof storage.
+			// Available in offchain db under both fork-proof key and canon key.
+			// We'll later check it is pruned from fork-proof key.
+			let expected = Some(mmr::Node::Hash(expected));
+			assert_eq!(
+				offchain_db.get(&MMR::node_canon_offchain_key(pos)).map(decode_node),
+				expected
+			);
 			assert_eq!(
 				offchain_db.get(&MMR::node_offchain_key(parent_hash, pos)).map(decode_node),
-				Some(mmr::Node::Hash(expected))
+				expected
 			);
 		};
 		verify(2, 1, hex("672c04a9cd05a644789d769daa552d35d8de7c33129f8a7cbf49e595234c4854"));

--- a/frame/merkle-mountain-range/src/tests.rs
+++ b/frame/merkle-mountain-range/src/tests.rs
@@ -171,20 +171,20 @@ fn should_append_to_mmr_when_on_initialize_is_called() {
 	let offchain_db = ext.offchain_db();
 
 	let expected = Some(mmr::Node::Data(((0, H256::repeat_byte(1)), LeafData::new(1))));
-	assert_eq!(offchain_db.get(&MMR::node_offchain_key(parent_b1, 0)).map(decode_node), expected);
+	assert_eq!(offchain_db.get(&MMR::node_offchain_key(0, parent_b1)).map(decode_node), expected);
 	assert_eq!(offchain_db.get(&MMR::node_canon_offchain_key(0)).map(decode_node), expected);
 
 	let expected = Some(mmr::Node::Data(((1, H256::repeat_byte(2)), LeafData::new(2))));
-	assert_eq!(offchain_db.get(&MMR::node_offchain_key(parent_b2, 1)).map(decode_node), expected);
+	assert_eq!(offchain_db.get(&MMR::node_offchain_key(1, parent_b2)).map(decode_node), expected);
 	assert_eq!(offchain_db.get(&MMR::node_canon_offchain_key(1)).map(decode_node), expected);
 
 	let expected = Some(mmr::Node::Hash(hex(
 		"672c04a9cd05a644789d769daa552d35d8de7c33129f8a7cbf49e595234c4854",
 	)));
-	assert_eq!(offchain_db.get(&MMR::node_offchain_key(parent_b2, 2)).map(decode_node), expected);
+	assert_eq!(offchain_db.get(&MMR::node_offchain_key(2, parent_b2)).map(decode_node), expected);
 	assert_eq!(offchain_db.get(&MMR::node_canon_offchain_key(2)).map(decode_node), expected);
 
-	assert_eq!(offchain_db.get(&MMR::node_offchain_key(parent_b2, 3)), None);
+	assert_eq!(offchain_db.get(&MMR::node_offchain_key(3, parent_b2)), None);
 	assert_eq!(offchain_db.get(&MMR::node_canon_offchain_key(3)), None);
 }
 
@@ -824,7 +824,7 @@ fn should_canonicalize_offchain() {
 				expected
 			);
 			assert_eq!(
-				offchain_db.get(&MMR::node_offchain_key(parent_hash, pos)).map(decode_node),
+				offchain_db.get(&MMR::node_offchain_key(pos, parent_hash)).map(decode_node),
 				expected
 			);
 		}
@@ -844,7 +844,7 @@ fn should_canonicalize_offchain() {
 				expected
 			);
 			assert_eq!(
-				offchain_db.get(&MMR::node_offchain_key(parent_hash, pos)).map(decode_node),
+				offchain_db.get(&MMR::node_offchain_key(pos, parent_hash)).map(decode_node),
 				expected
 			);
 		};
@@ -872,7 +872,7 @@ fn should_canonicalize_offchain() {
 			let parent_num: BlockNumber = (block_num - 1).into();
 			let parent_hash = <frame_system::Pallet<Test>>::block_hash(parent_num);
 			// no longer available in fork-proof storage (was pruned),
-			assert_eq!(offchain_db.get(&MMR::node_offchain_key(parent_hash, pos)), None);
+			assert_eq!(offchain_db.get(&MMR::node_offchain_key(pos, parent_hash)), None);
 			// but available using canon key.
 			assert_eq!(
 				offchain_db.get(&MMR::node_canon_offchain_key(pos)).map(decode_node),
@@ -891,7 +891,7 @@ fn should_canonicalize_offchain() {
 			let parent_num: BlockNumber = leaf_index.try_into().unwrap();
 			let parent_hash = <frame_system::Pallet<Test>>::block_hash(parent_num);
 			// no longer available in fork-proof storage (was pruned),
-			assert_eq!(offchain_db.get(&MMR::node_offchain_key(parent_hash, pos)), None);
+			assert_eq!(offchain_db.get(&MMR::node_offchain_key(pos, parent_hash)), None);
 			// but available using canon key.
 			assert_eq!(
 				offchain_db.get(&MMR::node_canon_offchain_key(pos)).map(decode_node),


### PR DESCRIPTION
MMR nodes are saved in off-chain db under fork-resistant keys based on `frame_system::block_hash()`, as such only nodes added by latest `frame_system::BlockHashCount` can be accessed that way.
Nodes added by blocks older than `frame_system::BlockHashCount` are moved by `offchain_worker` to "canon" (not fork resistant) location - thus being made available regardless of age.
See https://github.com/paritytech/substrate/pull/11594 for more details.

**Issue** is that `offchain_worker` doesn't run for blocks imported during initial sync. So for initial syncs > `frame_system::BlockHashCount` (practically any node syncing from scratch), MMR nodes aren't moved to canon position and access to them is lost.

**Solution** proposed by this PR: runtime block execution saves node to _both_ fork-resistant and canon locations:
- initial sync nodes directly end up in the right location,
- for the rest, we do a superfluous `offchain_index::set()` because it will be overwritten by `offchain_worker` with canon values anyway.