### PR TITLE
Fix the light client protocol protobuf schema

### DIFF
--- a/client/network/light/src/light_client_requests/handler.rs
+++ b/client/network/light/src/light_client_requests/handler.rs
@@ -147,18 +147,14 @@ where
 		let request = schema::v1::light::Request::decode(&payload[..])?;
 
 		let response = match &request.request {
-			Some(schema::v1::light::request::Request::RemoteCallRequest(r)) => {
-				self.on_remote_call_request(&peer, r)?
-			},
-			Some(schema::v1::light::request::Request::RemoteReadRequest(r)) => {
-				self.on_remote_read_request(&peer, r)?
-			},
-			Some(schema::v1::light::request::Request::RemoteReadChildRequest(r)) => {
-				self.on_remote_read_child_request(&peer, r)?
-			},
-			None => {
-				return Err(HandleRequestError::BadRequest("Remote request without request data."))
-			},
+			Some(schema::v1::light::request::Request::RemoteCallRequest(r)) =>
+				self.on_remote_call_request(&peer, r)?,
+			Some(schema::v1::light::request::Request::RemoteReadRequest(r)) =>
+				self.on_remote_read_request(&peer, r)?,
+			Some(schema::v1::light::request::Request::RemoteReadChildRequest(r)) =>
+				self.on_remote_read_child_request(&peer, r)?,
+			None =>
+				return Err(HandleRequestError::BadRequest("Remote request without request data.")),
 		};
 
 		let mut data = Vec::new();
