### PR TITLE
[ci] allow fail skip-if-draft job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -210,6 +210,7 @@ skip-if-draft:
      - echo "Ref is ${CI_COMMIT_REF_NAME}"
      - echo "pipeline source is ${CI_PIPELINE_SOURCE}"
      - ./scripts/ci/gitlab/skip_if_draft.sh
+  allow_failure:                   true
 
 include:
   # check jobs


### PR DESCRIPTION
PR allows to fail the `skip-if-draft` job. If job fails for some system reasons it blocks the pipeline but it's not that important