### PR TITLE
Release `sp-keyring` and `pallet-contracts-primitives` `7.0.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9675,7 +9675,7 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "6.0.0"
+version = "7.0.0"
 dependencies = [
  "lazy_static",
  "sp-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5326,7 +5326,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-primitives"
-version = "6.0.0"
+version = "7.0.0"
 dependencies = [
  "bitflags",
  "parity-scale-codec",

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -37,7 +37,7 @@ sc-client-api = { version = "4.0.0-dev", path = "../../../client/api" }
 sp-runtime = { version = "7.0.0", path = "../../../primitives/runtime" }
 sp-timestamp = { version = "4.0.0-dev", path = "../../../primitives/timestamp" }
 sp-inherents = { version = "4.0.0-dev", path = "../../../primitives/inherents" }
-sp-keyring = { version = "6.0.0", path = "../../../primitives/keyring" }
+sp-keyring = { version = "7.0.0", path = "../../../primitives/keyring" }
 frame-system = { version = "4.0.0-dev", path = "../../../frame/system" }
 pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, path = "../../../frame/transaction-payment" }
 

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -53,7 +53,7 @@ sp-runtime = { version = "7.0.0", path = "../../../primitives/runtime" }
 sp-timestamp = { version = "4.0.0-dev", path = "../../../primitives/timestamp" }
 sp-authorship = { version = "4.0.0-dev", path = "../../../primitives/authorship" }
 sp-inherents = { version = "4.0.0-dev", path = "../../../primitives/inherents" }
-sp-keyring = { version = "6.0.0", path = "../../../primitives/keyring" }
+sp-keyring = { version = "7.0.0", path = "../../../primitives/keyring" }
 sp-keystore = { version = "0.13.0", path = "../../../primitives/keystore" }
 sp-consensus = { version = "0.10.0-dev", path = "../../../primitives/consensus/common" }
 sp-transaction-pool = { version = "4.0.0-dev", path = "../../../primitives/transaction-pool" }

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -42,7 +42,7 @@ sp-application-crypto = { version = "7.0.0", path = "../../../primitives/applica
 pallet-root-testing = { version = "1.0.0-dev", path = "../../../frame/root-testing" }
 sp-consensus-babe = { version = "0.10.0-dev", path = "../../../primitives/consensus/babe" }
 sp-externalities = { version = "0.13.0", path = "../../../primitives/externalities" }
-sp-keyring = { version = "6.0.0", path = "../../../primitives/keyring" }
+sp-keyring = { version = "7.0.0", path = "../../../primitives/keyring" }
 sp-runtime = { version = "7.0.0", path = "../../../primitives/runtime" }
 
 [features]

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -61,7 +61,7 @@ pallet-bounties = { version = "4.0.0-dev", default-features = false, path = "../
 pallet-child-bounties = { version = "4.0.0-dev", default-features = false, path = "../../../frame/child-bounties" }
 pallet-collective = { version = "4.0.0-dev", default-features = false, path = "../../../frame/collective" }
 pallet-contracts = { version = "4.0.0-dev", default-features = false, path = "../../../frame/contracts" }
-pallet-contracts-primitives = { version = "6.0.0", default-features = false, path = "../../../frame/contracts/primitives/" }
+pallet-contracts-primitives = { version = "7.0.0", default-features = false, path = "../../../frame/contracts/primitives/" }
 pallet-conviction-voting = { version = "4.0.0-dev", default-features = false, path = "../../../frame/conviction-voting" }
 pallet-democracy = { version = "4.0.0-dev", default-features = false, path = "../../../frame/democracy" }
 pallet-election-provider-multi-phase = { version = "4.0.0-dev", default-features = false, path = "../../../frame/election-provider-multi-phase" }

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -42,7 +42,7 @@ sp-consensus = { version = "0.10.0-dev", path = "../../../primitives/consensus/c
 sp-core = { version = "7.0.0", path = "../../../primitives/core" }
 sp-inherents = { version = "4.0.0-dev", path = "../../../primitives/inherents" }
 sp-io = { version = "7.0.0", path = "../../../primitives/io" }
-sp-keyring = { version = "6.0.0", path = "../../../primitives/keyring" }
+sp-keyring = { version = "7.0.0", path = "../../../primitives/keyring" }
 sp-runtime = { version = "7.0.0", path = "../../../primitives/runtime" }
 sp-timestamp = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/timestamp" }
 substrate-test-client = { version = "2.0.0", path = "../../../test-utils/client" }

--- a/client/beefy/Cargo.toml
+++ b/client/beefy/Cargo.toml
@@ -48,6 +48,6 @@ tokio = "1.17.0"
 sc-block-builder = { version = "0.10.0-dev", path = "../block-builder" }
 sc-network-test = { version = "0.8.0", path = "../network/test" }
 sp-finality-grandpa = { version = "4.0.0-dev", path = "../../primitives/finality-grandpa" }
-sp-keyring = { version = "6.0.0", path = "../../primitives/keyring" }
+sp-keyring = { version = "7.0.0", path = "../../primitives/keyring" }
 sp-tracing = { version = "6.0.0", path = "../../primitives/tracing" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -41,7 +41,7 @@ sc-tracing = { version = "4.0.0-dev", path = "../tracing" }
 sc-utils = { version = "4.0.0-dev", path = "../utils" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sp-core = { version = "7.0.0", path = "../../primitives/core" }
-sp-keyring = { version = "6.0.0", path = "../../primitives/keyring" }
+sp-keyring = { version = "7.0.0", path = "../../primitives/keyring" }
 sp-keystore = { version = "0.13.0", path = "../../primitives/keystore" }
 sp-panic-handler = { version = "5.0.0", path = "../../primitives/panic-handler" }
 sp-runtime = { version = "7.0.0", path = "../../primitives/runtime" }

--- a/client/consensus/aura/Cargo.toml
+++ b/client/consensus/aura/Cargo.toml
@@ -42,7 +42,7 @@ tempfile = "3.1.0"
 sc-keystore = { version = "4.0.0-dev", path = "../../keystore" }
 sc-network = { version = "0.10.0-dev", path = "../../network" }
 sc-network-test = { version = "0.8.0", path = "../../network/test" }
-sp-keyring = { version = "6.0.0", path = "../../../primitives/keyring" }
+sp-keyring = { version = "7.0.0", path = "../../../primitives/keyring" }
 sp-timestamp = { version = "4.0.0-dev", path = "../../../primitives/timestamp" }
 sp-tracing = { version = "6.0.0", path = "../../../primitives/tracing" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }

--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -52,7 +52,7 @@ sp-version = { version = "5.0.0", path = "../../../primitives/version" }
 [dev-dependencies]
 rand_chacha = "0.2.2"
 sc-block-builder = { version = "0.10.0-dev", path = "../../block-builder" }
-sp-keyring = { version = "6.0.0", path = "../../../primitives/keyring" }
+sp-keyring = { version = "7.0.0", path = "../../../primitives/keyring" }
 sc-network = { version = "0.10.0-dev", path = "../../network" }
 sc-network-test = { version = "0.8.0", path = "../../network/test" }
 sp-timestamp = { version = "4.0.0-dev", path = "../../../primitives/timestamp" }

--- a/client/consensus/babe/rpc/Cargo.toml
+++ b/client/consensus/babe/rpc/Cargo.toml
@@ -35,5 +35,5 @@ tempfile = "3.1.0"
 tokio = "1.17.0"
 sc-consensus = { version = "0.10.0-dev", path = "../../../consensus/common" }
 sc-keystore = { version = "4.0.0-dev", path = "../../../keystore" }
-sp-keyring = { version = "6.0.0", path = "../../../../primitives/keyring" }
+sp-keyring = { version = "7.0.0", path = "../../../../primitives/keyring" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../../test-utils/runtime/client" }

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -56,6 +56,6 @@ serde = "1.0.136"
 tokio = "1.17.0"
 sc-network = { version = "0.10.0-dev", path = "../network" }
 sc-network-test = { version = "0.8.0", path = "../network/test" }
-sp-keyring = { version = "6.0.0", path = "../../primitives/keyring" }
+sp-keyring = { version = "7.0.0", path = "../../primitives/keyring" }
 sp-tracing = { version = "6.0.0", path = "../../primitives/tracing" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }

--- a/client/finality-grandpa/rpc/Cargo.toml
+++ b/client/finality-grandpa/rpc/Cargo.toml
@@ -32,6 +32,6 @@ sc-rpc = { version = "4.0.0-dev", features = [
 ], path = "../../rpc" }
 sp-core = { version = "7.0.0", path = "../../../primitives/core" }
 sp-finality-grandpa = { version = "4.0.0-dev", path = "../../../primitives/finality-grandpa" }
-sp-keyring = { version = "6.0.0", path = "../../../primitives/keyring" }
+sp-keyring = { version = "7.0.0", path = "../../../primitives/keyring" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }
 tokio = { version = "1.17.0", features = ["macros"] }

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -36,7 +36,7 @@ rand_pcg = { version = "0.3", optional = true }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
-pallet-contracts-primitives = { version = "6.0.0", default-features = false, path = "primitives" }
+pallet-contracts-primitives = { version = "7.0.0", default-features = false, path = "primitives" }
 pallet-contracts-proc-macro = { version = "4.0.0-dev", path = "proc-macro" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../primitives/api" }
 sp-core = { version = "7.0.0", default-features = false, path = "../../primitives/core" }

--- a/frame/contracts/primitives/Cargo.toml
+++ b/frame/contracts/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-contracts-primitives"
-version = "6.0.0"
+version = "7.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/frame/grandpa/Cargo.toml
+++ b/frame/grandpa/Cargo.toml
@@ -39,7 +39,7 @@ pallet-offences = { version = "4.0.0-dev", path = "../offences" }
 pallet-staking = { version = "4.0.0-dev", path = "../staking" }
 pallet-staking-reward-curve = { version = "4.0.0-dev", path = "../staking/reward-curve" }
 pallet-timestamp = { version = "4.0.0-dev", path = "../timestamp" }
-sp-keyring = { version = "6.0.0", path = "../../primitives/keyring" }
+sp-keyring = { version = "7.0.0", path = "../../primitives/keyring" }
 
 [features]
 default = ["std"]

--- a/frame/indices/Cargo.toml
+++ b/frame/indices/Cargo.toml
@@ -20,7 +20,7 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../su
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
 sp-core = { version = "7.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "7.0.0", default-features = false, path = "../../primitives/io" }
-sp-keyring = { version = "6.0.0", optional = true, path = "../../primitives/keyring" }
+sp-keyring = { version = "7.0.0", optional = true, path = "../../primitives/keyring" }
 sp-runtime = { version = "7.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-std = { version = "5.0.0", default-features = false, path = "../../primitives/std" }
 

--- a/primitives/keyring/Cargo.toml
+++ b/primitives/keyring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-keyring"
-version = "6.0.0"
+version = "7.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/test-utils/client/Cargo.toml
+++ b/test-utils/client/Cargo.toml
@@ -31,7 +31,7 @@ sc-service = { version = "0.10.0-dev", default-features = false, features = [
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }
 sp-core = { version = "7.0.0", path = "../../primitives/core" }
-sp-keyring = { version = "6.0.0", path = "../../primitives/keyring" }
+sp-keyring = { version = "7.0.0", path = "../../primitives/keyring" }
 sp-keystore = { version = "0.13.0", path = "../../primitives/keystore" }
 sp-runtime = { version = "7.0.0", path = "../../primitives/runtime" }
 sp-state-machine = { version = "0.13.0", path = "../../primitives/state-machine" }

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -22,7 +22,7 @@ sp-block-builder = { version = "4.0.0-dev", default-features = false, path = "..
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../../primitives/inherents" }
-sp-keyring = { version = "6.0.0", optional = true, path = "../../primitives/keyring" }
+sp-keyring = { version = "7.0.0", optional = true, path = "../../primitives/keyring" }
 memory-db = { version = "0.30.0", default-features = false }
 sp-offchain = { version = "4.0.0-dev", default-features = false, path = "../../primitives/offchain" }
 sp-core = { version = "7.0.0", default-features = false, path = "../../primitives/core" }


### PR DESCRIPTION
Allows updating of `subxt` and `cargo-contract`  to use latest [`sp-core` and `sp-runtime` releases](https://github.com/paritytech/substrate/pull/12599)