### PR TITLE
Bump `k256` to 0.11

### DIFF
--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -37,7 +37,7 @@ impl-trait-for-tuples = "0.2.2"
 smallvec = "1.8.0"
 log = { version = "0.4.17", default-features = false }
 sp-core-hashing-proc-macro = { version = "5.0.0", path = "../../primitives/core/hashing/proc-macro" }
-k256 = { version = "0.10.4", default-features = false, features = ["ecdsa"] }
+k256 = { version = "0.11.6", default-features = false, features = ["ecdsa"] }
 
 [dev-dependencies]
 serde_json = "1.0.85"

--- a/frame/support/src/crypto/ecdsa.rs
+++ b/frame/support/src/crypto/ecdsa.rs
@@ -41,7 +41,7 @@ impl ECDSAExt for Public {
 			let uncompressed = pub_key.to_encoded_point(false);
 			// convert to ETH address
 			<[u8; 20]>::try_from(
-				sp_io::hashing::keccak_256(&uncompressed.as_bytes()[1..])[12..].as_ref(),
+				sp_io::hashing::keccak_256(uncompressed.as_bytes())[12..].as_ref(),
 			)
 			.map_err(drop)
 		})


### PR DESCRIPTION
- Bump `k256` to 0.11. It includes some security fixes (added zeroization of secret data), bug fixes, and quality of life improvements (like recoverable signature derivation). Unfortunately, the old version of `k256` locks projects using `substrate` out of upgrading `k256` themselves (https://github.com/rust-lang/cargo/issues/7880).
- While we're at it, I added what I think is a fix for the address derivation. As far as I understand, the uncompressed `EncodedPoint` does not include a tag byte (see https://github.com/RustCrypto/formats/blob/master/sec1/src/point.rs#L120), so taking a hash of `[1..]` will lead to an incorrect address. 
