### PR TITLE
Backport "Contracts pallet: Bump Runtime API (#12677)" to 0.9.33 branch

### DIFF
--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -1199,6 +1199,7 @@ where
 
 sp_api::decl_runtime_apis! {
 	/// The API used to dry-run contract interactions.
+	#[api_version(2)]
 	pub trait ContractsApi<AccountId, Balance, BlockNumber, Hash> where
 		AccountId: Codec,
 		Balance: Codec,


### PR DESCRIPTION
cc @bkchr @athei 