### PR TITLE
Relax Copy to Clone for AssetId

### DIFF
--- a/frame/assets/src/benchmarking.rs
+++ b/frame/assets/src/benchmarking.rs
@@ -136,7 +136,7 @@ benchmarks_instance_pallet! {
 		let caller = T::CreateOrigin::ensure_origin(origin, &asset_id).unwrap();
 		let caller_lookup = T::Lookup::unlookup(caller.clone());
 		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
-	}: _(SystemOrigin::Signed(caller.clone()), asset_id, caller_lookup, 1u32.into())
+	}: _(SystemOrigin::Signed(caller.clone()), asset_id.clone(), caller_lookup, 1u32.into())
 	verify {
 		assert_last_event::<T, I>(Event::Created { asset_id, creator: caller.clone(), owner: caller }.into());
 	}
@@ -410,11 +410,11 @@ benchmarks_instance_pallet! {
 		let (caller, _) = create_default_minted_asset::<T, I>(true, 100u32.into());
 		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
 
-		let id = Default::default();
+		let id: T::AssetId = Default::default();
 		let delegate: T::AccountId = account("delegate", 0, SEED);
 		let delegate_lookup = T::Lookup::unlookup(delegate.clone());
 		let amount = 100u32.into();
-	}: _(SystemOrigin::Signed(caller.clone()), id, delegate_lookup, amount)
+	}: _(SystemOrigin::Signed(caller.clone()), id.clone(), delegate_lookup, amount)
 	verify {
 		assert_last_event::<T, I>(Event::ApprovedTransfer { asset_id: id, source: caller, delegate, amount }.into());
 	}
@@ -423,17 +423,17 @@ benchmarks_instance_pallet! {
 		let (owner, owner_lookup) = create_default_minted_asset::<T, I>(true, 100u32.into());
 		T::Currency::make_free_balance_be(&owner, DepositBalanceOf::<T, I>::max_value());
 
-		let id = Default::default();
+		let id: T::AssetId = Default::default();
 		let delegate: T::AccountId = account("delegate", 0, SEED);
 		whitelist_account!(delegate);
 		let delegate_lookup = T::Lookup::unlookup(delegate.clone());
 		let amount = 100u32.into();
 		let origin = SystemOrigin::Signed(owner.clone()).into();
-		Assets::<T, I>::approve_transfer(origin, id, delegate_lookup, amount)?;
+		Assets::<T, I>::approve_transfer(origin, id.clone(), delegate_lookup, amount)?;
 
 		let dest: T::AccountId = account("dest", 0, SEED);
 		let dest_lookup = T::Lookup::unlookup(dest.clone());
-	}: _(SystemOrigin::Signed(delegate.clone()), id, owner_lookup, dest_lookup, amount)
+	}: _(SystemOrigin::Signed(delegate.clone()), id.clone(), owner_lookup, dest_lookup, amount)
 	verify {
 		assert!(T::Currency::reserved_balance(&owner).is_zero());
 		assert_event::<T, I>(Event::Transferred { asset_id: id, from: owner, to: dest, amount }.into());
@@ -443,13 +443,13 @@ benchmarks_instance_pallet! {
 		let (caller, _) = create_default_minted_asset::<T, I>(true, 100u32.into());
 		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
 
-		let id = Default::default();
+		let id: T::AssetId = Default::default();
 		let delegate: T::AccountId = account("delegate", 0, SEED);
 		let delegate_lookup = T::Lookup::unlookup(delegate.clone());
 		let amount = 100u32.into();
 		let origin = SystemOrigin::Signed(caller.clone()).into();
-		Assets::<T, I>::approve_transfer(origin, id, delegate_lookup.clone(), amount)?;
-	}: _(SystemOrigin::Signed(caller.clone()), id, delegate_lookup)
+		Assets::<T, I>::approve_transfer(origin, id.clone(), delegate_lookup.clone(), amount)?;
+	}: _(SystemOrigin::Signed(caller.clone()), id.clone(), delegate_lookup)
 	verify {
 		assert_last_event::<T, I>(Event::ApprovalCancelled { asset_id: id, owner: caller, delegate }.into());
 	}
@@ -458,13 +458,13 @@ benchmarks_instance_pallet! {
 		let (caller, caller_lookup) = create_default_minted_asset::<T, I>(true, 100u32.into());
 		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
 
-		let id = Default::default();
+		let id: T::AssetId = Default::default();
 		let delegate: T::AccountId = account("delegate", 0, SEED);
 		let delegate_lookup = T::Lookup::unlookup(delegate.clone());
 		let amount = 100u32.into();
 		let origin = SystemOrigin::Signed(caller.clone()).into();
-		Assets::<T, I>::approve_transfer(origin, id, delegate_lookup.clone(), amount)?;
-	}: _(SystemOrigin::Signed(caller.clone()), id, caller_lookup, delegate_lookup)
+		Assets::<T, I>::approve_transfer(origin, id.clone(), delegate_lookup.clone(), amount)?;
+	}: _(SystemOrigin::Signed(caller.clone()), id.clone(), caller_lookup, delegate_lookup)
 	verify {
 		assert_last_event::<T, I>(Event::ApprovalCancelled { asset_id: id, owner: caller, delegate }.into());
 	}

