### PR TITLE
some suggestions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,6 @@ dependencies = [
  "futures-lite",
  "num_cpus",
  "once_cell",
- "tokio",
 ]
 
 [[package]]
@@ -4072,6 +4071,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4803,6 +4811,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4932,9 +4950,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "oorandom"
@@ -4974,6 +4992,12 @@ checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pallet-alliance"
@@ -7277,8 +7301,6 @@ dependencies = [
 name = "remote-externalities"
 version = "0.10.0-dev"
 dependencies = [
- "async-std",
- "env_logger",
  "frame-support",
  "jsonrpsee",
  "log",
@@ -7291,6 +7313,7 @@ dependencies = [
  "sp-runtime",
  "sp-version",
  "tokio",
+ "tracing-subscriber 0.3.16",
 ]
 
 [[package]]
@@ -8030,7 +8053,7 @@ dependencies = [
  "substrate-test-runtime",
  "tempfile",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
  "wasmi",
  "wat",
 ]
@@ -8791,7 +8814,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-log",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -9169,9 +9192,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
@@ -9237,9 +9260,9 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "snap"
@@ -10037,7 +10060,7 @@ dependencies = [
  "sp-std",
  "tracing",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -10859,9 +10882,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -10907,7 +10930,7 @@ dependencies = [
  "ansi_term",
  "chrono",
  "lazy_static",
- "matchers",
+ "matchers 0.0.1",
  "parking_lot 0.11.2",
  "regex",
  "serde",
@@ -10919,6 +10942,24 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "matchers 0.1.0",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/utils/frame/remote-externalities/Cargo.toml
+++ b/utils/frame/remote-externalities/Cargo.toml
@@ -14,7 +14,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 jsonrpsee = { version = "0.15.1", features = ["ws-client", "macros"] }
 log = "0.4.17"
 serde = "1.0.136"
@@ -27,9 +26,9 @@ sp-version = { version = "5.0.0", path = "../../../primitives/version" }
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 
 [dev-dependencies]
-tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 frame-support = { version = "4.0.0-dev", path = "../../../frame/support" }
 pallet-elections-phragmen = { version = "5.0.0-dev", path = "../../../frame/elections-phragmen" }
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 
 [features]
 remote-test = ["frame-support"]

--- a/utils/frame/remote-externalities/Cargo.toml
+++ b/utils/frame/remote-externalities/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
-env_logger = "0.9"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 jsonrpsee = { version = "0.15.1", features = ["ws-client", "macros"] }
 log = "0.4.17"
 serde = "1.0.136"
@@ -24,7 +24,7 @@ sp-core = { version = "6.0.0", path = "../../../primitives/core" }
 sp-io = { version = "6.0.0", path = "../../../primitives/io" }
 sp-runtime = { version = "6.0.0", path = "../../../primitives/runtime" }
 sp-version = { version = "5.0.0", path = "../../../primitives/version" }
-async-std = { version = "1.0.0", features = ["tokio1"] }
+tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 
 [dev-dependencies]
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }

--- a/utils/frame/remote-externalities/src/lib.rs
+++ b/utils/frame/remote-externalities/src/lib.rs
@@ -40,7 +40,7 @@ use sp_core::{
 };
 pub use sp_io::TestExternalities;
 use sp_runtime::{
-	traits::{Block as BlockT, Header as HeaderT},
+	traits::{Block as BlockT},
 	StateVersion,
 };
 use std::{
@@ -156,6 +156,9 @@ impl Transport {
 		log::info!(target: LOG_TARGET, "initializing remote client to {:?}", uri);
 		WsClientBuilder::default()
 			.max_request_body_size(u32::MAX)
+			.request_timeout(std::time::Duration::from_secs(5 * 10))
+			.connection_timeout(std::time::Duration::from_secs(60))
+			.max_notifs_per_subscription(1024)
 			.build(&uri)
 			.await
 			.map_err(|e| {
@@ -412,7 +415,7 @@ impl<B: BlockT + DeserializeOwned> Builder<B> {
 	) -> Result<Vec<KeyValue>, &'static str> {
 		let now = std::time::Instant::now();
 		let keys = self.rpc_get_keys_paged(prefix, at).await?;
-		let uri = Arc::new(self.as_online().transport.uri.clone().unwrap());
+		let client = self.as_online().transport.remote_client.clone().unwrap();
 		let thread_chunk_size = (keys.len() / self.as_online().threads).max(1);
 
 		log::info!(
@@ -428,10 +431,10 @@ impl<B: BlockT + DeserializeOwned> Builder<B> {
 		let keys_chunked: Vec<Vec<StorageKey>> =
 			keys.chunks(thread_chunk_size).map(|s| s.into()).collect::<Vec<_>>();
 		for thread_keys in keys_chunked {
-			let uri = Arc::clone(&uri);
+			let thread_client = client.clone();
 			let handle = std::thread::spawn(move || {
-				use async_std::task::block_on;
-				let thread_client = block_on(Transport::build_ws_client(&*uri)).unwrap();
+				let rt = tokio::runtime::Runtime::new().unwrap();
+
 				let mut thread_key_values = Vec::with_capacity(thread_keys.len());
 				for chunk_keys in thread_keys.chunks(DEFAULT_VALUE_DOWNLOAD_BATCH) {
 					let batch = chunk_keys
@@ -441,7 +444,7 @@ impl<B: BlockT + DeserializeOwned> Builder<B> {
 						.collect::<Vec<_>>();
 
 					let values =
-						block_on(thread_client.batch_request::<Option<StorageData>>(batch))
+						rt.block_on(thread_client.batch_request::<Option<StorageData>>(batch))
 							.map_err(|e| {
 								log::error!(
 									target: LOG_TARGET,
@@ -871,16 +874,15 @@ impl<B: BlockT + DeserializeOwned> Builder<B> {
 
 #[cfg(test)]
 mod test_prelude {
+	use tracing_subscriber::EnvFilter;
+
 	pub(crate) use super::*;
 	pub(crate) use sp_runtime::testing::{Block as RawBlock, ExtrinsicWrapper, H256 as Hash};
-
 	pub(crate) type Block = RawBlock<ExtrinsicWrapper<Hash>>;
 
 	pub(crate) fn init_logger() {
-		let _ = env_logger::Builder::from_default_env()
-			.format_module_path(true)
-			.format_level(true)
-			// .filter_module(LOG_TARGET, log::LevelFilter::Debug)
+		let _ = tracing_subscriber::fmt().with_env_filter(EnvFilter::from_default_env())
+			.with_level(true)
 			.try_init();
 	}
 }

--- a/utils/frame/remote-externalities/src/lib.rs
+++ b/utils/frame/remote-externalities/src/lib.rs
@@ -956,7 +956,7 @@ mod remote_tests {
 		todo!();
 	}
 
-	#[tokio::test]
+	#[tokio::test(flavor = "multi_thread")]
 	async fn snapshot_block_hash_works() {
 		const CACHE: &'static str = "snapshot_block_hash_works";
 		init_logger();
@@ -983,7 +983,7 @@ mod remote_tests {
 		assert_eq!(block_hash, cached_block_hash);
 	}
 
-	#[tokio::test]
+	#[tokio::test(flavor = "multi_thread")]
 	async fn offline_else_online_works() {
 		const CACHE: &'static str = "offline_else_online_works_data";
 		init_logger();
@@ -1028,7 +1028,7 @@ mod remote_tests {
 		std::fs::remove_file(to_delete[0].path()).unwrap();
 	}
 
-	#[tokio::test]
+	#[tokio::test(flavor = "multi_thread")]
 	async fn can_build_one_small_pallet() {
 		init_logger();
 		Builder::<Block>::new()
@@ -1043,7 +1043,7 @@ mod remote_tests {
 			.execute_with(|| {});
 	}
 
-	#[tokio::test]
+	#[tokio::test(flavor = "multi_thread")]
 	async fn can_build_few_pallet() {
 		init_logger();
 		Builder::<Block>::new()
@@ -1078,7 +1078,7 @@ mod remote_tests {
 			.execute_with(|| {});
 	}
 
-	#[tokio::test]
+	#[tokio::test(flavor = "multi_thread")]
 	async fn can_create_snapshot() {
 		const CACHE: &'static str = "can_create_snapshot";
 		init_logger();
@@ -1111,7 +1111,7 @@ mod remote_tests {
 		std::fs::remove_file(to_delete.path()).unwrap();
 	}
 
-	#[tokio::test]
+	#[tokio::test(flavor = "multi_thread")]
 	async fn can_create_child_snapshot() {
 		const CACHE: &'static str = "can_create_child_snapshot";
 		init_logger();
@@ -1143,7 +1143,7 @@ mod remote_tests {
 		std::fs::remove_file(to_delete.path()).unwrap();
 	}
 
-	#[tokio::test]
+	#[tokio::test(flavor = "multi_thread")]
 	// #[ignore = "only works if a local node is present."]
 	async fn can_fetch_all_local() {
 		init_logger();
@@ -1158,7 +1158,7 @@ mod remote_tests {
 			.execute_with(|| {});
 	}
 
-	#[tokio::test]
+	#[tokio::test(flavor = "multi_thread")]
 	// #[ignore = "slow af."]
 	async fn can_fetch_all_remote() {
 		init_logger();


### PR DESCRIPTION
- remove async-std
- use tracing subscriber to get jsonrpsee logs
- re-use client connection
- create a new tokio runtime in each thread (I think tokio::spawn) should be sufficient here but yeye
- increase connection and request timeout 