### PR TITLE
BlockId removal: refactor: Backend::block_indexed_body

### DIFF
--- a/client/api/src/client.rs
+++ b/client/api/src/client.rs
@@ -118,10 +118,8 @@ pub trait BlockBackend<Block: BlockT> {
 	///
 	/// Note that this will only fetch transactions
 	/// that are indexed by the runtime with `storage_index_transaction`.
-	fn block_indexed_body(
-		&self,
-		id: &BlockId<Block>,
-	) -> sp_blockchain::Result<Option<Vec<Vec<u8>>>>;
+	fn block_indexed_body(&self, hash: &Block::Hash)
+		-> sp_blockchain::Result<Option<Vec<Vec<u8>>>>;
 
 	/// Get full block by id.
 	fn block(&self, id: &BlockId<Block>) -> sp_blockchain::Result<Option<SignedBlock<Block>>>;

--- a/client/api/src/in_mem.rs
+++ b/client/api/src/in_mem.rs
@@ -451,7 +451,7 @@ impl<Block: BlockT> blockchain::Backend<Block> for Blockchain<Block> {
 
 	fn block_indexed_body(
 		&self,
-		_id: BlockId<Block>,
+		_hash: &Block::Hash,
 	) -> sp_blockchain::Result<Option<Vec<Vec<u8>>>> {
 		unimplemented!("Not supported by the in-mem backend.")
 	}

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -694,8 +694,13 @@ impl<Block: BlockT> sc_client_api::blockchain::Backend<Block> for BlockchainDb<B
 		Ok(self.db.contains(columns::TRANSACTION, hash.as_ref()))
 	}
 
-	fn block_indexed_body(&self, id: BlockId<Block>) -> ClientResult<Option<Vec<Vec<u8>>>> {
-		let body = match read_db(&*self.db, columns::KEY_LOOKUP, columns::BODY_INDEX, id)? {
+	fn block_indexed_body(&self, hash: &Block::Hash) -> ClientResult<Option<Vec<Vec<u8>>>> {
+		let body = match read_db(
+			&*self.db,
+			columns::KEY_LOOKUP,
+			columns::BODY_INDEX,
+			BlockId::<Block>::Hash(*hash),
+		)? {
 			Some(body) => body,
 			None => return Ok(None),
 		};

--- a/client/network/sync/src/block_request_handler.rs
+++ b/client/network/sync/src/block_request_handler.rs
@@ -374,7 +374,7 @@ where
 			};
 
 			let indexed_body = if get_indexed_body {
-				match self.client.block_indexed_body(&BlockId::Hash(hash))? {
+				match self.client.block_indexed_body(&hash)? {
 					Some(transactions) => transactions,
 					None => {
 						log::trace!(

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -1980,9 +1980,9 @@ where
 
 	fn block_indexed_body(
 		&self,
-		id: &BlockId<Block>,
+		hash: &Block::Hash,
 	) -> sp_blockchain::Result<Option<Vec<Vec<u8>>>> {
-		self.backend.blockchain().block_indexed_body(*id)
+		self.backend.blockchain().block_indexed_body(hash)
 	}
 
 	fn requires_full_sync(&self) -> bool {
@@ -2073,9 +2073,19 @@ where
 		&self,
 		number: NumberFor<B>,
 	) -> Result<Option<Vec<Vec<u8>>>, sp_transaction_storage_proof::Error> {
+		let hash = match self
+			.backend
+			.blockchain()
+			.block_hash_from_id(&BlockId::Number(number))
+			.map_err(|e| sp_transaction_storage_proof::Error::Application(Box::new(e)))?
+		{
+			Some(hash) => hash,
+			None => return Ok(None),
+		};
+
 		self.backend
 			.blockchain()
-			.block_indexed_body(BlockId::number(number))
+			.block_indexed_body(&hash)
 			.map_err(|e| sp_transaction_storage_proof::Error::Application(Box::new(e)))
 	}
 

--- a/primitives/blockchain/src/backend.rs
+++ b/primitives/blockchain/src/backend.rs
@@ -238,7 +238,7 @@ pub trait Backend<Block: BlockT>:
 		Ok(self.indexed_transaction(hash)?.is_some())
 	}
 
-	fn block_indexed_body(&self, id: BlockId<Block>) -> Result<Option<Vec<Vec<u8>>>>;
+	fn block_indexed_body(&self, hash: &Block::Hash) -> Result<Option<Vec<Vec<u8>>>>;
 }
 
 /// Blockchain info


### PR DESCRIPTION
It changes the arguments of `Backend::block_indexed_body` method from: `BlockId<Block>` to: `&Block::Hash`

This PR is part of BlockId::Number refactoring analysis (paritytech/substrate#11292)


polkadot companion: paritytech/polkadot#6233
