### PR TITLE
Pallet Assets: move is frozen to asset status

### DIFF
--- a/frame/assets/src/migration.rs
+++ b/frame/assets/src/migration.rs
@@ -41,6 +41,8 @@ pub mod v1 {
 
 	impl<Balance, AccountId, DepositBalance> OldAssetDetails<Balance, AccountId, DepositBalance> {
 		fn migrate_to_v1(self) -> AssetDetails<Balance, AccountId, DepositBalance> {
+			let status = if self.is_frozen { AssetStatus::Frozen } else { AssetStatus::Live };
+
 			AssetDetails {
 				owner: self.owner,
 				issuer: self.issuer,
@@ -53,8 +55,7 @@ pub mod v1 {
 				accounts: self.accounts,
 				sufficients: self.sufficients,
 				approvals: self.approvals,
-				is_frozen: self.is_frozen,
-				status: AssetStatus::Live,
+				status,
 			}
 		}
 	}

--- a/frame/assets/src/types.rs
+++ b/frame/assets/src/types.rs
@@ -35,6 +35,8 @@ pub(super) type AssetAccountOf<T, I> =
 pub(super) enum AssetStatus {
 	/// The asset is active and able to be used.
 	Live,
+	/// Whether the asset is frozen for non-admin transfers.
+	Frozen,
 	/// The asset is currently being destroyed, and all actions are no longer permitted on the
 	/// asset. Once set to `Destroying`, the asset can never transition back to a `Live` state.
 	Destroying,
@@ -65,8 +67,6 @@ pub struct AssetDetails<Balance, AccountId, DepositBalance> {
 	pub(super) sufficients: u32,
 	/// The total number of approvals.
 	pub(super) approvals: u32,
-	/// Whether the asset is frozen for non-admin transfers.
-	pub(super) is_frozen: bool,
 	/// The status of the asset
 	pub(super) status: AssetStatus,
 }


### PR DESCRIPTION
This PR moves the is_frozen field of the assetDetails into the AssetStatus Enum.  It's a separate PR to allow ease of reviewing, but should probably be either merged into #12310 or be merged into master immediately after #12310 

Related to: #12310 