### PR TITLE
BlockId removal: refactor: ProofProvider

### DIFF
--- a/client/api/src/proof_provider.rs
+++ b/client/api/src/proof_provider.rs
@@ -18,7 +18,7 @@
 
 //! Proof utilities
 use crate::{CompactProof, StorageProof};
-use sp_runtime::{generic::BlockId, traits::Block as BlockT};
+use sp_runtime::traits::Block as BlockT;
 use sp_state_machine::{KeyValueStates, KeyValueStorageLevel};
 use sp_storage::ChildInfo;
 
@@ -27,7 +27,7 @@ pub trait ProofProvider<Block: BlockT> {
 	/// Reads storage value at a given block + key, returning read proof.
 	fn read_proof(
 		&self,
-		id: &BlockId<Block>,
+		hash: &Block::Hash,
 		keys: &mut dyn Iterator<Item = &[u8]>,
 	) -> sp_blockchain::Result<StorageProof>;
 
@@ -35,7 +35,7 @@ pub trait ProofProvider<Block: BlockT> {
 	/// read proof.
 	fn read_child_proof(
 		&self,
-		id: &BlockId<Block>,
+		hash: &Block::Hash,
 		child_info: &ChildInfo,
 		keys: &mut dyn Iterator<Item = &[u8]>,
 	) -> sp_blockchain::Result<StorageProof>;
@@ -46,12 +46,12 @@ pub trait ProofProvider<Block: BlockT> {
 	/// No changes are made.
 	fn execution_proof(
 		&self,
-		id: &BlockId<Block>,
+		hash: &Block::Hash,
 		method: &str,
 		call_data: &[u8],
 	) -> sp_blockchain::Result<(Vec<u8>, StorageProof)>;
 
-	/// Given a `BlockId` iterate over all storage values starting at `start_keys`.
+	/// Given a `Hash` iterate over all storage values starting at `start_keys`.
 	/// Last `start_keys` element contains last accessed key value.
 	/// With multiple `start_keys`, first `start_keys` element is
 	/// the current storage key of of the last accessed child trie.
@@ -61,12 +61,12 @@ pub trait ProofProvider<Block: BlockT> {
 	/// Returns combined proof and the numbers of collected keys.
 	fn read_proof_collection(
 		&self,
-		id: &BlockId<Block>,
+		hash: &Block::Hash,
 		start_keys: &[Vec<u8>],
 		size_limit: usize,
 	) -> sp_blockchain::Result<(CompactProof, u32)>;
 
-	/// Given a `BlockId` iterate over all storage values starting at `start_key`.
+	/// Given a `Hash` iterate over all storage values starting at `start_key`.
 	/// Returns collected keys and values.
 	/// Returns the collected keys values content of the top trie followed by the
 	/// collected keys values of child tries.
@@ -76,7 +76,7 @@ pub trait ProofProvider<Block: BlockT> {
 	/// end.
 	fn storage_collection(
 		&self,
-		id: &BlockId<Block>,
+		hash: &Block::Hash,
 		start_key: &[Vec<u8>],
 		size_limit: usize,
 	) -> sp_blockchain::Result<Vec<(KeyValueStorageLevel, bool)>>;

--- a/client/network/light/src/light_client_requests/handler.rs
+++ b/client/network/light/src/light_client_requests/handler.rs
@@ -38,7 +38,7 @@ use sp_core::{
 	hexdisplay::HexDisplay,
 	storage::{ChildInfo, ChildType, PrefixedStorageKey},
 };
-use sp_runtime::{generic::BlockId, traits::Block};
+use sp_runtime::traits::{Block, BlockIdTo};
 use std::{marker::PhantomData, sync::Arc};
 
 const LOG_TARGET: &str = "light-client-request-handler";
@@ -54,7 +54,12 @@ pub struct LightClientRequestHandler<B, Client> {
 impl<B, Client> LightClientRequestHandler<B, Client>
 where
 	B: Block,
-	Client: BlockBackend<B> + ProofProvider<B> + Send + Sync + 'static,
+	Client: BlockBackend<B>
+		+ ProofProvider<B>
+		+ BlockIdTo<B, Error = sp_blockchain::Error>
+		+ Send
+		+ Sync
+		+ 'static,
 {
 	/// Create a new [`LightClientRequestHandler`].
 	pub fn new(
@@ -172,26 +177,22 @@ where
 
 		let block = Decode::decode(&mut request.block.as_ref())?;
 
-		let response =
-			match self
-				.client
-				.execution_proof(&BlockId::Hash(block), &request.method, &request.data)
-			{
-				Ok((_, proof)) => {
-					let r = schema::v1::light::RemoteCallResponse { proof: proof.encode() };
-					Some(schema::v1::light::response::Response::RemoteCallResponse(r))
-				},
-				Err(e) => {
-					trace!(
-						"remote call request from {} ({} at {:?}) failed with: {}",
-						peer,
-						request.method,
-						request.block,
-						e,
-					);
-					None
-				},
-			};
+		let response = match self.client.execution_proof(&block, &request.method, &request.data) {
+			Ok((_, proof)) => {
+				let r = schema::v1::light::RemoteCallResponse { proof: proof.encode() };
+				Some(schema::v1::light::response::Response::RemoteCallResponse(r))
+			},
+			Err(e) => {
+				trace!(
+					"remote call request from {} ({} at {:?}) failed with: {}",
+					peer,
+					request.method,
+					request.block,
+					e,
+				);
+				None
+			},
+		};
 
 		Ok(schema::v1::light::Response { response })
 	}
@@ -215,25 +216,23 @@ where
 
 		let block = Decode::decode(&mut request.block.as_ref())?;
 
-		let response = match self
-			.client
-			.read_proof(&BlockId::Hash(block), &mut request.keys.iter().map(AsRef::as_ref))
-		{
-			Ok(proof) => {
-				let r = schema::v1::light::RemoteReadResponse { proof: proof.encode() };
-				Some(schema::v1::light::response::Response::RemoteReadResponse(r))
-			},
-			Err(error) => {
-				trace!(
-					"remote read request from {} ({} at {:?}) failed with: {}",
-					peer,
-					fmt_keys(request.keys.first(), request.keys.last()),
-					request.block,
-					error,
-				);
-				None
-			},
-		};
+		let response =
+			match self.client.read_proof(&block, &mut request.keys.iter().map(AsRef::as_ref)) {
+				Ok(proof) => {
+					let r = schema::v1::light::RemoteReadResponse { proof: proof.encode() };
+					Some(schema::v1::light::response::Response::RemoteReadResponse(r))
+				},
+				Err(error) => {
+					trace!(
+						"remote read request from {} ({} at {:?}) failed with: {}",
+						peer,
+						fmt_keys(request.keys.first(), request.keys.last()),
+						request.block,
+						error,
+					);
+					None
+				},
+			};
 
 		Ok(schema::v1::light::Response { response })
 	}
@@ -265,7 +264,7 @@ where
 		};
 		let response = match child_info.and_then(|child_info| {
 			self.client.read_child_proof(
-				&BlockId::Hash(block),
+				&block,
 				&child_info,
 				&mut request.keys.iter().map(AsRef::as_ref),
 			)

--- a/client/network/light/src/light_client_requests/handler.rs
+++ b/client/network/light/src/light_client_requests/handler.rs
@@ -38,7 +38,7 @@ use sp_core::{
 	hexdisplay::HexDisplay,
 	storage::{ChildInfo, ChildType, PrefixedStorageKey},
 };
-use sp_runtime::traits::{Block, BlockIdTo};
+use sp_runtime::traits::Block;
 use std::{marker::PhantomData, sync::Arc};
 
 const LOG_TARGET: &str = "light-client-request-handler";

--- a/client/network/light/src/light_client_requests/handler.rs
+++ b/client/network/light/src/light_client_requests/handler.rs
@@ -56,7 +56,6 @@ where
 	B: Block,
 	Client: BlockBackend<B>
 		+ ProofProvider<B>
-		+ BlockIdTo<B, Error = sp_blockchain::Error>
 		+ Send
 		+ Sync
 		+ 'static,

--- a/client/network/light/src/light_client_requests/handler.rs
+++ b/client/network/light/src/light_client_requests/handler.rs
@@ -54,11 +54,7 @@ pub struct LightClientRequestHandler<B, Client> {
 impl<B, Client> LightClientRequestHandler<B, Client>
 where
 	B: Block,
-	Client: BlockBackend<B>
-		+ ProofProvider<B>
-		+ Send
-		+ Sync
-		+ 'static,
+	Client: BlockBackend<B> + ProofProvider<B> + Send + Sync + 'static,
 {
 	/// Create a new [`LightClientRequestHandler`].
 	pub fn new(

--- a/client/network/sync/src/state_request_handler.rs
+++ b/client/network/sync/src/state_request_handler.rs
@@ -32,7 +32,7 @@ use sc_network_common::{
 	config::ProtocolId,
 	request_responses::{IncomingRequest, OutgoingResponse, ProtocolConfig},
 };
-use sp_runtime::{generic::BlockId, traits::Block as BlockT};
+use sp_runtime::traits::Block as BlockT;
 use std::{
 	hash::{Hash, Hasher},
 	sync::Arc,
@@ -205,14 +205,14 @@ where
 
 			if !request.no_proof {
 				let (proof, _count) = self.client.read_proof_collection(
-					&BlockId::hash(block),
+					&block,
 					request.start.as_slice(),
 					MAX_RESPONSE_BYTES,
 				)?;
 				response.proof = proof.encode();
 			} else {
 				let entries = self.client.storage_collection(
-					&BlockId::hash(block),
+					&block,
 					request.start.as_slice(),
 					MAX_RESPONSE_BYTES,
 				)?;

--- a/client/rpc/src/state/state_full.rs
+++ b/client/rpc/src/state/state_full.rs
@@ -345,7 +345,7 @@ where
 		self.block_or_best(block)
 			.and_then(|block| {
 				self.client
-					.read_proof(&BlockId::Hash(block), &mut keys.iter().map(|key| key.0.as_ref()))
+					.read_proof(&block, &mut keys.iter().map(|key| key.0.as_ref()))
 					.map(|proof| proof.iter_nodes().map(|node| node.into()).collect())
 					.map(|proof| ReadProof { at: block, proof })
 			})
@@ -494,7 +494,7 @@ where
 				};
 				self.client
 					.read_child_proof(
-						&BlockId::Hash(block),
+						&block,
 						&child_info,
 						&mut keys.iter().map(|key| key.0.as_ref()),
 					)

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -1171,7 +1171,7 @@ where
 
 	fn execution_proof(
 		&self,
-		hash: &<Block as BlockT>::Hash,
+		hash: &Block::Hash,
 		method: &str,
 		call_data: &[u8],
 	) -> sp_blockchain::Result<(Vec<u8>, StorageProof)> {
@@ -1180,7 +1180,7 @@ where
 
 	fn read_proof_collection(
 		&self,
-		hash: &<Block as BlockT>::Hash,
+		hash: &Block::Hash,
 		start_key: &[Vec<u8>],
 		size_limit: usize,
 	) -> sp_blockchain::Result<(CompactProof, u32)> {
@@ -1199,7 +1199,7 @@ where
 
 	fn storage_collection(
 		&self,
-		hash: &<Block as BlockT>::Hash,
+		hash: &Block::Hash,
 		start_key: &[Vec<u8>],
 		size_limit: usize,
 	) -> sp_blockchain::Result<Vec<(KeyValueStorageLevel, bool)>> {

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -1152,42 +1152,39 @@ where
 {
 	fn read_proof(
 		&self,
-		id: &BlockId<Block>,
+		hash: &Block::Hash,
 		keys: &mut dyn Iterator<Item = &[u8]>,
 	) -> sp_blockchain::Result<StorageProof> {
-		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
-		self.state_at(&hash)
+		self.state_at(hash)
 			.and_then(|state| prove_read(state, keys).map_err(Into::into))
 	}
 
 	fn read_child_proof(
 		&self,
-		id: &BlockId<Block>,
+		hash: &Block::Hash,
 		child_info: &ChildInfo,
 		keys: &mut dyn Iterator<Item = &[u8]>,
 	) -> sp_blockchain::Result<StorageProof> {
-		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
-		self.state_at(&hash)
+		self.state_at(hash)
 			.and_then(|state| prove_child_read(state, child_info, keys).map_err(Into::into))
 	}
 
 	fn execution_proof(
 		&self,
-		id: &BlockId<Block>,
+		hash: &<Block as BlockT>::Hash,
 		method: &str,
 		call_data: &[u8],
 	) -> sp_blockchain::Result<(Vec<u8>, StorageProof)> {
-		self.executor.prove_execution(id, method, call_data)
+		self.executor.prove_execution(&BlockId::Hash(*hash), method, call_data)
 	}
 
 	fn read_proof_collection(
 		&self,
-		id: &BlockId<Block>,
+		hash: &<Block as BlockT>::Hash,
 		start_key: &[Vec<u8>],
 		size_limit: usize,
 	) -> sp_blockchain::Result<(CompactProof, u32)> {
-		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
-		let state = self.state_at(&hash)?;
+		let state = self.state_at(hash)?;
 		// this is a read proof, using version V0 or V1 is equivalent.
 		let root = state.storage_root(std::iter::empty(), StateVersion::V0).0;
 
@@ -1202,14 +1199,13 @@ where
 
 	fn storage_collection(
 		&self,
-		id: &BlockId<Block>,
+		hash: &<Block as BlockT>::Hash,
 		start_key: &[Vec<u8>],
 		size_limit: usize,
 	) -> sp_blockchain::Result<Vec<(KeyValueStorageLevel, bool)>> {
 		if start_key.len() > MAX_NESTED_TRIE_DEPTH {
 			return Err(Error::Backend("Invalid start key.".to_string()))
 		}
-		let hash = self.backend.blockchain().expect_block_hash_from_id(&id)?;
 		let state = self.state_at(&hash)?;
 		let child_info = |storage_key: &Vec<u8>| -> sp_blockchain::Result<ChildInfo> {
 			let storage_key = PrefixedStorageKey::new_ref(storage_key);


### PR DESCRIPTION
It changes the arguments of methods of `ProofProvider` trait from:
block: `BlockId<Block>` to: hash: `&Block::Hash`

This PR is part of BlockId::Number refactoring analysis (paritytech/substrate#11292)
