### PR TITLE
add Discord identity

### DIFF
--- a/frame/identity/src/tests.rs
+++ b/frame/identity/src/tests.rs
@@ -517,3 +517,16 @@ fn test_has_identity() {
 		));
 	});
 }
+
+#[test]
+fn test_set_identity_works_for_discord() {
+	new_test_ext().execute_with(|| {
+		let discord_ident = Data::Raw(b"foobar".to_vec().try_into().unwrap());
+		assert_ok!(Identity::set_identity(
+			Origin::signed(10),
+			Box::new(IdentityInfo { discord: discord_ident.clone(), ..Default::default() })
+		));
+		assert!(Identity::has_identity(&10, IdentityField::Discord as u64));
+		assert_eq!(Identity::identity(10).unwrap().info.discord, discord_ident);
+	});
+}

--- a/frame/identity/src/types.rs
+++ b/frame/identity/src/types.rs
@@ -248,6 +248,7 @@ pub enum IdentityField {
 	PgpFingerprint = 0b0000000000000000000000000000000000000000000000000000000000100000,
 	Image = 0b0000000000000000000000000000000000000000000000000000000001000000,
 	Twitter = 0b0000000000000000000000000000000000000000000000000000000010000000,
+	Discord = 0b0000000000000000000000000000000000000000000000000000000100000000u64,
 }
 
 /// Wrapper type for `BitFlags<IdentityField>` that implements `Codec`.
@@ -337,6 +338,9 @@ pub struct IdentityInfo<FieldLimit: Get<u32>> {
 
 	/// The Twitter identity. The leading `@` character may be elided.
 	pub twitter: Data,
+
+	/// The Discord identity.
+	pub discord: Data,
 }
 
 impl<FieldLimit: Get<u32>> IdentityInfo<FieldLimit> {
@@ -365,6 +369,9 @@ impl<FieldLimit: Get<u32>> IdentityInfo<FieldLimit> {
 		}
 		if !self.twitter.is_none() {
 			res.insert(IdentityField::Twitter);
+		}
+		if !self.discord.is_none() {
+			res.insert(IdentityField::Discord);
 		}
 		IdentityFields(res)
 	}


### PR DESCRIPTION
**Description**
Adds the `discord` field to `IdentityInfo`. Discord usage is quite prevalent within the community and many participating parties have a well established discord handles.
This PR will enable them to set their verifiable discord entity.