@@ -202,7 +198,7 @@ where
 	) -> Result<schema::v1::light::Response, HandleRequestError> {
 		if request.keys.is_empty() {
 			debug!("Invalid remote read request sent by {}.", peer);
-			return Err(HandleRequestError::BadRequest("Remote read request without keys."));
+			return Err(HandleRequestError::BadRequest("Remote read request without keys."))
 		}
 
 		trace!(
@@ -241,7 +237,7 @@ where
 	) -> Result<schema::v1::light::Response, HandleRequestError> {
 		if request.keys.is_empty() {
 			debug!("Invalid remote child read request sent by {}.", peer);
-			return Err(HandleRequestError::BadRequest("Remove read child request without keys."));
+			return Err(HandleRequestError::BadRequest("Remove read child request without keys."))
 		}
 
 		trace!(

--- a/client/network/light/src/schema.rs
+++ b/client/network/light/src/schema.rs
@@ -23,3 +23,35 @@ pub(crate) mod v1 {
 		include!(concat!(env!("OUT_DIR"), "/api.v1.light.rs"));
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use prost::Message as _;
+
+	#[test]
+	fn with_proof_encodes_correctly() {
+		let encoded = super::v1::light::Response {
+			response: Some(super::v1::light::response::Response::RemoteReadResponse(
+				super::v1::light::RemoteReadResponse { proof: Some(Vec::new()) },
+			)),
+		}
+		.encode_to_vec();
+
+		// Make sure that the response contains one field of number 2 and wire type 2 (message),
+		// then another field of number 2 and wire type 2 (bytes), then a length of 0.
+		assert_eq!(encoded, vec![(2 << 3) | 2, 2, (2 << 3) | 2, 0]);
+	}
+
+	#[test]
+	fn no_proof_encodes_correctly() {
+		let encoded = super::v1::light::Response {
+			response: Some(super::v1::light::response::Response::RemoteReadResponse(
+				super::v1::light::RemoteReadResponse { proof: None },
+			)),
+		}
+		.encode_to_vec();
+
+		// Make sure that the response contains one field of number 2 and wire type 2 (message).
+		assert_eq!(encoded, vec![(2 << 3) | 2, 0]);
+	}
+}

--- a/client/network/light/src/schema.rs
+++ b/client/network/light/src/schema.rs
@@ -29,7 +29,7 @@ mod tests {
 	use prost::Message as _;
 
 	#[test]
-	fn with_proof_encodes_correctly() {
+	fn empty_proof_encodes_correctly() {
 		let encoded = super::v1::light::Response {
 			response: Some(super::v1::light::response::Response::RemoteReadResponse(
 				super::v1::light::RemoteReadResponse { proof: Some(Vec::new()) },
@@ -53,5 +53,17 @@ mod tests {
 
 		// Make sure that the response contains one field of number 2 and wire type 2 (message).
 		assert_eq!(encoded, vec![(2 << 3) | 2, 0]);
+	}
+
+	#[test]
+	fn proof_encodes_correctly() {
+		let encoded = super::v1::light::Response {
+			response: Some(super::v1::light::response::Response::RemoteReadResponse(
+				super::v1::light::RemoteReadResponse { proof: Some(vec![1, 2, 3, 4]) },
+			)),
+		}
+		.encode_to_vec();
+
+		assert_eq!(encoded, vec![(2 << 3) | 2, 6, (2 << 3) | 2, 4, 1, 2, 3, 4]);
 	}
 }

--- a/client/network/light/src/schema/light.v1.proto
+++ b/client/network/light/src/schema/light.v1.proto
@@ -4,14 +4,6 @@ syntax = "proto2";
 
 package api.v1.light;
 
-// A pair of arbitrary bytes.
-message Pair {
-	// The first element of the pair.
-	required bytes fst = 1;
-	// The second element of the pair.
-	required bytes snd = 2;
-}
-
 // Enumerate all possible light client request messages.
 message Request {
 	oneof request {

--- a/client/network/light/src/schema/light.v1.proto
+++ b/client/network/light/src/schema/light.v1.proto
@@ -1,15 +1,15 @@
 // Schema definition for light client messages.
 
-syntax = "proto3";
+syntax = "proto2";
 
 package api.v1.light;
 
 // A pair of arbitrary bytes.
 message Pair {
 	// The first element of the pair.
-	bytes fst = 1;
+	required bytes fst = 1;
 	// The second element of the pair.
-	bytes snd = 2;
+	required bytes snd = 2;
 }
 
 // Enumerate all possible light client request messages.
@@ -34,40 +34,42 @@ message Response {
 // Remote call request.
 message RemoteCallRequest {
 	// Block at which to perform call.
-	bytes block = 2;
+	required bytes block = 2;
 	// Method name.
-	string method = 3;
+	required string method = 3;
 	// Call data.
-	bytes data = 4;
+	required bytes data = 4;
 }
 
 // Remote call response.
 message RemoteCallResponse {
-	// Execution proof.
-	bytes proof = 2;
+	// Execution proof. If missing, indicates that the remote couldn't answer, for example because
+	// the block is pruned.
+	optional bytes proof = 2;
 }
 
 // Remote storage read request.
 message RemoteReadRequest {
 	// Block at which to perform call.
-	bytes block = 2;
+	required bytes block = 2;
 	// Storage keys.
 	repeated bytes keys = 3;
 }
 
 // Remote read response.
 message RemoteReadResponse {
-	// Read proof.
-	bytes proof = 2;
+	// Read proof. If missing, indicates that the remote couldn't answer, for example because
+	// the block is pruned.
+	optional bytes proof = 2;
 }
 
 // Remote storage read child request.
 message RemoteReadChildRequest {
 	// Block at which to perform call.
-	bytes block = 2;
+	required bytes block = 2;
 	// Child Storage key, this is relative
 	// to the child type storage location.
-	bytes storage_key = 3;
+	required bytes storage_key = 3;
 	// Storage keys.
 	repeated bytes keys = 6;
 }


### PR DESCRIPTION
Fix #12727 
Amends https://github.com/paritytech/substrate/pull/12372

This PR fixes https://github.com/paritytech/substrate/pull/12372 to do what it was intended to do. Right now the light client handler sends back an empty response in case of error, while what I intended was that it sends a response (most importantly, indicating the type of response) but without a proof in it. This is what this PR does.

This PR also switches the schema to protobuf 2.
In protobuf 2, each field is either optional or required. This is good. It's explicit. You know exactly what you get on the wire. Google, the best™ company in the world, then saw that sometimes we send one or two extra bytes that aren't strictly necessary, and, because they have too many engineers and too much time, decided that they were going to release protobuf 3 where they know better than you. They made fields optional by default, and magically omitted fields from messages when the fields were present but equal to their default value. In other words, a lot of magic.
This confused a lot of people, and Google seemingly realized that sometimes it wasn't a good idea to do so, so they are now adding back an `optional` keyword to protobuf 3, and because it doesn't mean the same thing as "optional" in protobuf 2, it probably confuses people even more. This keyword could have been used in this PR, unfortunately it was unstable until recently and requires passing an option to older protobuf compilers, which we really don't want to bother with here.
You can read more at https://github.com/protocolbuffers/protobuf/blob/main/docs/field_presence.md if you are into self-harm.

So, long story short, I've switched back to protobuf 2. Libp2p as a whole still uses protobuf 2 as an example. The only reason why we've switched to protobuf 3 as far as I recall is "bigger number is better", and not anything in particular.
