### PR TITLE
Fix typo in `membership` docs

### DIFF
--- a/frame/membership/README.md
+++ b/frame/membership/README.md
@@ -1,6 +1,6 @@
 # Membership Module
 
-Allows control of membership of a set of `AccountId`s, useful for managing membership of of a
+Allows control of membership of a set of `AccountId`s, useful for managing membership of a
 collective. A prime member may be set.
 
 License: Apache-2.0

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -17,7 +17,7 @@
 
 //! # Membership Module
 //!
-//! Allows control of membership of a set of `AccountId`s, useful for managing membership of of a
+//! Allows control of membership of a set of `AccountId`s, useful for managing membership of a
 //! collective. A prime member may be set
 
 // Ensure we're `no_std` when compiling for Wasm.


### PR DESCRIPTION
This PR fixes a small typo in the documentation of `membership`.
