### PR TITLE
 Only ensure parent finalization when the parent isn't already finalized

### DIFF
--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -658,7 +658,7 @@ where
 		// sequentially.
 		if finalized &&
 			parent_exists &&
-			(self.backend.blockchain().last_finalized()? != parent_hash)
+			info.finalized_hash != parent_hash
 		{
 			self.apply_finality_with_block_hash(
 				operation,

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -656,7 +656,10 @@ where
 
 		// Ensure parent chain is finalized to maintain invariant that finality is called
 		// sequentially.
-		if finalized && parent_exists {
+		if finalized &&
+			parent_exists &&
+			(self.backend.blockchain().last_finalized()? != parent_hash)
+		{
 			self.apply_finality_with_block_hash(
 				operation,
 				parent_hash,


### PR DESCRIPTION
Fixes https://github.com/paritytech/substrate/issues/12614.

I'm unsure if this is the optimal edit, yet apply_finality is exposed to external APIs. Accordingly, I didn't want to remove the warning, which seemed sane. Just this flippant call which triggered it without meaning.

`cargo fmt` was run to ensure it complies with style.