### PR TITLE
Remove the `wasmtime` feature flag

### DIFF
--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -19,10 +19,10 @@ name = "node-template"
 [dependencies]
 clap = { version = "4.0.9", features = ["derive"] }
 
-sc-cli = { version = "0.10.0-dev", path = "../../../client/cli", features = ["wasmtime"] }
+sc-cli = { version = "0.10.0-dev", path = "../../../client/cli" }
 sp-core = { version = "6.0.0", path = "../../../primitives/core" }
-sc-executor = { version = "0.10.0-dev", path = "../../../client/executor", features = ["wasmtime"] }
-sc-service = { version = "0.10.0-dev", path = "../../../client/service", features = ["wasmtime"] }
+sc-executor = { version = "0.10.0-dev", path = "../../../client/executor" }
+sc-service = { version = "0.10.0-dev", path = "../../../client/service" }
 sc-telemetry = { version = "4.0.0-dev", path = "../../../client/telemetry" }
 sc-keystore = { version = "4.0.0-dev", path = "../../../client/keystore" }
 sc-transaction-pool = { version = "4.0.0-dev", path = "../../../client/transaction-pool" }

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -101,11 +101,6 @@ try-runtime-cli = { version = "0.10.0-dev", optional = true, path = "../../../ut
 serde_json = "1.0.85"
 
 [target.'cfg(any(target_arch="x86_64", target_arch="aarch64"))'.dependencies]
-node-executor = { version = "3.0.0-dev", path = "../executor", features = ["wasmtime"] }
-sc-cli = { version = "0.10.0-dev", optional = true, path = "../../../client/cli", features = ["wasmtime"] }
-sc-service = { version = "0.10.0-dev", default-features = false, path = "../../../client/service", features = [
-	"wasmtime",
-] }
 sp-trie = { version = "6.0.0", default-features = false, path = "../../../primitives/trie", features = [
 	"memory-tracker",
 ] }

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -45,7 +45,6 @@ sp-keyring = { version = "6.0.0", path = "../../../primitives/keyring" }
 sp-runtime = { version = "6.0.0", path = "../../../primitives/runtime" }
 
 [features]
-wasmtime = ["sc-executor/wasmtime"]
 stress-test = []
 
 [[bench]]

--- a/bin/node/executor/benches/bench.rs
+++ b/bin/node/executor/benches/bench.rs
@@ -25,9 +25,10 @@ use kitchensink_runtime::{
 use node_executor::ExecutorDispatch;
 use node_primitives::{BlockNumber, Hash};
 use node_testing::keyring::*;
-#[cfg(feature = "wasmtime")]
-use sc_executor::WasmtimeInstantiationStrategy;
-use sc_executor::{Externalities, NativeElseWasmExecutor, RuntimeVersionOf, WasmExecutionMethod};
+use sc_executor::{
+	Externalities, NativeElseWasmExecutor, RuntimeVersionOf, WasmExecutionMethod,
+	WasmtimeInstantiationStrategy,
+};
 use sp_core::{
 	storage::well_known_keys,
 	traits::{CodeExecutor, RuntimeCode},
@@ -161,7 +162,6 @@ fn bench_execute_block(c: &mut Criterion) {
 	let execution_methods = vec![
 		ExecutionMethod::Native,
 		ExecutionMethod::Wasm(WasmExecutionMethod::Interpreted),
-		#[cfg(feature = "wasmtime")]
 		ExecutionMethod::Wasm(WasmExecutionMethod::Compiled {
 			instantiation_strategy: WasmtimeInstantiationStrategy::PoolingCopyOnWrite,
 		}),

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -28,9 +28,7 @@ sc-block-builder = { version = "0.10.0-dev", path = "../../../client/block-build
 sc-client-api = { version = "4.0.0-dev", path = "../../../client/api" }
 sc-client-db = { version = "0.10.0-dev", features = ["rocksdb"], path = "../../../client/db" }
 sc-consensus = { version = "0.10.0-dev", path = "../../../client/consensus/common" }
-sc-executor = { version = "0.10.0-dev", features = [
-	"wasmtime",
-], path = "../../../client/executor" }
+sc-executor = { version = "0.10.0-dev", path = "../../../client/executor" }
 sc-service = { version = "0.10.0-dev", features = [
 	"test-helpers",
 	"rocksdb",

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -51,6 +51,5 @@ sp-version = { version = "5.0.0", path = "../../primitives/version" }
 tempfile = "3.1.0"
 
 [features]
-default = ["rocksdb", "wasmtime"]
+default = ["rocksdb"]
 rocksdb = ["sc-client-db/rocksdb"]
-wasmtime = ["sc-service/wasmtime"]

--- a/client/cli/src/arg_enums.rs
+++ b/client/cli/src/arg_enums.rs
@@ -18,7 +18,7 @@
 
 //! Definitions of [`ValueEnum`] types.
 
-use clap::{builder::PossibleValue, ValueEnum};
+use clap::ValueEnum;
 
 /// The instantiation strategy to use in compiled mode.
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -51,57 +51,14 @@ pub const DEFAULT_WASMTIME_INSTANTIATION_STRATEGY: WasmtimeInstantiationStrategy
 	WasmtimeInstantiationStrategy::PoolingCopyOnWrite;
 
 /// How to execute Wasm runtime code.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, ValueEnum)]
+#[value(rename_all = "kebab-case")]
 pub enum WasmExecutionMethod {
 	/// Uses an interpreter.
+	#[clap(name="interpreted-i-know-what-i-do")]
 	Interpreted,
 	/// Uses a compiled runtime.
 	Compiled,
-}
-
-const INTERPRETED_NAME: &str = "interpreted-i-know-what-i-do";
-
-impl clap::ValueEnum for WasmExecutionMethod {
-	/// All possible argument values, in display order.
-	fn value_variants<'a>() -> &'a [Self] {
-		let variants = &[Self::Interpreted, Self::Compiled];
-		if cfg!(feature = "wasmtime") {
-			variants
-		} else {
-			&variants[..1]
-		}
-	}
-
-	/// Parse an argument into `Self`.
-	fn from_str(s: &str, _: bool) -> Result<Self, String> {
-		if s.eq_ignore_ascii_case(INTERPRETED_NAME) {
-			Ok(Self::Interpreted)
-		} else if s.eq_ignore_ascii_case("compiled") {
-			#[cfg(feature = "wasmtime")]
-			{
-				Ok(Self::Compiled)
-			}
-			#[cfg(not(feature = "wasmtime"))]
-			{
-				Err("`Compiled` variant requires the `wasmtime` feature to be enabled".into())
-			}
-		} else {
-			Err(format!("Unknown variant `{}`", s))
-		}
-	}
-
-	/// The canonical argument value.
-	///
-	/// The value is `None` for skipped variants.
-	fn to_possible_value(&self) -> Option<PossibleValue> {
-		match self {
-			#[cfg(feature = "wasmtime")]
-			WasmExecutionMethod::Compiled => Some(PossibleValue::new("compiled")),
-			#[cfg(not(feature = "wasmtime"))]
-			WasmExecutionMethod::Compiled => None,
-			WasmExecutionMethod::Interpreted => Some(PossibleValue::new(INTERPRETED_NAME)),
-		}
-	}
 }
 
 impl std::fmt::Display for WasmExecutionMethod {
@@ -121,7 +78,6 @@ pub fn execution_method_from_cli(
 ) -> sc_service::config::WasmExecutionMethod {
 	match execution_method {
 		WasmExecutionMethod::Interpreted => sc_service::config::WasmExecutionMethod::Interpreted,
-		#[cfg(feature = "wasmtime")]
 		WasmExecutionMethod::Compiled => sc_service::config::WasmExecutionMethod::Compiled {
 			instantiation_strategy: match _instantiation_strategy {
 				WasmtimeInstantiationStrategy::PoolingCopyOnWrite =>
@@ -136,20 +92,11 @@ pub fn execution_method_from_cli(
 					sc_service::config::WasmtimeInstantiationStrategy::LegacyInstanceReuse,
 			},
 		},
-		#[cfg(not(feature = "wasmtime"))]
-		WasmExecutionMethod::Compiled => panic!(
-			"Substrate must be compiled with \"wasmtime\" feature for compiled Wasm execution"
-		),
 	}
 }
 
 /// The default [`WasmExecutionMethod`].
-#[cfg(feature = "wasmtime")]
 pub const DEFAULT_WASM_EXECUTION_METHOD: WasmExecutionMethod = WasmExecutionMethod::Compiled;
-
-/// The default [`WasmExecutionMethod`].
-#[cfg(not(feature = "wasmtime"))]
-pub const DEFAULT_WASM_EXECUTION_METHOD: WasmExecutionMethod = WasmExecutionMethod::Interpreted;
 
 #[allow(missing_docs)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ValueEnum)]

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -23,7 +23,7 @@ wasmi = "0.13"
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 sc-executor-common = { version = "0.10.0-dev", path = "common" }
 sc-executor-wasmi = { version = "0.10.0-dev", path = "wasmi" }
-sc-executor-wasmtime = { version = "0.10.0-dev", path = "wasmtime", optional = true }
+sc-executor-wasmtime = { version = "0.10.0-dev", path = "wasmtime" }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
 sp-core = { version = "6.0.0", path = "../../primitives/core" }
 sp-core-hashing-proc-macro = { version = "5.0.0", path = "../../primitives/core/hashing/proc-macro" }
@@ -61,5 +61,4 @@ default = ["std"]
 # This crate does not have `no_std` support, we just require this for tests
 std = []
 wasm-extern-trace = []
-wasmtime = ["sc-executor-wasmtime"]
 wasmer-sandbox = ["sc-executor-common/wasmer-sandbox"]

--- a/client/executor/benches/bench.rs
+++ b/client/executor/benches/bench.rs
@@ -23,7 +23,6 @@ use sc_executor_common::{
 	runtime_blob::RuntimeBlob,
 	wasm_runtime::{WasmInstance, WasmModule},
 };
-#[cfg(feature = "wasmtime")]
 use sc_executor_wasmtime::InstantiationStrategy;
 use sc_runtime_test::wasm_binary_unwrap as test_runtime;
 use sp_wasm_interface::HostFunctions as _;
@@ -35,11 +34,7 @@ use std::sync::{
 #[derive(Clone)]
 enum Method {
 	Interpreted,
-	#[cfg(feature = "wasmtime")]
-	Compiled {
-		instantiation_strategy: InstantiationStrategy,
-		precompile: bool,
-	},
+	Compiled { instantiation_strategy: InstantiationStrategy, precompile: bool },
 }
 
 // This is just a bog-standard Kusama runtime with an extra
@@ -67,7 +62,6 @@ fn initialize(
 			allow_missing_func_imports,
 		)
 		.map(|runtime| -> Arc<dyn WasmModule> { Arc::new(runtime) }),
-		#[cfg(feature = "wasmtime")]
 		Method::Compiled { instantiation_strategy, precompile } => {
 			let config = sc_executor_wasmtime::Config {
 				allow_missing_func_imports,
@@ -163,7 +157,6 @@ fn bench_call_instance(c: &mut Criterion) {
 	let _ = env_logger::try_init();
 
 	let strategies = [
-		#[cfg(feature = "wasmtime")]
 		(
 			"legacy_instance_reuse",
 			Method::Compiled {
@@ -171,7 +164,6 @@ fn bench_call_instance(c: &mut Criterion) {
 				precompile: false,
 			},
 		),
-		#[cfg(feature = "wasmtime")]
 		(
 			"recreate_instance_vanilla",
 			Method::Compiled {
@@ -179,7 +171,6 @@ fn bench_call_instance(c: &mut Criterion) {
 				precompile: false,
 			},
 		),
-		#[cfg(feature = "wasmtime")]
 		(
 			"recreate_instance_cow_fresh",
 			Method::Compiled {
@@ -187,7 +178,6 @@ fn bench_call_instance(c: &mut Criterion) {
 				precompile: false,
 			},
 		),
-		#[cfg(feature = "wasmtime")]
 		(
 			"recreate_instance_cow_precompiled",
 			Method::Compiled {
@@ -195,7 +185,6 @@ fn bench_call_instance(c: &mut Criterion) {
 				precompile: true,
 			},
 		),
-		#[cfg(feature = "wasmtime")]
 		(
 			"pooling_vanilla",
 			Method::Compiled {
@@ -203,7 +192,6 @@ fn bench_call_instance(c: &mut Criterion) {
 				precompile: false,
 			},
 		),
-		#[cfg(feature = "wasmtime")]
 		(
 			"pooling_cow_fresh",
 			Method::Compiled {
@@ -211,7 +199,6 @@ fn bench_call_instance(c: &mut Criterion) {
 				precompile: false,
 			},
 		),
-		#[cfg(feature = "wasmtime")]
 		(
 			"pooling_cow_precompiled",
 			Method::Compiled {

--- a/client/executor/src/integration_tests/linux.rs
+++ b/client/executor/src/integration_tests/linux.rs
@@ -18,11 +18,6 @@
 
 //! Tests that are only relevant for Linux.
 
-// Constrain this only to wasmtime for the time being. Without this rustc will complain on unused
-// imports and items. The alternative is to plop `cfg(feature = wasmtime)` everywhere which seems
-// borthersome.
-#![cfg(feature = "wasmtime")]
-
 use super::mk_test_runtime;
 use crate::WasmExecutionMethod;
 use codec::Encode as _;

--- a/client/executor/src/integration_tests/mod.rs
+++ b/client/executor/src/integration_tests/mod.rs
@@ -52,7 +52,6 @@ macro_rules! test_wasm_execution {
 			}
 
 			#[test]
-			#[cfg(feature = "wasmtime")]
 			fn [<$method_name _compiled_recreate_instance_cow>]() {
 				$method_name(WasmExecutionMethod::Compiled {
 					instantiation_strategy: sc_executor_wasmtime::InstantiationStrategy::RecreateInstanceCopyOnWrite
@@ -60,7 +59,6 @@ macro_rules! test_wasm_execution {
 			}
 
 			#[test]
-			#[cfg(feature = "wasmtime")]
 			fn [<$method_name _compiled_recreate_instance_vanilla>]() {
 				$method_name(WasmExecutionMethod::Compiled {
 					instantiation_strategy: sc_executor_wasmtime::InstantiationStrategy::RecreateInstance
@@ -68,7 +66,6 @@ macro_rules! test_wasm_execution {
 			}
 
 			#[test]
-			#[cfg(feature = "wasmtime")]
 			fn [<$method_name _compiled_pooling_cow>]() {
 				$method_name(WasmExecutionMethod::Compiled {
 					instantiation_strategy: sc_executor_wasmtime::InstantiationStrategy::PoolingCopyOnWrite
@@ -76,7 +73,6 @@ macro_rules! test_wasm_execution {
 			}
 
 			#[test]
-			#[cfg(feature = "wasmtime")]
 			fn [<$method_name _compiled_pooling_vanilla>]() {
 				$method_name(WasmExecutionMethod::Compiled {
 					instantiation_strategy: sc_executor_wasmtime::InstantiationStrategy::Pooling
@@ -84,7 +80,6 @@ macro_rules! test_wasm_execution {
 			}
 
 			#[test]
-			#[cfg(feature = "wasmtime")]
 			fn [<$method_name _compiled_legacy_instance_reuse>]() {
 				$method_name(WasmExecutionMethod::Compiled {
 					instantiation_strategy: sc_executor_wasmtime::InstantiationStrategy::LegacyInstanceReuse
@@ -120,7 +115,6 @@ macro_rules! test_wasm_execution_sandbox {
 			}
 
 			#[test]
-			#[cfg(feature = "wasmtime")]
 			fn [<$method_name _compiled_pooling_cow_host_executor>]() {
 				$method_name(WasmExecutionMethod::Compiled {
 					instantiation_strategy: sc_executor_wasmtime::InstantiationStrategy::PoolingCopyOnWrite
@@ -128,7 +122,6 @@ macro_rules! test_wasm_execution_sandbox {
 			}
 
 			#[test]
-			#[cfg(feature = "wasmtime")]
 			fn [<$method_name _compiled_pooling_cow_embedded_executor>]() {
 				$method_name(WasmExecutionMethod::Compiled {
 					instantiation_strategy: sc_executor_wasmtime::InstantiationStrategy::PoolingCopyOnWrite
@@ -136,7 +129,6 @@ macro_rules! test_wasm_execution_sandbox {
 			}
 
 			#[test]
-			#[cfg(feature = "wasmtime")]
 			fn [<$method_name _compiled_pooling_vanilla_host_executor>]() {
 				$method_name(WasmExecutionMethod::Compiled {
 					instantiation_strategy: sc_executor_wasmtime::InstantiationStrategy::Pooling
@@ -144,7 +136,6 @@ macro_rules! test_wasm_execution_sandbox {
 			}
 
 			#[test]
-			#[cfg(feature = "wasmtime")]
 			fn [<$method_name _compiled_pooling_vanilla_embedded_executor>]() {
 				$method_name(WasmExecutionMethod::Compiled {
 					instantiation_strategy: sc_executor_wasmtime::InstantiationStrategy::Pooling
@@ -152,7 +143,6 @@ macro_rules! test_wasm_execution_sandbox {
 			}
 
 			#[test]
-			#[cfg(feature = "wasmtime")]
 			fn [<$method_name _compiled_recreate_instance_cow_host_executor>]() {
 				$method_name(WasmExecutionMethod::Compiled {
 					instantiation_strategy: sc_executor_wasmtime::InstantiationStrategy::RecreateInstanceCopyOnWrite
@@ -160,7 +150,6 @@ macro_rules! test_wasm_execution_sandbox {
 			}
 
 			#[test]
-			#[cfg(feature = "wasmtime")]
 			fn [<$method_name _compiled_recreate_instance_cow_embedded_executor>]() {
 				$method_name(WasmExecutionMethod::Compiled {
 					instantiation_strategy: sc_executor_wasmtime::InstantiationStrategy::RecreateInstanceCopyOnWrite
@@ -168,7 +157,6 @@ macro_rules! test_wasm_execution_sandbox {
 			}
 
 			#[test]
-			#[cfg(feature = "wasmtime")]
 			fn [<$method_name _compiled_recreate_instance_vanilla_host_executor>]() {
 				$method_name(WasmExecutionMethod::Compiled {
 					instantiation_strategy: sc_executor_wasmtime::InstantiationStrategy::RecreateInstance
@@ -176,7 +164,6 @@ macro_rules! test_wasm_execution_sandbox {
 			}
 
 			#[test]
-			#[cfg(feature = "wasmtime")]
 			fn [<$method_name _compiled_recreate_instance_vanilla_embedded_executor>]() {
 				$method_name(WasmExecutionMethod::Compiled {
 					instantiation_strategy: sc_executor_wasmtime::InstantiationStrategy::RecreateInstance
@@ -184,7 +171,6 @@ macro_rules! test_wasm_execution_sandbox {
 			}
 
 			#[test]
-			#[cfg(feature = "wasmtime")]
 			fn [<$method_name _compiled_legacy_instance_reuse_host_executor>]() {
 				$method_name(WasmExecutionMethod::Compiled {
 					instantiation_strategy: sc_executor_wasmtime::InstantiationStrategy::LegacyInstanceReuse
@@ -192,7 +178,6 @@ macro_rules! test_wasm_execution_sandbox {
 			}
 
 			#[test]
-			#[cfg(feature = "wasmtime")]
 			fn [<$method_name _compiled_legacy_instance_reuse_embedded_executor>]() {
 				$method_name(WasmExecutionMethod::Compiled {
 					instantiation_strategy: sc_executor_wasmtime::InstantiationStrategy::LegacyInstanceReuse
@@ -253,7 +238,6 @@ fn call_not_existing_function(wasm_method: WasmExecutionMethod) {
 		Error::AbortedDueToTrap(error) => {
 			let expected = match wasm_method {
 				WasmExecutionMethod::Interpreted => "Other: Function `missing_external` is only a stub. Calling a stub is not allowed.",
-				#[cfg(feature = "wasmtime")]
 				WasmExecutionMethod::Compiled { .. } => "call to a missing function env:missing_external"
 			};
 			assert_eq!(error.message, expected);
@@ -273,7 +257,6 @@ fn call_yet_another_not_existing_function(wasm_method: WasmExecutionMethod) {
 		Error::AbortedDueToTrap(error) => {
 			let expected = match wasm_method {
 				WasmExecutionMethod::Interpreted => "Other: Function `yet_another_missing_external` is only a stub. Calling a stub is not allowed.",
-				#[cfg(feature = "wasmtime")]
 				WasmExecutionMethod::Compiled { .. } => "call to a missing function env:yet_another_missing_external"
 			};
 			assert_eq!(error.message, expected);
@@ -577,7 +560,6 @@ fn should_trap_when_heap_exhausted(wasm_method: WasmExecutionMethod) {
 		.unwrap_err();
 
 	match err {
-		#[cfg(feature = "wasmtime")]
 		Error::AbortedDueToTrap(error)
 			if matches!(wasm_method, WasmExecutionMethod::Compiled { .. }) =>
 		{
@@ -886,8 +868,8 @@ fn unreachable_intrinsic(wasm_method: WasmExecutionMethod) {
 		Error::AbortedDueToTrap(error) => {
 			let expected = match wasm_method {
 				WasmExecutionMethod::Interpreted => "unreachable",
-				#[cfg(feature = "wasmtime")]
-				WasmExecutionMethod::Compiled { .. } => "wasm trap: wasm `unreachable` instruction executed",
+				WasmExecutionMethod::Compiled { .. } =>
+					"wasm trap: wasm `unreachable` instruction executed",
 			};
 			assert_eq!(error.message, expected);
 		},

--- a/client/executor/src/lib.rs
+++ b/client/executor/src/lib.rs
@@ -50,8 +50,6 @@ pub use wasm_runtime::{read_embedded_version, WasmExecutionMethod};
 pub use wasmi;
 
 pub use sc_executor_common::{error, sandbox};
-
-#[cfg(feature = "wasmtime")]
 pub use sc_executor_wasmtime::InstantiationStrategy as WasmtimeInstantiationStrategy;
 
 /// Extracts the runtime version of a given runtime code.

--- a/client/executor/src/wasm_runtime.rs
+++ b/client/executor/src/wasm_runtime.rs
@@ -46,7 +46,6 @@ pub enum WasmExecutionMethod {
 	/// Uses the Wasmi interpreter.
 	Interpreted,
 	/// Uses the Wasmtime compiled runtime.
-	#[cfg(feature = "wasmtime")]
 	Compiled {
 		/// The instantiation strategy to use.
 		instantiation_strategy: sc_executor_wasmtime::InstantiationStrategy,
@@ -314,7 +313,6 @@ where
 			)
 			.map(|runtime| -> Arc<dyn WasmModule> { Arc::new(runtime) })
 		},
-		#[cfg(feature = "wasmtime")]
 		WasmExecutionMethod::Compiled { instantiation_strategy } =>
 			sc_executor_wasmtime::create_runtime::<H>(
 				blob,

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -33,7 +33,7 @@ sc-allocator = { version = "4.1.0-dev", path = "../../allocator" }
 sc-executor-common = { version = "0.10.0-dev", path = "../common" }
 sp-runtime-interface = { version = "6.0.0", path = "../../../primitives/runtime-interface" }
 sp-sandbox = { version = "0.10.0-dev", path = "../../../primitives/sandbox" }
-sp-wasm-interface = { version = "6.0.0", features = ["wasmtime"], path = "../../../primitives/wasm-interface" }
+sp-wasm-interface = { version = "6.0.0", path = "../../../primitives/wasm-interface" }
 
 # Here we include the rustix crate in the exactly same semver-compatible version as used by
 # wasmtime and enable its 'use-libc' flag.

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -17,7 +17,6 @@ default = ["rocksdb"]
 # The RocksDB feature activates the RocksDB database backend. If it is not activated, and you pass
 # a path to a database, an error will be produced at runtime.
 rocksdb = ["sc-client-db/rocksdb"]
-wasmtime = ["sc-executor/wasmtime"]
 # exposes the client type
 test-helpers = []
 runtime-benchmarks = ["sc-client-db/runtime-benchmarks"]

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -20,9 +20,7 @@
 
 pub use sc_client_api::execution_extensions::{ExecutionStrategies, ExecutionStrategy};
 pub use sc_client_db::{BlocksPruning, Database, DatabaseSource, PruningMode};
-pub use sc_executor::WasmExecutionMethod;
-#[cfg(feature = "wasmtime")]
-pub use sc_executor::WasmtimeInstantiationStrategy;
+pub use sc_executor::{WasmExecutionMethod, WasmtimeInstantiationStrategy};
 pub use sc_network::{
 	config::{NetworkConfiguration, NodeKeyConfig, Role},
 	Multiaddr,

--- a/primitives/wasm-interface/Cargo.toml
+++ b/primitives/wasm-interface/Cargo.toml
@@ -23,4 +23,4 @@ sp-std = { version = "4.0.0", default-features = false, path = "../std" }
 
 [features]
 default = [ "std" ]
-std = [ "codec/std", "log", "sp-std/std", "wasmi" ]
+std = [ "codec/std", "log", "sp-std/std", "wasmi", "wasmtime" ]


### PR DESCRIPTION
Fixes https://github.com/paritytech/substrate/issues/12495

Followup of https://github.com/paritytech/substrate/pull/12486

This PR removes the `wasmtime` feature flag. Now `wasmtime` will be always unconditionally compiled in.

Any downstream project that depends on `substrate` and which used to specify the `wasmtime` feature flag in its dependencies now needs to remove it.