### PR TITLE
BlockId removal: &Hash to Hash

### DIFF
--- a/bin/node/bench/src/import.rs
+++ b/bin/node/bench/src/import.rs
@@ -135,7 +135,7 @@ impl core::Benchmark for ImportBenchmark {
 		// Sanity checks.
 		context
 			.client
-			.state_at(&hash)
+			.state_at(hash)
 			.expect("state_at failed for block#1")
 			.inspect_state(|| {
 				match self.block_type {

--- a/bin/node/inspect/src/lib.rs
+++ b/bin/node/inspect/src/lib.rs
@@ -144,7 +144,7 @@ impl<TBlock: Block, TPrinter: PrettyPrinter<TBlock>> Inspector<TBlock, TPrinter>
 				let not_found = format!("Could not find block {:?}", id);
 				let body = self
 					.chain
-					.block_body(&hash)?
+					.block_body(hash)?
 					.ok_or_else(|| Error::NotFound(not_found.clone()))?;
 				let header =
 					self.chain.header(id)?.ok_or_else(|| Error::NotFound(not_found.clone()))?;
@@ -155,7 +155,7 @@ impl<TBlock: Block, TPrinter: PrettyPrinter<TBlock>> Inspector<TBlock, TPrinter>
 				let not_found = format!("Could not find block {:?}", id);
 				let body = self
 					.chain
-					.block_body(&hash)?
+					.block_body(hash)?
 					.ok_or_else(|| Error::NotFound(not_found.clone()))?;
 				let header =
 					self.chain.header(id)?.ok_or_else(|| Error::NotFound(not_found.clone()))?;

--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -215,13 +215,13 @@ pub trait BlockImportOperation<Block: BlockT> {
 	/// Mark a block as finalized.
 	fn mark_finalized(
 		&mut self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		justification: Option<Justification>,
 	) -> sp_blockchain::Result<()>;
 
 	/// Mark a block as new head. If both block import and set head are specified, set head
 	/// overrides block import's best block rule.
-	fn mark_head(&mut self, hash: &Block::Hash) -> sp_blockchain::Result<()>;
+	fn mark_head(&mut self, hash: Block::Hash) -> sp_blockchain::Result<()>;
 
 	/// Add a transaction index operation.
 	fn update_transaction_index(&mut self, index: Vec<IndexOperation>)
@@ -251,7 +251,7 @@ pub trait Finalizer<Block: BlockT, B: Backend<Block>> {
 	fn apply_finality(
 		&self,
 		operation: &mut ClientImportOperation<Block, B>,
-		block: &Block::Hash,
+		block: Block::Hash,
 		justification: Option<Justification>,
 		notify: bool,
 	) -> sp_blockchain::Result<()>;
@@ -271,7 +271,7 @@ pub trait Finalizer<Block: BlockT, B: Backend<Block>> {
 	/// while performing major synchronization work.
 	fn finalize_block(
 		&self,
-		block: &Block::Hash,
+		block: Block::Hash,
 		justification: Option<Justification>,
 		notify: bool,
 	) -> sp_blockchain::Result<()>;
@@ -359,21 +359,21 @@ pub trait StorageProvider<Block: BlockT, B: Backend<Block>> {
 	/// Given a block's `Hash` and a key, return the value under the key in that block.
 	fn storage(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<StorageData>>;
 
 	/// Given a block's `Hash` and a key prefix, return the matching storage keys in that block.
 	fn storage_keys(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		key_prefix: &StorageKey,
 	) -> sp_blockchain::Result<Vec<StorageKey>>;
 
 	/// Given a block's `Hash` and a key, return the value under the hash in that block.
 	fn storage_hash(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<Block::Hash>>;
 
@@ -381,7 +381,7 @@ pub trait StorageProvider<Block: BlockT, B: Backend<Block>> {
 	/// in that block.
 	fn storage_pairs(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		key_prefix: &StorageKey,
 	) -> sp_blockchain::Result<Vec<(StorageKey, StorageData)>>;
 
@@ -389,7 +389,7 @@ pub trait StorageProvider<Block: BlockT, B: Backend<Block>> {
 	/// keys in that block.
 	fn storage_keys_iter<'a>(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		prefix: Option<&'a StorageKey>,
 		start_key: Option<&StorageKey>,
 	) -> sp_blockchain::Result<KeyIterator<'a, B::State, Block>>;
@@ -398,7 +398,7 @@ pub trait StorageProvider<Block: BlockT, B: Backend<Block>> {
 	/// that block.
 	fn child_storage(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		child_info: &ChildInfo,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<StorageData>>;
@@ -407,7 +407,7 @@ pub trait StorageProvider<Block: BlockT, B: Backend<Block>> {
 	/// storage keys.
 	fn child_storage_keys(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		child_info: &ChildInfo,
 		key_prefix: &StorageKey,
 	) -> sp_blockchain::Result<Vec<StorageKey>>;
@@ -416,7 +416,7 @@ pub trait StorageProvider<Block: BlockT, B: Backend<Block>> {
 	/// return a `KeyIterator` that iterates matching storage keys in that block.
 	fn child_storage_keys_iter<'a>(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		child_info: ChildInfo,
 		prefix: Option<&'a StorageKey>,
 		start_key: Option<&StorageKey>,
@@ -426,7 +426,7 @@ pub trait StorageProvider<Block: BlockT, B: Backend<Block>> {
 	/// block.
 	fn child_storage_hash(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		child_info: &ChildInfo,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<Block::Hash>>;
@@ -466,7 +466,7 @@ pub trait Backend<Block: BlockT>: AuxStore + Send + Sync {
 	fn begin_state_operation(
 		&self,
 		operation: &mut Self::BlockImportOperation,
-		block: &Block::Hash,
+		block: Block::Hash,
 	) -> sp_blockchain::Result<()>;
 
 	/// Commit block insertion.
@@ -480,7 +480,7 @@ pub trait Backend<Block: BlockT>: AuxStore + Send + Sync {
 	/// This should only be called if the parent of the given block has been finalized.
 	fn finalize_block(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		justification: Option<Justification>,
 	) -> sp_blockchain::Result<()>;
 
@@ -489,7 +489,7 @@ pub trait Backend<Block: BlockT>: AuxStore + Send + Sync {
 	/// This should only be called for blocks that are already finalized.
 	fn append_justification(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		justification: Justification,
 	) -> sp_blockchain::Result<()>;
 
@@ -503,12 +503,12 @@ pub trait Backend<Block: BlockT>: AuxStore + Send + Sync {
 	fn offchain_storage(&self) -> Option<Self::OffchainStorage>;
 
 	/// Returns true if state for given block is available.
-	fn have_state_at(&self, hash: &Block::Hash, _number: NumberFor<Block>) -> bool {
+	fn have_state_at(&self, hash: Block::Hash, _number: NumberFor<Block>) -> bool {
 		self.state_at(hash).is_ok()
 	}
 
 	/// Returns state backend with post-state of given block.
-	fn state_at(&self, hash: &Block::Hash) -> sp_blockchain::Result<Self::State>;
+	fn state_at(&self, hash: Block::Hash) -> sp_blockchain::Result<Self::State>;
 
 	/// Attempts to revert the chain by `n` blocks. If `revert_finalized` is set it will attempt to
 	/// revert past any finalized block, this is unsafe and can potentially leave the node in an
@@ -524,7 +524,7 @@ pub trait Backend<Block: BlockT>: AuxStore + Send + Sync {
 	) -> sp_blockchain::Result<(NumberFor<Block>, HashSet<Block::Hash>)>;
 
 	/// Discard non-best, unfinalized leaf block.
-	fn remove_leaf_block(&self, hash: &Block::Hash) -> sp_blockchain::Result<()>;
+	fn remove_leaf_block(&self, hash: Block::Hash) -> sp_blockchain::Result<()>;
 
 	/// Insert auxiliary data into key-value store.
 	fn insert_aux<

--- a/client/api/src/client.rs
+++ b/client/api/src/client.rs
@@ -110,7 +110,7 @@ pub trait BlockBackend<Block: BlockT> {
 	/// Get block body by ID. Returns `None` if the body is not stored.
 	fn block_body(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 	) -> sp_blockchain::Result<Option<Vec<<Block as BlockT>::Extrinsic>>>;
 
 	/// Get all indexed transactions for a block,
@@ -118,8 +118,7 @@ pub trait BlockBackend<Block: BlockT> {
 	///
 	/// Note that this will only fetch transactions
 	/// that are indexed by the runtime with `storage_index_transaction`.
-	fn block_indexed_body(&self, hash: &Block::Hash)
-		-> sp_blockchain::Result<Option<Vec<Vec<u8>>>>;
+	fn block_indexed_body(&self, hash: Block::Hash) -> sp_blockchain::Result<Option<Vec<Vec<u8>>>>;
 
 	/// Get full block by id.
 	fn block(&self, id: &BlockId<Block>) -> sp_blockchain::Result<Option<SignedBlock<Block>>>;
@@ -129,7 +128,7 @@ pub trait BlockBackend<Block: BlockT> {
 		-> sp_blockchain::Result<sp_consensus::BlockStatus>;
 
 	/// Get block justifications for the block with the given id.
-	fn justifications(&self, hash: &Block::Hash) -> sp_blockchain::Result<Option<Justifications>>;
+	fn justifications(&self, hash: Block::Hash) -> sp_blockchain::Result<Option<Justifications>>;
 
 	/// Get block hash by number.
 	fn block_hash(&self, number: NumberFor<Block>) -> sp_blockchain::Result<Option<Block::Hash>>;
@@ -138,10 +137,10 @@ pub trait BlockBackend<Block: BlockT> {
 	///
 	/// Note that this will only fetch transactions
 	/// that are indexed by the runtime with `storage_index_transaction`.
-	fn indexed_transaction(&self, hash: &Block::Hash) -> sp_blockchain::Result<Option<Vec<u8>>>;
+	fn indexed_transaction(&self, hash: Block::Hash) -> sp_blockchain::Result<Option<Vec<u8>>>;
 
 	/// Check if transaction index exists.
-	fn has_indexed_transaction(&self, hash: &Block::Hash) -> sp_blockchain::Result<bool> {
+	fn has_indexed_transaction(&self, hash: Block::Hash) -> sp_blockchain::Result<bool> {
 		Ok(self.indexed_transaction(hash)?.is_some())
 	}
 

--- a/client/api/src/proof_provider.rs
+++ b/client/api/src/proof_provider.rs
@@ -27,7 +27,7 @@ pub trait ProofProvider<Block: BlockT> {
 	/// Reads storage value at a given block + key, returning read proof.
 	fn read_proof(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		keys: &mut dyn Iterator<Item = &[u8]>,
 	) -> sp_blockchain::Result<StorageProof>;
 
@@ -35,7 +35,7 @@ pub trait ProofProvider<Block: BlockT> {
 	/// read proof.
 	fn read_child_proof(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		child_info: &ChildInfo,
 		keys: &mut dyn Iterator<Item = &[u8]>,
 	) -> sp_blockchain::Result<StorageProof>;
@@ -46,7 +46,7 @@ pub trait ProofProvider<Block: BlockT> {
 	/// No changes are made.
 	fn execution_proof(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		method: &str,
 		call_data: &[u8],
 	) -> sp_blockchain::Result<(Vec<u8>, StorageProof)>;
@@ -61,7 +61,7 @@ pub trait ProofProvider<Block: BlockT> {
 	/// Returns combined proof and the numbers of collected keys.
 	fn read_proof_collection(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		start_keys: &[Vec<u8>],
 		size_limit: usize,
 	) -> sp_blockchain::Result<(CompactProof, u32)>;
@@ -76,7 +76,7 @@ pub trait ProofProvider<Block: BlockT> {
 	/// end.
 	fn storage_collection(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		start_key: &[Vec<u8>],
 		size_limit: usize,
 	) -> sp_blockchain::Result<Vec<(KeyValueStorageLevel, bool)>>;

--- a/client/basic-authorship/src/basic_authorship.rs
+++ b/client/basic-authorship/src/basic_authorship.rs
@@ -736,7 +736,7 @@ mod tests {
 		let api = client.runtime_api();
 		api.execute_block(&block_id, proposal.block).unwrap();
 
-		let state = backend.state_at(&genesis_hash).unwrap();
+		let state = backend.state_at(genesis_hash).unwrap();
 
 		let storage_changes = api.into_storage_changes(&state, genesis_hash).unwrap();
 

--- a/client/beefy/src/communication/request_response/incoming_requests_handler.rs
+++ b/client/beefy/src/communication/request_response/incoming_requests_handler.rs
@@ -153,7 +153,7 @@ where
 			self.client.block_hash(request.payload.begin).map_err(Error::Client)?
 		{
 			self.client
-				.justifications(&hash)
+				.justifications(hash)
 				.map_err(Error::Client)?
 				.and_then(|justifs| justifs.get(BEEFY_ENGINE_ID).cloned())
 				// No BEEFY justification present.

--- a/client/beefy/src/tests.rs
+++ b/client/beefy/src/tests.rs
@@ -512,7 +512,7 @@ fn finalize_block_and_wait_for_beefy(
 		peers.clone().for_each(|(index, _)| {
 			let client = net.lock().peer(index).client().as_client();
 			let finalize = client.expect_block_hash_from_id(&BlockId::number(*block)).unwrap();
-			client.finalize_block(&finalize, None).unwrap();
+			client.finalize_block(finalize, None).unwrap();
 		})
 	}
 
@@ -608,7 +608,7 @@ fn lagging_validators() {
 		.expect_block_hash_from_id(&BlockId::number(25))
 		.unwrap();
 	let (best_blocks, versioned_finality_proof) = get_beefy_streams(&mut net.lock(), peers.clone());
-	net.lock().peer(0).client().as_client().finalize_block(&finalize, None).unwrap();
+	net.lock().peer(0).client().as_client().finalize_block(finalize, None).unwrap();
 	// verify nothing gets finalized by BEEFY
 	let timeout = Some(Duration::from_millis(250));
 	streams_empty_after_timeout(best_blocks, &net, &mut runtime, timeout);
@@ -616,7 +616,7 @@ fn lagging_validators() {
 
 	// Bob catches up and also finalizes #25
 	let (best_blocks, versioned_finality_proof) = get_beefy_streams(&mut net.lock(), peers.clone());
-	net.lock().peer(1).client().as_client().finalize_block(&finalize, None).unwrap();
+	net.lock().peer(1).client().as_client().finalize_block(finalize, None).unwrap();
 	// expected beefy finalizes block #17 from diff-power-of-two
 	wait_for_best_beefy_blocks(best_blocks, &net, &mut runtime, &[23, 24, 25]);
 	wait_for_beefy_signed_commitments(versioned_finality_proof, &net, &mut runtime, &[23, 24, 25]);
@@ -637,7 +637,7 @@ fn lagging_validators() {
 		.as_client()
 		.expect_block_hash_from_id(&BlockId::number(60))
 		.unwrap();
-	net.lock().peer(0).client().as_client().finalize_block(&finalize, None).unwrap();
+	net.lock().peer(0).client().as_client().finalize_block(finalize, None).unwrap();
 	// verify nothing gets finalized by BEEFY
 	let timeout = Some(Duration::from_millis(250));
 	streams_empty_after_timeout(best_blocks, &net, &mut runtime, timeout);
@@ -645,7 +645,7 @@ fn lagging_validators() {
 
 	// Bob catches up and also finalizes #60 (and should have buffered Alice's vote on #60)
 	let (best_blocks, versioned_finality_proof) = get_beefy_streams(&mut net.lock(), peers);
-	net.lock().peer(1).client().as_client().finalize_block(&finalize, None).unwrap();
+	net.lock().peer(1).client().as_client().finalize_block(finalize, None).unwrap();
 	// verify beefy skips intermediary votes, and successfully finalizes mandatory block #60
 	wait_for_best_beefy_blocks(best_blocks, &net, &mut runtime, &[60]);
 	wait_for_beefy_signed_commitments(versioned_finality_proof, &net, &mut runtime, &[60]);
@@ -696,9 +696,9 @@ fn correct_beefy_payload() {
 		.as_client()
 		.expect_block_hash_from_id(&BlockId::number(11))
 		.unwrap();
-	net.lock().peer(0).client().as_client().finalize_block(&hashof11, None).unwrap();
-	net.lock().peer(1).client().as_client().finalize_block(&hashof11, None).unwrap();
-	net.lock().peer(3).client().as_client().finalize_block(&hashof11, None).unwrap();
+	net.lock().peer(0).client().as_client().finalize_block(hashof11, None).unwrap();
+	net.lock().peer(1).client().as_client().finalize_block(hashof11, None).unwrap();
+	net.lock().peer(3).client().as_client().finalize_block(hashof11, None).unwrap();
 
 	// verify consensus is _not_ reached
 	let timeout = Some(Duration::from_millis(250));
@@ -708,7 +708,7 @@ fn correct_beefy_payload() {
 	// 3rd good validator catches up and votes as well
 	let (best_blocks, versioned_finality_proof) =
 		get_beefy_streams(&mut net.lock(), [(0, BeefyKeyring::Alice)].into_iter());
-	net.lock().peer(2).client().as_client().finalize_block(&hashof11, None).unwrap();
+	net.lock().peer(2).client().as_client().finalize_block(hashof11, None).unwrap();
 
 	// verify consensus is reached
 	wait_for_best_beefy_blocks(best_blocks, &net, &mut runtime, &[11]);
@@ -760,7 +760,7 @@ fn beefy_importing_blocks() {
 		// none in backend,
 		assert_eq!(
 			full_client
-				.justifications(&hashof1)
+				.justifications(hashof1)
 				.unwrap()
 				.and_then(|j| j.get(BEEFY_ENGINE_ID).cloned()),
 			None
@@ -799,7 +799,7 @@ fn beefy_importing_blocks() {
 		// still not in backend (worker is responsible for appending to backend),
 		assert_eq!(
 			full_client
-				.justifications(&hashof2)
+				.justifications(hashof2)
 				.unwrap()
 				.and_then(|j| j.get(BEEFY_ENGINE_ID).cloned()),
 			None
@@ -843,7 +843,7 @@ fn beefy_importing_blocks() {
 		// none in backend,
 		assert_eq!(
 			full_client
-				.justifications(&hashof3)
+				.justifications(hashof3)
 				.unwrap()
 				.and_then(|j| j.get(BEEFY_ENGINE_ID).cloned()),
 			None
@@ -941,7 +941,7 @@ fn on_demand_beefy_justification_sync() {
 		get_beefy_streams(&mut net.lock(), [(dave_index, BeefyKeyring::Dave)].into_iter());
 	let client = net.lock().peer(dave_index).client().as_client();
 	let hashof1 = client.expect_block_hash_from_id(&BlockId::number(1)).unwrap();
-	client.finalize_block(&hashof1, None).unwrap();
+	client.finalize_block(hashof1, None).unwrap();
 	// Give Dave task some cpu cycles to process the finality notification,
 	run_for(Duration::from_millis(100), &net, &mut runtime);
 	// freshly spun up Dave now needs to listen for gossip to figure out the state of his peers.

--- a/client/beefy/src/worker.rs
+++ b/client/beefy/src/worker.rs
@@ -511,7 +511,7 @@ where
 						.expect("forwards closure result; the closure always returns Ok; qed.");
 
 					self.backend
-						.append_justification(&hash, (BEEFY_ENGINE_ID, finality_proof.encode()))
+						.append_justification(hash, (BEEFY_ENGINE_ID, finality_proof.encode()))
 				}) {
 				error!(target: "beefy", "🥩 Error {:?} on appending justification: {:?}", e, finality_proof);
 			}
@@ -709,7 +709,7 @@ where
 			// a BEEFY justification, or at this session's boundary; voter will resume from there.
 			loop {
 				if let Some(true) = blockchain
-					.justifications(&header.hash())
+					.justifications(header.hash())
 					.ok()
 					.flatten()
 					.map(|justifs| justifs.get(BEEFY_ENGINE_ID).is_some())
@@ -1375,8 +1375,8 @@ pub(crate) mod tests {
 		// finalize 1 and 2 without justifications
 		let hashof1 = backend.blockchain().expect_block_hash_from_id(&BlockId::Number(1)).unwrap();
 		let hashof2 = backend.blockchain().expect_block_hash_from_id(&BlockId::Number(2)).unwrap();
-		backend.finalize_block(&hashof1, None).unwrap();
-		backend.finalize_block(&hashof2, None).unwrap();
+		backend.finalize_block(hashof1, None).unwrap();
+		backend.finalize_block(hashof2, None).unwrap();
 
 		let justif = create_finality_proof(2);
 		// create new session at block #2
@@ -1401,7 +1401,7 @@ pub(crate) mod tests {
 		}));
 
 		// check BEEFY justifications are also appended to backend
-		let justifs = backend.blockchain().justifications(&hashof2).unwrap().unwrap();
+		let justifs = backend.blockchain().justifications(hashof2).unwrap().unwrap();
 		assert!(justifs.get(BEEFY_ENGINE_ID).is_some())
 	}
 
@@ -1512,7 +1512,7 @@ pub(crate) mod tests {
 		// finalize 13 without justifications
 		let hashof13 =
 			backend.blockchain().expect_block_hash_from_id(&BlockId::Number(13)).unwrap();
-		net.peer(0).client().as_client().finalize_block(&hashof13, None).unwrap();
+		net.peer(0).client().as_client().finalize_block(hashof13, None).unwrap();
 
 		// Test initialization at session boundary.
 		{
@@ -1551,7 +1551,7 @@ pub(crate) mod tests {
 			let hashof10 =
 				backend.blockchain().expect_block_hash_from_id(&BlockId::Number(10)).unwrap();
 			backend
-				.append_justification(&hashof10, (BEEFY_ENGINE_ID, justif.encode()))
+				.append_justification(hashof10, (BEEFY_ENGINE_ID, justif.encode()))
 				.unwrap();
 
 			// initialize voter at block 13, expect rounds initialized at last beefy finalized 10
@@ -1587,7 +1587,7 @@ pub(crate) mod tests {
 			let hashof12 =
 				backend.blockchain().expect_block_hash_from_id(&BlockId::Number(12)).unwrap();
 			backend
-				.append_justification(&hashof12, (BEEFY_ENGINE_ID, justif.encode()))
+				.append_justification(hashof12, (BEEFY_ENGINE_ID, justif.encode()))
 				.unwrap();
 
 			// initialize voter at block 13, expect rounds initialized at last beefy finalized 12

--- a/client/block-builder/src/lib.rs
+++ b/client/block-builder/src/lib.rs
@@ -258,7 +258,7 @@ where
 
 		let proof = self.api.extract_proof();
 
-		let state = self.backend.state_at(&self.parent_hash)?;
+		let state = self.backend.state_at(self.parent_hash)?;
 
 		let storage_changes = self
 			.api

--- a/client/cli/src/commands/export_state_cmd.rs
+++ b/client/cli/src/commands/export_state_cmd.rs
@@ -69,7 +69,7 @@ impl ExportStateCmd {
 			Some(id) => client.expect_block_hash_from_id(&id)?,
 			None => client.usage_info().chain.best_hash,
 		};
-		let raw_state = sc_service::chain_ops::export_raw_state(client, &hash)?;
+		let raw_state = sc_service::chain_ops::export_raw_state(client, hash)?;
 		input_spec.set_storage(raw_state);
 
 		info!("Generating new chain spec...");

--- a/client/consensus/babe/src/tests.rs
+++ b/client/consensus/babe/src/tests.rs
@@ -822,7 +822,7 @@ fn revert_not_allowed_for_finalized() {
 	let canon = propose_and_import_blocks_wrap(BlockId::Number(0), 3);
 
 	// Finalize best block
-	client.finalize_block(&canon[2], None, false).unwrap();
+	client.finalize_block(canon[2], None, false).unwrap();
 
 	// Revert canon chain to last finalized block
 	revert(client.clone(), backend, 100).expect("revert should work for baked test scenario");
@@ -884,7 +884,7 @@ fn importing_epoch_change_block_prunes_tree() {
 
 	// We finalize block #13 from the canon chain, so on the next epoch
 	// change the tree should be pruned, to not contain F (#7).
-	client.finalize_block(&canon_hashes[12], None, false).unwrap();
+	client.finalize_block(canon_hashes[12], None, false).unwrap();
 	propose_and_import_blocks_wrap(BlockId::Hash(client.chain_info().best_hash), 7);
 
 	// at this point no hashes from the first fork must exist on the tree
@@ -911,7 +911,7 @@ fn importing_epoch_change_block_prunes_tree() {
 		.any(|h| fork_3.contains(h)),);
 
 	// finalizing block #25 from the canon chain should prune out the second fork
-	client.finalize_block(&canon_hashes[24], None, false).unwrap();
+	client.finalize_block(canon_hashes[24], None, false).unwrap();
 	propose_and_import_blocks_wrap(BlockId::Hash(client.chain_info().best_hash), 8);
 
 	// at this point no hashes from the second fork must exist on the tree
@@ -1049,7 +1049,7 @@ fn obsolete_blocks_aux_data_cleanup() {
 	assert!(aux_data_check(&fork3_hashes, true));
 
 	// Finalize A3
-	client.finalize_block(&fork1_hashes[2], None, true).unwrap();
+	client.finalize_block(fork1_hashes[2], None, true).unwrap();
 
 	// Wiped: A1, A2
 	assert!(aux_data_check(&fork1_hashes[..2], false));
@@ -1060,7 +1060,7 @@ fn obsolete_blocks_aux_data_cleanup() {
 	// Present C4, C5
 	assert!(aux_data_check(&fork3_hashes, true));
 
-	client.finalize_block(&fork1_hashes[3], None, true).unwrap();
+	client.finalize_block(fork1_hashes[3], None, true).unwrap();
 
 	// Wiped: A3
 	assert!(aux_data_check(&fork1_hashes[2..3], false));

--- a/client/consensus/manual-seal/src/finalize_block.rs
+++ b/client/consensus/manual-seal/src/finalize_block.rs
@@ -46,7 +46,7 @@ where
 {
 	let FinalizeBlockParams { hash, mut sender, justification, finalizer, .. } = params;
 
-	match finalizer.finalize_block(&hash, justification, true) {
+	match finalizer.finalize_block(hash, justification, true) {
 		Err(e) => {
 			log::warn!("Failed to finalize block {}", e);
 			rpc::send_result(&mut sender, Err(e.into()))

--- a/client/db/benches/state_access.rs
+++ b/client/db/benches/state_access.rs
@@ -66,7 +66,7 @@ fn insert_blocks(db: &Backend<Block>, storage: Vec<(Vec<u8>, Vec<u8>)>) -> H256 
 	for i in 0..10 {
 		let mut op = db.begin_operation().unwrap();
 
-		db.begin_state_operation(&mut op, &parent_hash).unwrap();
+		db.begin_state_operation(&mut op, parent_hash).unwrap();
 
 		let mut header = Header {
 			number,
@@ -83,7 +83,7 @@ fn insert_blocks(db: &Backend<Block>, storage: Vec<(Vec<u8>, Vec<u8>)>) -> H256 
 			.map(|(k, v)| (k.clone(), Some(v.clone())))
 			.collect::<Vec<_>>();
 
-		let (state_root, tx) = db.state_at(&parent_hash).unwrap().storage_root(
+		let (state_root, tx) = db.state_at(parent_hash).unwrap().storage_root(
 			changes.iter().map(|(k, v)| (k.as_slice(), v.as_deref())),
 			StateVersion::V1,
 		);
@@ -175,7 +175,7 @@ fn state_access_benchmarks(c: &mut Criterion) {
 
 		group.bench_function(desc, |b| {
 			b.iter_batched(
-				|| backend.state_at(&block_hash).expect("Creates state"),
+				|| backend.state_at(block_hash).expect("Creates state"),
 				|state| {
 					for key in keys.iter().cycle().take(keys.len() * multiplier) {
 						let _ = state.storage(&key).expect("Doesn't fail").unwrap();
@@ -213,7 +213,7 @@ fn state_access_benchmarks(c: &mut Criterion) {
 
 		group.bench_function(desc, |b| {
 			b.iter_batched(
-				|| backend.state_at(&block_hash).expect("Creates state"),
+				|| backend.state_at(block_hash).expect("Creates state"),
 				|state| {
 					for key in keys.iter().take(1).cycle().take(multiplier) {
 						let _ = state.storage(&key).expect("Doesn't fail").unwrap();
@@ -251,7 +251,7 @@ fn state_access_benchmarks(c: &mut Criterion) {
 
 		group.bench_function(desc, |b| {
 			b.iter_batched(
-				|| backend.state_at(&block_hash).expect("Creates state"),
+				|| backend.state_at(block_hash).expect("Creates state"),
 				|state| {
 					for key in keys.iter().take(1).cycle().take(multiplier) {
 						let _ = state.storage_hash(&key).expect("Doesn't fail").unwrap();
@@ -289,7 +289,7 @@ fn state_access_benchmarks(c: &mut Criterion) {
 
 		group.bench_function(desc, |b| {
 			b.iter_batched(
-				|| backend.state_at(&block_hash).expect("Creates state"),
+				|| backend.state_at(block_hash).expect("Creates state"),
 				|state| {
 					let _ = state
 						.storage_hash(sp_core::storage::well_known_keys::CODE)

--- a/client/finality-grandpa/src/environment.rs
+++ b/client/finality-grandpa/src/environment.rs
@@ -1352,7 +1352,7 @@ where
 		// ideally some handle to a synchronization oracle would be used
 		// to avoid unconditionally notifying.
 		client
-			.apply_finality(import_op, &hash, persisted_justification, true)
+			.apply_finality(import_op, hash, persisted_justification, true)
 			.map_err(|e| {
 				warn!(target: "afg", "Error applying finality to block {:?}: {}", (hash, number), e);
 				e

--- a/client/finality-grandpa/src/finality_proof.rs
+++ b/client/finality-grandpa/src/finality_proof.rs
@@ -188,7 +188,7 @@ where
 				.expect_block_hash_from_id(&BlockId::Number(last_block_for_set))?;
 			let justification = if let Some(grandpa_justification) = backend
 				.blockchain()
-				.justifications(&last_block_for_set_id)?
+				.justifications(last_block_for_set_id)?
 				.and_then(|justifications| justifications.into_justification(GRANDPA_ENGINE_ID))
 			{
 				grandpa_justification
@@ -312,7 +312,7 @@ mod tests {
 
 		for block in to_finalize {
 			let hash = blocks[*block as usize - 1].hash();
-			client.finalize_block(&hash, None).unwrap();
+			client.finalize_block(hash, None).unwrap();
 		}
 		(client, backend, blocks)
 	}
@@ -492,7 +492,7 @@ mod tests {
 		let grandpa_just8 = GrandpaJustification::from_commit(&client, round, commit).unwrap();
 
 		client
-			.finalize_block(&block8.hash(), Some((ID, grandpa_just8.encode().clone())))
+			.finalize_block(block8.hash(), Some((ID, grandpa_just8.encode().clone())))
 			.unwrap();
 
 		// Authority set change at block 8, so the justification stored there will be used in the

--- a/client/finality-grandpa/src/import.rs
+++ b/client/finality-grandpa/src/import.rs
@@ -424,8 +424,8 @@ where
 	}
 
 	/// Read current set id form a given state.
-	fn current_set_id(&self, hash: &Block::Hash) -> Result<SetId, ConsensusError> {
-		let id = &BlockId::hash(*hash);
+	fn current_set_id(&self, hash: Block::Hash) -> Result<SetId, ConsensusError> {
+		let id = &BlockId::hash(hash);
 		let runtime_version = self.inner.runtime_api().version(id).map_err(|e| {
 			ConsensusError::ClientImport(format!(
 				"Unable to retrieve current runtime version. {}",
@@ -480,7 +480,7 @@ where
 					.runtime_api()
 					.grandpa_authorities(&BlockId::hash(hash))
 					.map_err(|e| ConsensusError::ClientImport(e.to_string()))?;
-				let set_id = self.current_set_id(&hash)?;
+				let set_id = self.current_set_id(hash)?;
 				let authority_set = AuthoritySet::new(
 					authorities.clone(),
 					set_id,

--- a/client/finality-grandpa/src/tests.rs
+++ b/client/finality-grandpa/src/tests.rs
@@ -375,7 +375,7 @@ fn finalize_3_voters_no_observers() {
 
 	// normally there's no justification for finalized blocks
 	assert!(
-		net.lock().peer(0).client().justifications(&hashof20).unwrap().is_none(),
+		net.lock().peer(0).client().justifications(hashof20).unwrap().is_none(),
 		"Extra justification for block#1",
 	);
 }
@@ -621,7 +621,7 @@ fn justification_is_generated_periodically() {
 	// when block#32 (justification_period) is finalized, justification
 	// is required => generated
 	for i in 0..3 {
-		assert!(net.lock().peer(i).client().justifications(&hashof32).unwrap().is_some());
+		assert!(net.lock().peer(i).client().justifications(hashof32).unwrap().is_some());
 	}
 }
 
@@ -665,12 +665,12 @@ fn sync_justifications_on_change_blocks() {
 	// the first 3 peers are grandpa voters and therefore have already finalized
 	// block 21 and stored a justification
 	for i in 0..3 {
-		assert!(net.lock().peer(i).client().justifications(&hashof21).unwrap().is_some());
+		assert!(net.lock().peer(i).client().justifications(hashof21).unwrap().is_some());
 	}
 
 	// the last peer should get the justification by syncing from other peers
 	futures::executor::block_on(futures::future::poll_fn(move |cx| {
-		if net.lock().peer(3).client().justifications(&hashof21).unwrap().is_none() {
+		if net.lock().peer(3).client().justifications(hashof21).unwrap().is_none() {
 			net.lock().poll(cx);
 			Poll::Pending
 		} else {
@@ -1428,7 +1428,7 @@ fn grandpa_environment_respects_voting_rules() {
 		.as_client()
 		.expect_block_hash_from_id(&BlockId::Number(19))
 		.unwrap();
-	peer.client().finalize_block(&hashof19, None, false).unwrap();
+	peer.client().finalize_block(hashof19, None, false).unwrap();
 
 	// the 3/4 environment should propose block 21 for voting
 	assert_eq!(
@@ -1455,7 +1455,7 @@ fn grandpa_environment_respects_voting_rules() {
 		.as_client()
 		.expect_block_hash_from_id(&BlockId::Number(21))
 		.unwrap();
-	peer.client().finalize_block(&hashof21, None, false).unwrap();
+	peer.client().finalize_block(hashof21, None, false).unwrap();
 
 	// even though the default environment will always try to not vote on the
 	// best block, there's a hard rule that we can't cast any votes lower than
@@ -1666,7 +1666,7 @@ fn imports_justification_for_regular_blocks_on_import() {
 	);
 
 	// the justification should be imported and available from the client
-	assert!(client.justifications(&block_hash).unwrap().is_some());
+	assert!(client.justifications(block_hash).unwrap().is_some());
 }
 
 #[test]

--- a/client/finality-grandpa/src/warp_proof.rs
+++ b/client/finality-grandpa/src/warp_proof.rs
@@ -130,7 +130,7 @@ impl<Block: BlockT> WarpSyncProof<Block> {
 			}
 
 			let justification = blockchain
-				.justifications(&header.hash())?
+				.justifications(header.hash())?
 				.and_then(|just| just.into_justification(GRANDPA_ENGINE_ID))
 				.expect(
 					"header is last in set and contains standard change signal; \
@@ -412,7 +412,7 @@ mod tests {
 				let justification = GrandpaJustification::from_commit(&client, 42, commit).unwrap();
 
 				client
-					.finalize_block(&target_hash, Some((GRANDPA_ENGINE_ID, justification.encode())))
+					.finalize_block(target_hash, Some((GRANDPA_ENGINE_ID, justification.encode())))
 					.unwrap();
 
 				authority_set_changes.push((current_set_id, n));

--- a/client/network/bitswap/src/lib.rs
+++ b/client/network/bitswap/src/lib.rs
@@ -203,7 +203,7 @@ impl<B: BlockT> BitswapRequestHandler<B> {
 
 			let mut hash = B::Hash::default();
 			hash.as_mut().copy_from_slice(&cid.hash().digest()[0..32]);
-			let transaction = match self.client.indexed_transaction(&hash) {
+			let transaction = match self.client.indexed_transaction(hash) {
 				Ok(ex) => ex,
 				Err(e) => {
 					error!(target: LOG_TARGET, "Error retrieving transaction {}: {}", hash, e);

--- a/client/network/light/src/light_client_requests/handler.rs
+++ b/client/network/light/src/light_client_requests/handler.rs
@@ -172,7 +172,7 @@ where
 
 		let block = Decode::decode(&mut request.block.as_ref())?;
 
-		let response = match self.client.execution_proof(&block, &request.method, &request.data) {
+		let response = match self.client.execution_proof(block, &request.method, &request.data) {
 			Ok((_, proof)) => {
 				let r = schema::v1::light::RemoteCallResponse { proof: proof.encode() };
 				Some(schema::v1::light::response::Response::RemoteCallResponse(r))
@@ -212,7 +212,7 @@ where
 		let block = Decode::decode(&mut request.block.as_ref())?;
 
 		let response =
-			match self.client.read_proof(&block, &mut request.keys.iter().map(AsRef::as_ref)) {
+			match self.client.read_proof(block, &mut request.keys.iter().map(AsRef::as_ref)) {
 				Ok(proof) => {
 					let r = schema::v1::light::RemoteReadResponse { proof: proof.encode() };
 					Some(schema::v1::light::response::Response::RemoteReadResponse(r))
@@ -259,7 +259,7 @@ where
 		};
 		let response = match child_info.and_then(|child_info| {
 			self.client.read_child_proof(
-				&block,
+				block,
 				&child_info,
 				&mut request.keys.iter().map(AsRef::as_ref),
 			)

--- a/client/network/sync/src/block_request_handler.rs
+++ b/client/network/sync/src/block_request_handler.rs
@@ -332,7 +332,7 @@ where
 			let hash = header.hash();
 			let parent_hash = *header.parent_hash();
 			let justifications =
-				if get_justification { self.client.justifications(&hash)? } else { None };
+				if get_justification { self.client.justifications(hash)? } else { None };
 
 			let (justifications, justification, is_empty_justification) =
 				if support_multiple_justifications {
@@ -361,7 +361,7 @@ where
 				};
 
 			let body = if get_body {
-				match self.client.block_body(&hash)? {
+				match self.client.block_body(hash)? {
 					Some(mut extrinsics) =>
 						extrinsics.iter_mut().map(|extrinsic| extrinsic.encode()).collect(),
 					None => {
@@ -374,7 +374,7 @@ where
 			};
 
 			let indexed_body = if get_indexed_body {
-				match self.client.block_indexed_body(&hash)? {
+				match self.client.block_indexed_body(hash)? {
 					Some(transactions) => transactions,
 					None => {
 						log::trace!(

--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -3201,7 +3201,7 @@ mod test {
 
 		let finalized_block = blocks[MAX_BLOCKS_TO_LOOK_BACKWARDS as usize * 2 - 1].clone();
 		let just = (*b"TEST", Vec::new());
-		client.finalize_block(&finalized_block.hash(), Some(just)).unwrap();
+		client.finalize_block(finalized_block.hash(), Some(just)).unwrap();
 		sync.update_chain_info(&info.best_hash, info.best_number);
 
 		let peer_id1 = PeerId::random();
@@ -3333,7 +3333,7 @@ mod test {
 
 		let finalized_block = blocks[MAX_BLOCKS_TO_LOOK_BACKWARDS as usize * 2 - 1].clone();
 		let just = (*b"TEST", Vec::new());
-		client.finalize_block(&finalized_block.hash(), Some(just)).unwrap();
+		client.finalize_block(finalized_block.hash(), Some(just)).unwrap();
 		sync.update_chain_info(&info.best_hash, info.best_number);
 
 		let peer_id1 = PeerId::random();

--- a/client/network/sync/src/state_request_handler.rs
+++ b/client/network/sync/src/state_request_handler.rs
@@ -205,14 +205,14 @@ where
 
 			if !request.no_proof {
 				let (proof, _count) = self.client.read_proof_collection(
-					&block,
+					block,
 					request.start.as_slice(),
 					MAX_RESPONSE_BYTES,
 				)?;
 				response.proof = proof.encode();
 			} else {
 				let entries = self.client.storage_collection(
-					&block,
+					block,
 					request.start.as_slice(),
 					MAX_RESPONSE_BYTES,
 				)?;

--- a/client/network/test/src/block_import.rs
+++ b/client/network/test/src/block_import.rs
@@ -40,7 +40,7 @@ fn prepare_good_block() -> (TestClient, Hash, u64, PeerId, IncomingBlock<Block>)
 
 	let (hash, number) = (client.block_hash(1).unwrap().unwrap(), 1);
 	let header = client.header(&BlockId::Number(1)).unwrap();
-	let justifications = client.justifications(&hash).unwrap();
+	let justifications = client.justifications(hash).unwrap();
 	let peer_id = PeerId::random();
 	(
 		client,

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -173,12 +173,12 @@ impl PeersClient {
 			Some(header) => header,
 			None => return false,
 		};
-		self.backend.have_state_at(&header.hash(), *header.number())
+		self.backend.have_state_at(header.hash(), *header.number())
 	}
 
 	pub fn justifications(
 		&self,
-		hash: &<Block as BlockT>::Hash,
+		hash: <Block as BlockT>::Hash,
 	) -> ClientResult<Option<Justifications>> {
 		self.client.justifications(hash)
 	}
@@ -193,7 +193,7 @@ impl PeersClient {
 
 	pub fn finalize_block(
 		&self,
-		hash: &<Block as BlockT>::Hash,
+		hash: <Block as BlockT>::Hash,
 		justification: Option<Justification>,
 		notify: bool,
 	) -> ClientResult<()> {
@@ -535,14 +535,14 @@ where
 		self.verifier.failed_verifications.lock().clone()
 	}
 
-	pub fn has_block(&self, hash: &H256) -> bool {
+	pub fn has_block(&self, hash: H256) -> bool {
 		self.backend
 			.as_ref()
-			.map(|backend| backend.blockchain().header(BlockId::hash(*hash)).unwrap().is_some())
+			.map(|backend| backend.blockchain().header(BlockId::hash(hash)).unwrap().is_some())
 			.unwrap_or(false)
 	}
 
-	pub fn has_body(&self, hash: &H256) -> bool {
+	pub fn has_body(&self, hash: H256) -> bool {
 		self.backend
 			.as_ref()
 			.map(|backend| backend.blockchain().body(hash).unwrap().is_some())
@@ -1124,7 +1124,7 @@ impl JustificationImport<Block> for ForceFinalized {
 		justification: Justification,
 	) -> Result<(), Self::Error> {
 		self.0
-			.finalize_block(&hash, Some(justification), true)
+			.finalize_block(hash, Some(justification), true)
 			.map_err(|_| ConsensusError::InvalidJustification)
 	}
 }

--- a/client/rpc/src/chain/tests.rs
+++ b/client/rpc/src/chain/tests.rs
@@ -206,7 +206,7 @@ async fn should_return_finalized_hash() {
 	assert_eq!(res, client.genesis_hash());
 
 	// finalize
-	client.finalize_block(&block_hash, None).unwrap();
+	client.finalize_block(block_hash, None).unwrap();
 	let res: H256 = api.call("chain_getFinalizedHead", EmptyParams::new()).await.unwrap();
 	assert_eq!(res, block_hash);
 }
@@ -235,7 +235,7 @@ async fn test_head_subscription(method: &str) {
 		let block = client.new_block(Default::default()).unwrap().build().unwrap().block;
 		let block_hash = block.hash();
 		client.import(BlockOrigin::Own, block).await.unwrap();
-		client.finalize_block(&block_hash, None).unwrap();
+		client.finalize_block(block_hash, None).unwrap();
 		sub
 	};
 

--- a/client/rpc/src/state/state_full.rs
+++ b/client/rpc/src/state/state_full.rs
@@ -147,7 +147,7 @@ where
 			let mut block_changes = StorageChangeSet { block: *block_hash, changes: Vec::new() };
 			for key in keys {
 				let (has_changed, data) = {
-					let curr_data = self.client.storage(block_hash, key).map_err(client_err)?;
+					let curr_data = self.client.storage(*block_hash, key).map_err(client_err)?;
 					match last_values.get(key) {
 						Some(prev_data) => (curr_data != *prev_data, curr_data),
 						None => (true, curr_data),
@@ -213,7 +213,7 @@ where
 		prefix: StorageKey,
 	) -> std::result::Result<Vec<StorageKey>, Error> {
 		self.block_or_best(block)
-			.and_then(|block| self.client.storage_keys(&block, &prefix))
+			.and_then(|block| self.client.storage_keys(block, &prefix))
 			.map_err(client_err)
 	}
 
@@ -223,7 +223,7 @@ where
 		prefix: StorageKey,
 	) -> std::result::Result<Vec<(StorageKey, StorageData)>, Error> {
 		self.block_or_best(block)
-			.and_then(|block| self.client.storage_pairs(&block, &prefix))
+			.and_then(|block| self.client.storage_pairs(block, &prefix))
 			.map_err(client_err)
 	}
 
@@ -236,7 +236,7 @@ where
 	) -> std::result::Result<Vec<StorageKey>, Error> {
 		self.block_or_best(block)
 			.and_then(|block| {
-				self.client.storage_keys_iter(&block, prefix.as_ref(), start_key.as_ref())
+				self.client.storage_keys_iter(block, prefix.as_ref(), start_key.as_ref())
 			})
 			.map(|iter| iter.take(count as usize).collect())
 			.map_err(client_err)
@@ -248,7 +248,7 @@ where
 		key: StorageKey,
 	) -> std::result::Result<Option<StorageData>, Error> {
 		self.block_or_best(block)
-			.and_then(|block| self.client.storage(&block, &key))
+			.and_then(|block| self.client.storage(block, &key))
 			.map_err(client_err)
 	}
 
@@ -262,14 +262,14 @@ where
 			Err(e) => return Err(client_err(e)),
 		};
 
-		match self.client.storage(&block, &key) {
+		match self.client.storage(block, &key) {
 			Ok(Some(d)) => return Ok(Some(d.0.len() as u64)),
 			Err(e) => return Err(client_err(e)),
 			Ok(None) => {},
 		}
 
 		self.client
-			.storage_pairs(&block, &key)
+			.storage_pairs(block, &key)
 			.map(|kv| {
 				let item_sum = kv.iter().map(|(_, v)| v.0.len() as u64).sum::<u64>();
 				if item_sum > 0 {
@@ -287,7 +287,7 @@ where
 		key: StorageKey,
 	) -> std::result::Result<Option<Block::Hash>, Error> {
 		self.block_or_best(block)
-			.and_then(|block| self.client.storage_hash(&block, &key))
+			.and_then(|block| self.client.storage_hash(block, &key))
 			.map_err(client_err)
 	}
 
@@ -345,7 +345,7 @@ where
 		self.block_or_best(block)
 			.and_then(|block| {
 				self.client
-					.read_proof(&block, &mut keys.iter().map(|key| key.0.as_ref()))
+					.read_proof(block, &mut keys.iter().map(|key| key.0.as_ref()))
 					.map(|proof| proof.into_iter_nodes().map(|node| node.into()).collect())
 					.map(|proof| ReadProof { at: block, proof })
 			})
@@ -413,7 +413,7 @@ where
 			let changes = keys
 				.into_iter()
 				.map(|key| {
-					let v = self.client.storage(&block, &key).ok().flatten();
+					let v = self.client.storage(block, &key).ok().flatten();
 					(key, v)
 				})
 				.collect();
@@ -494,7 +494,7 @@ where
 				};
 				self.client
 					.read_child_proof(
-						&block,
+						block,
 						&child_info,
 						&mut keys.iter().map(|key| key.0.as_ref()),
 					)
@@ -517,7 +517,7 @@ where
 						ChildInfo::new_default(storage_key),
 					None => return Err(sp_blockchain::Error::InvalidChildStorageKey),
 				};
-				self.client.child_storage_keys(&block, &child_info, &prefix)
+				self.client.child_storage_keys(block, &child_info, &prefix)
 			})
 			.map_err(client_err)
 	}
@@ -538,7 +538,7 @@ where
 					None => return Err(sp_blockchain::Error::InvalidChildStorageKey),
 				};
 				self.client.child_storage_keys_iter(
-					&block,
+					block,
 					child_info,
 					prefix.as_ref(),
 					start_key.as_ref(),
@@ -561,7 +561,7 @@ where
 						ChildInfo::new_default(storage_key),
 					None => return Err(sp_blockchain::Error::InvalidChildStorageKey),
 				};
-				self.client.child_storage(&block, &child_info, &key)
+				self.client.child_storage(block, &child_info, &key)
 			})
 			.map_err(client_err)
 	}
@@ -584,7 +584,7 @@ where
 
 		keys.into_iter()
 			.map(move |key| {
-				client.clone().child_storage(&block, &child_info, &key).map_err(client_err)
+				client.clone().child_storage(block, &child_info, &key).map_err(client_err)
 			})
 			.collect()
 	}
@@ -602,7 +602,7 @@ where
 						ChildInfo::new_default(storage_key),
 					None => return Err(sp_blockchain::Error::InvalidChildStorageKey),
 				};
-				self.client.child_storage_hash(&block, &child_info, &key)
+				self.client.child_storage_hash(block, &child_info, &key)
 			})
 			.map_err(client_err)
 	}

--- a/client/service/src/chain_ops/export_raw_state.rs
+++ b/client/service/src/chain_ops/export_raw_state.rs
@@ -25,7 +25,7 @@ use std::{collections::HashMap, sync::Arc};
 
 /// Export the raw state at the given `block`. If `block` is `None`, the
 /// best block will be used.
-pub fn export_raw_state<B, BA, C>(client: Arc<C>, hash: &B::Hash) -> Result<Storage, Error>
+pub fn export_raw_state<B, BA, C>(client: Arc<C>, hash: B::Hash) -> Result<Storage, Error>
 where
 	C: UsageProvider<B> + StorageProvider<B, BA>,
 	B: BlockT,

--- a/client/service/src/client/call_executor.rs
+++ b/client/service/src/client/call_executor.rs
@@ -148,7 +148,7 @@ where
 	) -> sp_blockchain::Result<Vec<u8>> {
 		let mut changes = OverlayedChanges::default();
 		let at_hash = self.backend.blockchain().expect_block_hash_from_id(at)?;
-		let state = self.backend.state_at(&at_hash)?;
+		let state = self.backend.state_at(at_hash)?;
 		let state_runtime_code = sp_state_machine::backend::BackendRuntimeCode::new(&state);
 		let runtime_code =
 			state_runtime_code.runtime_code().map_err(sp_blockchain::Error::RuntimeCode)?;
@@ -193,7 +193,7 @@ where
 		let mut storage_transaction_cache = storage_transaction_cache.map(|c| c.borrow_mut());
 
 		let at_hash = self.backend.blockchain().expect_block_hash_from_id(at)?;
-		let state = self.backend.state_at(&at_hash)?;
+		let state = self.backend.state_at(at_hash)?;
 
 		let changes = &mut *changes.borrow_mut();
 
@@ -251,7 +251,7 @@ where
 		let mut overlay = OverlayedChanges::default();
 
 		let at_hash = self.backend.blockchain().expect_block_hash_from_id(id)?;
-		let state = self.backend.state_at(&at_hash)?;
+		let state = self.backend.state_at(at_hash)?;
 		let mut cache = StorageTransactionCache::<Block, B::State>::default();
 		let mut ext = Ext::new(&mut overlay, &mut cache, &state, None);
 		let state_runtime_code = sp_state_machine::backend::BackendRuntimeCode::new(&state);
@@ -269,7 +269,7 @@ where
 		call_data: &[u8],
 	) -> sp_blockchain::Result<(Vec<u8>, StorageProof)> {
 		let at_hash = self.backend.blockchain().expect_block_hash_from_id(at)?;
-		let state = self.backend.state_at(&at_hash)?;
+		let state = self.backend.state_at(at_hash)?;
 
 		let trie_backend = state.as_trie_backend();
 

--- a/client/service/test/src/client/mod.rs
+++ b/client/service/test/src/client/mod.rs
@@ -346,7 +346,7 @@ fn block_builder_works_with_transactions() {
 		.expect("block 1 was just imported. qed");
 
 	assert_eq!(client.chain_info().best_number, 1);
-	assert_ne!(client.state_at(&hash1).unwrap().pairs(), client.state_at(&hash0).unwrap().pairs());
+	assert_ne!(client.state_at(hash1).unwrap().pairs(), client.state_at(hash0).unwrap().pairs());
 	assert_eq!(
 		client
 			.runtime_api()
@@ -405,10 +405,10 @@ fn block_builder_does_not_include_invalid() {
 
 	assert_eq!(client.chain_info().best_number, 1);
 	assert_ne!(
-		client.state_at(&hashof1).unwrap().pairs(),
-		client.state_at(&hashof0).unwrap().pairs()
+		client.state_at(hashof1).unwrap().pairs(),
+		client.state_at(hashof0).unwrap().pairs()
 	);
-	assert_eq!(client.body(&hashof1).unwrap().unwrap().len(), 1)
+	assert_eq!(client.body(hashof1).unwrap().unwrap().len(), 1)
 }
 
 #[test]
@@ -870,7 +870,7 @@ fn import_with_justification() {
 		.unwrap()
 		.block;
 	block_on(client.import(BlockOrigin::Own, a2.clone())).unwrap();
-	client.finalize_block(&a2.hash(), None).unwrap();
+	client.finalize_block(a2.hash(), None).unwrap();
 
 	// A2 -> A3
 	let justification = Justifications::from((TEST_ENGINE_ID, vec![1, 2, 3]));
@@ -884,11 +884,11 @@ fn import_with_justification() {
 
 	assert_eq!(client.chain_info().finalized_hash, a3.hash());
 
-	assert_eq!(client.justifications(&a3.hash()).unwrap(), Some(justification));
+	assert_eq!(client.justifications(a3.hash()).unwrap(), Some(justification));
 
-	assert_eq!(client.justifications(&a1.hash()).unwrap(), None);
+	assert_eq!(client.justifications(a1.hash()).unwrap(), None);
 
-	assert_eq!(client.justifications(&a2.hash()).unwrap(), None);
+	assert_eq!(client.justifications(a2.hash()).unwrap(), None);
 
 	finality_notification_check(&mut finality_notifications, &[a1.hash(), a2.hash()], &[]);
 	finality_notification_check(&mut finality_notifications, &[a3.hash()], &[]);
@@ -999,7 +999,7 @@ fn finalizing_diverged_block_should_trigger_reorg() {
 
 	// we finalize block B1 which is on a different branch from current best
 	// which should trigger a re-org.
-	ClientExt::finalize_block(&client, &b1.hash(), None).unwrap();
+	ClientExt::finalize_block(&client, b1.hash(), None).unwrap();
 
 	// B1 should now be the latest finalized
 	assert_eq!(client.chain_info().finalized_hash, b1.hash());
@@ -1023,7 +1023,7 @@ fn finalizing_diverged_block_should_trigger_reorg() {
 
 	assert_eq!(client.chain_info().best_hash, b3.hash());
 
-	ClientExt::finalize_block(&client, &b3.hash(), None).unwrap();
+	ClientExt::finalize_block(&client, b3.hash(), None).unwrap();
 
 	finality_notification_check(&mut finality_notifications, &[b1.hash()], &[]);
 	finality_notification_check(&mut finality_notifications, &[b2.hash(), b3.hash()], &[a2.hash()]);
@@ -1121,7 +1121,7 @@ fn finality_notifications_content() {
 
 	// Postpone import to test behavior of import of finalized block.
 
-	ClientExt::finalize_block(&client, &a2.hash(), None).unwrap();
+	ClientExt::finalize_block(&client, a2.hash(), None).unwrap();
 
 	// Import and finalize D4
 	block_on(client.import_as_final(BlockOrigin::Own, d4.clone())).unwrap();
@@ -1285,7 +1285,7 @@ fn doesnt_import_blocks_that_revert_finality() {
 
 	// we will finalize A2 which should make it impossible to import a new
 	// B3 at the same height but that doesn't include it
-	ClientExt::finalize_block(&client, &a2.hash(), None).unwrap();
+	ClientExt::finalize_block(&client, a2.hash(), None).unwrap();
 
 	let import_err = block_on(client.import(BlockOrigin::Own, b3)).err().unwrap();
 	let expected_err =
@@ -1320,7 +1320,7 @@ fn doesnt_import_blocks_that_revert_finality() {
 		.unwrap()
 		.block;
 	block_on(client.import(BlockOrigin::Own, a3.clone())).unwrap();
-	ClientExt::finalize_block(&client, &a3.hash(), None).unwrap();
+	ClientExt::finalize_block(&client, a3.hash(), None).unwrap();
 
 	finality_notification_check(&mut finality_notifications, &[a1.hash(), a2.hash()], &[]);
 
@@ -1620,7 +1620,7 @@ fn storage_keys_iter_prefix_and_start_key_works() {
 	let child_prefix = StorageKey(b"sec".to_vec());
 
 	let res: Vec<_> = client
-		.storage_keys_iter(&block_hash, Some(&prefix), None)
+		.storage_keys_iter(block_hash, Some(&prefix), None)
 		.unwrap()
 		.map(|x| x.0)
 		.collect();
@@ -1635,7 +1635,7 @@ fn storage_keys_iter_prefix_and_start_key_works() {
 
 	let res: Vec<_> = client
 		.storage_keys_iter(
-			&block_hash,
+			block_hash,
 			Some(&prefix),
 			Some(&StorageKey(array_bytes::hex2bytes_unchecked("3a636f6465"))),
 		)
@@ -1646,7 +1646,7 @@ fn storage_keys_iter_prefix_and_start_key_works() {
 
 	let res: Vec<_> = client
 		.storage_keys_iter(
-			&block_hash,
+			block_hash,
 			Some(&prefix),
 			Some(&StorageKey(array_bytes::hex2bytes_unchecked("3a686561707061676573"))),
 		)
@@ -1656,7 +1656,7 @@ fn storage_keys_iter_prefix_and_start_key_works() {
 	assert_eq!(res, Vec::<Vec<u8>>::new());
 
 	let res: Vec<_> = client
-		.child_storage_keys_iter(&block_hash, child_info.clone(), Some(&child_prefix), None)
+		.child_storage_keys_iter(block_hash, child_info.clone(), Some(&child_prefix), None)
 		.unwrap()
 		.map(|x| x.0)
 		.collect();
@@ -1664,7 +1664,7 @@ fn storage_keys_iter_prefix_and_start_key_works() {
 
 	let res: Vec<_> = client
 		.child_storage_keys_iter(
-			&block_hash,
+			block_hash,
 			child_info,
 			None,
 			Some(&StorageKey(b"second".to_vec())),
@@ -1684,7 +1684,7 @@ fn storage_keys_iter_works() {
 	let prefix = StorageKey(array_bytes::hex2bytes_unchecked(""));
 
 	let res: Vec<_> = client
-		.storage_keys_iter(&block_hash, Some(&prefix), None)
+		.storage_keys_iter(block_hash, Some(&prefix), None)
 		.unwrap()
 		.take(9)
 		.map(|x| array_bytes::bytes2hex("", &x.0))
@@ -1706,7 +1706,7 @@ fn storage_keys_iter_works() {
 
 	let res: Vec<_> = client
 		.storage_keys_iter(
-			&block_hash,
+			block_hash,
 			Some(&prefix),
 			Some(&StorageKey(array_bytes::hex2bytes_unchecked("3a636f6465"))),
 		)
@@ -1729,7 +1729,7 @@ fn storage_keys_iter_works() {
 
 	let res: Vec<_> = client
 		.storage_keys_iter(
-			&block_hash,
+			block_hash,
 			Some(&prefix),
 			Some(&StorageKey(array_bytes::hex2bytes_unchecked(
 				"7d5007603a7f5dd729d51d93cf695d6465789443bb967c0d1fe270e388c96eaa",

--- a/client/tracing/src/block/mod.rs
+++ b/client/tracing/src/block/mod.rs
@@ -225,7 +225,7 @@ where
 			.ok_or_else(|| Error::MissingBlockComponent("Header not found".to_string()))?;
 		let extrinsics = self
 			.client
-			.block_body(&self.block)
+			.block_body(self.block)
 			.map_err(Error::InvalidBlockId)?
 			.ok_or_else(|| Error::MissingBlockComponent("Extrinsics not found".to_string()))?;
 		tracing::debug!(target: "state_tracing", "Found {} extrinsics", extrinsics.len());

--- a/client/transaction-pool/benches/basics.rs
+++ b/client/transaction-pool/benches/basics.rs
@@ -111,7 +111,7 @@ impl ChainApi for TestApi {
 		(blake2_256(&encoded).into(), encoded.len())
 	}
 
-	fn block_body(&self, _id: &<Self::Block as BlockT>::Hash) -> Self::BodyFuture {
+	fn block_body(&self, _id: <Self::Block as BlockT>::Hash) -> Self::BodyFuture {
 		ready(Ok(None))
 	}
 

--- a/client/transaction-pool/src/api.rs
+++ b/client/transaction-pool/src/api.rs
@@ -126,7 +126,7 @@ where
 		Pin<Box<dyn Future<Output = error::Result<TransactionValidity>> + Send>>;
 	type BodyFuture = Ready<error::Result<Option<Vec<<Self::Block as BlockT>::Extrinsic>>>>;
 
-	fn block_body(&self, hash: &Block::Hash) -> Self::BodyFuture {
+	fn block_body(&self, hash: Block::Hash) -> Self::BodyFuture {
 		ready(self.client.block_body(hash).map_err(error::Error::from))
 	}
 

--- a/client/transaction-pool/src/graph/pool.rs
+++ b/client/transaction-pool/src/graph/pool.rs
@@ -91,7 +91,7 @@ pub trait ChainApi: Send + Sync {
 	fn hash_and_length(&self, uxt: &ExtrinsicFor<Self>) -> (ExtrinsicHash<Self>, usize);
 
 	/// Returns a block body given the block.
-	fn block_body(&self, at: &<Self::Block as BlockT>::Hash) -> Self::BodyFuture;
+	fn block_body(&self, at: <Self::Block as BlockT>::Hash) -> Self::BodyFuture;
 
 	/// Returns a block header given the block id.
 	fn block_header(

--- a/client/transaction-pool/src/tests.rs
+++ b/client/transaction-pool/src/tests.rs
@@ -164,7 +164,7 @@ impl ChainApi for TestApi {
 		(Hashing::hash(&encoded), len)
 	}
 
-	fn block_body(&self, _id: &<Self::Block as BlockT>::Hash) -> Self::BodyFuture {
+	fn block_body(&self, _id: <Self::Block as BlockT>::Hash) -> Self::BodyFuture {
 		futures::future::ready(Ok(None))
 	}
 

--- a/primitives/blockchain/src/backend.rs
+++ b/primitives/blockchain/src/backend.rs
@@ -89,9 +89,9 @@ pub trait Backend<Block: BlockT>:
 	HeaderBackend<Block> + HeaderMetadata<Block, Error = Error>
 {
 	/// Get block body. Returns `None` if block is not found.
-	fn body(&self, hash: &Block::Hash) -> Result<Option<Vec<<Block as BlockT>::Extrinsic>>>;
+	fn body(&self, hash: Block::Hash) -> Result<Option<Vec<<Block as BlockT>::Extrinsic>>>;
 	/// Get block justifications. Returns `None` if no justification exists.
-	fn justifications(&self, hash: &Block::Hash) -> Result<Option<Justifications>>;
+	fn justifications(&self, hash: Block::Hash) -> Result<Option<Justifications>>;
 	/// Get last finalized block hash.
 	fn last_finalized(&self) -> Result<Block::Hash>;
 
@@ -231,14 +231,14 @@ pub trait Backend<Block: BlockT>:
 
 	/// Get single indexed transaction by content hash. Note that this will only fetch transactions
 	/// that are indexed by the runtime with `storage_index_transaction`.
-	fn indexed_transaction(&self, hash: &Block::Hash) -> Result<Option<Vec<u8>>>;
+	fn indexed_transaction(&self, hash: Block::Hash) -> Result<Option<Vec<u8>>>;
 
 	/// Check if indexed transaction exists.
-	fn has_indexed_transaction(&self, hash: &Block::Hash) -> Result<bool> {
+	fn has_indexed_transaction(&self, hash: Block::Hash) -> Result<bool> {
 		Ok(self.indexed_transaction(hash)?.is_some())
 	}
 
-	fn block_indexed_body(&self, hash: &Block::Hash) -> Result<Option<Vec<Vec<u8>>>>;
+	fn block_indexed_body(&self, hash: Block::Hash) -> Result<Option<Vec<Vec<u8>>>>;
 }
 
 /// Blockchain info

--- a/test-utils/client/src/client_ext.rs
+++ b/test-utils/client/src/client_ext.rs
@@ -29,7 +29,7 @@ pub trait ClientExt<Block: BlockT>: Sized {
 	/// Finalize a block.
 	fn finalize_block(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		justification: Option<Justification>,
 	) -> sp_blockchain::Result<()>;
 
@@ -75,7 +75,7 @@ where
 {
 	fn finalize_block(
 		&self,
-		hash: &Block::Hash,
+		hash: Block::Hash,
 		justification: Option<Justification>,
 	) -> sp_blockchain::Result<()> {
 		Finalizer::finalize_block(self, hash, justification, true)

--- a/test-utils/runtime/transaction-pool/src/lib.rs
+++ b/test-utils/runtime/transaction-pool/src/lib.rs
@@ -315,12 +315,12 @@ impl sc_transaction_pool::ChainApi for TestApi {
 		Self::hash_and_length_inner(ex)
 	}
 
-	fn block_body(&self, hash: &<Self::Block as BlockT>::Hash) -> Self::BodyFuture {
+	fn block_body(&self, hash: <Self::Block as BlockT>::Hash) -> Self::BodyFuture {
 		futures::future::ready(Ok(self
 			.chain
 			.read()
 			.block_by_hash
-			.get(hash)
+			.get(&hash)
 			.map(|b| b.extrinsics().to_vec())))
 	}
 

--- a/utils/frame/benchmarking-cli/src/block/bench.rs
+++ b/utils/frame/benchmarking-cli/src/block/bench.rs
@@ -142,7 +142,7 @@ where
 		let block_hash = self.client.expect_block_hash_from_id(block)?;
 		let mut raw_weight = &self
 			.client
-			.storage(&block_hash, &key)?
+			.storage(block_hash, &key)?
 			.ok_or(format!("Could not find System::BlockWeight for block: {}", block))?
 			.0[..];
 

--- a/utils/frame/benchmarking-cli/src/storage/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/storage/cmd.rs
@@ -193,7 +193,7 @@ impl StorageCmd {
 	{
 		let hash = client.usage_info().chain.best_hash;
 		let empty_prefix = StorageKey(Vec::new());
-		let mut keys = client.storage_keys(&hash, &empty_prefix)?;
+		let mut keys = client.storage_keys(hash, &empty_prefix)?;
 		let (mut rng, _) = new_rng(None);
 		keys.shuffle(&mut rng);
 
@@ -201,7 +201,7 @@ impl StorageCmd {
 			info!("Warmup round {}/{}", i + 1, self.params.warmups);
 			for key in keys.as_slice() {
 				let _ = client
-					.storage(&hash, &key)
+					.storage(hash, &key)
 					.expect("Checked above to exist")
 					.ok_or("Value unexpectedly empty");
 			}

--- a/utils/frame/benchmarking-cli/src/storage/read.rs
+++ b/utils/frame/benchmarking-cli/src/storage/read.rs
@@ -43,7 +43,7 @@ impl StorageCmd {
 		info!("Preparing keys from block {}", best_hash);
 		// Load all keys and randomly shuffle them.
 		let empty_prefix = StorageKey(Vec::new());
-		let mut keys = client.storage_keys(&best_hash, &empty_prefix)?;
+		let mut keys = client.storage_keys(best_hash, &empty_prefix)?;
 		let (mut rng, _) = new_rng(None);
 		keys.shuffle(&mut rng);
 
@@ -55,7 +55,7 @@ impl StorageCmd {
 			match (self.params.include_child_trees, self.is_child_key(key.clone().0)) {
 				(true, Some(info)) => {
 					// child tree key
-					let child_keys = client.child_storage_keys(&best_hash, &info, &empty_prefix)?;
+					let child_keys = client.child_storage_keys(best_hash, &info, &empty_prefix)?;
 					for ck in child_keys {
 						child_nodes.push((ck.clone(), info.clone()));
 					}
@@ -64,7 +64,7 @@ impl StorageCmd {
 					// regular key
 					let start = Instant::now();
 					let v = client
-						.storage(&best_hash, &key)
+						.storage(best_hash, &key)
 						.expect("Checked above to exist")
 						.ok_or("Value unexpectedly empty")?;
 					record.append(v.0.len(), start.elapsed())?;
@@ -79,7 +79,7 @@ impl StorageCmd {
 			for (key, info) in child_nodes.as_slice() {
 				let start = Instant::now();
 				let v = client
-					.child_storage(&best_hash, info, key)
+					.child_storage(best_hash, info, key)
 					.expect("Checked above to exist")
 					.ok_or("Value unexpectedly empty")?;
 				record.append(v.0.len(), start.elapsed())?;

--- a/utils/frame/benchmarking-cli/src/storage/write.rs
+++ b/utils/frame/benchmarking-cli/src/storage/write.rs
@@ -77,7 +77,7 @@ impl StorageCmd {
 			match (self.params.include_child_trees, self.is_child_key(k.to_vec())) {
 				(true, Some(info)) => {
 					let child_keys =
-						client.child_storage_keys_iter(&best_hash, info.clone(), None, None)?;
+						client.child_storage_keys_iter(best_hash, info.clone(), None, None)?;
 					for ck in child_keys {
 						child_nodes.push((ck.clone(), info.clone()));
 					}
@@ -124,7 +124,7 @@ impl StorageCmd {
 
 			for (key, info) in child_nodes {
 				if let Some(original_v) = client
-					.child_storage(&best_hash, &info.clone(), &key)
+					.child_storage(best_hash, &info.clone(), &key)
 					.expect("Checked above to exist")
 				{
 					let mut new_v = vec![0; original_v.0.len()];

--- a/utils/frame/rpc/state-trie-migration-rpc/src/lib.rs
+++ b/utils/frame/rpc/state-trie-migration-rpc/src/lib.rs
@@ -145,7 +145,7 @@ where
 		self.deny_unsafe.check_if_safe()?;
 
 		let hash = at.unwrap_or_else(|| self.client.info().best_hash);
-		let state = self.backend.state_at(&hash).map_err(error_into_rpc_err)?;
+		let state = self.backend.state_at(hash).map_err(error_into_rpc_err)?;
 		let (top, child) = migration_status(&state).map_err(error_into_rpc_err)?;
 
 		Ok(MigrationStatusResult {


### PR DESCRIPTION
It changes &Block::Hash argument to Block::Hash.

This PR is part of BlockId::Number refactoring analysis (paritytech/substrate#11292)


polkadot companion: paritytech/polkadot#6246
cumulus companion: paritytech/cumulus#1818
