### PR TITLE
Do not update peer information if ancestor search is in progress

### DIFF
--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -2043,15 +2043,15 @@ where
 			return PollBlockAnnounceValidation::Nothing { is_best, who, announce }
 		};
 
+		if let PeerSyncState::AncestorSearch { .. } = peer.state {
+			trace!(target: "sync", "Peer state is ancestor search.");
+			return PollBlockAnnounceValidation::Nothing { is_best, who, announce }
+		}
+
 		if is_best {
 			// update their best block
 			peer.best_number = number;
 			peer.best_hash = hash;
-		}
-
-		if let PeerSyncState::AncestorSearch { .. } = peer.state {
-			trace!(target: "sync", "Peer state is ancestor search.");
-			return PollBlockAnnounceValidation::Nothing { is_best, who, announce }
 		}
 
 		// If the announced block is the best they have and is not ahead of us, our common number

--- a/client/network/test/src/sync.rs
+++ b/client/network/test/src/sync.rs
@@ -558,6 +558,9 @@ fn syncs_header_only_forks() {
 	while !net.peer(1).has_block(&small_hash) {
 		net.block_until_idle();
 	}
+
+	assert_eq!(net.peer(0).client().info().best_hash, net.peer(1).client().info().best_hash);
+	assert_ne!(small_hash, net.peer(0).client().info().best_hash);
 }
 
 #[test]

--- a/client/network/test/src/sync.rs
+++ b/client/network/test/src/sync.rs
@@ -559,6 +559,7 @@ fn syncs_header_only_forks() {
 		net.block_until_idle();
 	}
 
+	net.block_until_sync();
 	assert_eq!(net.peer(0).client().info().best_hash, net.peer(1).client().info().best_hash);
 	assert_ne!(small_hash, net.peer(0).client().info().best_hash);
 }


### PR DESCRIPTION
If block announcement is received from a peer while ancestor search for that same peer is still in progress, do not update the peer's best hash and best number as that causes the ancestor search to yield different information from what was expected and can cause, for example, a fork of lower height not to be downloaded.

Problem basically was that there was a race condition between concluding the ancestor search for a peer and receiving a block announcement from the same peer with higher block number. If the block announcement was received before the ancestor search was concluded (for a fork with a smaller best block number), the peer information was overwritten and the fork was never downloaded.

Resolves https://github.com/paritytech/substrate/issues/12607
