### PR TITLE
Pipeline with ci image with rust 1.65

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ variables:
   CARGO_INCREMENTAL:               0
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  CI_IMAGE:                        "paritytech/ci-linux:production"
+  CI_IMAGE:                        "paritytech/ci-linux:staging"
   RUSTY_CACHIER_SINGLE_BRANCH:     master
   RUSTY_CACHIER_DONT_OPERATE_ON_MAIN_BRANCH: "true"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ variables:
   CARGO_INCREMENTAL:               0
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  CI_IMAGE:                        "paritytech/ci-linux:staging"
+  CI_IMAGE:                        "paritytech/ci-linux@sha256:c977b383c2033de50083fad18f6b9e698644230455e016ba708da00eb98d4683" # staging 07.11.2022
   RUSTY_CACHIER_SINGLE_BRANCH:     master
   RUSTY_CACHIER_DONT_OPERATE_ON_MAIN_BRANCH: "true"
 

--- a/frame/support/test/tests/construct_runtime_ui/no_std_genesis_config.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/no_std_genesis_config.stderr
@@ -29,19 +29,6 @@ help: consider importing this struct
    |
 1  | use frame_system::GenesisConfig;
    |
-help: if you import `GenesisConfig`, refer to it directly
-   |
-40 - construct_runtime! {
-41 -     pub enum Runtime where
-42 -         Block = Block,
-43 -         NodeBlock = Block,
-44 -         UncheckedExtrinsic = UncheckedExtrinsic
-45 -     {
-46 -         System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
-47 -         Pallet: test_pallet::{Pallet, Config},
-48 -     }
-49 - }
-   |
 
 error[E0283]: type annotations needed
   --> tests/construct_runtime_ui/no_std_genesis_config.rs:40:1

--- a/frame/support/test/tests/construct_runtime_ui/undefined_event_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_event_part.stderr
@@ -32,16 +32,3 @@ help: consider importing this enum
    |
 1  | use frame_system::Event;
    |
-help: if you import `Event`, refer to it directly
-   |
-49 - construct_runtime! {
-50 -     pub enum Runtime where
-51 -         Block = Block,
-52 -         NodeBlock = Block,
-53 -         UncheckedExtrinsic = UncheckedExtrinsic
-54 -     {
-55 -         System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
-56 -         Pallet: pallet::{Pallet, Event},
-57 -     }
-58 - }
-   |

--- a/frame/support/test/tests/construct_runtime_ui/undefined_genesis_config_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_genesis_config_part.stderr
@@ -32,19 +32,6 @@ help: consider importing this struct
    |
 1  | use frame_system::GenesisConfig;
    |
-help: if you import `GenesisConfig`, refer to it directly
-   |
-49 - construct_runtime! {
-50 -     pub enum Runtime where
-51 -         Block = Block,
-52 -         NodeBlock = Block,
-53 -         UncheckedExtrinsic = UncheckedExtrinsic
-54 -     {
-55 -         System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
-56 -         Pallet: pallet::{Pallet, Config},
-57 -     }
-58 - }
-   |
 
 error[E0283]: type annotations needed
   --> tests/construct_runtime_ui/undefined_genesis_config_part.rs:49:1

--- a/frame/support/test/tests/construct_runtime_ui/undefined_origin_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_origin_part.stderr
@@ -32,19 +32,6 @@ help: consider importing this type alias
    |
 1  | use frame_system::Origin;
    |
-help: if you import `Origin`, refer to it directly
-   |
-49 - construct_runtime! {
-50 -     pub enum Runtime where
-51 -         Block = Block,
-52 -         NodeBlock = Block,
-53 -         UncheckedExtrinsic = UncheckedExtrinsic
-54 -     {
-55 -         System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
-56 -         Pallet: pallet::{Pallet, Origin},
-57 -     }
-58 - }
-   |
 
 error[E0282]: type annotations needed
   --> tests/construct_runtime_ui/undefined_origin_part.rs:49:1

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
@@ -5,7 +5,7 @@ error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
    |                                          ^^^ `<T as pallet::Config>::Bar` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
