### PR TITLE
Check scale-info future release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,3 +311,6 @@ inherits = "release"
 lto = "fat"
 # https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
 codegen-units = 1
+
+[patch.crates-io]
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "cl/next-release" }


### PR DESCRIPTION
The next `scale-info` release should not break the API (do not merge - only here for a CI run)