### PR TITLE
Machine metrics: remove duplicate units

### DIFF
--- a/client/sysinfo/src/lib.rs
+++ b/client/sysinfo/src/lib.rs
@@ -131,14 +131,14 @@ pub fn print_sysinfo(sysinfo: &sc_telemetry::SysInfo) {
 
 /// Prints out the results of the hardware benchmarks in the logs.
 pub fn print_hwbench(hwbench: &HwBench) {
-	log::info!("🏁 CPU score: {}MB/s", hwbench.cpu_hashrate_score);
-	log::info!("🏁 Memory score: {}MB/s", hwbench.memory_memcpy_score);
+	log::info!("🏁 CPU score: {}", hwbench.cpu_hashrate_score);
+	log::info!("🏁 Memory score: {}", hwbench.memory_memcpy_score);
 
 	if let Some(score) = hwbench.disk_sequential_write_score {
-		log::info!("🏁 Disk score (seq. writes): {}MB/s", score);
+		log::info!("🏁 Disk score (seq. writes): {}", score);
 	}
 	if let Some(score) = hwbench.disk_random_write_score {
-		log::info!("🏁 Disk score (rand. writes): {}MB/s", score);
+		log::info!("🏁 Disk score (rand. writes): {}", score);
 	}
 }
 


### PR DESCRIPTION
The unit already gets serialized after https://github.com/paritytech/substrate/pull/12368. New output:  
```pre
🏁 CPU score: 981.62 MiBs    
🏁 Memory score: 14.94 GiBs    
🏁 Disk score (seq. writes): 4.57 GiBs    
🏁 Disk score (rand. writes): 2.04 GiBs
```
cc @Szegoo 