-   = note: required because of the requirements on the impl of `std::fmt::Debug` for `&<T as pallet::Config>::Bar`
+   = note: required for `&<T as pallet::Config>::Bar` to implement `std::fmt::Debug`
    = note: required for the cast from `&<T as pallet::Config>::Bar` to the object type `dyn std::fmt::Debug`
 
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: Clone` is not satisfied

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
@@ -5,7 +5,7 @@ error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
    |                                          ^^^ `<T as pallet::Config>::Bar` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
-   = note: required because of the requirements on the impl of `std::fmt::Debug` for `&<T as pallet::Config>::Bar`
+   = note: required for `&<T as pallet::Config>::Bar` to implement `std::fmt::Debug`
    = note: required for the cast from `&<T as pallet::Config>::Bar` to the object type `dyn std::fmt::Debug`
 
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: Clone` is not satisfied
@@ -21,23 +21,21 @@ error[E0369]: binary operation `==` cannot be applied to type `&<T as pallet::Co
    |                                          ^^^
 
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeEncode` is not satisfied
-  --> tests/pallet_ui/call_argument_invalid_bound_2.rs:1:1
+  --> tests/pallet_ui/call_argument_invalid_bound_2.rs:20:36
    |
-1  |   #[frame_support::pallet]
-   |   ^-----------------------
-   |   |
-   |  _in this procedural macro expansion
-   | |
+1  | / #[frame_support::pallet]
 2  | | mod pallet {
 3  | |     use frame_support::pallet_prelude::{Hooks, DispatchResultWithPostInfo};
 4  | |     use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
 ...  |
 16 | |
 17 | |     #[pallet::call]
-   | |__________________^ the trait `WrapperTypeEncode` is not implemented for `<T as pallet::Config>::Bar`
+   | |__________________- required by a bound introduced by this call
+...
+20 |           pub fn foo(origin: OriginFor<T>, bar: T::Bar) -> DispatchResultWithPostInfo {
+   |                                            ^^^ the trait `WrapperTypeEncode` is not implemented for `<T as pallet::Config>::Bar`
    |
-   = note: required because of the requirements on the impl of `Encode` for `<T as pallet::Config>::Bar`
-   = note: this error originates in the derive macro `frame_support::codec::Encode` which comes from the expansion of the attribute macro `frame_support::pallet` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: required for `<T as pallet::Config>::Bar` to implement `Encode`
 
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeDecode` is not satisfied
   --> tests/pallet_ui/call_argument_invalid_bound_2.rs:17:12
@@ -45,4 +43,4 @@ error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeDecode` is
 17 |     #[pallet::call]
    |               ^^^^ the trait `WrapperTypeDecode` is not implemented for `<T as pallet::Config>::Bar`
    |
-   = note: required because of the requirements on the impl of `Decode` for `<T as pallet::Config>::Bar`
+   = note: required for `<T as pallet::Config>::Bar` to implement `Decode`

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.stderr
@@ -6,7 +6,7 @@ error[E0277]: `Bar` doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `Bar`
    = note: add `#[derive(Debug)]` to `Bar` or manually `impl std::fmt::Debug for Bar`
-   = note: required because of the requirements on the impl of `std::fmt::Debug` for `&Bar`
+   = note: required for `&Bar` to implement `std::fmt::Debug`
    = note: required for the cast from `&Bar` to the object type `dyn std::fmt::Debug`
 help: consider annotating `Bar` with `#[derive(Debug)]`
    |

--- a/frame/support/test/tests/pallet_ui/event_field_not_member.stderr
+++ b/frame/support/test/tests/pallet_ui/event_field_not_member.stderr
@@ -17,5 +17,5 @@ error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
    |             ^ `<T as pallet::Config>::Bar` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
-   = note: required because of the requirements on the impl of `std::fmt::Debug` for `&<T as pallet::Config>::Bar`
+   = note: required for `&<T as pallet::Config>::Bar` to implement `std::fmt::Debug`
    = note: required for the cast from `&<T as pallet::Config>::Bar` to the object type `dyn std::fmt::Debug`

--- a/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.stderr
+++ b/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.stderr
@@ -9,9 +9,9 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
              Box<T>
              Rc<T>
              frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
-   = note: required because of the requirements on the impl of `Decode` for `Bar`
-   = note: required because of the requirements on the impl of `FullCodec` for `Bar`
-   = note: required because of the requirements on the impl of `PartialStorageInfoTrait` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`
+   = note: required for `Bar` to implement `Decode`
+   = note: required for `Bar` to implement `FullCodec`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `PartialStorageInfoTrait`
 
 error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:10:12
@@ -29,9 +29,9 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
              <&[(T,)] as EncodeLike<LinkedList<LikeT>>>
              <&[T] as EncodeLike<Vec<U>>>
            and 278 others
-   = note: required because of the requirements on the impl of `FullEncode` for `Bar`
-   = note: required because of the requirements on the impl of `FullCodec` for `Bar`
-   = note: required because of the requirements on the impl of `PartialStorageInfoTrait` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`
+   = note: required for `Bar` to implement `FullEncode`
+   = note: required for `Bar` to implement `FullCodec`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `PartialStorageInfoTrait`
 
 error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:10:12
@@ -49,10 +49,10 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
              Vec<T>
              bytes::bytes::Bytes
            and 3 others
-   = note: required because of the requirements on the impl of `Encode` for `Bar`
-   = note: required because of the requirements on the impl of `FullEncode` for `Bar`
-   = note: required because of the requirements on the impl of `FullCodec` for `Bar`
-   = note: required because of the requirements on the impl of `PartialStorageInfoTrait` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`
+   = note: required for `Bar` to implement `Encode`
+   = note: required for `Bar` to implement `FullEncode`
+   = note: required for `Bar` to implement `FullCodec`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `PartialStorageInfoTrait`
 
 error[E0277]: the trait bound `Bar: TypeInfo` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:21:12
@@ -70,8 +70,8 @@ error[E0277]: the trait bound `Bar: TypeInfo` is not satisfied
              (A, B, C, D, E)
              (A, B, C, D, E, F)
            and 161 others
-   = note: required because of the requirements on the impl of `StaticTypeInfo` for `Bar`
-   = note: required because of the requirements on the impl of `StorageEntryMetadataBuilder` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`
+   = note: required for `Bar` to implement `StaticTypeInfo`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
 
 error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:21:12
@@ -84,9 +84,9 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
              Box<T>
              Rc<T>
              frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
-   = note: required because of the requirements on the impl of `Decode` for `Bar`
-   = note: required because of the requirements on the impl of `FullCodec` for `Bar`
-   = note: required because of the requirements on the impl of `StorageEntryMetadataBuilder` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`
+   = note: required for `Bar` to implement `Decode`
+   = note: required for `Bar` to implement `FullCodec`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
 
 error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:21:12
@@ -104,9 +104,9 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
              <&[(T,)] as EncodeLike<LinkedList<LikeT>>>
              <&[T] as EncodeLike<Vec<U>>>
            and 278 others
-   = note: required because of the requirements on the impl of `FullEncode` for `Bar`
-   = note: required because of the requirements on the impl of `FullCodec` for `Bar`
-   = note: required because of the requirements on the impl of `StorageEntryMetadataBuilder` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`
+   = note: required for `Bar` to implement `FullEncode`
+   = note: required for `Bar` to implement `FullCodec`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
 
 error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:21:12
@@ -124,7 +124,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
              Vec<T>
              bytes::bytes::Bytes
            and 3 others
-   = note: required because of the requirements on the impl of `Encode` for `Bar`
-   = note: required because of the requirements on the impl of `FullEncode` for `Bar`
-   = note: required because of the requirements on the impl of `FullCodec` for `Bar`
-   = note: required because of the requirements on the impl of `StorageEntryMetadataBuilder` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`
+   = note: required for `Bar` to implement `Encode`
+   = note: required for `Bar` to implement `FullEncode`
+   = note: required for `Bar` to implement `FullCodec`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`

--- a/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.stderr
+++ b/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.stderr
@@ -9,9 +9,9 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
              Box<T>
              Rc<T>
              frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
-   = note: required because of the requirements on the impl of `Decode` for `Bar`
-   = note: required because of the requirements on the impl of `FullCodec` for `Bar`
-   = note: required because of the requirements on the impl of `PartialStorageInfoTrait` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`
+   = note: required for `Bar` to implement `Decode`
+   = note: required for `Bar` to implement `FullCodec`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `PartialStorageInfoTrait`
 
 error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:10:12
@@ -29,9 +29,9 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
              <&[(T,)] as EncodeLike<LinkedList<LikeT>>>
              <&[T] as EncodeLike<Vec<U>>>
            and 278 others
-   = note: required because of the requirements on the impl of `FullEncode` for `Bar`
-   = note: required because of the requirements on the impl of `FullCodec` for `Bar`
-   = note: required because of the requirements on the impl of `PartialStorageInfoTrait` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`
+   = note: required for `Bar` to implement `FullEncode`
+   = note: required for `Bar` to implement `FullCodec`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `PartialStorageInfoTrait`
 
 error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:10:12
@@ -49,10 +49,10 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
              Vec<T>
              bytes::bytes::Bytes
            and 3 others
-   = note: required because of the requirements on the impl of `Encode` for `Bar`
-   = note: required because of the requirements on the impl of `FullEncode` for `Bar`
-   = note: required because of the requirements on the impl of `FullCodec` for `Bar`
-   = note: required because of the requirements on the impl of `PartialStorageInfoTrait` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`
+   = note: required for `Bar` to implement `Encode`
+   = note: required for `Bar` to implement `FullEncode`
+   = note: required for `Bar` to implement `FullCodec`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `PartialStorageInfoTrait`
 
 error[E0277]: the trait bound `Bar: TypeInfo` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:21:12
@@ -70,8 +70,8 @@ error[E0277]: the trait bound `Bar: TypeInfo` is not satisfied
              (A, B, C, D, E)
              (A, B, C, D, E, F)
            and 161 others
-   = note: required because of the requirements on the impl of `StaticTypeInfo` for `Bar`
-   = note: required because of the requirements on the impl of `StorageEntryMetadataBuilder` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`
+   = note: required for `Bar` to implement `StaticTypeInfo`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
 
 error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:21:12
@@ -84,9 +84,9 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
              Box<T>
              Rc<T>
              frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
-   = note: required because of the requirements on the impl of `Decode` for `Bar`
-   = note: required because of the requirements on the impl of `FullCodec` for `Bar`
-   = note: required because of the requirements on the impl of `StorageEntryMetadataBuilder` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`
+   = note: required for `Bar` to implement `Decode`
+   = note: required for `Bar` to implement `FullCodec`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
 
 error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:21:12
@@ -104,9 +104,9 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
              <&[(T,)] as EncodeLike<LinkedList<LikeT>>>
              <&[T] as EncodeLike<Vec<U>>>
            and 278 others
-   = note: required because of the requirements on the impl of `FullEncode` for `Bar`
-   = note: required because of the requirements on the impl of `FullCodec` for `Bar`
-   = note: required because of the requirements on the impl of `StorageEntryMetadataBuilder` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`
+   = note: required for `Bar` to implement `FullEncode`
+   = note: required for `Bar` to implement `FullCodec`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
 
 error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:21:12
@@ -124,7 +124,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
              Vec<T>
              bytes::bytes::Bytes
            and 3 others
-   = note: required because of the requirements on the impl of `Encode` for `Bar`
-   = note: required because of the requirements on the impl of `FullEncode` for `Bar`
-   = note: required because of the requirements on the impl of `FullCodec` for `Bar`
-   = note: required because of the requirements on the impl of `StorageEntryMetadataBuilder` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`
+   = note: required for `Bar` to implement `Encode`
+   = note: required for `Bar` to implement `FullEncode`
+   = note: required for `Bar` to implement `FullCodec`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`

--- a/frame/support/test/tests/pallet_ui/storage_info_unsatisfied.stderr
+++ b/frame/support/test/tests/pallet_ui/storage_info_unsatisfied.stderr
@@ -14,4 +14,4 @@ error[E0277]: the trait bound `Bar: MaxEncodedLen` is not satisfied
             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6)
             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6, TupleElement7)
           and 78 others
