### PR TITLE
CI: Enable debug assertions in Wasmer sandbox test

### DIFF
--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -394,6 +394,10 @@ test-wasmer-sandbox:
     - .docker-env
     - .test-refs-wasmer-sandbox
   variables:
+    RUSTFLAGS:                     "-Cdebug-assertions=y -Dwarnings"
+    RUST_BACKTRACE:                1
+    WASM_BUILD_NO_COLOR:           1
+    WASM_BUILD_RUSTFLAGS:          "-Cdebug-assertions=y -Dwarnings"
     CI_JOB_NAME:                   "test-wasmer-sandbox"
   parallel: 3
   script:


### PR DESCRIPTION
CI: Enable debug assertions in Wasmer sandbox test

Copied from the linux stable test. Not sure if all of them are needed.