### PR TITLE
Normalize keystore type and its usage across tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7846,6 +7846,7 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-io",
+ "sp-keyring",
  "sp-keystore",
  "sp-runtime",
  "sp-timestamp",
@@ -7853,7 +7854,6 @@ dependencies = [
  "sp-version",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
- "tempfile",
  "thiserror",
 ]
 
@@ -8130,7 +8130,6 @@ dependencies = [
  "sp-tracing",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
- "tempfile",
  "thiserror",
  "tokio",
 ]

--- a/client/beefy/src/tests.rs
+++ b/client/beefy/src/tests.rs
@@ -29,12 +29,12 @@ use sc_consensus::{
 	BlockImport, BlockImportParams, BoxJustificationImport, ForkChoiceStrategy, ImportResult,
 	ImportedAux,
 };
-use sc_keystore::LocalKeystore;
 use sc_network_test::{
 	Block, BlockImportAdapter, FullPeerConfig, PassThroughVerifier, Peer, PeersClient,
 	PeersFullClient, TestNetFactory,
 };
 use sc_utils::notification::NotificationReceiver;
+use sp_keystore::testing::KeyStore as TestKeystore;
 
 use beefy_primitives::{
 	crypto::{AuthorityId, Signature},
@@ -333,7 +333,7 @@ pub(crate) fn make_beefy_ids(keys: &[BeefyKeyring]) -> Vec<AuthorityId> {
 }
 
 pub(crate) fn create_beefy_keystore(authority: BeefyKeyring) -> SyncCryptoStorePtr {
-	let keystore = Arc::new(LocalKeystore::in_memory());
+	let keystore = Arc::new(TestKeystore::new());
 	SyncCryptoStore::ecdsa_generate_new(&*keystore, BeefyKeyType, Some(&authority.to_seed()))
 		.expect("Creates authority key");
 	keystore

--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -54,8 +54,8 @@ sp-version = { version = "5.0.0", path = "../../../primitives/version" }
 
 [dev-dependencies]
 rand_chacha = "0.2.2"
-tempfile = "3.1.0"
 sc-block-builder = { version = "0.10.0-dev", path = "../../block-builder" }
+sp-keyring = { version = "6.0.0", path = "../../../primitives/keyring" }
 sc-network = { version = "0.10.0-dev", path = "../../network" }
 sc-network-test = { version = "0.8.0", path = "../../network/test" }
 sp-timestamp = { version = "4.0.0-dev", path = "../../../primitives/timestamp" }

--- a/client/consensus/babe/src/tests.rs
+++ b/client/consensus/babe/src/tests.rs
@@ -28,7 +28,6 @@ use sc_block_builder::{BlockBuilder, BlockBuilderProvider};
 use sc_client_api::{backend::TransactionFor, BlockchainEvents, Finalizer};
 use sc_consensus::{BoxBlockImport, BoxJustificationImport};
 use sc_consensus_slots::BackoffAuthoringOnFinalizedHeadLagging;
-use sc_keystore::LocalKeystore;
 use sc_network_test::{Block as TestBlock, *};
 use sp_application_crypto::key_types::BABE;
 use sp_consensus::{DisableProofRecording, NoNetwork as DummyOracle, Proposal};
@@ -38,7 +37,11 @@ use sp_consensus_babe::{
 };
 use sp_consensus_slots::SlotDuration;
 use sp_core::crypto::Pair;
-use sp_keystore::{vrf::make_transcript as transcript_from_data, SyncCryptoStore};
+use sp_keyring::Sr25519Keyring;
+use sp_keystore::{
+	testing::KeyStore as TestKeyStore, vrf::make_transcript as transcript_from_data,
+	SyncCryptoStore,
+};
 use sp_runtime::{
 	generic::{Digest, DigestItem},
 	traits::Block as BlockT,
@@ -363,6 +366,13 @@ fn rejects_empty_block() {
 	})
 }
 
+fn create_keystore(authority: Sr25519Keyring) -> SyncCryptoStorePtr {
+	let keystore = Arc::new(TestKeyStore::new());
+	SyncCryptoStore::sr25519_generate_new(&*keystore, BABE, Some(&authority.to_seed()))
+		.expect("Generates authority key");
+	keystore
+}
+
 fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static) {
 	sp_tracing::try_init_simple();
 	let mutator = Arc::new(mutator) as Mutator;
@@ -370,25 +380,20 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
 	MUTATOR.with(|m| *m.borrow_mut() = mutator.clone());
 	let net = BabeTestNet::new(3);
 
-	let peers = &[(0, "//Alice"), (1, "//Bob"), (2, "//Charlie")];
+	let peers =
+		&[(0, Sr25519Keyring::Alice), (1, Sr25519Keyring::Bob), (2, Sr25519Keyring::Charlie)];
 
 	let net = Arc::new(Mutex::new(net));
 	let mut import_notifications = Vec::new();
 	let mut babe_futures = Vec::new();
-	let mut keystore_paths = Vec::new();
 
-	for (peer_id, seed) in peers {
+	for (peer_id, auth_id) in peers {
 		let mut net = net.lock();
 		let peer = net.peer(*peer_id);
 		let client = peer.client().as_client();
 		let select_chain = peer.select_chain().expect("Full client has select_chain");
 
-		let keystore_path = tempfile::tempdir().expect("Creates keystore path");
-		let keystore: SyncCryptoStorePtr =
-			Arc::new(LocalKeystore::open(keystore_path.path(), None).expect("Creates keystore"));
-		SyncCryptoStore::sr25519_generate_new(&*keystore, BABE, Some(seed))
-			.expect("Generates authority key");
-		keystore_paths.push(keystore_path);
+		let keystore = create_keystore(*auth_id);
 
 		let mut got_own = false;
 		let mut got_other = false;
@@ -536,16 +541,14 @@ fn sig_is_not_pre_digest() {
 #[test]
 fn can_author_block() {
 	sp_tracing::try_init_simple();
-	let keystore_path = tempfile::tempdir().expect("Creates keystore path");
-	let keystore: SyncCryptoStorePtr =
-		Arc::new(LocalKeystore::open(keystore_path.path(), None).expect("Creates keystore"));
-	let public = SyncCryptoStore::sr25519_generate_new(&*keystore, BABE, Some("//Alice"))
-		.expect("Generates authority pair");
+
+	let authority = Sr25519Keyring::Alice;
+	let keystore = create_keystore(authority);
 
 	let mut i = 0;
 	let epoch = Epoch {
 		start_slot: 0.into(),
-		authorities: vec![(public.into(), 1)],
+		authorities: vec![(authority.public().into(), 1)],
 		randomness: [0; 32],
 		epoch_index: 1,
 		duration: 100,
@@ -967,15 +970,13 @@ fn verify_slots_are_strictly_increasing() {
 #[test]
 fn babe_transcript_generation_match() {
 	sp_tracing::try_init_simple();
-	let keystore_path = tempfile::tempdir().expect("Creates keystore path");
-	let keystore: SyncCryptoStorePtr =
-		Arc::new(LocalKeystore::open(keystore_path.path(), None).expect("Creates keystore"));
-	let public = SyncCryptoStore::sr25519_generate_new(&*keystore, BABE, Some("//Alice"))
-		.expect("Generates authority pair");
+
+	let authority = Sr25519Keyring::Alice;
+	let _keystore = create_keystore(authority);
 
 	let epoch = Epoch {
 		start_slot: 0.into(),
-		authorities: vec![(public.into(), 1)],
+		authorities: vec![(authority.public().into(), 1)],
 		randomness: [0; 32],
 		epoch_index: 1,
 		duration: 100,

--- a/client/consensus/babe/src/tests.rs
+++ b/client/consensus/babe/src/tests.rs
@@ -380,16 +380,15 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
 	MUTATOR.with(|m| *m.borrow_mut() = mutator.clone());
 	let net = BabeTestNet::new(3);
 
-	let peers =
-		&[(0, Sr25519Keyring::Alice), (1, Sr25519Keyring::Bob), (2, Sr25519Keyring::Charlie)];
+	let peers = [Sr25519Keyring::Alice, Sr25519Keyring::Bob, Sr25519Keyring::Charlie];
 
 	let net = Arc::new(Mutex::new(net));
 	let mut import_notifications = Vec::new();
 	let mut babe_futures = Vec::new();
 
-	for (peer_id, auth_id) in peers {
+	for (peer_id, auth_id) in peers.iter().enumerate() {
 		let mut net = net.lock();
-		let peer = net.peer(*peer_id);
+		let peer = net.peer(peer_id);
 		let client = peer.client().as_client();
 		let select_chain = peer.select_chain().expect("Full client has select_chain");
 

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -51,12 +51,8 @@ sp-runtime = { version = "6.0.0", path = "../../primitives/runtime" }
 
 [dev-dependencies]
 assert_matches = "1.3.0"
-finality-grandpa = { version = "0.16.0", features = [
-	"derive-codec",
-	"test-helpers",
-] }
+finality-grandpa = { version = "0.16.0", features = ["derive-codec", "test-helpers"] }
 serde = "1.0.136"
-tempfile = "3.1.0"
 tokio = "1.17.0"
 sc-network = { version = "0.10.0-dev", path = "../network" }
 sc-network-test = { version = "0.8.0", path = "../network/test" }

--- a/client/finality-grandpa/src/tests.rs
+++ b/client/finality-grandpa/src/tests.rs
@@ -41,7 +41,7 @@ use sp_finality_grandpa::{
 	AuthorityList, EquivocationProof, GrandpaApi, OpaqueKeyOwnershipProof, GRANDPA_ENGINE_ID,
 };
 use sp_keyring::Ed25519Keyring;
-use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
+use sp_keystore::{testing::KeyStore as TestKeyStore, SyncCryptoStore, SyncCryptoStorePtr};
 use sp_runtime::{
 	codec::Encode,
 	generic::{BlockId, DigestItem},
@@ -59,7 +59,6 @@ use authorities::AuthoritySet;
 use communication::grandpa_protocol_name;
 use sc_block_builder::{BlockBuilder, BlockBuilderProvider};
 use sc_consensus::LongestChain;
-use sc_keystore::LocalKeystore;
 use sp_application_crypto::key_types::GRANDPA;
 
 type TestLinkHalf =
@@ -213,14 +212,11 @@ fn make_ids(keys: &[Ed25519Keyring]) -> AuthorityList {
 	keys.iter().map(|&key| key.public().into()).map(|id| (id, 1)).collect()
 }
 
-fn create_keystore(authority: Ed25519Keyring) -> (SyncCryptoStorePtr, tempfile::TempDir) {
-	let keystore_path = tempfile::tempdir().expect("Creates keystore path");
-	let keystore =
-		Arc::new(LocalKeystore::open(keystore_path.path(), None).expect("Creates keystore"));
+fn create_keystore(authority: Ed25519Keyring) -> SyncCryptoStorePtr {
+	let keystore = Arc::new(TestKeyStore::new());
 	SyncCryptoStore::ed25519_generate_new(&*keystore, GRANDPA, Some(&authority.to_seed()))
 		.expect("Creates authority key");
-
-	(keystore, keystore_path)
+	keystore
 }
 
 fn block_until_complete(
@@ -243,7 +239,7 @@ fn initialize_grandpa(
 	let voters = stream::FuturesUnordered::new();
 
 	for (peer_id, key) in peers.iter().enumerate() {
-		let (keystore, _) = create_keystore(*key);
+		let keystore = create_keystore(*key);
 
 		let (net_service, link) = {
 			// temporary needed for some reason
@@ -480,11 +476,9 @@ fn transition_3_voters_twice_1_full_observer() {
 
 	let mut runtime = Runtime::new().unwrap();
 
-	let mut keystore_paths = Vec::new();
 	let mut voters = Vec::new();
 	for (peer_id, local_key) in all_peers.clone().into_iter().enumerate() {
-		let (keystore, keystore_path) = create_keystore(local_key);
-		keystore_paths.push(keystore_path);
+		let keystore = create_keystore(local_key);
 
 		let (net_service, link) = {
 			let net = net.lock();
@@ -934,7 +928,6 @@ fn voter_persists_its_votes() {
 
 	sp_tracing::try_init_simple();
 	let mut runtime = Runtime::new().unwrap();
-	let mut keystore_paths = Vec::new();
 
 	// we have two authorities but we'll only be running the voter for alice
 	// we are going to be listening for the prevotes it casts
@@ -947,11 +940,7 @@ fn voter_persists_its_votes() {
 	// create the communication layer for bob, but don't start any
 	// voter. instead we'll listen for the prevote that alice casts
 	// and cast our own manually
-	let bob_keystore = {
-		let (keystore, keystore_path) = create_keystore(peers[1]);
-		keystore_paths.push(keystore_path);
-		keystore
-	};
+	let bob_keystore = create_keystore(peers[1]);
 	let bob_network = {
 		let config = Config {
 			gossip_duration: TEST_GOSSIP_DURATION,
@@ -984,7 +973,7 @@ fn voter_persists_its_votes() {
 	// spawn two voters for alice.
 	// half-way through the test, we stop one and start the other.
 	let (alice_voter1, abort) = future::abortable({
-		let (keystore, _) = create_keystore(peers[0]);
+		let keystore = create_keystore(peers[0]);
 
 		let (net_service, link) = {
 			// temporary needed for some reason
@@ -1018,7 +1007,7 @@ fn voter_persists_its_votes() {
 		peers: &[Ed25519Keyring],
 		net: Arc<Mutex<GrandpaTestNet>>,
 	) -> impl Future<Output = ()> + Send {
-		let (keystore, _) = create_keystore(peers[0]);
+		let keystore = create_keystore(peers[0]);
 		let mut net = net.lock();
 
 		// we add a new peer to the test network and we'll use
@@ -1266,8 +1255,6 @@ fn voter_catches_up_to_latest_round_when_behind() {
 		Box::pin(run_grandpa_voter(grandpa_params).expect("all in order with client and network"))
 	};
 
-	let mut keystore_paths = Vec::new();
-
 	// spawn authorities
 	for (peer_id, key) in peers.iter().enumerate() {
 		let (client, link) = {
@@ -1284,8 +1271,7 @@ fn voter_catches_up_to_latest_round_when_behind() {
 				.for_each(move |_| future::ready(())),
 		);
 
-		let (keystore, keystore_path) = create_keystore(*key);
-		keystore_paths.push(keystore_path);
+		let keystore = create_keystore(*key);
 
 		let voter = voter(Some(keystore), peer_id, link, net.clone());
 
@@ -1515,7 +1501,7 @@ fn grandpa_environment_never_overwrites_round_voter_state() {
 	let network_service = peer.network_service().clone();
 	let link = peer.data.lock().take().unwrap();
 
-	let (keystore, _keystore_path) = create_keystore(peers[0]);
+	let keystore = create_keystore(peers[0]);
 	let environment = test_environment(&link, Some(keystore), network_service.clone(), ());
 
 	let round_state = || finality_grandpa::round::State::genesis(Default::default());
@@ -1715,7 +1701,7 @@ fn grandpa_environment_doesnt_send_equivocation_reports_for_itself() {
 		let peer = net.peer(0);
 		let network_service = peer.network_service().clone();
 		let link = peer.data.lock().take().unwrap();
-		let (keystore, _keystore_path) = create_keystore(alice);
+		let keystore = create_keystore(alice);
 		test_environment(&link, Some(keystore), network_service.clone(), ())
 	};
 


### PR DESCRIPTION
This PR sets the `sp_keystore::testing::KeyStore` as the type used across Babe/Grandpa/Beefy tests.

Previously:
- Babe and Grandpa were using a keystore in a temporary filesystem folder. This is not really required.
- Beefy was using the `LocalKeystore::in_memory`. That for testing purposes should behave equivalently to the `testing::KeyStore`.

Some additional minor cleanup has been introduced
