### PR TITLE
Use `ArgAction::Set` for enable-offchain-indexing flag

### DIFF
--- a/client/cli/src/params/offchain_worker_params.rs
+++ b/client/cli/src/params/offchain_worker_params.rs
@@ -48,7 +48,7 @@ pub struct OffchainWorkerParams {
 	///
 	/// Enables a runtime to write directly to a offchain workers
 	/// DB during block import.
-	#[arg(long = "enable-offchain-indexing", value_name = "ENABLE_OFFCHAIN_INDEXING", action = ArgAction::Set)]
+	#[arg(long = "enable-offchain-indexing", value_name = "ENABLE_OFFCHAIN_INDEXING", default_value_t = false, action = ArgAction::Set)]
 	pub indexing_enabled: bool,
 }
 

--- a/client/cli/src/params/offchain_worker_params.rs
+++ b/client/cli/src/params/offchain_worker_params.rs
@@ -23,7 +23,7 @@
 //! targeted at handling input parameter parsing providing
 //! a reasonable abstraction.
 
-use clap::Args;
+use clap::{ArgAction, Args};
 use sc_network::config::Role;
 use sc_service::config::OffchainWorkerConfig;
 
@@ -48,7 +48,7 @@ pub struct OffchainWorkerParams {
 	///
 	/// Enables a runtime to write directly to a offchain workers
 	/// DB during block import.
-	#[arg(long = "enable-offchain-indexing", value_name = "ENABLE_OFFCHAIN_INDEXING")]
+	#[arg(long = "enable-offchain-indexing", value_name = "ENABLE_OFFCHAIN_INDEXING", action = ArgAction::Set)]
 	pub indexing_enabled: bool,
 }
 


### PR DESCRIPTION
Follow up for https://github.com/paritytech/substrate/pull/12381
There are some places where we pass `enable-offchain-indexing=true` to binaries.

This does not work by default anymore in clap 4 which uses `ArgAction::SetTrue` as default. This means that the occurence of the flag sets the value to true and additional values are not allowed.

While I think the new approach makes more sense, there are some users of this flag and we should not break it if not necessary. 