### PR TITLE
bump ed25519-zebra; fixes `full_crypto` feature flag in `no_std`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,15 +1782,15 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403ef3e961ab98f0ba902771d29f842058578bb1ce7e3c59dad5a6a93e784c69"
+checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
 dependencies = [
  "curve25519-dalek 3.0.2",
+ "hashbrown 0.12.3",
  "hex",
  "rand_core 0.6.2",
  "sha2 0.9.8",
- "thiserror",
  "zeroize",
 ]
 

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -48,7 +48,7 @@ bitflags = "1.3"
 
 # full crypto
 array-bytes = { version = "4.1", optional = true }
-ed25519-zebra = { version = "3.0.0", default-features = false, optional = true}
+ed25519-zebra = { version = "3.1.0", default-features = false, optional = true }
 blake2 = { version = "0.10.4", default-features = false, optional = true }
 schnorrkel = { version = "0.9.1", features = [
 	"preaudit_deprecated",
@@ -99,7 +99,7 @@ std = [
 	"serde",
 	"blake2/std",
 	"array-bytes",
-	"ed25519-zebra",
+	"ed25519-zebra/std",
 	"base58",
 	"substrate-bip39",
 	"tiny-bip39",


### PR DESCRIPTION
* Closes #12225