### PR TITLE
Nomination Pool Commission

### DIFF
--- a/frame/nomination-pools/src/lib.rs
+++ b/frame/nomination-pools/src/lib.rs
@@ -560,6 +560,12 @@ pub struct Commission<T: Config> {
 	throttle: Option<CommissionThrottle<T>>,
 }
 
+impl<T: Config> Default for Commission<T> {
+	fn default() -> Self {
+		Self { current: Perbill::zero(), max: Some(Perbill::zero()), throttle: None }
+	}
+}
+
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, DebugNoBound, PartialEq, Clone)]
 #[codec(mel_bound(T: Config))]
 #[scale_info(skip_type_params(T))]
@@ -569,12 +575,6 @@ pub struct CommissionThrottle<T: Config> {
 	pub change_rate: (Perbill, T::BlockNumber),
 	/// The block the previous commission update took place.
 	previous_set_at: T::BlockNumber,
-}
-
-impl<T: Config> Default for Commission<T> {
-	fn default() -> Self {
-		Self { current: Perbill::zero(), max: Some(Perbill::zero()), throttle: None }
-	}
 }
 
 impl<T: Config> CommissionThrottle<T> {

--- a/frame/nomination-pools/src/lib.rs
+++ b/frame/nomination-pools/src/lib.rs
@@ -2119,7 +2119,7 @@ pub mod pallet {
 				Error::<T>::DoesNotHavePermission
 			);
 
-			BondedPools::<T>::try_mutate_exists(pool_id, |maybe_pool| {
+			BondedPools::<T>::try_mutate(pool_id, |maybe_pool| {
 				let pool = maybe_pool.as_mut().ok_or(Error::<T>::PoolNotFound)?;
 				let block_number = <frame_system::Pallet<T>>::block_number();
 
@@ -2171,7 +2171,7 @@ pub mod pallet {
 				Error::<T>::DoesNotHavePermission
 			);
 
-			BondedPools::<T>::try_mutate_exists(pool_id, |maybe_pool| {
+			BondedPools::<T>::try_mutate(pool_id, |maybe_pool| {
 				let pool = maybe_pool.as_mut().ok_or(Error::<T>::PoolNotFound)?;
 				ensure!(
 					pool.commission.max.unwrap_or(Perbill::max_value()) > max_commission,
@@ -2216,7 +2216,7 @@ pub mod pallet {
 					.can_set_commission(&who),
 				Error::<T>::DoesNotHavePermission
 			);
-			BondedPools::<T>::try_mutate_exists(pool_id, |maybe_pool| {
+			BondedPools::<T>::try_mutate(pool_id, |maybe_pool| {
 				let pool = maybe_pool.as_mut().ok_or(Error::<T>::PoolNotFound)?;
 				if let Some(throttle) = &pool.commission.throttle {
 					let (current_max_increase, current_min_delay) = throttle.change_rate;

--- a/frame/nomination-pools/src/lib.rs
+++ b/frame/nomination-pools/src/lib.rs
@@ -1513,8 +1513,6 @@ pub mod pallet {
 		Defensive(DefensiveError),
 		/// Partial unbonding now allowed permissionlessly.
 		PartialUnbondNotAllowedPermissionlessly,
-		/// The pool commission has been misconfigured.
-		CommissionMisconfigured,
 		/// The pool's max commission cannot be set higher than the existing value.
 		MaxCommissionRestricted,
 		/// The supplied commission exceeds the max allowed commission.

--- a/frame/nomination-pools/src/migration.rs
+++ b/frame/nomination-pools/src/migration.rs
@@ -53,6 +53,7 @@ pub mod v1 {
 	impl<T: Config> OldBondedPoolInner<T> {
 		fn migrate_to_v1(self) -> BondedPoolInner<T> {
 			BondedPoolInner {
+				commission: Commission::default(),
 				member_counter: self.member_counter,
 				points: self.points,
 				state: self.state,

--- a/frame/nomination-pools/src/mock.rs
+++ b/frame/nomination-pools/src/mock.rs
@@ -293,7 +293,6 @@ impl ExtBuilder {
 			assert_ok!(Pools::create(
 				RawOrigin::Signed(10).into(),
 				amount_to_bond,
-				Commission::default(),
 				900,
 				901,
 				902

--- a/frame/nomination-pools/src/mock.rs
+++ b/frame/nomination-pools/src/mock.rs
@@ -290,7 +290,14 @@ impl ExtBuilder {
 			// make a pool
 			let amount_to_bond = Pools::depositor_min_bond();
 			Balances::make_free_balance_be(&10, amount_to_bond * 5);
-			assert_ok!(Pools::create(RawOrigin::Signed(10).into(), amount_to_bond, 900, 901, 902));
+			assert_ok!(Pools::create(
+				RawOrigin::Signed(10).into(),
+				amount_to_bond,
+				Commission::default(),
+				900,
+				901,
+				902
+			));
 			assert_ok!(Pools::set_metadata(RuntimeOrigin::signed(900), 1, vec![1, 1]));
 			let last_pool = LastPoolId::<Runtime>::get();
 			for (account_id, bonded) in self.members {

--- a/frame/nomination-pools/src/mock.rs
+++ b/frame/nomination-pools/src/mock.rs
@@ -290,13 +290,7 @@ impl ExtBuilder {
 			// make a pool
 			let amount_to_bond = Pools::depositor_min_bond();
 			Balances::make_free_balance_be(&10, amount_to_bond * 5);
-			assert_ok!(Pools::create(
-				RawOrigin::Signed(10).into(),
-				amount_to_bond,
-				900,
-				901,
-				902
-			));
+			assert_ok!(Pools::create(RawOrigin::Signed(10).into(), amount_to_bond, 900, 901, 902));
 			assert_ok!(Pools::set_metadata(RuntimeOrigin::signed(900), 1, vec![1, 1]));
 			let last_pool = LastPoolId::<Runtime>::get();
 			for (account_id, bonded) in self.members {

--- a/frame/nomination-pools/src/mock.rs
+++ b/frame/nomination-pools/src/mock.rs
@@ -324,6 +324,23 @@ parameter_types! {
 	storage BalancesEvents: u32 = 0;
 }
 
+/// Helper to tun a specified amount of blocks.
+pub(crate) fn run_blocks(n: u64) {
+	let current_block = System::block_number();
+	run_to_block(n + current_block);
+}
+
+/// Helper to run to a specific block.
+pub(crate) fn run_to_block(n: u64) {
+	let current_block = System::block_number();
+	assert!(n > current_block);
+	while System::block_number() < n {
+		Pools::on_finalize(System::block_number());
+		System::set_block_number(System::block_number() + 1);
+		Pools::on_initialize(System::block_number());
+	}
+}
+
 /// All events of this pallet.
 pub(crate) fn pool_events_since_last_call() -> Vec<super::Event<Runtime>> {
 	let events = System::events()

--- a/frame/nomination-pools/src/tests.rs
+++ b/frame/nomination-pools/src/tests.rs
@@ -244,6 +244,58 @@ mod bonded_pool {
 			assert_ok!(pool.ok_to_join(0));
 		});
 	}
+
+	#[test]
+	fn set_commission_works() {
+		ExtBuilder::default().build_and_execute(|| {
+			// Set a commission pool 1
+			assert_ok!(Pools::set_commission(
+				RuntimeOrigin::signed(900),
+				1,
+				Perbill::from_percent(50)
+			));
+			assert_eq!(
+				BondedPools::<Runtime>::get(1).unwrap().commission.current,
+				Perbill::from_percent(50)
+			);
+		});
+	}
+
+	#[test]
+	fn set_max_commission_works() {
+		ExtBuilder::default().build_and_execute(|| {
+			// Set a max commission commission pool 1
+			assert_ok!(Pools::set_max_commission(
+				RuntimeOrigin::signed(900),
+				1,
+				Perbill::from_percent(100)
+			));
+			assert_eq!(
+				BondedPools::<Runtime>::get(1).unwrap().commission.max,
+				Some(Perbill::from_percent(100))
+			);
+		});
+	}
+
+	#[test]
+	fn set_commission_throttle_works() {
+		ExtBuilder::default().build_and_execute(|| {
+			// Set a commission throttle for pool 1
+			assert_ok!(Pools::set_commission_throttle(
+				RuntimeOrigin::signed(900),
+				1,
+				Perbill::from_percent(5),
+				1000_u64
+			));
+			assert_eq!(
+				BondedPools::<Runtime>::get(1).unwrap().commission.throttle,
+				Some(CommissionThrottle {
+					change_rate: (Perbill::from_percent(5), 1000_u64),
+					previous_set_at: None
+				})
+			);
+		});
+	}
 }
 
 mod reward_pool {

--- a/frame/nomination-pools/src/tests.rs
+++ b/frame/nomination-pools/src/tests.rs
@@ -639,7 +639,6 @@ mod join {
 			assert_ok!(Pools::create(
 				RuntimeOrigin::signed(104),
 				100,
-				Commission::default(),
 				104,
 				104,
 				104
@@ -1616,7 +1615,6 @@ mod claim_payout {
 			assert_ok!(Pools::create(
 				RuntimeOrigin::signed(20),
 				10,
-				Commission::default(),
 				20,
 				20,
 				20
@@ -1639,7 +1637,6 @@ mod claim_payout {
 			assert_ok!(Pools::create(
 				RuntimeOrigin::signed(30),
 				10,
-				Commission::default(),
 				30,
 				30,
 				30
@@ -4116,7 +4113,6 @@ mod create {
 			assert_ok!(Pools::create(
 				RuntimeOrigin::signed(11),
 				StakingMock::minimum_bond(),
-				Commission::default(),
 				123,
 				456,
 				789
@@ -4174,7 +4170,7 @@ mod create {
 	fn create_errors_correctly() {
 		ExtBuilder::default().with_check(0).build_and_execute(|| {
 			assert_noop!(
-				Pools::create(RuntimeOrigin::signed(10), 420, Commission::default(), 123, 456, 789),
+				Pools::create(RuntimeOrigin::signed(10), 420, 123, 456, 789),
 				Error::<Runtime>::AccountBelongsToOtherPool
 			);
 
@@ -4184,7 +4180,7 @@ mod create {
 
 			// Then
 			assert_noop!(
-				Pools::create(RuntimeOrigin::signed(11), 9, Commission::default(), 123, 456, 789),
+				Pools::create(RuntimeOrigin::signed(11), 9, 123, 456, 789),
 				Error::<Runtime>::MinimumBondNotMet
 			);
 
@@ -4193,7 +4189,7 @@ mod create {
 
 			// Then
 			assert_noop!(
-				Pools::create(RuntimeOrigin::signed(11), 19, Commission::default(), 123, 456, 789),
+				Pools::create(RuntimeOrigin::signed(11), 19, 123, 456, 789),
 				Error::<Runtime>::MinimumBondNotMet
 			);
 
@@ -4214,7 +4210,7 @@ mod create {
 
 			// Then
 			assert_noop!(
-				Pools::create(RuntimeOrigin::signed(11), 20, Commission::default(), 123, 456, 789),
+				Pools::create(RuntimeOrigin::signed(11), 20, 123, 456, 789),
 				Error::<Runtime>::MaxPools
 			);
 
@@ -4227,7 +4223,6 @@ mod create {
 			// Then
 			let create = RuntimeCall::Pools(crate::Call::<Runtime>::create {
 				amount: 20,
-				commission: Commission::default(),
 				root: 11,
 				nominator: 11,
 				state_toggler: 11,

--- a/frame/nomination-pools/src/tests.rs
+++ b/frame/nomination-pools/src/tests.rs
@@ -549,7 +549,7 @@ mod bonded_pool {
 				),
 				Error::<Runtime>::CommissionThrottleNotAllowed
 			);
-			
+
 			// Successful more restrictive change of min_delay with the current max_increase
 			assert_ok!(Pools::set_commission_throttle(
 				RuntimeOrigin::signed(900),

--- a/frame/nomination-pools/src/tests.rs
+++ b/frame/nomination-pools/src/tests.rs
@@ -55,10 +55,11 @@ fn test_setup_works() {
 			BondedPool::<Runtime> {
 				id: last_pool,
 				inner: BondedPoolInner {
-					state: PoolState::Open,
-					points: 10,
+					commission: Commission::default(),
 					member_counter: 1,
-					roles: DEFAULT_ROLES
+					points: 10,
+					roles: DEFAULT_ROLES,
+					state: PoolState::Open,
 				},
 			}
 		);
@@ -98,10 +99,11 @@ mod bonded_pool {
 			let mut bonded_pool = BondedPool::<Runtime> {
 				id: 123123,
 				inner: BondedPoolInner {
-					state: PoolState::Open,
-					points: 100,
+					commission: Commission::default(),
 					member_counter: 1,
+					points: 100,
 					roles: DEFAULT_ROLES,
+					state: PoolState::Open,
 				},
 			};
 
@@ -153,10 +155,11 @@ mod bonded_pool {
 			let mut bonded_pool = BondedPool::<Runtime> {
 				id: 123123,
 				inner: BondedPoolInner {
-					state: PoolState::Open,
-					points: 100,
+					commission: Commission::default(),
 					member_counter: 1,
+					points: 100,
 					roles: DEFAULT_ROLES,
+					state: PoolState::Open,
 				},
 			};
 
@@ -201,10 +204,11 @@ mod bonded_pool {
 			let pool = BondedPool::<Runtime> {
 				id: 123,
 				inner: BondedPoolInner {
-					state: PoolState::Open,
-					points: 100,
+					commission: Commission::default(),
 					member_counter: 1,
+					points: 100,
 					roles: DEFAULT_ROLES,
+					state: PoolState::Open,
 				},
 			};
 
@@ -431,10 +435,11 @@ mod join {
 		let bonded = |points, member_counter| BondedPool::<Runtime> {
 			id: 1,
 			inner: BondedPoolInner {
-				state: PoolState::Open,
-				points,
+				commission: Commission::default(),
 				member_counter,
+				points,
 				roles: DEFAULT_ROLES,
+				state: PoolState::Open,
 			},
 		};
 		ExtBuilder::default().build_and_execute(|| {
@@ -514,10 +519,11 @@ mod join {
 			BondedPool::<Runtime> {
 				id: 123,
 				inner: BondedPoolInner {
+					commission: Commission::default(),
 					member_counter: 1,
-					state: PoolState::Open,
 					points: 100,
 					roles: DEFAULT_ROLES,
+					state: PoolState::Open,
 				},
 			}
 			.put();
@@ -583,10 +589,11 @@ mod join {
 			BondedPool::<Runtime> {
 				id: 123,
 				inner: BondedPoolInner {
-					state: PoolState::Open,
-					points: 100,
+					commission: Commission::default(),
 					member_counter: 1,
+					points: 100,
 					roles: DEFAULT_ROLES,
+					state: PoolState::Open,
 				},
 			}
 			.put();
@@ -629,7 +636,14 @@ mod join {
 			assert_eq!(MaxPoolMembers::<Runtime>::get(), Some(4));
 
 			Balances::make_free_balance_be(&104, 100 + Balances::minimum_balance());
-			assert_ok!(Pools::create(RuntimeOrigin::signed(104), 100, 104, 104, 104));
+			assert_ok!(Pools::create(
+				RuntimeOrigin::signed(104),
+				100,
+				Commission::default(),
+				104,
+				104,
+				104
+			));
 
 			let pool_account = BondedPools::<Runtime>::iter()
 				.find(|(_, bonded_pool)| bonded_pool.roles.depositor == 104)
@@ -1599,7 +1613,14 @@ mod claim_payout {
 
 			// create pool 2
 			Balances::make_free_balance_be(&20, 100);
-			assert_ok!(Pools::create(RuntimeOrigin::signed(20), 10, 20, 20, 20));
+			assert_ok!(Pools::create(
+				RuntimeOrigin::signed(20),
+				10,
+				Commission::default(),
+				20,
+				20,
+				20
+			));
 
 			// has no impact -- initial
 			let (member_20, _, reward_pool_20) = Pools::get_member_with_pools(&20).unwrap();
@@ -1615,7 +1636,14 @@ mod claim_payout {
 
 			// create pool 3
 			Balances::make_free_balance_be(&30, 100);
-			assert_ok!(Pools::create(RuntimeOrigin::signed(30), 10, 30, 30, 30));
+			assert_ok!(Pools::create(
+				RuntimeOrigin::signed(30),
+				10,
+				Commission::default(),
+				30,
+				30,
+				30
+			));
 
 			// reward counter is still the same.
 			let (member_30, _, reward_pool_30) = Pools::get_member_with_pools(&30).unwrap();
@@ -2360,10 +2388,11 @@ mod unbond {
 				BondedPool {
 					id: 1,
 					inner: BondedPoolInner {
-						state: PoolState::Destroying,
-						points: 0,
+						commission: Commission::default(),
 						member_counter: 1,
+						points: 0,
 						roles: DEFAULT_ROLES,
+						state: PoolState::Destroying,
 					}
 				}
 			);
@@ -2396,10 +2425,11 @@ mod unbond {
 					BondedPool {
 						id: 1,
 						inner: BondedPoolInner {
-							state: PoolState::Open,
-							points: 560,
+							commission: Commission::default(),
 							member_counter: 3,
+							points: 560,
 							roles: DEFAULT_ROLES,
+							state: PoolState::Open,
 						}
 					}
 				);
@@ -2436,10 +2466,11 @@ mod unbond {
 					BondedPool {
 						id: 1,
 						inner: BondedPoolInner {
-							state: PoolState::Destroying,
-							points: 10,
+							commission: Commission::default(),
 							member_counter: 3,
-							roles: DEFAULT_ROLES
+							points: 10,
+							roles: DEFAULT_ROLES,
+							state: PoolState::Destroying,
 						}
 					}
 				);
@@ -2479,10 +2510,11 @@ mod unbond {
 					BondedPool {
 						id: 1,
 						inner: BondedPoolInner {
-							state: PoolState::Destroying,
-							points: 0,
+							commission: Commission::default(),
 							member_counter: 1,
-							roles: DEFAULT_ROLES
+							points: 0,
+							roles: DEFAULT_ROLES,
+							state: PoolState::Destroying,
 						}
 					}
 				);
@@ -2607,10 +2639,11 @@ mod unbond {
 					BondedPool {
 						id: 1,
 						inner: BondedPoolInner {
+							commission: Commission::default(),
+							member_counter: 3,
+							points: 10, // Only 10 points because 200 + 100 was unbonded
 							roles: DEFAULT_ROLES,
 							state: PoolState::Blocked,
-							points: 10, // Only 10 points because 200 + 100 was unbonded
-							member_counter: 3,
 						}
 					}
 				);
@@ -2757,10 +2790,11 @@ mod unbond {
 			BondedPool::<Runtime> {
 				id: 1,
 				inner: BondedPoolInner {
-					state: PoolState::Open,
-					points: 10,
+					commission: Commission::default(),
 					member_counter: 1,
+					points: 10,
 					roles: DEFAULT_ROLES,
+					state: PoolState::Open,
 				},
 			}
 			.put();
@@ -3469,10 +3503,11 @@ mod withdraw_unbonded {
 					BondedPool {
 						id: 1,
 						inner: BondedPoolInner {
-							points: 10,
-							state: PoolState::Open,
+							commission: Commission::default(),
 							member_counter: 3,
-							roles: DEFAULT_ROLES
+							points: 10,
+							roles: DEFAULT_ROLES,
+							state: PoolState::Open,
 						}
 					}
 				);
@@ -3549,10 +3584,11 @@ mod withdraw_unbonded {
 				BondedPool {
 					id: 1,
 					inner: BondedPoolInner {
-						points: 10,
-						state: PoolState::Open,
+						commission: Commission::default(),
 						member_counter: 2,
+						points: 10,
 						roles: DEFAULT_ROLES,
+						state: PoolState::Open,
 					}
 				}
 			);
@@ -4080,6 +4116,7 @@ mod create {
 			assert_ok!(Pools::create(
 				RuntimeOrigin::signed(11),
 				StakingMock::minimum_bond(),
+				Commission::default(),
 				123,
 				456,
 				789
@@ -4099,15 +4136,16 @@ mod create {
 				BondedPool {
 					id: 2,
 					inner: BondedPoolInner {
-						points: StakingMock::minimum_bond(),
+						commission: Commission::default(),
 						member_counter: 1,
-						state: PoolState::Open,
+						points: StakingMock::minimum_bond(),
 						roles: PoolRoles {
 							depositor: 11,
 							root: Some(123),
 							nominator: Some(456),
 							state_toggler: Some(789)
-						}
+						},
+						state: PoolState::Open,
 					}
 				}
 			);
@@ -4136,7 +4174,7 @@ mod create {
 	fn create_errors_correctly() {
 		ExtBuilder::default().with_check(0).build_and_execute(|| {
 			assert_noop!(
-				Pools::create(RuntimeOrigin::signed(10), 420, 123, 456, 789),
+				Pools::create(RuntimeOrigin::signed(10), 420, Commission::default(), 123, 456, 789),
 				Error::<Runtime>::AccountBelongsToOtherPool
 			);
 
@@ -4146,7 +4184,7 @@ mod create {
 
 			// Then
 			assert_noop!(
-				Pools::create(RuntimeOrigin::signed(11), 9, 123, 456, 789),
+				Pools::create(RuntimeOrigin::signed(11), 9, Commission::default(), 123, 456, 789),
 				Error::<Runtime>::MinimumBondNotMet
 			);
 
@@ -4155,7 +4193,7 @@ mod create {
 
 			// Then
 			assert_noop!(
-				Pools::create(RuntimeOrigin::signed(11), 19, 123, 456, 789),
+				Pools::create(RuntimeOrigin::signed(11), 19, Commission::default(), 123, 456, 789),
 				Error::<Runtime>::MinimumBondNotMet
 			);
 
@@ -4163,10 +4201,11 @@ mod create {
 			BondedPool::<Runtime> {
 				id: 2,
 				inner: BondedPoolInner {
-					state: PoolState::Open,
-					points: 10,
+					commission: Commission::default(),
 					member_counter: 1,
+					points: 10,
 					roles: DEFAULT_ROLES,
+					state: PoolState::Open,
 				},
 			}
 			.put();
@@ -4175,7 +4214,7 @@ mod create {
 
 			// Then
 			assert_noop!(
-				Pools::create(RuntimeOrigin::signed(11), 20, 123, 456, 789),
+				Pools::create(RuntimeOrigin::signed(11), 20, Commission::default(), 123, 456, 789),
 				Error::<Runtime>::MaxPools
 			);
 
@@ -4188,6 +4227,7 @@ mod create {
 			// Then
 			let create = RuntimeCall::Pools(crate::Call::<Runtime>::create {
 				amount: 20,
+				commission: Commission::default(),
 				root: 11,
 				nominator: 11,
 				state_toggler: 11,

--- a/frame/nomination-pools/src/tests.rs
+++ b/frame/nomination-pools/src/tests.rs
@@ -636,13 +636,7 @@ mod join {
 			assert_eq!(MaxPoolMembers::<Runtime>::get(), Some(4));
 
 			Balances::make_free_balance_be(&104, 100 + Balances::minimum_balance());
-			assert_ok!(Pools::create(
-				RuntimeOrigin::signed(104),
-				100,
-				104,
-				104,
-				104
-			));
+			assert_ok!(Pools::create(RuntimeOrigin::signed(104), 100, 104, 104, 104));
 
 			let pool_account = BondedPools::<Runtime>::iter()
 				.find(|(_, bonded_pool)| bonded_pool.roles.depositor == 104)
@@ -1612,13 +1606,7 @@ mod claim_payout {
 
 			// create pool 2
 			Balances::make_free_balance_be(&20, 100);
-			assert_ok!(Pools::create(
-				RuntimeOrigin::signed(20),
-				10,
-				20,
-				20,
-				20
-			));
+			assert_ok!(Pools::create(RuntimeOrigin::signed(20), 10, 20, 20, 20));
 
 			// has no impact -- initial
 			let (member_20, _, reward_pool_20) = Pools::get_member_with_pools(&20).unwrap();
@@ -1634,13 +1622,7 @@ mod claim_payout {
 
 			// create pool 3
 			Balances::make_free_balance_be(&30, 100);
-			assert_ok!(Pools::create(
-				RuntimeOrigin::signed(30),
-				10,
-				30,
-				30,
-				30
-			));
+			assert_ok!(Pools::create(RuntimeOrigin::signed(30), 10, 30, 30, 30));
 
 			// reward counter is still the same.
 			let (member_30, _, reward_pool_30) = Pools::get_member_with_pools(&30).unwrap();


### PR DESCRIPTION
This PR adds commission functionality to Nomination Pools.

[More thorough description incoming...]

TODO:
- [ ] Add a configurable `receiver` field to `Commission` struct.
- [ ] Make commission payouts to `receiver` instead of `depositor`.
- [ ] Make primitive `Commission` struct to take over into `staking` & implement this in `nomination-pools`.