### PR TITLE
Use `minimum_nominator_bond` instead of `nominator_bond`

### DIFF
--- a/frame/nomination-pools/src/tests.rs
+++ b/frame/nomination-pools/src/tests.rs
@@ -4207,10 +4207,10 @@ mod create {
 		ExtBuilder::default().build_and_execute(|| {
 			let ed = Balances::minimum_balance();
 
-			Balances::make_free_balance_be(&11, StakingMock::minimum_bond() + ed);
+			Balances::make_free_balance_be(&11, StakingMock::minimum_nominator_bond() + ed);
 			assert_ok!(Pools::create(
 				RuntimeOrigin::signed(11),
-				StakingMock::minimum_bond(),
+				StakingMock::minimum_nominator_bond(),
 				123,
 				456,
 				789


### PR DESCRIPTION
Resolve CI conflict between #12424 and #12407 to make the master CI :green_heart:  