### PR TITLE
Make public is_passing and ReferendumStatus

### DIFF
--- a/frame/referenda/src/lib.rs
+++ b/frame/referenda/src/lib.rs
@@ -701,23 +701,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		}
 	}
 
-	/// Returns the referendum's current approval/support and TrackId.
-	/// Referendum must be ongoing.
-	pub fn current_referendum_threshold(
-		ref_index: ReferendumIndex,
-	) -> Result<(Perbill, Perbill, Option<T::BlockNumber>, TrackIdOf<T, I>), DispatchError> {
-		let info = ReferendumInfoFor::<T, I>::get(ref_index).ok_or(Error::<T, I>::BadReferendum)?;
-		match info {
-			ReferendumInfo::Ongoing(status) => {
-				let maybe_since = if let Some(d) = status.deciding { Some(d.since) } else { None };
-				let (current_approval, current_support) =
-					(status.tally.approval(status.track), status.tally.support(status.track));
-				Ok((current_approval, current_support, maybe_since, status.track))
-			},
-			_ => Err(Error::<T, I>::NotOngoing.into()),
-		}
-	}
-
 	/// Returns whether the referendum is passing.
 	/// Referendum must be ongoing and its track must exist.
 	pub fn is_referendum_passing(ref_index: ReferendumIndex) -> Result<bool, DispatchError> {

--- a/frame/referenda/src/lib.rs
+++ b/frame/referenda/src/lib.rs
@@ -701,6 +701,48 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		}
 	}
 