-  = note: required because of the requirements on the impl of `StorageInfoTrait` for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>`
+  = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageInfoTrait`

--- a/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.stderr
+++ b/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.stderr
@@ -14,5 +14,5 @@ error[E0277]: the trait bound `Bar: MaxEncodedLen` is not satisfied
              (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6)
              (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6, TupleElement7)
            and 78 others
-   = note: required because of the requirements on the impl of `KeyGeneratorMaxEncodedLen` for `Key<frame_support::Twox64Concat, Bar>`
-   = note: required because of the requirements on the impl of `StorageInfoTrait` for `frame_support::pallet_prelude::StorageNMap<_GeneratedPrefixForStorageFoo<T>, Key<frame_support::Twox64Concat, Bar>, u32>`
+   = note: required for `Key<frame_support::Twox64Concat, Bar>` to implement `KeyGeneratorMaxEncodedLen`
+   = note: required for `frame_support::pallet_prelude::StorageNMap<_GeneratedPrefixForStorageFoo<T>, Key<frame_support::Twox64Concat, Bar>, u32>` to implement `StorageInfoTrait`

--- a/primitives/api/test/tests/ui/type_reference_in_impl_runtime_apis_call.stderr
+++ b/primitives/api/test/tests/ui/type_reference_in_impl_runtime_apis_call.stderr
@@ -35,6 +35,5 @@ note: associated function defined here
    |            ^^^^
 help: consider removing the borrow
    |
