### PR TITLE
BlockId removal: refactor: Backend::begin_state_operation

### DIFF
--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -467,7 +467,7 @@ pub trait Backend<Block: BlockT>: AuxStore + Send + Sync {
 	fn begin_state_operation(
 		&self,
 		operation: &mut Self::BlockImportOperation,
-		block: BlockId<Block>,
+		block: &Block::Hash,
 	) -> sp_blockchain::Result<()>;
 
 	/// Commit block insertion.

--- a/client/api/src/in_mem.rs
+++ b/client/api/src/in_mem.rs
@@ -695,10 +695,9 @@ where
 	fn begin_state_operation(
 		&self,
 		operation: &mut Self::BlockImportOperation,
-		block: BlockId<Block>,
+		block: &Block::Hash,
 	) -> sp_blockchain::Result<()> {
-		let hash = self.blockchain.expect_block_hash_from_id(&block)?;
-		operation.old_state = self.state_at(&hash)?;
+		operation.old_state = self.state_at(block)?;
 		Ok(())
 	}
 

--- a/client/db/benches/state_access.rs
+++ b/client/db/benches/state_access.rs
@@ -22,7 +22,6 @@ use sc_client_api::{Backend as _, BlockImportOperation, NewBlockState, StateBack
 use sc_client_db::{Backend, BlocksPruning, DatabaseSettings, DatabaseSource, PruningMode};
 use sp_core::H256;
 use sp_runtime::{
-	generic::BlockId,
 	testing::{Block as RawBlock, ExtrinsicWrapper, Header},
 	StateVersion, Storage,
 };
@@ -67,7 +66,7 @@ fn insert_blocks(db: &Backend<Block>, storage: Vec<(Vec<u8>, Vec<u8>)>) -> H256 
 	for i in 0..10 {
 		let mut op = db.begin_operation().unwrap();
 
-		db.begin_state_operation(&mut op, BlockId::Hash(parent_hash)).unwrap();
+		db.begin_state_operation(&mut op, &parent_hash).unwrap();
 
 		let mut header = Header {
 			number,

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -586,8 +586,7 @@ where
 			Some(storage_changes) => {
 				let storage_changes = match storage_changes {
 					sc_consensus::StorageChanges::Changes(storage_changes) => {
-						self.backend
-							.begin_state_operation(&mut operation.op, BlockId::Hash(parent_hash))?;
+						self.backend.begin_state_operation(&mut operation.op, &parent_hash)?;
 						let (main_sc, child_sc, offchain_sc, tx, _, tx_index) =
 							storage_changes.into_inner();
 


### PR DESCRIPTION
It changes the arguments of `Backend::begin_state_operation`
from: block: `BlockId<Block>` to: hash: `&Block::Hash`

This PR is part of BlockId::Number refactoring analysis (paritytech/substrate#11292)
