### PR TITLE
Contracts pallet: Bump Runtime API

### DIFF
--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -1199,6 +1199,7 @@ where
 
 sp_api::decl_runtime_apis! {
 	/// The API used to dry-run contract interactions.
+	#[api_version(2)]
 	pub trait ContractsApi<AccountId, Balance, BlockNumber, Hash> where
 		AccountId: Codec,
 		Balance: Codec,


### PR DESCRIPTION
Detail discussed at https://github.com/polkadot-js/api/pull/5324

We need to bump API version for the change of https://github.com/paritytech/substrate/pull/12429