### PR TITLE
derive Serialize/Deserialize for BeefyAuthoritySet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,7 @@ dependencies = [
  "array-bytes",
  "parity-scale-codec",
  "scale-info",
+ "serde",
  "sp-api",
  "sp-application-crypto",
  "sp-core",

--- a/primitives/beefy/Cargo.toml
+++ b/primitives/beefy/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.136", optional = true, features = ["derive"] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }
 sp-application-crypto = { version = "6.0.0", default-features = false, path = "../application-crypto" }
@@ -32,6 +33,7 @@ default = ["std"]
 std = [
 	"codec/std",
 	"scale-info/std",
+	"serde",
 	"sp-api/std",
 	"sp-application-crypto/std",
 	"sp-core/std",

--- a/primitives/beefy/src/mmr.rs
+++ b/primitives/beefy/src/mmr.rs
@@ -101,6 +101,7 @@ impl MmrLeafVersion {
 
 /// Details of a BEEFY authority set.
 #[derive(Debug, Default, PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct BeefyAuthoritySet<MerkleRoot> {
 	/// Id of the set.
 	///


### PR DESCRIPTION
Related to: https://github.com/paritytech/parity-bridges-common/issues/1574

We are working on implementing BEEFY finality in the [bridges](https://github.com/paritytech/parity-bridges-common) project and as part of this we'll need to have the initial `BeefyAuthoritySet` in the `GenesisConfig` structure. In order to do this we need `BeefyAuthoritySet` to implement serde serialize/deserialize. 