### PR TITLE
txpool: enactment state forced update

### DIFF
--- a/client/transaction-pool/src/enactment_state.rs
+++ b/client/transaction-pool/src/enactment_state.rs
@@ -134,6 +134,16 @@ where
 
 		Ok(Some(tree_route))
 	}
+
+	/// Forces update of the state according to the given `ChainEvent`. Intended to be used as a
+	/// fallback when tree_route cannot be computed.
+	pub fn force_update(&mut self, event: &ChainEvent<Block>) {
+		match event {
+			ChainEvent::NewBestBlock { hash, .. } => self.recent_best_block = *hash,
+			ChainEvent::Finalized { hash, .. } => self.recent_finalized_block = *hash,
+		};
+		log::debug!(target: "txpool", "forced update: {:?}, {:?}", self.recent_best_block, self.recent_finalized_block);
+	}
 }
 
 #[cfg(test)]

--- a/client/transaction-pool/src/enactment_state.rs
+++ b/client/transaction-pool/src/enactment_state.rs
@@ -586,4 +586,22 @@ mod enactment_state_tests {
 		assert_eq!(result, false);
 		assert_es_eq(&es, e1(), d1());
 	}
+
+	#[test]
+	fn test_enactment_forced_update_best_block() {
+		sp_tracing::try_init_simple();
+		let mut es = EnactmentState::new(a().hash, a().hash);
+
+		es.force_update(&ChainEvent::NewBestBlock { hash: b1().hash, tree_route: None });
+		assert_es_eq(&es, b1(), a());
+	}
+
+	#[test]
+	fn test_enactment_forced_update_finalize() {
+		sp_tracing::try_init_simple();
+		let mut es = EnactmentState::new(a().hash, a().hash);
+
+		es.force_update(&ChainEvent::Finalized { hash: b1().hash, tree_route: Arc::from([]) });
+		assert_es_eq(&es, a(), b1());
+	}
 }

--- a/client/transaction-pool/src/lib.rs
+++ b/client/transaction-pool/src/lib.rs
@@ -748,7 +748,7 @@ where
 
 		match result {
 			Err(msg) => {
-				log::error!(target: "txpool", "{msg}");
+				log::debug!(target: "txpool", "{msg}");
 				self.enactment_state.lock().force_update(&event);
 			},
 			Ok(None) => {},

--- a/client/transaction-pool/src/lib.rs
+++ b/client/transaction-pool/src/lib.rs
@@ -748,8 +748,8 @@ where
 
 		match result {
 			Err(msg) => {
-				log::warn!(target: "txpool", "{msg}");
-				return
+				log::error!(target: "txpool", "{msg}");
+				self.enactment_state.lock().force_update(&event);
 			},
 			Ok(None) => {},
 			Ok(Some(tree_route)) => {


### PR DESCRIPTION
When `tree_route` computation fails, we still need to update the
`enactment_state` to be aligned with last known finalized/best block.

We do not execute enactment phase of maintain procedure, but we do
update the state.

Fixes: #12623