+	/// Return the current approval, support requirements and the current tally
+	pub fn referendum_threshold(ref_index: ReferendumIndex) -> () {
+		let info =
+			if let Some(i) = ReferendumInfoFor::<T, I>::get(ref_index) { i } else { return false };
+		let track = if let Some(t) = Self::track(status.track) { t } else { return false };
+		let elapsed = if let Some(deciding) = status.deciding {
+			frame_system::Pallet::<T>::block_number().saturating_sub(deciding.since)
+		} else {
+			Zero::zero()
+		};
+		let period = track.decision_period;
+		let x = Perbill::from_rational(elapsed.min(period), period);
+		// TODO
+		()
+	}// TODO: referendum_decision_time to expose fn decision_time
+
+	/// Return whether the given referendum is in a passing state or already approved
+	pub fn is_referendum_passing(ref_index: ReferendumIndex) -> bool {
+		let info =
+			if let Some(i) = ReferendumInfoFor::<T, I>::get(ref_index) { i } else { return false };
+		match info {
+			ReferendumInfo::Ongoing(status) => {
+				let track = if let Some(t) = Self::track(status.track) { t } else { return false };
+				let elapsed = if let Some(deciding) = status.deciding {
+					frame_system::Pallet::<T>::block_number().saturating_sub(deciding.since)
+				} else {
+					Zero::zero()
+				};
+				Self::is_passing(
+					&status.tally,
+					elapsed,
+					track.decision_period,
+					&track.min_support,
+					&track.min_approval,
+					status.track,
+				)
+			},
+			ReferendumInfo::Approved(..) => true,
+			_ => false,
+		}
+	}
+
 	// Enqueue a proposal from a referendum which has presumably passed.
 	fn schedule_enactment(
 		index: ReferendumIndex,

--- a/frame/referenda/src/types.rs
+++ b/frame/referenda/src/types.rs
@@ -101,16 +101,16 @@ impl<T: Ord, S: Get<u32>> InsertSorted<T> for BoundedVec<T, S> {
 pub struct DecidingStatus<BlockNumber> {
 	/// When this referendum began being "decided". If confirming, then the
 	/// end will actually be delayed until the end of the confirmation period.
-	pub(crate) since: BlockNumber,
+	pub since: BlockNumber,
 	/// If `Some`, then the referendum has entered confirmation stage and will end at
 	/// the block number as long as it doesn't lose its approval in the meantime.
-	pub(crate) confirming: Option<BlockNumber>,
+	pub confirming: Option<BlockNumber>,
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub struct Deposit<AccountId, Balance> {
-	pub(crate) who: AccountId,
-	pub(crate) amount: Balance,
+	pub who: AccountId,
+	pub amount: Balance,
 }
 
 #[derive(Clone, Encode, TypeInfo)]
@@ -171,28 +171,28 @@ pub struct ReferendumStatus<
 	ScheduleAddress: Eq + PartialEq + Debug + Encode + Decode + TypeInfo + Clone,
 > {
 	/// The track of this referendum.
-	pub(crate) track: TrackId,
+	pub track: TrackId,
 	/// The origin for this referendum.
-	pub(crate) origin: RuntimeOrigin,
+	pub origin: RuntimeOrigin,
 	/// The hash of the proposal up for referendum.
-	pub(crate) proposal: Call,
+	pub proposal: Call,
 	/// The time the proposal should be scheduled for enactment.
-	pub(crate) enactment: DispatchTime<Moment>,
+	pub enactment: DispatchTime<Moment>,
 	/// The time of submission. Once `UndecidingTimeout` passes, it may be closed by anyone if
 	/// `deciding` is `None`.
-	pub(crate) submitted: Moment,
+	pub submitted: Moment,
 	/// The deposit reserved for the submission of this referendum.
-	pub(crate) submission_deposit: Deposit<AccountId, Balance>,
+	pub submission_deposit: Deposit<AccountId, Balance>,
 	/// The deposit reserved for this referendum to be decided.
-	pub(crate) decision_deposit: Option<Deposit<AccountId, Balance>>,
+	pub decision_deposit: Option<Deposit<AccountId, Balance>>,
 	/// The status of a decision being made. If `None`, it has not entered the deciding period.
-	pub(crate) deciding: Option<DecidingStatus<Moment>>,
+	pub deciding: Option<DecidingStatus<Moment>>,
 	/// The current tally of votes in this referendum.
-	pub(crate) tally: Tally,
+	pub tally: Tally,
 	/// Whether we have been placed in the queue for being decided or not.
-	pub(crate) in_queue: bool,
+	pub in_queue: bool,
 	/// The next scheduled wake-up, if `Some`.
-	pub(crate) alarm: Option<(Moment, ScheduleAddress)>,
+	pub alarm: Option<(Moment, ScheduleAddress)>,
 }
 
 impl<

--- a/frame/referenda/src/types.rs
+++ b/frame/referenda/src/types.rs
@@ -207,9 +207,12 @@ impl<
 	>
 	ReferendumStatus<TrackId, RuntimeOrigin, Moment, Call, Balance, Tally, AccountId, ScheduleAddress>
 {
+	/// Return whether referendum status is deciding.
+	/// confirming => deciding so deciding does not preclude confirming
 	pub fn is_deciding(&self) -> bool {
 		self.deciding.is_some()
 	}
+	/// Return whether referendum status is confirming.
 	pub fn is_confirming(&self) -> bool {
 		if let Some(deciding_status) = &self.deciding {
 			deciding_status.confirming.is_some()

--- a/frame/referenda/src/types.rs
+++ b/frame/referenda/src/types.rs
@@ -195,33 +195,6 @@ pub struct ReferendumStatus<
 	pub alarm: Option<(Moment, ScheduleAddress)>,
 }
 
-impl<
-		TrackId: Eq + PartialEq + Debug + Encode + Decode + TypeInfo + Clone,
-		RuntimeOrigin: Eq + PartialEq + Debug + Encode + Decode + TypeInfo + Clone,
-		Moment: Parameter + Eq + PartialEq + Debug + Encode + Decode + TypeInfo + Clone + EncodeLike,
-		Call: Eq + PartialEq + Debug + Encode + Decode + TypeInfo + Clone,
-		Balance: Eq + PartialEq + Debug + Encode + Decode + TypeInfo + Clone,
-		Tally: Eq + PartialEq + Debug + Encode + Decode + TypeInfo + Clone,
-		AccountId: Eq + PartialEq + Debug + Encode + Decode + TypeInfo + Clone,
-		ScheduleAddress: Eq + PartialEq + Debug + Encode + Decode + TypeInfo + Clone,
-	>
-	ReferendumStatus<TrackId, RuntimeOrigin, Moment, Call, Balance, Tally, AccountId, ScheduleAddress>
-{
-	/// Return whether referendum status is deciding.
-	/// confirming => deciding so deciding does not preclude confirming
-	pub fn is_deciding(&self) -> bool {
-		self.deciding.is_some()
-	}
-	/// Return whether referendum status is confirming.
-	pub fn is_confirming(&self) -> bool {
-		if let Some(deciding_status) = &self.deciding {
-			deciding_status.confirming.is_some()
-		} else {
-			false
-		}
-	}
-}
-
 /// Info regarding a referendum, present or past.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub enum ReferendumInfo<

--- a/frame/referenda/src/types.rs
+++ b/frame/referenda/src/types.rs
@@ -195,6 +195,30 @@ pub struct ReferendumStatus<
 	pub(crate) alarm: Option<(Moment, ScheduleAddress)>,
 }
 
+impl<
+		TrackId: Eq + PartialEq + Debug + Encode + Decode + TypeInfo + Clone,
+		RuntimeOrigin: Eq + PartialEq + Debug + Encode + Decode + TypeInfo + Clone,
+		Moment: Parameter + Eq + PartialEq + Debug + Encode + Decode + TypeInfo + Clone + EncodeLike,
+		Call: Eq + PartialEq + Debug + Encode + Decode + TypeInfo + Clone,
+		Balance: Eq + PartialEq + Debug + Encode + Decode + TypeInfo + Clone,
+		Tally: Eq + PartialEq + Debug + Encode + Decode + TypeInfo + Clone,
+		AccountId: Eq + PartialEq + Debug + Encode + Decode + TypeInfo + Clone,
+		ScheduleAddress: Eq + PartialEq + Debug + Encode + Decode + TypeInfo + Clone,
+	>
+	ReferendumStatus<TrackId, RuntimeOrigin, Moment, Call, Balance, Tally, AccountId, ScheduleAddress>
+{
+	pub fn is_deciding(&self) -> bool {
+		self.deciding.is_some()
+	}
+	pub fn is_confirming(&self) -> bool {
+		if let Some(deciding_status) = &self.deciding {
+			deciding_status.confirming.is_some()
+		} else {
+			false
+		}
+	}
+}
+
 /// Info regarding a referendum, present or past.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub enum ReferendumInfo<


### PR DESCRIPTION
Exposes read access to `is_passing` and `ReferendumStatus` for precompiles

`TrackInfo` has fields with visibility `pub` so its data can be read in the precompile, but field visibility of `ReferendumStatus`, `DecidingStatus`, `Deposit` are `pub(crate)` so their data cannot be read in the precompile. The options for providing the precompile with read access to `ReferendumStatus` are:
1. change `pub(crate)` to `pub` or conservatively `pub(super)` for `ReferendumStatus`, `DecidingStatus`, `Deposit`
2. add public getters for the fields in `ReferendumStatus`

After initially going with public getters, I changed my mind and went with making the fields `pub` because it's fewer changes. Happy to change it to `pub(super)` or instead add public getters again if requested by reviewers.

Also exposed `fn is_passing(..)` for a given referendum as `pub fn is_referendum_passing(ReferendumIndex)`

## use case example

The example use case is a smart contract DAO that allocates pooled capital to voting in referendas based on **active state of referenda** and preferences of its members. This motivates providing read access to `ReferendumStatus` and `TrackInfo` via a precompile.

Related: https://github.com/PureStake/moonbeam/pull/1885