### PR TITLE
sp-api: Remove invalid unsafe trait bounds

### DIFF
--- a/client/beefy/src/import.rs
+++ b/client/beefy/src/import.rs
@@ -78,7 +78,7 @@ where
 	Block: BlockT,
 	BE: Backend<Block>,
 	Runtime: ProvideRuntimeApi<Block>,
-	Runtime::Api: BeefyApi<Block> + Send + Sync,
+	Runtime::Api: BeefyApi<Block> + Send,
 {
 	fn decode_and_verify(
 		&self,

--- a/primitives/api/proc-macro/src/decl_runtime_apis.rs
+++ b/primitives/api/proc-macro/src/decl_runtime_apis.rs
@@ -535,7 +535,7 @@ impl<'a> Fold for ToClientSideDecl<'a> {
 
 		if is_core_trait {
 			// Add all the supertraits we want to have for `Core`.
-			input.supertraits = parse_quote!('static + Send + Sync);
+			input.supertraits = parse_quote!('static + Send);
 		} else {
 			// Add the `Core` runtime api as super trait.
 			let crate_ = &self.crate_;

--- a/primitives/api/proc-macro/src/impl_runtime_apis.rs
+++ b/primitives/api/proc-macro/src/impl_runtime_apis.rs
@@ -211,19 +211,6 @@ fn generate_runtime_api_base_structures() -> Result<TokenStream> {
 			recorder: std::option::Option<#crate_::ProofRecorder<Block>>,
 		}
 
-		// `RuntimeApi` itself is not threadsafe. However, an instance is only available in a
-		// `ApiRef` object and `ApiRef` also has an associated lifetime. This lifetimes makes it
-		// impossible to move `RuntimeApi` into another thread.
-		#[cfg(any(feature = "std", test))]
-		unsafe impl<Block: #crate_::BlockT, C: #crate_::CallApiAt<Block>> Send
-			for RuntimeApiImpl<Block, C>
-		{}
-
-		#[cfg(any(feature = "std", test))]
-		unsafe impl<Block: #crate_::BlockT, C: #crate_::CallApiAt<Block>> Sync
-			for RuntimeApiImpl<Block, C>
-		{}
-
 		#[cfg(any(feature = "std", test))]
 		impl<Block: #crate_::BlockT, C: #crate_::CallApiAt<Block>> #crate_::ApiExt<Block> for
 			RuntimeApiImpl<Block, C>
@@ -514,6 +501,8 @@ impl<'a> Fold for ApiRuntimeImplToApiRuntimeApiImpl<'a> {
 			RuntimeApiImplCall::StateBackend:
 				#crate_::StateBackend<#crate_::HashFor<__SR_API_BLOCK__>>
 		});
+
+		where_clause.predicates.push(parse_quote! { &'static RuntimeApiImplCall: Send });
 
 		// Require that all types used in the function signatures are unwind safe.
 		extract_all_signature_types(&input.items).iter().for_each(|i| {


### PR DESCRIPTION
The runtime api implementation contained invalid unsafe trait bounds. `Sync` was never correct there and `Send` should have not been "force implemented".