--- a/frame/assets/src/extra_mutator.rs
+++ b/frame/assets/src/extra_mutator.rs
@@ -62,7 +62,7 @@ impl<T: Config<I>, I: 'static> ExtraMutator<T, I> {
 		id: T::AssetId,
 		who: impl sp_std::borrow::Borrow<T::AccountId>,
 	) -> Option<ExtraMutator<T, I>> {
-		if let Some(a) = Account::<T, I>::get(id, who.borrow()) {
+		if let Some(a) = Account::<T, I>::get(&id, who.borrow()) {
 			Some(ExtraMutator::<T, I> {
 				id,
 				who: who.borrow().clone(),
@@ -77,7 +77,7 @@ impl<T: Config<I>, I: 'static> ExtraMutator<T, I> {
 	/// Commit any changes to storage.
 	pub fn commit(&mut self) -> Result<(), ()> {
 		if let Some(extra) = self.pending.take() {
-			Account::<T, I>::try_mutate(self.id, self.who.borrow(), |maybe_account| {
+			Account::<T, I>::try_mutate(&self.id, self.who.borrow(), |maybe_account| {
 				maybe_account.as_mut().ok_or(()).map(|account| account.extra = extra)
 			})
 		} else {
@@ -88,7 +88,7 @@ impl<T: Config<I>, I: 'static> ExtraMutator<T, I> {
 	/// Revert any changes, even those already committed by `self` and drop self.
 	pub fn revert(mut self) -> Result<(), ()> {
 		self.pending = None;
-		Account::<T, I>::try_mutate(self.id, self.who.borrow(), |maybe_account| {
+		Account::<T, I>::try_mutate(&self.id, self.who.borrow(), |maybe_account| {
 			maybe_account
 				.as_mut()
 				.ok_or(())

--- a/frame/assets/src/functions.rs
+++ b/frame/assets/src/functions.rs
@@ -116,14 +116,14 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		amount: T::Balance,
 		increase_supply: bool,
 	) -> DepositConsequence {
-		let details = match Asset::<T, I>::get(id) {
+		let details = match Asset::<T, I>::get(&id) {
 			Some(details) => details,
 			None => return DepositConsequence::UnknownAsset,
 		};
 		if increase_supply && details.supply.checked_add(&amount).is_none() {
 			return DepositConsequence::Overflow
 		}
-		if let Some(balance) = Self::maybe_balance(id, who) {
+		if let Some(balance) = Self::maybe_balance(id.clone(), who) {
 			if balance.checked_add(&amount).is_none() {
 				return DepositConsequence::Overflow
 			}
@@ -150,7 +150,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		keep_alive: bool,
 	) -> WithdrawConsequence<T::Balance> {
 		use WithdrawConsequence::*;
-		let details = match Asset::<T, I>::get(id) {
+		let details = match Asset::<T, I>::get(&id) {
 			Some(details) => details,
 			None => return UnknownAsset,
 		};
@@ -163,7 +163,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		if amount.is_zero() {
 			return Success
 		}
-		let account = match Account::<T, I>::get(id, who) {
+		let account = match Account::<T, I>::get(&id, who) {
 			Some(a) => a,
 			None => return NoFunds,
 		};
@@ -171,7 +171,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			return Frozen
 		}
 		if let Some(rest) = account.balance.checked_sub(&amount) {
-			if let Some(frozen) = T::Freezer::frozen_balance(id, who) {
+			if let Some(frozen) = T::Freezer::frozen_balance(id.clone(), who) {
 				match frozen.checked_add(&details.min_balance) {
 					Some(required) if rest < required => return Frozen,
 					None => return Overflow,
@@ -204,10 +204,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		who: &T::AccountId,
 		keep_alive: bool,
 	) -> Result<T::Balance, DispatchError> {
-		let details = Asset::<T, I>::get(id).ok_or(Error::<T, I>::Unknown)?;
+		let details = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 		ensure!(details.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
 
-		let account = Account::<T, I>::get(id, who).ok_or(Error::<T, I>::NoAccount)?;
+		let account = Account::<T, I>::get(&id, who).ok_or(Error::<T, I>::NoAccount)?;
 		ensure!(!account.is_frozen, Error::<T, I>::Frozen);
 
 		let amount = if let Some(frozen) = T::Freezer::frozen_balance(id, who) {
@@ -250,7 +250,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		amount: T::Balance,
 		f: DebitFlags,
 	) -> Result<T::Balance, DispatchError> {
-		let actual = Self::reducible_balance(id, target, f.keep_alive)?.min(amount);
+		let actual = Self::reducible_balance(id.clone(), target, f.keep_alive)?.min(amount);
 		ensure!(f.best_effort || actual >= amount, Error::<T, I>::BalanceLow);
 
 		let conseq = Self::can_decrease(id, target, actual, f.keep_alive);
@@ -297,7 +297,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	/// Creates a account for `who` to hold asset `id` with a zero balance and takes a deposit.
 	pub(super) fn do_touch(id: T::AssetId, who: T::AccountId) -> DispatchResult {
-		ensure!(!Account::<T, I>::contains_key(id, &who), Error::<T, I>::AlreadyExists);
+		ensure!(!Account::<T, I>::contains_key(&id, &who), Error::<T, I>::AlreadyExists);
 		let deposit = T::AssetAccountDeposit::get();
 		let mut details = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 		ensure!(details.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
@@ -319,7 +319,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	/// Returns a deposit, destroying an asset-account.
 	pub(super) fn do_refund(id: T::AssetId, who: T::AccountId, allow_burn: bool) -> DispatchResult {
-		let mut account = Account::<T, I>::get(id, &who).ok_or(Error::<T, I>::NoDeposit)?;
+		let mut account = Account::<T, I>::get(&id, &who).ok_or(Error::<T, I>::NoDeposit)?;
 		let deposit = account.reason.take_deposit().ok_or(Error::<T, I>::NoDeposit)?;
 		let mut details = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 		ensure!(details.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
@@ -329,7 +329,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		T::Currency::unreserve(&who, deposit);
 
 		if let Remove = Self::dead_account(&who, &mut details, &account.reason, false) {
-			Account::<T, I>::remove(id, &who);
+			Account::<T, I>::remove(&id, &who);
 		} else {
 			debug_assert!(false, "refund did not result in dead account?!");
 		}
@@ -350,7 +350,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		amount: T::Balance,
 		maybe_check_issuer: Option<T::AccountId>,
 	) -> DispatchResult {
-		Self::increase_balance(id, beneficiary, amount, |details| -> DispatchResult {
+		Self::increase_balance(id.clone(), beneficiary, amount, |details| -> DispatchResult {
 			if let Some(check_issuer) = maybe_check_issuer {
 				ensure!(check_issuer == details.issuer, Error::<T, I>::NoPermission);
 			}
@@ -387,13 +387,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			return Ok(())
 		}
 
-		Self::can_increase(id, beneficiary, amount, true).into_result()?;
-		Asset::<T, I>::try_mutate(id, |maybe_details| -> DispatchResult {
+		Self::can_increase(id.clone(), beneficiary, amount, true).into_result()?;
+		Asset::<T, I>::try_mutate(id.clone(), |maybe_details| -> DispatchResult {
 			let details = maybe_details.as_mut().ok_or(Error::<T, I>::Unknown)?;
 			ensure!(details.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
 			check(details)?;
 
-			Account::<T, I>::try_mutate(id, beneficiary, |maybe_account| -> DispatchResult {
+			Account::<T, I>::try_mutate(id.clone(), beneficiary, |maybe_account| -> DispatchResult {
 				match maybe_account {
 					Some(ref mut account) => {
 						account.balance.saturating_accrue(amount);
@@ -430,13 +430,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		maybe_check_admin: Option<T::AccountId>,
 		f: DebitFlags,
 	) -> Result<T::Balance, DispatchError> {
-		let d = Asset::<T, I>::get(id).ok_or(Error::<T, I>::Unknown)?;
+		let d = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 		ensure!(
 			d.status == AssetStatus::Live || d.status == AssetStatus::Frozen,
 			Error::<T, I>::AssetNotLive
 		);
 
-		let actual = Self::decrease_balance(id, target, amount, f, |actual, details| {
+		let actual = Self::decrease_balance(id.clone(), target, amount, f, |actual, details| {
 			// Check admin rights.
 			if let Some(check_admin) = maybe_check_admin {
 				ensure!(check_admin == details.admin, Error::<T, I>::NoPermission);
@@ -473,17 +473,17 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			return Ok(amount)
 		}
 
-		let details = Asset::<T, I>::get(id).ok_or(Error::<T, I>::Unknown)?;
+		let details = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 		ensure!(details.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
 
-		let actual = Self::prep_debit(id, target, amount, f)?;
+		let actual = Self::prep_debit(id.clone(), target, amount, f)?;
 		let mut target_died: Option<DeadConsequence> = None;
 
-		Asset::<T, I>::try_mutate(id, |maybe_details| -> DispatchResult {
+		Asset::<T, I>::try_mutate(id.clone(), |maybe_details| -> DispatchResult {
 			let details = maybe_details.as_mut().ok_or(Error::<T, I>::Unknown)?;
 			check(actual, details)?;
 
-			Account::<T, I>::try_mutate(id, target, |maybe_account| -> DispatchResult {
+			Account::<T, I>::try_mutate(id.clone(), target, |maybe_account| -> DispatchResult {
 				let mut account = maybe_account.take().ok_or(Error::<T, I>::NoAccount)?;
 				debug_assert!(account.balance >= actual, "checked in prep; qed");
 
@@ -527,7 +527,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		f: TransferFlags,
 	) -> Result<T::Balance, DispatchError> {
 		let (balance, died) =
-			Self::transfer_and_die(id, source, dest, amount, maybe_need_admin, f)?;
+			Self::transfer_and_die(id.clone(), source, dest, amount, maybe_need_admin, f)?;
 		if let Some(Remove) = died {
 			T::Freezer::died(id, source);
 		}
@@ -548,18 +548,18 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		if amount.is_zero() {
 			return Ok((amount, None))
 		}
-		let details = Asset::<T, I>::get(id).ok_or(Error::<T, I>::Unknown)?;
+		let details = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 		ensure!(details.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
 
 		// Figure out the debit and credit, together with side-effects.
-		let debit = Self::prep_debit(id, source, amount, f.into())?;
-		let (credit, maybe_burn) = Self::prep_credit(id, dest, amount, debit, f.burn_dust)?;
+		let debit = Self::prep_debit(id.clone(), source, amount, f.into())?;
+		let (credit, maybe_burn) = Self::prep_credit(id.clone(), dest, amount, debit, f.burn_dust)?;
 
 		let mut source_account =
-			Account::<T, I>::get(id, &source).ok_or(Error::<T, I>::NoAccount)?;
+			Account::<T, I>::get(id.clone(), &source).ok_or(Error::<T, I>::NoAccount)?;
 		let mut source_died: Option<DeadConsequence> = None;
 
-		Asset::<T, I>::try_mutate(id, |maybe_details| -> DispatchResult {
+		Asset::<T, I>::try_mutate(&id, |maybe_details| -> DispatchResult {
 			let details = maybe_details.as_mut().ok_or(Error::<T, I>::Unknown)?;
 
 			// Check admin rights.
@@ -584,7 +584,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			debug_assert!(source_account.balance >= debit, "checked in prep; qed");
 			source_account.balance = source_account.balance.saturating_sub(debit);
 
-			Account::<T, I>::try_mutate(id, &dest, |maybe_account| -> DispatchResult {
+			Account::<T, I>::try_mutate(id.clone(), &dest, |maybe_account| -> DispatchResult {
 				match maybe_account {
 					Some(ref mut account) => {
 						// Calculate new balance; this will not saturate since it's already checked
@@ -613,11 +613,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				source_died =
 					Some(Self::dead_account(source, details, &source_account.reason, false));
 				if let Some(Remove) = source_died {
-					Account::<T, I>::remove(id, &source);
+					Account::<T, I>::remove(id.clone(), &source);
 					return Ok(())
 				}
 			}
-			Account::<T, I>::insert(id, &source, &source_account);
+			Account::<T, I>::insert(id.clone(), &source, &source_account);
 			Ok(())
 		})?;
 
@@ -644,11 +644,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		is_sufficient: bool,
 		min_balance: T::Balance,
 	) -> DispatchResult {
-		ensure!(!Asset::<T, I>::contains_key(id), Error::<T, I>::InUse);
+		ensure!(!Asset::<T, I>::contains_key(&id), Error::<T, I>::InUse);
 		ensure!(!min_balance.is_zero(), Error::<T, I>::MinBalanceZero);
 
 		Asset::<T, I>::insert(
-			id,
+			id.clone(),
 			AssetDetails {
 				owner: owner.clone(),
 				issuer: owner.clone(),
@@ -674,7 +674,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		id: T::AssetId,
 		maybe_check_owner: Option<T::AccountId>,
 	) -> DispatchResult {
-		Asset::<T, I>::try_mutate_exists(id, |maybe_details| -> Result<(), DispatchError> {
+		Asset::<T, I>::try_mutate_exists(id.clone(), |maybe_details| -> Result<(), DispatchError> {
 			let mut details = maybe_details.as_mut().ok_or(Error::<T, I>::Unknown)?;
 			if let Some(check_owner) = maybe_check_owner {
 				ensure!(details.owner == check_owner, Error::<T, I>::NoPermission);
@@ -697,12 +697,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		let mut dead_accounts: Vec<T::AccountId> = vec![];
 		let mut remaining_accounts = 0;
 		let _ =
-			Asset::<T, I>::try_mutate_exists(id, |maybe_details| -> Result<(), DispatchError> {
+			Asset::<T, I>::try_mutate_exists(id.clone(), |maybe_details| -> Result<(), DispatchError> {
 				let mut details = maybe_details.as_mut().ok_or(Error::<T, I>::Unknown)?;
 				// Should only destroy accounts while the asset is in a destroying state
 				ensure!(details.status == AssetStatus::Destroying, Error::<T, I>::IncorrectStatus);
 
-				for (who, v) in Account::<T, I>::drain_prefix(id) {
+				for (who, v) in Account::<T, I>::drain_prefix(id.clone()) {
 					let _ = Self::dead_account(&who, &mut details, &v.reason, true);
 					dead_accounts.push(who);
 					if dead_accounts.len() >= (max_items as usize) {
@@ -714,7 +714,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			})?;
 
 		for who in &dead_accounts {
-			T::Freezer::died(id, &who);
+			T::Freezer::died(id.clone(), &who);
 		}
 
 		Self::deposit_event(Event::AccountsDestroyed {
@@ -735,13 +735,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	) -> Result<u32, DispatchError> {
 		let mut removed_approvals = 0;
 		let _ =
-			Asset::<T, I>::try_mutate_exists(id, |maybe_details| -> Result<(), DispatchError> {
+			Asset::<T, I>::try_mutate_exists(id.clone(), |maybe_details| -> Result<(), DispatchError> {
 				let mut details = maybe_details.as_mut().ok_or(Error::<T, I>::Unknown)?;
 
 				// Should only destroy accounts while the asset is in a destroying state.
 				ensure!(details.status == AssetStatus::Destroying, Error::<T, I>::IncorrectStatus);
 
-				for ((owner, _), approval) in Approvals::<T, I>::drain_prefix((id,)) {
+				for ((owner, _), approval) in Approvals::<T, I>::drain_prefix((id.clone(),)) {
 					T::Currency::unreserve(&owner, approval.deposit);
 					removed_approvals = removed_approvals.saturating_add(1);
 					details.approvals = details.approvals.saturating_sub(1);
@@ -763,7 +763,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// On success, the `Event::Destroyed` event is emitted.
 	pub(super) fn do_finish_destroy(id: T::AssetId) -> DispatchResult {
-		Asset::<T, I>::try_mutate_exists(id, |maybe_details| -> Result<(), DispatchError> {
+		Asset::<T, I>::try_mutate_exists(id.clone(), |maybe_details| -> Result<(), DispatchError> {
 			let details = maybe_details.take().ok_or(Error::<T, I>::Unknown)?;
 			ensure!(details.status == AssetStatus::Destroying, Error::<T, I>::IncorrectStatus);
 			ensure!(details.accounts == 0, Error::<T, I>::InUse);
@@ -790,10 +790,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		delegate: &T::AccountId,
 		amount: T::Balance,
 	) -> DispatchResult {
-		let mut d = Asset::<T, I>::get(id).ok_or(Error::<T, I>::Unknown)?;
+		let mut d = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 		ensure!(d.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
 		Approvals::<T, I>::try_mutate(
-			(id, &owner, &delegate),
+			(id.clone(), &owner, &delegate),
 			|maybe_approved| -> DispatchResult {
 				let mut approved = match maybe_approved.take() {
 					// an approval already exists and is being updated
@@ -814,7 +814,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				Ok(())
 			},
 		)?;
-		Asset::<T, I>::insert(id, d);
+		Asset::<T, I>::insert(id.clone(), d);
 		Self::deposit_event(Event::ApprovedTransfer {
 			asset_id: id,
 			source: owner.clone(),
@@ -841,22 +841,22 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	) -> DispatchResult {
 		let mut owner_died: Option<DeadConsequence> = None;
 
-		let d = Asset::<T, I>::get(id).ok_or(Error::<T, I>::Unknown)?;
+		let d = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 		ensure!(d.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
 
 		Approvals::<T, I>::try_mutate_exists(
-			(id, &owner, delegate),
+			(id.clone(), &owner, delegate),
 			|maybe_approved| -> DispatchResult {
 				let mut approved = maybe_approved.take().ok_or(Error::<T, I>::Unapproved)?;
 				let remaining =
 					approved.amount.checked_sub(&amount).ok_or(Error::<T, I>::Unapproved)?;
 
 				let f = TransferFlags { keep_alive: false, best_effort: false, burn_dust: false };
-				owner_died = Self::transfer_and_die(id, owner, destination, amount, None, f)?.1;
+				owner_died = Self::transfer_and_die(id.clone(), owner, destination, amount, None, f)?.1;
 
 				if remaining.is_zero() {
 					T::Currency::unreserve(owner, approved.deposit);
-					Asset::<T, I>::mutate(id, |maybe_details| {
+					Asset::<T, I>::mutate(id.clone(), |maybe_details| {
 						if let Some(details) = maybe_details {
 							details.approvals.saturating_dec();
 						}
@@ -889,11 +889,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		let bounded_symbol: BoundedVec<u8, T::StringLimit> =
 			symbol.clone().try_into().map_err(|_| Error::<T, I>::BadMetadata)?;
 
-		let d = Asset::<T, I>::get(id).ok_or(Error::<T, I>::Unknown)?;
+		let d = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 		ensure!(d.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
 		ensure!(from == &d.owner, Error::<T, I>::NoPermission);
 
-		Metadata::<T, I>::try_mutate_exists(id, |metadata| {
+		Metadata::<T, I>::try_mutate_exists(id.clone(), |metadata| {
 			ensure!(metadata.as_ref().map_or(true, |m| !m.is_frozen), Error::<T, I>::NoPermission);
 
 			let old_deposit = metadata.take().map_or(Zero::zero(), |m| m.deposit);

--- a/frame/assets/src/impl_stored_map.rs
+++ b/frame/assets/src/impl_stored_map.rs
@@ -21,7 +21,7 @@ use super::*;
 
 impl<T: Config<I>, I: 'static> StoredMap<(T::AssetId, T::AccountId), T::Extra> for Pallet<T, I> {
 	fn get(id_who: &(T::AssetId, T::AccountId)) -> T::Extra {
-		let &(id, ref who) = id_who;
+		let &(ref id, ref who) = id_who;
 		Account::<T, I>::get(id, who).map(|a| a.extra).unwrap_or_default()
 	}
 
@@ -29,7 +29,7 @@ impl<T: Config<I>, I: 'static> StoredMap<(T::AssetId, T::AccountId), T::Extra> f
 		id_who: &(T::AssetId, T::AccountId),
 		f: impl FnOnce(&mut Option<T::Extra>) -> Result<R, E>,
 	) -> Result<R, E> {
-		let &(id, ref who) = id_who;
+		let &(ref id, ref who) = id_who;
 		let mut maybe_extra = Account::<T, I>::get(id, who).map(|a| a.extra);
 		let r = f(&mut maybe_extra)?;
 		// They want to write some value or delete it.

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -213,7 +213,7 @@ pub mod pallet {
 		type AssetId: Member
 			+ Parameter
 			+ Default
-			+ Copy
+			+ Clone
 			+ HasCompact
 			+ MaybeSerializeDeserialize
 			+ MaxEncodedLen
@@ -381,7 +381,7 @@ pub mod pallet {
 
 			for (id, account_id, amount) in &self.accounts {
 				let result = <Pallet<T, I>>::increase_balance(
-					*id,
+					id.clone(),
 					account_id,
 					*amount,
 					|details| -> DispatchResult {
@@ -553,14 +553,14 @@ pub mod pallet {
 			let owner = T::CreateOrigin::ensure_origin(origin, &id)?;
 			let admin = T::Lookup::lookup(admin)?;
 
-			ensure!(!Asset::<T, I>::contains_key(id), Error::<T, I>::InUse);
+			ensure!(!Asset::<T, I>::contains_key(&id), Error::<T, I>::InUse);
 			ensure!(!min_balance.is_zero(), Error::<T, I>::MinBalanceZero);
 
 			let deposit = T::AssetDeposit::get();
 			T::Currency::reserve(&owner, deposit)?;
 
 			Asset::<T, I>::insert(
-				id,
+				id.clone(),
 				AssetDetails {
 					owner: owner.clone(),
 					issuer: admin.clone(),
@@ -869,7 +869,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let origin = ensure_signed(origin)?;
 
-			let d = Asset::<T, I>::get(id).ok_or(Error::<T, I>::Unknown)?;
+			let d = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 			ensure!(
 				d.status == AssetStatus::Live || d.status == AssetStatus::Frozen,
 				Error::<T, I>::AssetNotLive
@@ -877,7 +877,7 @@ pub mod pallet {
 			ensure!(origin == d.freezer, Error::<T, I>::NoPermission);
 			let who = T::Lookup::lookup(who)?;
 
-			Account::<T, I>::try_mutate(id, &who, |maybe_account| -> DispatchResult {
+			Account::<T, I>::try_mutate(&id, &who, |maybe_account| -> DispatchResult {
 				maybe_account.as_mut().ok_or(Error::<T, I>::NoAccount)?.is_frozen = true;
 				Ok(())
 			})?;
@@ -904,7 +904,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let origin = ensure_signed(origin)?;
 
-			let details = Asset::<T, I>::get(id).ok_or(Error::<T, I>::Unknown)?;
+			let details = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 			ensure!(
 				details.status == AssetStatus::Live || details.status == AssetStatus::Frozen,
 				Error::<T, I>::AssetNotLive
@@ -912,7 +912,7 @@ pub mod pallet {
 			ensure!(origin == details.admin, Error::<T, I>::NoPermission);
 			let who = T::Lookup::lookup(who)?;
 
-			Account::<T, I>::try_mutate(id, &who, |maybe_account| -> DispatchResult {
+			Account::<T, I>::try_mutate(&id, &who, |maybe_account| -> DispatchResult {
 				maybe_account.as_mut().ok_or(Error::<T, I>::NoAccount)?.is_frozen = false;
 				Ok(())
 			})?;
@@ -937,7 +937,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let origin = ensure_signed(origin)?;
 
-			Asset::<T, I>::try_mutate(id, |maybe_details| {
+			Asset::<T, I>::try_mutate(id.clone(), |maybe_details| {
 				let d = maybe_details.as_mut().ok_or(Error::<T, I>::Unknown)?;
 				ensure!(d.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
 				ensure!(origin == d.freezer, Error::<T, I>::NoPermission);
@@ -965,7 +965,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let origin = ensure_signed(origin)?;
 
-			Asset::<T, I>::try_mutate(id, |maybe_details| {
+			Asset::<T, I>::try_mutate(id.clone(), |maybe_details| {
 				let d = maybe_details.as_mut().ok_or(Error::<T, I>::Unknown)?;
 				ensure!(origin == d.admin, Error::<T, I>::NoPermission);
 				ensure!(d.status == AssetStatus::Frozen, Error::<T, I>::NotFrozen);
@@ -996,7 +996,7 @@ pub mod pallet {
 			let origin = ensure_signed(origin)?;
 			let owner = T::Lookup::lookup(owner)?;
 
-			Asset::<T, I>::try_mutate(id, |maybe_details| {
+			Asset::<T, I>::try_mutate(id.clone(), |maybe_details| {
 				let details = maybe_details.as_mut().ok_or(Error::<T, I>::Unknown)?;
 				ensure!(details.status == AssetStatus::Live, Error::<T, I>::LiveAsset);
 				ensure!(origin == details.owner, Error::<T, I>::NoPermission);
@@ -1004,7 +1004,7 @@ pub mod pallet {
 					return Ok(())
 				}
 
-				let metadata_deposit = Metadata::<T, I>::get(id).deposit;
+				let metadata_deposit = Metadata::<T, I>::get(&id).deposit;
 				let deposit = details.deposit + metadata_deposit;
 
 				// Move the deposit to the new owner.
@@ -1042,7 +1042,7 @@ pub mod pallet {
 			let admin = T::Lookup::lookup(admin)?;
 			let freezer = T::Lookup::lookup(freezer)?;
 
-			Asset::<T, I>::try_mutate(id, |maybe_details| {
+			Asset::<T, I>::try_mutate(id.clone(), |maybe_details| {
 				let details = maybe_details.as_mut().ok_or(Error::<T, I>::Unknown)?;
 				ensure!(details.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
 				ensure!(origin == details.owner, Error::<T, I>::NoPermission);
@@ -1102,11 +1102,11 @@ pub mod pallet {
 		) -> DispatchResult {
 			let origin = ensure_signed(origin)?;
 
-			let d = Asset::<T, I>::get(id).ok_or(Error::<T, I>::Unknown)?;
+			let d = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 			ensure!(d.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
 			ensure!(origin == d.owner, Error::<T, I>::NoPermission);
 
-			Metadata::<T, I>::try_mutate_exists(id, |metadata| {
+			Metadata::<T, I>::try_mutate_exists(id.clone(), |metadata| {
 				let deposit = metadata.take().ok_or(Error::<T, I>::Unknown)?.deposit;
 				T::Currency::unreserve(&d.owner, deposit);
 				Self::deposit_event(Event::MetadataCleared { asset_id: id });
@@ -1145,8 +1145,8 @@ pub mod pallet {
 			let bounded_symbol: BoundedVec<u8, T::StringLimit> =
 				symbol.clone().try_into().map_err(|_| Error::<T, I>::BadMetadata)?;
 
-			ensure!(Asset::<T, I>::contains_key(id), Error::<T, I>::Unknown);
-			Metadata::<T, I>::try_mutate_exists(id, |metadata| {
+			ensure!(Asset::<T, I>::contains_key(&id), Error::<T, I>::Unknown);
+			Metadata::<T, I>::try_mutate_exists(id.clone(), |metadata| {
 				let deposit = metadata.take().map_or(Zero::zero(), |m| m.deposit);
 				*metadata = Some(AssetMetadata {
 					deposit,
@@ -1185,8 +1185,8 @@ pub mod pallet {
 		) -> DispatchResult {
 			T::ForceOrigin::ensure_origin(origin)?;
 
-			let d = Asset::<T, I>::get(id).ok_or(Error::<T, I>::Unknown)?;
-			Metadata::<T, I>::try_mutate_exists(id, |metadata| {
+			let d = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
+			Metadata::<T, I>::try_mutate_exists(id.clone(), |metadata| {
 				let deposit = metadata.take().ok_or(Error::<T, I>::Unknown)?.deposit;
 				T::Currency::unreserve(&d.owner, deposit);
 				Self::deposit_event(Event::MetadataCleared { asset_id: id });
@@ -1230,7 +1230,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			T::ForceOrigin::ensure_origin(origin)?;
 
-			Asset::<T, I>::try_mutate(id, |maybe_asset| {
+			Asset::<T, I>::try_mutate(id.clone(), |maybe_asset| {
 				let mut asset = maybe_asset.take().ok_or(Error::<T, I>::Unknown)?;
 				ensure!(asset.status != AssetStatus::Destroying, Error::<T, I>::AssetNotLive);
 				asset.owner = T::Lookup::lookup(owner)?;
@@ -1304,14 +1304,14 @@ pub mod pallet {
 		) -> DispatchResult {
 			let owner = ensure_signed(origin)?;
 			let delegate = T::Lookup::lookup(delegate)?;
-			let mut d = Asset::<T, I>::get(id).ok_or(Error::<T, I>::Unknown)?;
+			let mut d = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 			ensure!(d.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
 			let approval =
-				Approvals::<T, I>::take((id, &owner, &delegate)).ok_or(Error::<T, I>::Unknown)?;
+				Approvals::<T, I>::take((id.clone(), &owner, &delegate)).ok_or(Error::<T, I>::Unknown)?;
 			T::Currency::unreserve(&owner, approval.deposit);
 
 			d.approvals.saturating_dec();
-			Asset::<T, I>::insert(id, d);
+			Asset::<T, I>::insert(id.clone(), d);
 
 			Self::deposit_event(Event::ApprovalCancelled { asset_id: id, owner, delegate });
 			Ok(())
@@ -1337,7 +1337,7 @@ pub mod pallet {
 			owner: AccountIdLookupOf<T>,
 			delegate: AccountIdLookupOf<T>,
 		) -> DispatchResult {
-			let mut d = Asset::<T, I>::get(id).ok_or(Error::<T, I>::Unknown)?;
+			let mut d = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 			ensure!(d.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
 			T::ForceOrigin::try_origin(origin)
 				.map(|_| ())
@@ -1351,10 +1351,10 @@ pub mod pallet {
 			let delegate = T::Lookup::lookup(delegate)?;
 
 			let approval =
-				Approvals::<T, I>::take((id, &owner, &delegate)).ok_or(Error::<T, I>::Unknown)?;
+				Approvals::<T, I>::take((id.clone(), &owner, &delegate)).ok_or(Error::<T, I>::Unknown)?;
 			T::Currency::unreserve(&owner, approval.deposit);
 			d.approvals.saturating_dec();
-			Asset::<T, I>::insert(id, d);
+			Asset::<T, I>::insert(id.clone(), d);
 
 			Self::deposit_event(Event::ApprovalCancelled { asset_id: id, owner, delegate });
 			Ok(())

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -1306,8 +1306,8 @@ pub mod pallet {
 			let delegate = T::Lookup::lookup(delegate)?;
 			let mut d = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 			ensure!(d.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
-			let approval =
-				Approvals::<T, I>::take((id.clone(), &owner, &delegate)).ok_or(Error::<T, I>::Unknown)?;
+			let approval = Approvals::<T, I>::take((id.clone(), &owner, &delegate))
+				.ok_or(Error::<T, I>::Unknown)?;
 			T::Currency::unreserve(&owner, approval.deposit);
 
 			d.approvals.saturating_dec();
@@ -1350,8 +1350,8 @@ pub mod pallet {
 			let owner = T::Lookup::lookup(owner)?;
 			let delegate = T::Lookup::lookup(delegate)?;
 
-			let approval =
-				Approvals::<T, I>::take((id.clone(), &owner, &delegate)).ok_or(Error::<T, I>::Unknown)?;
+			let approval = Approvals::<T, I>::take((id.clone(), &owner, &delegate))
+				.ok_or(Error::<T, I>::Unknown)?;
 			T::Currency::unreserve(&owner, approval.deposit);
 			d.approvals.saturating_dec();
 			Asset::<T, I>::insert(id.clone(), d);

--- a/frame/support/src/traits/tokens/fungibles.rs
+++ b/frame/support/src/traits/tokens/fungibles.rs
@@ -148,7 +148,8 @@ pub trait Mutate<AccountId>: Inspect<AccountId> {
 		let extra = Self::can_withdraw(asset.clone(), &source, amount).into_result()?;
 		// As we first burn and then mint, we don't need to check if `mint` fits into the supply.
 		// If we can withdraw/burn it, we can also mint it again.
-		Self::can_deposit(asset.clone(), dest, amount.saturating_add(extra), false).into_result()?;
+		Self::can_deposit(asset.clone(), dest, amount.saturating_add(extra), false)
+			.into_result()?;
 		let actual = Self::burn_from(asset.clone(), source, amount)?;
 		debug_assert!(
 			actual == amount.saturating_add(extra),

--- a/frame/support/src/traits/tokens/fungibles/balanced.rs
+++ b/frame/support/src/traits/tokens/fungibles/balanced.rs
@@ -185,11 +185,12 @@ pub trait Unbalanced<AccountId>: Inspect<AccountId> {
 		amount: Self::Balance,
 	) -> Result<Self::Balance, DispatchError> {
 		let old_balance = Self::balance(asset.clone(), who);
-		let (mut new_balance, mut amount) = if Self::reducible_balance(asset.clone(), who, false) < amount {
-			return Err(TokenError::NoFunds.into())
-		} else {
-			(old_balance - amount, amount)
-		};
+		let (mut new_balance, mut amount) =
+			if Self::reducible_balance(asset.clone(), who, false) < amount {
+				return Err(TokenError::NoFunds.into())
+			} else {
+				(old_balance - amount, amount)
+			};
 		if new_balance < Self::minimum_balance(asset.clone()) {
 			amount = amount.saturating_add(new_balance);
 			new_balance = Zero::zero();
@@ -352,11 +353,17 @@ impl<AccountId, U: Unbalanced<AccountId>> Balanced<AccountId> for U {
 	type OnDropCredit = DecreaseIssuance<AccountId, U>;
 	type OnDropDebt = IncreaseIssuance<AccountId, U>;
 	fn rescind(asset: Self::AssetId, amount: Self::Balance) -> Debt<AccountId, Self> {
-		U::set_total_issuance(asset.clone(), U::total_issuance(asset.clone()).saturating_sub(amount));
+		U::set_total_issuance(
+			asset.clone(),
+			U::total_issuance(asset.clone()).saturating_sub(amount),
+		);
 		debt(asset, amount)
 	}
 	fn issue(asset: Self::AssetId, amount: Self::Balance) -> Credit<AccountId, Self> {
-		U::set_total_issuance(asset.clone(), U::total_issuance(asset.clone()).saturating_add(amount));
+		U::set_total_issuance(
+			asset.clone(),
+			U::total_issuance(asset.clone()).saturating_add(amount),
+		);
 		credit(asset, amount)
 	}
 	fn slash(

--- a/frame/support/src/traits/tokens/fungibles/imbalance.rs
+++ b/frame/support/src/traits/tokens/fungibles/imbalance.rs
@@ -60,7 +60,7 @@ impl<
 {
 	fn drop(&mut self) {
 		if !self.amount.is_zero() {
-			OnDrop::handle(self.asset, self.amount)
+			OnDrop::handle(self.asset.clone(), self.amount)
 		}
 	}
 }
@@ -105,9 +105,9 @@ impl<
 	pub fn split(self, amount: B) -> (Self, Self) {
 		let first = self.amount.min(amount);
 		let second = self.amount - first;
-		let asset = self.asset;
+		let asset = self.asset.clone();
 		sp_std::mem::forget(self);
-		(Imbalance::new(asset, first), Imbalance::new(asset, second))
+		(Imbalance::new(asset.clone(), first), Imbalance::new(asset, second))
 	}
 	pub fn merge(mut self, other: Self) -> Result<Self, (Self, Self)> {
 		if self.asset == other.asset {
@@ -136,7 +136,7 @@ impl<
 	> {
 		if self.asset == other.asset {
 			let (a, b) = (self.amount, other.amount);
-			let asset = self.asset;
+			let asset = self.asset.clone();
 			sp_std::mem::forget((self, other));
 
 			if a == b {
@@ -155,7 +155,7 @@ impl<
 	}
 
 	pub fn asset(&self) -> A {
-		self.asset
+		self.asset.clone()
 	}
 }
 

--- a/frame/support/src/traits/tokens/misc.rs
+++ b/frame/support/src/traits/tokens/misc.rs
@@ -164,10 +164,10 @@ impl WithdrawReasons {
 
 /// Simple amalgamation trait to collect together properties for an AssetId under one roof.
 pub trait AssetId:
-	FullCodec + Copy + Eq + PartialEq + Debug + scale_info::TypeInfo + MaxEncodedLen
+	FullCodec + Clone + Eq + PartialEq + Debug + scale_info::TypeInfo + MaxEncodedLen
 {
 }
-impl<T: FullCodec + Copy + Eq + PartialEq + Debug + scale_info::TypeInfo + MaxEncodedLen> AssetId
+impl<T: FullCodec + Clone + Eq + PartialEq + Debug + scale_info::TypeInfo + MaxEncodedLen> AssetId
 	for T
 {
 }


### PR DESCRIPTION
For the bridgehub we want to use a second Asset pallet for bridged assets. The suggestion is to have the `AssetId` of this instance be a `MultiLocation`. However `Multilocation` is not `Copy`, so this PR is exploring the impact of relaxing the `Copy` bound to only require `Clone`.

cumulus companion: https://github.com/paritytech/cumulus/pull/1900