### PR TITLE
Do not finalize parent twice

### DIFF
--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -656,7 +656,7 @@ where
 
 		// Ensure parent chain is finalized to maintain invariant that finality is called
 		// sequentially.
-		if finalized && parent_exists {
+		if finalized && parent_exists && info.finalized_hash != parent_hash {
 			self.apply_finality_with_block_hash(
 				operation,
 				parent_hash,


### PR DESCRIPTION
If the parent block is alread finalized, we don't need to do this again.