-19 -         fn test(data: &u64) {
-19 +         fn test(data: &u64) {
+19 |         fn test(data: &u64) {
    |


### PR DESCRIPTION
In order to update rust in CI image tests should be fixed. 
cc https://github.com/paritytech/ci_cd/issues/653

```bash
test tests/pallet_ui/pass/trait_constant_valid_bounds.rs [should pass] ... ok
thread 'pallet_ui' panicked at '8 of 71 tests failed', /cargo_home/registry/src/github.com-1ecc6299db9ec823/trybuild-1.0.60/src/run.rs:85:13
stack backtrace:
   0: rust_begin_unwind
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/panicking.rs:142:14
   2: trybuild::run::<impl trybuild::Runner>::run
   3: <trybuild::TestCases as core::ops::drop::Drop>::drop
   4: core::ops::function::FnOnce::call_once
   5: core::ops::function::FnOnce::call_once
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/ops/function.rs:248:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
        PASS [ 513.992s]                                                  frame-support-test::derive_no_bound_ui derive_no_bound_ui
        PASS [ 516.846s]                                                     frame-support-test::decl_storage_ui decl_storage_ui
------------
     Summary [ 516.954s] 1596 tests run: 1593 passed (8 slow), 3 failed, 2985 skipped
        FAIL [ 353.310s]                                                frame-support-test::construct_runtime_ui ui
        FAIL [ 504.512s]                                                           frame-support-test::pallet_ui pallet_ui
        FAIL [ 326.503s]                                                                   sp-api-test::trybuild ui
error: test run failed
```

Close https://github.com/paritytech/substrate/issues/12629