### PR TITLE
Move block/state/warpc sync requests/responses to `ChainSync`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,9 +340,9 @@ checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-trait"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8321,6 +8321,7 @@ version = "0.10.0-dev"
 dependencies = [
  "array-bytes",
  "async-std",
+ "async-trait",
  "fork-tree",
  "futures",
  "libp2p",

--- a/client/network/common/src/sync.rs
+++ b/client/network/common/src/sync.rs
@@ -125,7 +125,7 @@ pub enum OnBlockJustification<Block: BlockT> {
 	},
 }
 
-/// Result of [`ChainSync::on_state_data`].
+/// Result of `ChainSync::on_state_data`.
 #[derive(Debug)]
 pub enum OnStateData<Block: BlockT> {
 	/// The block and state that should be imported.

--- a/client/network/common/src/sync.rs
+++ b/client/network/common/src/sync.rs
@@ -24,14 +24,16 @@ pub mod warp;
 
 use libp2p::PeerId;
 use message::{BlockAnnounce, BlockData, BlockRequest, BlockResponse};
-use sc_consensus::{BlockImportError, BlockImportStatus, IncomingBlock};
+use sc_consensus::{
+	import_queue::RuntimeOrigin, BlockImportError, BlockImportStatus, IncomingBlock,
+};
 use sp_consensus::BlockOrigin;
 use sp_runtime::{
 	traits::{Block as BlockT, NumberFor},
 	Justifications,
 };
 use std::{any::Any, fmt, fmt::Formatter, task::Poll};
-use warp::{EncodedProof, WarpProofRequest, WarpSyncProgress};
+use warp::WarpSyncProgress;
 
 /// The sync status of a peer we are trying to sync with
 #[derive(Debug)]
@@ -132,6 +134,20 @@ pub enum OnStateData<Block: BlockT> {
 	Continue,
 }
 
+/// Block or justification request polled from `ChainSync`
+#[derive(Debug)]
+pub enum ImportResult<B: BlockT> {
+	BlockImport(BlockOrigin, Vec<IncomingBlock<B>>),
+	JustificationImport(RuntimeOrigin, B::Hash, NumberFor<B>, Justifications),
+}
+
+/// Value polled from `ChainSync`
+#[derive(Debug)]
+pub enum PollResult<B: BlockT> {
+	Import(ImportResult<B>),
+	Announce(PollBlockAnnounceValidation<B::Header>),
+}
+
 /// Result of [`ChainSync::poll_block_announce_validation`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PollBlockAnnounceValidation<H> {
@@ -184,6 +200,13 @@ pub struct Metrics {
 	pub queued_blocks: u32,
 	pub fork_targets: u32,
 	pub justifications: metrics::Metrics,
+}
+
+#[derive(Debug)]
+pub enum PeerRequest<B: BlockT> {
+	Block(BlockRequest<B>),
+	State,
+	WarpProof,
 }
 
 /// Wrapper for implementation-specific state request.
@@ -250,6 +273,9 @@ pub trait ChainSync<Block: BlockT>: Send {
 	/// Returns the current number of peers stored within this state machine.
 	fn num_peers(&self) -> usize;
 
+	/// Returns the number of peers we're connected to and that are being queried.
+	fn num_active_peers(&self) -> usize;
+
 	/// Handle a new connected peer.
 	///
 	/// Call this method whenever we connect to a new peer.
@@ -277,22 +303,6 @@ pub trait ChainSync<Block: BlockT>: Send {
 		number: NumberFor<Block>,
 	);
 
-	/// Get an iterator over all scheduled justification requests.
-	fn justification_requests<'a>(
-		&'a mut self,
-	) -> Box<dyn Iterator<Item = (PeerId, BlockRequest<Block>)> + 'a>;
-
-	/// Get an iterator over all block requests of all peers.
-	fn block_requests<'a>(
-		&'a mut self,
-	) -> Box<dyn Iterator<Item = (PeerId, BlockRequest<Block>)> + 'a>;
-
-	/// Get a state request, if any.
-	fn state_request(&mut self) -> Option<(PeerId, OpaqueStateRequest)>;
-
-	/// Get a warp sync request, if any.
-	fn warp_sync_request(&mut self) -> Option<(PeerId, WarpProofRequest<Block>)>;
-
 	/// Handle a response from the remote to a block request that we made.
 	///
 	/// `request` must be the original request that triggered `response`.
@@ -306,16 +316,6 @@ pub trait ChainSync<Block: BlockT>: Send {
 		request: Option<BlockRequest<Block>>,
 		response: BlockResponse<Block>,
 	) -> Result<OnBlockData<Block>, BadPeer>;
-
-	/// Handle a response from the remote to a state request that we made.
-	fn on_state_data(
-		&mut self,
-		who: &PeerId,
-		response: OpaqueStateResponse,
-	) -> Result<OnStateData<Block>, BadPeer>;
-
-	/// Handle a response from the remote to a warp proof request that we made.
-	fn on_warp_sync_data(&mut self, who: &PeerId, response: EncodedProof) -> Result<(), BadPeer>;
 
 	/// Handle a response from the remote to a justification request that we made.
 	///
@@ -383,15 +383,6 @@ pub trait ChainSync<Block: BlockT>: Send {
 	/// Return some key metrics.
 	fn metrics(&self) -> Metrics;
 
-	/// Create implementation-specific block request.
-	fn create_opaque_block_request(&self, request: &BlockRequest<Block>) -> OpaqueBlockRequest;
-
-	/// Encode implementation-specific block request.
-	fn encode_block_request(&self, request: &OpaqueBlockRequest) -> Result<Vec<u8>, String>;
-
-	/// Decode implementation-specific block response.
-	fn decode_block_response(&self, response: &[u8]) -> Result<OpaqueBlockResponse, String>;
-
 	/// Access blocks from implementation-specific block response.
 	fn block_response_into_blocks(
 		&self,
@@ -399,19 +390,13 @@ pub trait ChainSync<Block: BlockT>: Send {
 		response: OpaqueBlockResponse,
 	) -> Result<Vec<BlockData<Block>>, String>;
 
-	/// Encode implementation-specific state request.
-	fn encode_state_request(&self, request: &OpaqueStateRequest) -> Result<Vec<u8>, String>;
-
-	/// Decode implementation-specific state response.
-	fn decode_state_response(&self, response: &[u8]) -> Result<OpaqueStateResponse, String>;
-
 	/// Advance the state of `ChainSync`
 	///
 	/// Internally calls [`ChainSync::poll_block_announce_validation()`] and
 	/// this function should be polled until it returns [`Poll::Pending`] to
 	/// consume all pending events.
-	fn poll(
-		&mut self,
-		cx: &mut std::task::Context,
-	) -> Poll<PollBlockAnnounceValidation<Block::Header>>;
+	fn poll(&mut self, cx: &mut std::task::Context) -> Poll<PollResult<Block>>;
+
+	/// Send block request to peer
+	fn send_block_request(&mut self, who: PeerId, request: BlockRequest<Block>);
 }

--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -101,39 +101,6 @@ where
 	/// Block announce protocol configuration
 	pub block_announce_config: NonDefaultSetConfig,
 
-	/// Request response configuration for the block request protocol.
-	///
-	/// [`RequestResponseConfig::name`] is used to tag outgoing block requests with the correct
-	/// protocol name. In addition all of [`RequestResponseConfig`] is used to handle incoming
-	/// block requests, if enabled.
-	///
-	/// Can be constructed either via
-	/// `sc_network_sync::block_request_handler::generate_protocol_config` allowing outgoing but
-	/// not incoming requests, or constructed via `sc_network_sync::block_request_handler::
-	/// BlockRequestHandler::new` allowing both outgoing and incoming requests.
-	pub block_request_protocol_config: RequestResponseConfig,
-
-	/// Request response configuration for the light client request protocol.
-	///
-	/// Can be constructed either via
-	/// `sc_network_light::light_client_requests::generate_protocol_config` allowing outgoing but
-	/// not incoming requests, or constructed via
-	/// `sc_network_light::light_client_requests::handler::LightClientRequestHandler::new`
-	/// allowing both outgoing and incoming requests.
-	pub light_client_request_protocol_config: RequestResponseConfig,
-
-	/// Request response configuration for the state request protocol.
-	///
-	/// Can be constructed either via
-	/// `sc_network_sync::state_request_handler::generate_protocol_config` allowing outgoing but
-	/// not incoming requests, or constructed via
-	/// `sc_network_sync::state_request_handler::StateRequestHandler::new` allowing
-	/// both outgoing and incoming requests.
-	pub state_request_protocol_config: RequestResponseConfig,
-
-	/// Optional warp sync protocol config.
-	pub warp_sync_protocol_config: Option<RequestResponseConfig>,
-
 	/// Request response protocol configurations
 	pub request_response_protocol_configs: Vec<RequestResponseConfig>,
 }

--- a/client/network/sync/Cargo.toml
+++ b/client/network/sync/Cargo.toml
@@ -18,7 +18,7 @@ prost-build = "0.11"
 
 [dependencies]
 array-bytes = "4.1"
-async-trait = "0.1"
+async-trait = "0.1.58"
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 futures = "0.3.21"
 libp2p = "0.49.0"

--- a/client/network/sync/Cargo.toml
+++ b/client/network/sync/Cargo.toml
@@ -18,6 +18,7 @@ prost-build = "0.11"
 
 [dependencies]
 array-bytes = "4.1"
+async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 futures = "0.3.21"
 libp2p = "0.49.0"

--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -2159,7 +2159,9 @@ where
 			(Some(first), Some(_)) => format!(" ({})", first),
 			_ => Default::default(),
 		};
-		trace!(target: "sync", "BlockResponse {} from {} with {} blocks {}",
+		trace!(
+			target: "sync",
+			"BlockResponse {} from {} with {} blocks {}",
 			block_response.id,
 			peer_id,
 			block_response.blocks.len(),
@@ -2226,7 +2228,6 @@ where
 	fn process_outbound_requests(&mut self) {
 		for (id, request) in self
 			.block_requests()
-			.map(|(peer_id, request)| (peer_id, request))
 			.collect::<Vec<_>>()
 		{
 			self.send_block_request(id, request);

--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -49,8 +49,10 @@ use crate::{
 };
 use codec::{Decode, DecodeAll, Encode};
 use extra_requests::ExtraRequests;
-use futures::{stream::FuturesUnordered, task::Poll, Future, FutureExt, StreamExt};
-use libp2p::PeerId;
+use futures::{
+	channel::oneshot, stream::FuturesUnordered, task::Poll, Future, FutureExt, StreamExt,
+};
+use libp2p::{request_response::OutboundFailure, PeerId};
 use log::{debug, error, info, trace, warn};
 use prost::Message;
 use sc_client_api::{BlockBackend, ProofProvider};
@@ -59,16 +61,18 @@ use sc_network_common::{
 	config::{
 		NonDefaultSetConfig, NonReservedPeerMode, NotificationHandshake, ProtocolId, SetConfig,
 	},
-	protocol::role::Roles,
+	protocol::{role::Roles, ProtocolName},
+	request_responses::{IfDisconnected, RequestFailure},
 	sync::{
 		message::{
 			BlockAnnounce, BlockAnnouncesHandshake, BlockAttributes, BlockData, BlockRequest,
 			BlockResponse, Direction, FromBlock,
 		},
 		warp::{EncodedProof, WarpProofRequest, WarpSyncPhase, WarpSyncProgress, WarpSyncProvider},
-		BadPeer, ChainSync as ChainSyncT, Metrics, OnBlockData, OnBlockJustification, OnStateData,
-		OpaqueBlockRequest, OpaqueBlockResponse, OpaqueStateRequest, OpaqueStateResponse, PeerInfo,
-		PollBlockAnnounceValidation, SyncMode, SyncState, SyncStatus,
+		BadPeer, ChainSync as ChainSyncT, ImportResult, Metrics, OnBlockData, OnBlockJustification,
+		OnStateData, OpaqueBlockRequest, OpaqueBlockResponse, OpaqueStateRequest,
+		OpaqueStateResponse, PeerInfo, PeerRequest, PollBlockAnnounceValidation, PollResult,
+		SyncMode, SyncState, SyncStatus,
 	},
 };
 use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver};
@@ -170,6 +174,18 @@ mod rep {
 
 	/// Peer response data does not have requested bits.
 	pub const BAD_RESPONSE: Rep = Rep::new(-(1 << 12), "Incomplete response");
+
+	/// Reputation change when a peer doesn't respond in time to our messages.
+	pub const TIMEOUT: Rep = Rep::new(-(1 << 10), "Request timeout");
+
+	/// Peer is on unsupported protocol version.
+	pub const BAD_PROTOCOL: Rep = Rep::new_fatal("Unsupported protocol");
+
+	/// Reputation change when a peer refuses a request.
+	pub const REFUSED: Rep = Rep::new(-(1 << 10), "Request refused");
+
+	/// We received a message that failed to decode.
+	pub const BAD_MESSAGE: Rep = Rep::new(-(1 << 12), "Bad message");
 }
 
 enum AllowedRequests {
@@ -223,6 +239,18 @@ struct GapSync<B: BlockT> {
 	target: NumberFor<B>,
 }
 
+type PendingResponse<B> = Pin<
+	Box<
+		dyn Future<
+				Output = (
+					PeerId,
+					PeerRequest<B>,
+					Result<Result<Vec<u8>, RequestFailure>, oneshot::Canceled>,
+				),
+			> + Send,
+	>,
+>;
+
 /// The main data structure which contains all the state for a chains
 /// active syncing strategy.
 pub struct ChainSync<B: BlockT, Client> {
@@ -272,7 +300,17 @@ pub struct ChainSync<B: BlockT, Client> {
 	/// Channel for receiving service commands
 	service_rx: TracingUnboundedReceiver<ToServiceCommand<B>>,
 	/// Handle for communicating with `NetworkService`
-	_network_service: service::network::NetworkServiceHandle,
+	network_service: service::network::NetworkServiceHandle,
+	/// Protocol name used for block announcements
+	block_announce_protocol_name: ProtocolName,
+	/// Protocol name used to send out block requests
+	block_request_protocol_name: ProtocolName,
+	/// Protocol name used to send out state requests
+	state_request_protocol_name: ProtocolName,
+	/// Protocol name used to send out warp sync requests
+	warp_sync_protocol_name: Option<ProtocolName>,
+	/// Pending responses
+	pending_responses: FuturesUnordered<PendingResponse<B>>,
 }
 
 /// All the data we have about a Peer that we are trying to sync with
@@ -470,6 +508,10 @@ where
 		self.peers.len()
 	}
 
+	fn num_active_peers(&self) -> usize {
+		self.pending_responses.len()
+	}
+
 	fn new_peer(
 		&mut self,
 		who: PeerId,
@@ -659,222 +701,6 @@ where
 			.or_insert_with(|| ForkTarget { number, peers: Default::default(), parent_hash: None })
 			.peers
 			.extend(peers);
-	}
-
-	fn justification_requests<'a>(
-		&'a mut self,
-	) -> Box<dyn Iterator<Item = (PeerId, BlockRequest<B>)> + 'a> {
-		let peers = &mut self.peers;
-		let mut matcher = self.extra_justifications.matcher();
-		Box::new(std::iter::from_fn(move || {
-			if let Some((peer, request)) = matcher.next(peers) {
-				peers
-					.get_mut(&peer)
-					.expect(
-						"`Matcher::next` guarantees the `PeerId` comes from the given peers; qed",
-					)
-					.state = PeerSyncState::DownloadingJustification(request.0);
-				let req = BlockRequest::<B> {
-					id: 0,
-					fields: BlockAttributes::JUSTIFICATION,
-					from: FromBlock::Hash(request.0),
-					direction: Direction::Ascending,
-					max: Some(1),
-				};
-				Some((peer, req))
-			} else {
-				None
-			}
-		}))
-	}
-
-	fn block_requests<'a>(
-		&'a mut self,
-	) -> Box<dyn Iterator<Item = (PeerId, BlockRequest<B>)> + 'a> {
-		if self.mode == SyncMode::Warp {
-			return Box::new(std::iter::once(self.warp_target_block_request()).flatten())
-		}
-
-		if self.allowed_requests.is_empty() || self.state_sync.is_some() {
-			return Box::new(std::iter::empty())
-		}
-
-		if self.queue_blocks.len() > MAX_IMPORTING_BLOCKS {
-			trace!(target: "sync", "Too many blocks in the queue.");
-			return Box::new(std::iter::empty())
-		}
-		let is_major_syncing = self.status().state.is_major_syncing();
-		let attrs = self.required_block_attributes();
-		let blocks = &mut self.blocks;
-		let fork_targets = &mut self.fork_targets;
-		let last_finalized =
-			std::cmp::min(self.best_queued_number, self.client.info().finalized_number);
-		let best_queued = self.best_queued_number;
-		let client = &self.client;
-		let queue = &self.queue_blocks;
-		let allowed_requests = self.allowed_requests.take();
-		let max_parallel = if is_major_syncing { 1 } else { self.max_parallel_downloads };
-		let gap_sync = &mut self.gap_sync;
-		let iter = self.peers.iter_mut().filter_map(move |(&id, peer)| {
-			if !peer.state.is_available() || !allowed_requests.contains(&id) {
-				return None
-			}
-
-			// If our best queued is more than `MAX_BLOCKS_TO_LOOK_BACKWARDS` blocks away from the
-			// common number, the peer best number is higher than our best queued and the common
-			// number is smaller than the last finalized block number, we should do an ancestor
-			// search to find a better common block. If the queue is full we wait till all blocks
-			// are imported though.
-			if best_queued.saturating_sub(peer.common_number) > MAX_BLOCKS_TO_LOOK_BACKWARDS.into() &&
-				best_queued < peer.best_number &&
-				peer.common_number < last_finalized &&
-				queue.len() <= MAJOR_SYNC_BLOCKS.into()
-			{
-				trace!(
-					target: "sync",
-					"Peer {:?} common block {} too far behind of our best {}. Starting ancestry search.",
-					id,
-					peer.common_number,
-					best_queued,
-				);
-				let current = std::cmp::min(peer.best_number, best_queued);
-				peer.state = PeerSyncState::AncestorSearch {
-					current,
-					start: best_queued,
-					state: AncestorSearchState::ExponentialBackoff(One::one()),
-				};
-				Some((id, ancestry_request::<B>(current)))
-			} else if let Some((range, req)) = peer_block_request(
-				&id,
-				peer,
-				blocks,
-				attrs,
-				max_parallel,
-				last_finalized,
-				best_queued,
-			) {
-				peer.state = PeerSyncState::DownloadingNew(range.start);
-				trace!(
-					target: "sync",
-					"New block request for {}, (best:{}, common:{}) {:?}",
-					id,
-					peer.best_number,
-					peer.common_number,
-					req,
-				);
-				Some((id, req))
-			} else if let Some((hash, req)) =
-				fork_sync_request(&id, fork_targets, best_queued, last_finalized, attrs, |hash| {
-					if queue.contains(hash) {
-						BlockStatus::Queued
-					} else {
-						client.block_status(&BlockId::Hash(*hash)).unwrap_or(BlockStatus::Unknown)
-					}
-				}) {
-				trace!(target: "sync", "Downloading fork {:?} from {}", hash, id);
-				peer.state = PeerSyncState::DownloadingStale(hash);
-				Some((id, req))
-			} else if let Some((range, req)) = gap_sync.as_mut().and_then(|sync| {
-				peer_gap_block_request(
-					&id,
-					peer,
-					&mut sync.blocks,
-					attrs,
-					sync.target,
-					sync.best_queued_number,
-				)
-			}) {
-				peer.state = PeerSyncState::DownloadingGap(range.start);
-				trace!(
-					target: "sync",
-					"New gap block request for {}, (best:{}, common:{}) {:?}",
-					id,
-					peer.best_number,
-					peer.common_number,
-					req,
-				);
-				Some((id, req))
-			} else {
-				None
-			}
-		});
-		Box::new(iter)
-	}
-
-	fn state_request(&mut self) -> Option<(PeerId, OpaqueStateRequest)> {
-		if self.allowed_requests.is_empty() {
-			return None
-		}
-		if (self.state_sync.is_some() || self.warp_sync.is_some()) &&
-			self.peers.iter().any(|(_, peer)| peer.state == PeerSyncState::DownloadingState)
-		{
-			// Only one pending state request is allowed.
-			return None
-		}
-		if let Some(sync) = &self.state_sync {
-			if sync.is_complete() {
-				return None
-			}
-
-			for (id, peer) in self.peers.iter_mut() {
-				if peer.state.is_available() && peer.common_number >= sync.target_block_num() {
-					peer.state = PeerSyncState::DownloadingState;
-					let request = sync.next_request();
-					trace!(target: "sync", "New StateRequest for {}: {:?}", id, request);
-					self.allowed_requests.clear();
-					return Some((*id, OpaqueStateRequest(Box::new(request))))
-				}
-			}
-		}
-		if let Some(sync) = &self.warp_sync {
-			if sync.is_complete() {
-				return None
-			}
-			if let (Some(request), Some(target)) =
-				(sync.next_state_request(), sync.target_block_number())
-			{
-				for (id, peer) in self.peers.iter_mut() {
-					if peer.state.is_available() && peer.best_number >= target {
-						trace!(target: "sync", "New StateRequest for {}: {:?}", id, request);
-						peer.state = PeerSyncState::DownloadingState;
-						self.allowed_requests.clear();
-						return Some((*id, OpaqueStateRequest(Box::new(request))))
-					}
-				}
-			}
-		}
-		None
-	}
-
-	fn warp_sync_request(&mut self) -> Option<(PeerId, WarpProofRequest<B>)> {
-		if let Some(sync) = &self.warp_sync {
-			if self.allowed_requests.is_empty() ||
-				sync.is_complete() ||
-				self.peers
-					.iter()
-					.any(|(_, peer)| peer.state == PeerSyncState::DownloadingWarpProof)
-			{
-				// Only one pending state request is allowed.
-				return None
-			}
-			if let Some(request) = sync.next_warp_proof_request() {
-				let mut targets: Vec<_> = self.peers.values().map(|p| p.best_number).collect();
-				if !targets.is_empty() {
-					targets.sort();
-					let median = targets[targets.len() / 2];
-					// Find a random peer that is synced as much as peer majority.
-					for (id, peer) in self.peers.iter_mut() {
-						if peer.state.is_available() && peer.best_number >= median {
-							trace!(target: "sync", "New WarpProofRequest for {}", id);
-							peer.state = PeerSyncState::DownloadingWarpProof;
-							self.allowed_requests.clear();
-							return Some((*id, request))
-						}
-					}
-				}
-			}
-		}
-		None
 	}
 
 	fn on_block_data(
@@ -1133,104 +959,6 @@ where
 		};
 
 		Ok(self.validate_and_queue_blocks(new_blocks, gap))
-	}
-
-	fn on_state_data(
-		&mut self,
-		who: &PeerId,
-		response: OpaqueStateResponse,
-	) -> Result<OnStateData<B>, BadPeer> {
-		let response: Box<StateResponse> = response.0.downcast().map_err(|_error| {
-			error!(
-				target: "sync",
-				"Failed to downcast opaque state response, this is an implementation bug."
-			);
-
-			BadPeer(*who, rep::BAD_RESPONSE)
-		})?;
-
-		if let Some(peer) = self.peers.get_mut(who) {
-			if let PeerSyncState::DownloadingState = peer.state {
-				peer.state = PeerSyncState::Available;
-				self.allowed_requests.set_all();
-			}
-		}
-		let import_result = if let Some(sync) = &mut self.state_sync {
-			debug!(
-				target: "sync",
-				"Importing state data from {} with {} keys, {} proof nodes.",
-				who,
-				response.entries.len(),
-				response.proof.len(),
-			);
-			sync.import(*response)
-		} else if let Some(sync) = &mut self.warp_sync {
-			debug!(
-				target: "sync",
-				"Importing state data from {} with {} keys, {} proof nodes.",
-				who,
-				response.entries.len(),
-				response.proof.len(),
-			);
-			sync.import_state(*response)
-		} else {
-			debug!(target: "sync", "Ignored obsolete state response from {}", who);
-			return Err(BadPeer(*who, rep::NOT_REQUESTED))
-		};
-
-		match import_result {
-			state::ImportResult::Import(hash, header, state, body, justifications) => {
-				let origin = BlockOrigin::NetworkInitialSync;
-				let block = IncomingBlock {
-					hash,
-					header: Some(header),
-					body,
-					indexed_body: None,
-					justifications,
-					origin: None,
-					allow_missing_state: true,
-					import_existing: true,
-					skip_execution: self.skip_execution(),
-					state: Some(state),
-				};
-				debug!(target: "sync", "State download is complete. Import is queued");
-				Ok(OnStateData::Import(origin, block))
-			},
-			state::ImportResult::Continue => Ok(OnStateData::Continue),
-			state::ImportResult::BadResponse => {
-				debug!(target: "sync", "Bad state data received from {}", who);
-				Err(BadPeer(*who, rep::BAD_BLOCK))
-			},
-		}
-	}
-
-	fn on_warp_sync_data(&mut self, who: &PeerId, response: EncodedProof) -> Result<(), BadPeer> {
-		if let Some(peer) = self.peers.get_mut(who) {
-			if let PeerSyncState::DownloadingWarpProof = peer.state {
-				peer.state = PeerSyncState::Available;
-				self.allowed_requests.set_all();
-			}
-		}
-		let import_result = if let Some(sync) = &mut self.warp_sync {
-			debug!(
-				target: "sync",
-				"Importing warp proof data from {}, {} bytes.",
-				who,
-				response.0.len(),
-			);
-			sync.import_warp_proof(response)
-		} else {
-			debug!(target: "sync", "Ignored obsolete warp sync response from {}", who);
-			return Err(BadPeer(*who, rep::NOT_REQUESTED))
-		};
-
-		match import_result {
-			WarpProofImportResult::Success => Ok(()),
-			WarpProofImportResult::BadResponse => {
-				debug!(target: "sync", "Bad proof data received from {}", who);
-				Err(BadPeer(*who, rep::BAD_BLOCK))
-			},
-		}
 	}
 
 	fn on_block_justification(
@@ -1627,38 +1355,6 @@ where
 		}
 	}
 
-	/// Create implementation-specific block request.
-	fn create_opaque_block_request(&self, request: &BlockRequest<B>) -> OpaqueBlockRequest {
-		OpaqueBlockRequest(Box::new(schema::v1::BlockRequest {
-			fields: request.fields.to_be_u32(),
-			from_block: match request.from {
-				FromBlock::Hash(h) => Some(schema::v1::block_request::FromBlock::Hash(h.encode())),
-				FromBlock::Number(n) =>
-					Some(schema::v1::block_request::FromBlock::Number(n.encode())),
-			},
-			direction: request.direction as i32,
-			max_blocks: request.max.unwrap_or(0),
-			support_multiple_justifications: true,
-		}))
-	}
-
-	fn encode_block_request(&self, request: &OpaqueBlockRequest) -> Result<Vec<u8>, String> {
-		let request: &schema::v1::BlockRequest = request.0.downcast_ref().ok_or_else(|| {
-			"Failed to downcast opaque block response during encoding, this is an \
-				implementation bug."
-				.to_string()
-		})?;
-
-		Ok(request.encode_to_vec())
-	}
-
-	fn decode_block_response(&self, response: &[u8]) -> Result<OpaqueBlockResponse, String> {
-		let response = schema::v1::BlockResponse::decode(response)
-			.map_err(|error| format!("Failed to decode block response: {error}"))?;
-
-		Ok(OpaqueBlockResponse(Box::new(response)))
-	}
-
 	fn block_response_into_blocks(
 		&self,
 		request: &BlockRequest<B>,
@@ -1725,27 +1421,7 @@ where
 			.map_err(|error: codec::Error| error.to_string())
 	}
 
-	fn encode_state_request(&self, request: &OpaqueStateRequest) -> Result<Vec<u8>, String> {
-		let request: &StateRequest = request.0.downcast_ref().ok_or_else(|| {
-			"Failed to downcast opaque state response during encoding, this is an \
-				implementation bug."
-				.to_string()
-		})?;
-
-		Ok(request.encode_to_vec())
-	}
-
-	fn decode_state_response(&self, response: &[u8]) -> Result<OpaqueStateResponse, String> {
-		let response = StateResponse::decode(response)
-			.map_err(|error| format!("Failed to decode state response: {error}"))?;
-
-		Ok(OpaqueStateResponse(Box::new(response)))
-	}
-
-	fn poll(
-		&mut self,
-		cx: &mut std::task::Context,
-	) -> Poll<PollBlockAnnounceValidation<B::Header>> {
+	fn poll(&mut self, cx: &mut std::task::Context) -> Poll<PollResult<B>> {
 		while let Poll::Ready(Some(event)) = self.service_rx.poll_next_unpin(cx) {
 			match event {
 				ToServiceCommand::SetSyncForkRequest(peers, hash, number) => {
@@ -1753,8 +1429,46 @@ where
 				},
 			}
 		}
+		self.process_outbound_requests();
 
-		self.poll_block_announce_validation(cx)
+		if let Poll::Ready(result) = self.poll_pending_responses(cx) {
+			return Poll::Ready(PollResult::Import(result))
+		}
+
+		if let Poll::Ready(announce) = self.poll_block_announce_validation(cx) {
+			return Poll::Ready(PollResult::Announce(announce))
+		}
+
+		Poll::Pending
+	}
+
+	fn send_block_request(&mut self, who: PeerId, request: BlockRequest<B>) {
+		let (tx, rx) = oneshot::channel();
+		let opaque_req = self.create_opaque_block_request(&request);
+
+		if self.peers.contains_key(&who) {
+			self.pending_responses
+				.push(Box::pin(async move { (who, PeerRequest::Block(request), rx.await) }));
+		}
+
+		match self.encode_block_request(&opaque_req) {
+			Ok(data) => {
+				self.network_service.start_request(
+					who,
+					self.block_request_protocol_name.clone(),
+					data,
+					tx,
+					IfDisconnected::ImmediateError,
+				);
+			},
+			Err(err) => {
+				log::warn!(
+					target: "sync",
+					"Failed to encode block request {:?}: {:?}",
+					opaque_req, err
+				);
+			},
+		}
 	}
 }
 
@@ -1774,12 +1488,30 @@ where
 	pub fn new(
 		mode: SyncMode,
 		client: Arc<Client>,
+		protocol_id: ProtocolId,
+		fork_id: &Option<String>,
+		roles: Roles,
 		block_announce_validator: Box<dyn BlockAnnounceValidator<B> + Send>,
 		max_parallel_downloads: u32,
 		warp_sync_provider: Option<Arc<dyn WarpSyncProvider<B>>>,
-		_network_service: service::network::NetworkServiceHandle,
-	) -> Result<(Self, Box<ChainSyncInterfaceHandle<B>>), ClientError> {
+		network_service: service::network::NetworkServiceHandle,
+		block_request_protocol_name: ProtocolName,
+		state_request_protocol_name: ProtocolName,
+		warp_sync_protocol_name: Option<ProtocolName>,
+	) -> Result<(Self, Box<ChainSyncInterfaceHandle<B>>, NonDefaultSetConfig), ClientError> {
 		let (tx, service_rx) = tracing_unbounded("mpsc_chain_sync");
+		let block_announce_config = Self::get_block_announce_proto_config(
+			protocol_id,
+			fork_id,
+			roles,
+			client.info().best_number,
+			client.info().best_hash,
+			client
+				.block_hash(Zero::zero())
+				.ok()
+				.flatten()
+				.expect("Genesis block exists; qed"),
+		);
 
 		let mut sync = Self {
 			client,
@@ -1803,10 +1535,19 @@ where
 			import_existing: false,
 			gap_sync: None,
 			service_rx,
-			_network_service,
+			network_service,
+			block_request_protocol_name,
+			state_request_protocol_name,
+			warp_sync_protocol_name,
+			block_announce_protocol_name: block_announce_config
+				.notifications_protocol
+				.clone()
+				.into(),
+			pending_responses: Default::default(),
 		};
+
 		sync.reset_sync_start_point()?;
-		Ok((sync, Box::new(ChainSyncInterfaceHandle::new(tx))))
+		Ok((sync, Box::new(ChainSyncInterfaceHandle::new(tx)), block_announce_config))
 	}
 
 	/// Returns the median seen block number.
@@ -2278,7 +2019,6 @@ where
 
 	/// Get config for the block announcement protocol
 	pub fn get_block_announce_proto_config(
-		&self,
 		protocol_id: ProtocolId,
 		fork_id: &Option<String>,
 		roles: Roles,
@@ -2319,6 +2059,644 @@ where
 				out_peers: 0,
 				reserved_nodes: Vec::new(),
 				non_reserved_mode: NonReservedPeerMode::Deny,
+			},
+		}
+	}
+
+	fn decode_block_response(response: &[u8]) -> Result<OpaqueBlockResponse, String> {
+		let response = schema::v1::BlockResponse::decode(response)
+			.map_err(|error| format!("Failed to decode block response: {error}"))?;
+
+		Ok(OpaqueBlockResponse(Box::new(response)))
+	}
+
+	fn decode_state_response(response: &[u8]) -> Result<OpaqueStateResponse, String> {
+		let response = StateResponse::decode(response)
+			.map_err(|error| format!("Failed to decode state response: {error}"))?;
+
+		Ok(OpaqueStateResponse(Box::new(response)))
+	}
+
+	fn send_state_request(&mut self, who: PeerId, request: OpaqueStateRequest) {
+		let (tx, rx) = oneshot::channel();
+
+		if self.peers.contains_key(&who) {
+			self.pending_responses
+				.push(Box::pin(async move { (who, PeerRequest::State, rx.await) }));
+		}
+
+		match self.encode_state_request(&request) {
+			Ok(data) => {
+				self.network_service.start_request(
+					who,
+					self.state_request_protocol_name.clone(),
+					data,
+					tx,
+					IfDisconnected::ImmediateError,
+				);
+			},
+			Err(err) => {
+				log::warn!(
+					target: "sync",
+					"Failed to encode state request {:?}: {:?}",
+					request, err
+				);
+			},
+		}
+	}
+
+	fn send_warp_sync_request(&mut self, who: PeerId, request: WarpProofRequest<B>) {
+		let (tx, rx) = oneshot::channel();
+
+		if self.peers.contains_key(&who) {
+			self.pending_responses
+				.push(Box::pin(async move { (who, PeerRequest::WarpProof, rx.await) }));
+		}
+
+		match &self.warp_sync_protocol_name {
+			Some(name) => self.network_service.start_request(
+				who,
+				name.clone(),
+				request.encode(),
+				tx,
+				IfDisconnected::ImmediateError,
+			),
+			None => {
+				log::warn!(
+					target: "sync",
+					"Trying to send warp sync request when no protocol is configured {:?}",
+					request,
+				);
+			},
+		}
+	}
+
+	pub fn on_block_response(
+		&mut self,
+		peer_id: PeerId,
+		request: BlockRequest<B>,
+		response: OpaqueBlockResponse,
+	) -> Option<ImportResult<B>> {
+		let blocks = match self.block_response_into_blocks(&request, response) {
+			Ok(blocks) => blocks,
+			Err(err) => {
+				debug!(target: "sync", "Failed to decode block response from {}: {}", peer_id, err);
+				self.network_service.report_peer(peer_id, rep::BAD_MESSAGE);
+				return None
+			},
+		};
+
+		let block_response = BlockResponse::<B> { id: request.id, blocks };
+
+		let blocks_range = || match (
+			block_response
+				.blocks
+				.first()
+				.and_then(|b| b.header.as_ref().map(|h| h.number())),
+			block_response.blocks.last().and_then(|b| b.header.as_ref().map(|h| h.number())),
+		) {
+			(Some(first), Some(last)) if first != last => format!(" ({}..{})", first, last),
+			(Some(first), Some(_)) => format!(" ({})", first),
+			_ => Default::default(),
+		};
+		trace!(target: "sync", "BlockResponse {} from {} with {} blocks {}",
+			block_response.id,
+			peer_id,
+			block_response.blocks.len(),
+			blocks_range(),
+		);
+
+		if request.fields == BlockAttributes::JUSTIFICATION {
+			match self.on_block_justification(peer_id, block_response) {
+				Ok(OnBlockJustification::Nothing) => None,
+				Ok(OnBlockJustification::Import { peer, hash, number, justifications }) =>
+					Some(ImportResult::JustificationImport(peer, hash, number, justifications)),
+				Err(BadPeer(id, repu)) => {
+					self.network_service
+						.disconnect_peer(id, self.block_announce_protocol_name.clone());
+					self.network_service.report_peer(id, repu);
+					None
+				},
+			}
+		} else {
+			match self.on_block_data(&peer_id, Some(request), block_response) {
+				Ok(OnBlockData::Import(origin, blocks)) =>
+					Some(ImportResult::BlockImport(origin, blocks)),
+				Ok(OnBlockData::Request(peer, req)) => {
+					self.send_block_request(peer, req);
+					None
+				},
+				Ok(OnBlockData::Continue) => None,
+				Err(BadPeer(id, repu)) => {
+					self.network_service
+						.disconnect_peer(id, self.block_announce_protocol_name.clone());
+					self.network_service.report_peer(id, repu);
+					None
+				},
+			}
+		}
+	}
+
+	pub fn on_state_response(
+		&mut self,
+		peer_id: PeerId,
+		response: OpaqueStateResponse,
+	) -> Option<ImportResult<B>> {
+		match self.on_state_data(&peer_id, response) {
+			Ok(OnStateData::Import(origin, block)) =>
+				Some(ImportResult::BlockImport(origin, vec![block])),
+			Ok(OnStateData::Continue) => None,
+			Err(BadPeer(id, repu)) => {
+				self.network_service
+					.disconnect_peer(id, self.block_announce_protocol_name.clone());
+				self.network_service.report_peer(id, repu);
+				None
+			},
+		}
+	}
+
+	pub fn on_warp_sync_response(&mut self, peer_id: PeerId, response: EncodedProof) {
+		if let Err(BadPeer(id, repu)) = self.on_warp_sync_data(&peer_id, response) {
+			self.network_service
+				.disconnect_peer(id, self.block_announce_protocol_name.clone());
+			self.network_service.report_peer(id, repu);
+		}
+	}
+
+	fn process_outbound_requests(&mut self) {
+		for (id, request) in self
+			.block_requests()
+			.map(|(peer_id, request)| (peer_id, request))
+			.collect::<Vec<_>>()
+		{
+			self.send_block_request(id, request);
+		}
+
+		if let Some((id, request)) = self.state_request() {
+			self.send_state_request(id, request);
+		}
+
+		for (id, request) in self.justification_requests().collect::<Vec<_>>() {
+			self.send_block_request(id, request);
+		}
+
+		if let Some((id, request)) = self.warp_sync_request() {
+			self.send_warp_sync_request(id, request);
+		}
+	}
+
+	fn poll_pending_responses(&mut self, cx: &mut std::task::Context) -> Poll<ImportResult<B>> {
+		while let Poll::Ready(Some((id, request, response))) =
+			self.pending_responses.poll_next_unpin(cx)
+		{
+			match response {
+				Ok(Ok(resp)) => match request {
+					PeerRequest::Block(req) => {
+						let response = match Self::decode_block_response(&resp[..]) {
+							Ok(proto) => proto,
+							Err(e) => {
+								debug!(
+									target: "sync",
+									"Failed to decode block response from peer {:?}: {:?}.",
+									id,
+									e
+								);
+								self.network_service.report_peer(id, rep::BAD_MESSAGE);
+								self.network_service
+									.disconnect_peer(id, self.block_announce_protocol_name.clone());
+								continue
+							},
+						};
+
+						if let Some(import) = self.on_block_response(id, req, response) {
+							return Poll::Ready(import)
+						}
+					},
+					PeerRequest::State => {
+						let response = match Self::decode_state_response(&resp[..]) {
+							Ok(proto) => proto,
+							Err(e) => {
+								debug!(
+									target: "sync",
+									"Failed to decode state response from peer {:?}: {:?}.",
+									id,
+									e
+								);
+								self.network_service.report_peer(id, rep::BAD_MESSAGE);
+								self.network_service
+									.disconnect_peer(id, self.block_announce_protocol_name.clone());
+								continue
+							},
+						};
+
+						if let Some(import) = self.on_state_response(id, response) {
+							return Poll::Ready(import)
+						}
+					},
+					PeerRequest::WarpProof => {
+						self.on_warp_sync_response(id, EncodedProof(resp));
+					},
+				},
+				Ok(Err(e)) => {
+					debug!(target: "sync", "Request to peer {:?} failed: {:?}.", id, e);
+
+					match e {
+						RequestFailure::Network(OutboundFailure::Timeout) => {
+							self.network_service.report_peer(id, rep::TIMEOUT);
+							self.network_service
+								.disconnect_peer(id, self.block_announce_protocol_name.clone());
+						},
+						RequestFailure::Network(OutboundFailure::UnsupportedProtocols) => {
+							self.network_service.report_peer(id, rep::BAD_PROTOCOL);
+							self.network_service
+								.disconnect_peer(id, self.block_announce_protocol_name.clone());
+						},
+						RequestFailure::Network(OutboundFailure::DialFailure) => {
+							self.network_service
+								.disconnect_peer(id, self.block_announce_protocol_name.clone());
+						},
+						RequestFailure::Refused => {
+							self.network_service.report_peer(id, rep::REFUSED);
+							self.network_service
+								.disconnect_peer(id, self.block_announce_protocol_name.clone());
+						},
+						RequestFailure::Network(OutboundFailure::ConnectionClosed) |
+						RequestFailure::NotConnected => {
+							self.network_service
+								.disconnect_peer(id, self.block_announce_protocol_name.clone());
+						},
+						RequestFailure::UnknownProtocol => {
+							debug_assert!(false, "Block request protocol should always be known.");
+						},
+						RequestFailure::Obsolete => {
+							debug_assert!(
+								false,
+								"Can not receive `RequestFailure::Obsolete` after dropping the \
+								 response receiver.",
+							);
+						},
+					}
+				},
+				Err(oneshot::Canceled) => {
+					trace!(
+						target: "sync",
+						"Request to peer {:?} failed due to oneshot being canceled.",
+						id,
+					);
+					self.network_service
+						.disconnect_peer(id, self.block_announce_protocol_name.clone());
+				},
+			}
+		}
+
+		Poll::Pending
+	}
+
+	/// Create implementation-specific block request.
+	fn create_opaque_block_request(&self, request: &BlockRequest<B>) -> OpaqueBlockRequest {
+		OpaqueBlockRequest(Box::new(schema::v1::BlockRequest {
+			fields: request.fields.to_be_u32(),
+			from_block: match request.from {
+				FromBlock::Hash(h) => Some(schema::v1::block_request::FromBlock::Hash(h.encode())),
+				FromBlock::Number(n) =>
+					Some(schema::v1::block_request::FromBlock::Number(n.encode())),
+			},
+			direction: request.direction as i32,
+			max_blocks: request.max.unwrap_or(0),
+			support_multiple_justifications: true,
+		}))
+	}
+
+	fn encode_block_request(&self, request: &OpaqueBlockRequest) -> Result<Vec<u8>, String> {
+		let request: &schema::v1::BlockRequest = request.0.downcast_ref().ok_or_else(|| {
+			"Failed to downcast opaque block response during encoding, this is an \
+				implementation bug."
+				.to_string()
+		})?;
+
+		Ok(request.encode_to_vec())
+	}
+
+	fn encode_state_request(&self, request: &OpaqueStateRequest) -> Result<Vec<u8>, String> {
+		let request: &StateRequest = request.0.downcast_ref().ok_or_else(|| {
+			"Failed to downcast opaque state response during encoding, this is an \
+				implementation bug."
+				.to_string()
+		})?;
+
+		Ok(request.encode_to_vec())
+	}
+
+	fn justification_requests<'a>(
+		&'a mut self,
+	) -> Box<dyn Iterator<Item = (PeerId, BlockRequest<B>)> + 'a> {
+		let peers = &mut self.peers;
+		let mut matcher = self.extra_justifications.matcher();
+		Box::new(std::iter::from_fn(move || {
+			if let Some((peer, request)) = matcher.next(peers) {
+				peers
+					.get_mut(&peer)
+					.expect(
+						"`Matcher::next` guarantees the `PeerId` comes from the given peers; qed",
+					)
+					.state = PeerSyncState::DownloadingJustification(request.0);
+				let req = BlockRequest::<B> {
+					id: 0,
+					fields: BlockAttributes::JUSTIFICATION,
+					from: FromBlock::Hash(request.0),
+					direction: Direction::Ascending,
+					max: Some(1),
+				};
+				Some((peer, req))
+			} else {
+				None
+			}
+		}))
+	}
+
+	fn block_requests<'a>(
+		&'a mut self,
+	) -> Box<dyn Iterator<Item = (PeerId, BlockRequest<B>)> + 'a> {
+		if self.mode == SyncMode::Warp {
+			return Box::new(std::iter::once(self.warp_target_block_request()).flatten())
+		}
+
+		if self.allowed_requests.is_empty() || self.state_sync.is_some() {
+			return Box::new(std::iter::empty())
+		}
+
+		if self.queue_blocks.len() > MAX_IMPORTING_BLOCKS {
+			trace!(target: "sync", "Too many blocks in the queue.");
+			return Box::new(std::iter::empty())
+		}
+		let is_major_syncing = self.status().state.is_major_syncing();
+		let attrs = self.required_block_attributes();
+		let blocks = &mut self.blocks;
+		let fork_targets = &mut self.fork_targets;
+		let last_finalized =
+			std::cmp::min(self.best_queued_number, self.client.info().finalized_number);
+		let best_queued = self.best_queued_number;
+		let client = &self.client;
+		let queue = &self.queue_blocks;
+		let allowed_requests = self.allowed_requests.take();
+		let max_parallel = if is_major_syncing { 1 } else { self.max_parallel_downloads };
+		let gap_sync = &mut self.gap_sync;
+		let iter = self.peers.iter_mut().filter_map(move |(&id, peer)| {
+			if !peer.state.is_available() || !allowed_requests.contains(&id) {
+				return None
+			}
+
+			// If our best queued is more than `MAX_BLOCKS_TO_LOOK_BACKWARDS` blocks away from the
+			// common number, the peer best number is higher than our best queued and the common
+			// number is smaller than the last finalized block number, we should do an ancestor
+			// search to find a better common block. If the queue is full we wait till all blocks
+			// are imported though.
+			if best_queued.saturating_sub(peer.common_number) > MAX_BLOCKS_TO_LOOK_BACKWARDS.into() &&
+				best_queued < peer.best_number &&
+				peer.common_number < last_finalized &&
+				queue.len() <= MAJOR_SYNC_BLOCKS.into()
+			{
+				trace!(
+					target: "sync",
+					"Peer {:?} common block {} too far behind of our best {}. Starting ancestry search.",
+					id,
+					peer.common_number,
+					best_queued,
+				);
+				let current = std::cmp::min(peer.best_number, best_queued);
+				peer.state = PeerSyncState::AncestorSearch {
+					current,
+					start: best_queued,
+					state: AncestorSearchState::ExponentialBackoff(One::one()),
+				};
+				Some((id, ancestry_request::<B>(current)))
+			} else if let Some((range, req)) = peer_block_request(
+				&id,
+				peer,
+				blocks,
+				attrs,
+				max_parallel,
+				last_finalized,
+				best_queued,
+			) {
+				peer.state = PeerSyncState::DownloadingNew(range.start);
+				trace!(
+					target: "sync",
+					"New block request for {}, (best:{}, common:{}) {:?}",
+					id,
+					peer.best_number,
+					peer.common_number,
+					req,
+				);
+				Some((id, req))
+			} else if let Some((hash, req)) =
+				fork_sync_request(&id, fork_targets, best_queued, last_finalized, attrs, |hash| {
+					if queue.contains(hash) {
+						BlockStatus::Queued
+					} else {
+						client.block_status(&BlockId::Hash(*hash)).unwrap_or(BlockStatus::Unknown)
+					}
+				}) {
+				trace!(target: "sync", "Downloading fork {:?} from {}", hash, id);
+				peer.state = PeerSyncState::DownloadingStale(hash);
+				Some((id, req))
+			} else if let Some((range, req)) = gap_sync.as_mut().and_then(|sync| {
+				peer_gap_block_request(
+					&id,
+					peer,
+					&mut sync.blocks,
+					attrs,
+					sync.target,
+					sync.best_queued_number,
+				)
+			}) {
+				peer.state = PeerSyncState::DownloadingGap(range.start);
+				trace!(
+					target: "sync",
+					"New gap block request for {}, (best:{}, common:{}) {:?}",
+					id,
+					peer.best_number,
+					peer.common_number,
+					req,
+				);
+				Some((id, req))
+			} else {
+				None
+			}
+		});
+		Box::new(iter)
+	}
+
+	fn state_request(&mut self) -> Option<(PeerId, OpaqueStateRequest)> {
+		if self.allowed_requests.is_empty() {
+			return None
+		}
+		if (self.state_sync.is_some() || self.warp_sync.is_some()) &&
+			self.peers.iter().any(|(_, peer)| peer.state == PeerSyncState::DownloadingState)
+		{
+			// Only one pending state request is allowed.
+			return None
+		}
+		if let Some(sync) = &self.state_sync {
+			if sync.is_complete() {
+				return None
+			}
+
+			for (id, peer) in self.peers.iter_mut() {
+				if peer.state.is_available() && peer.common_number >= sync.target_block_num() {
+					peer.state = PeerSyncState::DownloadingState;
+					let request = sync.next_request();
+					trace!(target: "sync", "New StateRequest for {}: {:?}", id, request);
+					self.allowed_requests.clear();
+					return Some((*id, OpaqueStateRequest(Box::new(request))))
+				}
+			}
+		}
+		if let Some(sync) = &self.warp_sync {
+			if sync.is_complete() {
+				return None
+			}
+			if let (Some(request), Some(target)) =
+				(sync.next_state_request(), sync.target_block_number())
+			{
+				for (id, peer) in self.peers.iter_mut() {
+					if peer.state.is_available() && peer.best_number >= target {
+						trace!(target: "sync", "New StateRequest for {}: {:?}", id, request);
+						peer.state = PeerSyncState::DownloadingState;
+						self.allowed_requests.clear();
+						return Some((*id, OpaqueStateRequest(Box::new(request))))
+					}
+				}
+			}
+		}
+		None
+	}
+
+	fn warp_sync_request(&mut self) -> Option<(PeerId, WarpProofRequest<B>)> {
+		if let Some(sync) = &self.warp_sync {
+			if self.allowed_requests.is_empty() ||
+				sync.is_complete() ||
+				self.peers
+					.iter()
+					.any(|(_, peer)| peer.state == PeerSyncState::DownloadingWarpProof)
+			{
+				// Only one pending state request is allowed.
+				return None
+			}
+			if let Some(request) = sync.next_warp_proof_request() {
+				let mut targets: Vec<_> = self.peers.values().map(|p| p.best_number).collect();
+				if !targets.is_empty() {
+					targets.sort();
+					let median = targets[targets.len() / 2];
+					// Find a random peer that is synced as much as peer majority.
+					for (id, peer) in self.peers.iter_mut() {
+						if peer.state.is_available() && peer.best_number >= median {
+							trace!(target: "sync", "New WarpProofRequest for {}", id);
+							peer.state = PeerSyncState::DownloadingWarpProof;
+							self.allowed_requests.clear();
+							return Some((*id, request))
+						}
+					}
+				}
+			}
+		}
+		None
+	}
+
+	fn on_state_data(
+		&mut self,
+		who: &PeerId,
+		response: OpaqueStateResponse,
+	) -> Result<OnStateData<B>, BadPeer> {
+		let response: Box<StateResponse> = response.0.downcast().map_err(|_error| {
+			error!(
+				target: "sync",
+				"Failed to downcast opaque state response, this is an implementation bug."
+			);
+
+			BadPeer(*who, rep::BAD_RESPONSE)
+		})?;
+
+		if let Some(peer) = self.peers.get_mut(who) {
+			if let PeerSyncState::DownloadingState = peer.state {
+				peer.state = PeerSyncState::Available;
+				self.allowed_requests.set_all();
+			}
+		}
+		let import_result = if let Some(sync) = &mut self.state_sync {
+			debug!(
+				target: "sync",
+				"Importing state data from {} with {} keys, {} proof nodes.",
+				who,
+				response.entries.len(),
+				response.proof.len(),
+			);
+			sync.import(*response)
+		} else if let Some(sync) = &mut self.warp_sync {
+			debug!(
+				target: "sync",
+				"Importing state data from {} with {} keys, {} proof nodes.",
+				who,
+				response.entries.len(),
+				response.proof.len(),
+			);
+			sync.import_state(*response)
+		} else {
+			debug!(target: "sync", "Ignored obsolete state response from {}", who);
+			return Err(BadPeer(*who, rep::NOT_REQUESTED))
+		};
+
+		match import_result {
+			state::ImportResult::Import(hash, header, state, body, justifications) => {
+				let origin = BlockOrigin::NetworkInitialSync;
+				let block = IncomingBlock {
+					hash,
+					header: Some(header),
+					body,
+					indexed_body: None,
+					justifications,
+					origin: None,
+					allow_missing_state: true,
+					import_existing: true,
+					skip_execution: self.skip_execution(),
+					state: Some(state),
+				};
+				debug!(target: "sync", "State download is complete. Import is queued");
+				Ok(OnStateData::Import(origin, block))
+			},
+			state::ImportResult::Continue => Ok(OnStateData::Continue),
+			state::ImportResult::BadResponse => {
+				debug!(target: "sync", "Bad state data received from {}", who);
+				Err(BadPeer(*who, rep::BAD_BLOCK))
+			},
+		}
+	}
+
+	fn on_warp_sync_data(&mut self, who: &PeerId, response: EncodedProof) -> Result<(), BadPeer> {
+		if let Some(peer) = self.peers.get_mut(who) {
+			if let PeerSyncState::DownloadingWarpProof = peer.state {
+				peer.state = PeerSyncState::Available;
+				self.allowed_requests.set_all();
+			}
+		}
+		let import_result = if let Some(sync) = &mut self.warp_sync {
+			debug!(
+				target: "sync",
+				"Importing warp proof data from {}, {} bytes.",
+				who,
+				response.0.len(),
+			);
+			sync.import_warp_proof(response)
+		} else {
+			debug!(target: "sync", "Ignored obsolete warp sync response from {}", who);
+			return Err(BadPeer(*who, rep::NOT_REQUESTED))
+		};
+
+		match import_result {
+			WarpProofImportResult::Success => Ok(()),
+			WarpProofImportResult::BadResponse => {
+				debug!(target: "sync", "Bad proof data received from {}", who);
+				Err(BadPeer(*who, rep::BAD_BLOCK))
 			},
 		}
 	}
@@ -2677,7 +3055,10 @@ mod test {
 	use crate::service::network::NetworkServiceProvider;
 	use futures::{executor::block_on, future::poll_fn};
 	use sc_block_builder::BlockBuilderProvider;
-	use sc_network_common::sync::message::{BlockData, BlockState, FromBlock};
+	use sc_network_common::{
+		protocol::role::Role,
+		sync::message::{BlockData, BlockState, FromBlock},
+	};
 	use sp_blockchain::HeaderBackend;
 	use sp_consensus::block_validation::DefaultBlockAnnounceValidator;
 	use substrate_test_runtime_client::{
@@ -2698,13 +3079,19 @@ mod test {
 
 		let (_chain_sync_network_provider, chain_sync_network_handle) =
 			NetworkServiceProvider::new();
-		let (mut sync, _) = ChainSync::new(
+		let (mut sync, _, _) = ChainSync::new(
 			SyncMode::Full,
 			client.clone(),
+			ProtocolId::from("test-protocol-name"),
+			&Some(String::from("test-fork-id")),
+			Roles::from(&Role::Full),
 			block_announce_validator,
 			1,
 			None,
 			chain_sync_network_handle,
+			ProtocolName::from("block-request"),
+			ProtocolName::from("state-request"),
+			None,
 		)
 		.unwrap();
 
@@ -2755,13 +3142,19 @@ mod test {
 		let (_chain_sync_network_provider, chain_sync_network_handle) =
 			NetworkServiceProvider::new();
 
-		let (mut sync, _) = ChainSync::new(
+		let (mut sync, _, _) = ChainSync::new(
 			SyncMode::Full,
 			client.clone(),
+			ProtocolId::from("test-protocol-name"),
+			&Some(String::from("test-fork-id")),
+			Roles::from(&Role::Full),
 			Box::new(DefaultBlockAnnounceValidator),
 			1,
 			None,
 			chain_sync_network_handle,
+			ProtocolName::from("block-request"),
+			ProtocolName::from("state-request"),
+			None,
 		)
 		.unwrap();
 
@@ -2925,13 +3318,19 @@ mod test {
 		let (_chain_sync_network_provider, chain_sync_network_handle) =
 			NetworkServiceProvider::new();
 
-		let (mut sync, _) = ChainSync::new(
+		let (mut sync, _, _) = ChainSync::new(
 			SyncMode::Full,
 			client.clone(),
+			ProtocolId::from("test-protocol-name"),
+			&Some(String::from("test-fork-id")),
+			Roles::from(&Role::Full),
 			Box::new(DefaultBlockAnnounceValidator),
 			5,
 			None,
 			chain_sync_network_handle,
+			ProtocolName::from("block-request"),
+			ProtocolName::from("state-request"),
+			None,
 		)
 		.unwrap();
 
@@ -3043,13 +3442,19 @@ mod test {
 			NetworkServiceProvider::new();
 		let info = client.info();
 
-		let (mut sync, _) = ChainSync::new(
+		let (mut sync, _, _) = ChainSync::new(
 			SyncMode::Full,
 			client.clone(),
+			ProtocolId::from("test-protocol-name"),
+			&Some(String::from("test-fork-id")),
+			Roles::from(&Role::Full),
 			Box::new(DefaultBlockAnnounceValidator),
 			5,
 			None,
 			chain_sync_network_handle,
+			ProtocolName::from("block-request"),
+			ProtocolName::from("state-request"),
+			None,
 		)
 		.unwrap();
 
@@ -3189,13 +3594,19 @@ mod test {
 
 		let info = client.info();
 
-		let (mut sync, _) = ChainSync::new(
+		let (mut sync, _, _) = ChainSync::new(
 			SyncMode::Full,
 			client.clone(),
+			ProtocolId::from("test-protocol-name"),
+			&Some(String::from("test-fork-id")),
+			Roles::from(&Role::Full),
 			Box::new(DefaultBlockAnnounceValidator),
 			5,
 			None,
 			chain_sync_network_handle,
+			ProtocolName::from("block-request"),
+			ProtocolName::from("state-request"),
+			None,
 		)
 		.unwrap();
 
@@ -3321,13 +3732,19 @@ mod test {
 
 		let info = client.info();
 
-		let (mut sync, _) = ChainSync::new(
+		let (mut sync, _, _) = ChainSync::new(
 			SyncMode::Full,
 			client.clone(),
+			ProtocolId::from("test-protocol-name"),
+			&Some(String::from("test-fork-id")),
+			Roles::from(&Role::Full),
 			Box::new(DefaultBlockAnnounceValidator),
 			5,
 			None,
 			chain_sync_network_handle,
+			ProtocolName::from("block-request"),
+			ProtocolName::from("state-request"),
+			None,
 		)
 		.unwrap();
 
@@ -3453,13 +3870,19 @@ mod test {
 		let mut client = Arc::new(TestClientBuilder::new().build());
 		let blocks = (0..3).map(|_| build_block(&mut client, None, false)).collect::<Vec<_>>();
 
-		let (mut sync, _) = ChainSync::new(
+		let (mut sync, _, _) = ChainSync::new(
 			SyncMode::Full,
 			client.clone(),
+			ProtocolId::from("test-protocol-name"),
+			&Some(String::from("test-fork-id")),
+			Roles::from(&Role::Full),
 			Box::new(DefaultBlockAnnounceValidator),
 			1,
 			None,
 			chain_sync_network_handle,
+			ProtocolName::from("block-request"),
+			ProtocolName::from("state-request"),
+			None,
 		)
 		.unwrap();
 
@@ -3489,13 +3912,19 @@ mod test {
 
 		let empty_client = Arc::new(TestClientBuilder::new().build());
 
-		let (mut sync, _) = ChainSync::new(
+		let (mut sync, _, _) = ChainSync::new(
 			SyncMode::Full,
 			empty_client.clone(),
+			ProtocolId::from("test-protocol-name"),
+			&Some(String::from("test-fork-id")),
+			Roles::from(&Role::Full),
 			Box::new(DefaultBlockAnnounceValidator),
 			1,
 			None,
 			chain_sync_network_handle,
+			ProtocolName::from("block-request"),
+			ProtocolName::from("state-request"),
+			None,
 		)
 		.unwrap();
 

--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -2228,9 +2228,7 @@ where
 	}
 
 	fn process_outbound_requests(&mut self) {
-		for (id, request) in self
-			.block_requests()
-		{
+		for (id, request) in self.block_requests() {
 			self.send_block_request(id, request);
 		}
 

--- a/client/network/sync/src/service/network.rs
+++ b/client/network/sync/src/service/network.rs
@@ -16,17 +16,21 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use futures::StreamExt;
+use futures::{channel::oneshot, StreamExt};
 use libp2p::PeerId;
-use sc_network_common::{protocol::ProtocolName, service::NetworkPeers};
+use sc_network_common::{
+	protocol::ProtocolName,
+	request_responses::{IfDisconnected, RequestFailure},
+	service::{NetworkPeers, NetworkRequest},
+};
 use sc_peerset::ReputationChange;
 use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnboundedSender};
 use std::sync::Arc;
 
 /// Network-related services required by `sc-network-sync`
-pub trait Network: NetworkPeers {}
+pub trait Network: NetworkPeers + NetworkRequest {}
 
-impl<T> Network for T where T: NetworkPeers {}
+impl<T> Network for T where T: NetworkPeers + NetworkRequest {}
 
 /// Network service provider for `ChainSync`
 ///
@@ -43,6 +47,15 @@ pub enum ToServiceCommand {
 
 	/// Call `NetworkPeers::report_peer()`
 	ReportPeer(PeerId, ReputationChange),
+
+	/// Call `NetworkRequest::start_request()`
+	StartRequest(
+		PeerId,
+		ProtocolName,
+		Vec<u8>,
+		oneshot::Sender<Result<Vec<u8>, RequestFailure>>,
+		IfDisconnected,
+	),
 }
 
 /// Handle that is (temporarily) passed to `ChainSync` so it can
@@ -67,6 +80,19 @@ impl NetworkServiceHandle {
 	pub fn disconnect_peer(&self, who: PeerId, protocol: ProtocolName) {
 		let _ = self.tx.unbounded_send(ToServiceCommand::DisconnectPeer(who, protocol));
 	}
+
+	pub fn start_request(
+		&self,
+		who: PeerId,
+		protocol: ProtocolName,
+		request: Vec<u8>,
+		tx: oneshot::Sender<Result<Vec<u8>, RequestFailure>>,
+		connect: IfDisconnected,
+	) {
+		let _ = self
+			.tx
+			.unbounded_send(ToServiceCommand::StartRequest(who, protocol, request, tx, connect));
+	}
 }
 
 impl NetworkServiceProvider {
@@ -85,6 +111,8 @@ impl NetworkServiceProvider {
 					service.disconnect_peer(peer, protocol_name),
 				ToServiceCommand::ReportPeer(peer, reputation_change) =>
 					service.report_peer(peer, reputation_change),
+				ToServiceCommand::StartRequest(peer, protocol, request, tx, connect) =>
+					service.start_request(peer, protocol, request, tx, connect),
 			}
 		}
 	}

--- a/client/network/sync/src/service/network.rs
+++ b/client/network/sync/src/service/network.rs
@@ -81,6 +81,7 @@ impl NetworkServiceHandle {
 		let _ = self.tx.unbounded_send(ToServiceCommand::DisconnectPeer(who, protocol));
 	}
 
+	/// Send request to peer
 	pub fn start_request(
 		&self,
 		who: PeerId,

--- a/client/network/sync/src/tests.rs
+++ b/client/network/sync/src/tests.rs
@@ -19,7 +19,15 @@
 use crate::{service::network::NetworkServiceProvider, ChainSync, ForkTarget};
 
 use libp2p::PeerId;
-use sc_network_common::{service::NetworkSyncForkRequest, sync::ChainSync as ChainSyncT};
+use sc_network_common::{
+	config::ProtocolId,
+	protocol::{
+		role::{Role, Roles},
+		ProtocolName,
+	},
+	service::NetworkSyncForkRequest,
+	sync::ChainSync as ChainSyncT,
+};
 use sp_consensus::block_validation::DefaultBlockAnnounceValidator;
 use sp_core::H256;
 use std::{sync::Arc, task::Poll};
@@ -30,13 +38,19 @@ use substrate_test_runtime_client::{TestClientBuilder, TestClientBuilderExt as _
 #[async_std::test]
 async fn delegate_to_chainsync() {
 	let (_chain_sync_network_provider, chain_sync_network_handle) = NetworkServiceProvider::new();
-	let (mut chain_sync, chain_sync_service) = ChainSync::new(
+	let (mut chain_sync, chain_sync_service, _) = ChainSync::new(
 		sc_network_common::sync::SyncMode::Full,
 		Arc::new(TestClientBuilder::with_default_backend().build_with_longest_chain().0),
+		ProtocolId::from("test-protocol-name"),
+		&Some(String::from("test-fork-id")),
+		Roles::from(&Role::Full),
 		Box::new(DefaultBlockAnnounceValidator),
 		1u32,
 		None,
 		chain_sync_network_handle,
+		ProtocolName::from("block-request"),
+		ProtocolName::from("state-request"),
+		None,
 	)
 	.unwrap();
 

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -77,7 +77,7 @@ use sp_core::H256;
 use sp_runtime::{
 	codec::{Decode, Encode},
 	generic::{BlockId, OpaqueDigestItemId},
-	traits::{Block as BlockT, Header as HeaderT, NumberFor, Zero},
+	traits::{Block as BlockT, Header as HeaderT, NumberFor},
 	Justification, Justifications,
 };
 use substrate_test_runtime_client::AccountKeyring;
@@ -869,7 +869,7 @@ where
 			.unwrap_or_else(|| Box::new(DefaultBlockAnnounceValidator));
 		let (chain_sync_network_provider, chain_sync_network_handle) =
 			NetworkServiceProvider::new();
-		let (chain_sync, chain_sync_service) = ChainSync::new(
+		let (chain_sync, chain_sync_service, block_announce_config) = ChainSync::new(
 			match network_config.sync_mode {
 				SyncMode::Full => sc_network_common::sync::SyncMode::Full,
 				SyncMode::Fast { skip_proofs, storage_chain_mode } =>
@@ -880,24 +880,18 @@ where
 				SyncMode::Warp => sc_network_common::sync::SyncMode::Warp,
 			},
 			client.clone(),
+			protocol_id.clone(),
+			&fork_id,
+			Roles::from(if config.is_authority { &Role::Authority } else { &Role::Full }),
 			block_announce_validator,
 			network_config.max_parallel_downloads,
 			Some(warp_sync),
 			chain_sync_network_handle,
+			block_request_protocol_config.name.clone(),
+			state_request_protocol_config.name.clone(),
+			Some(warp_protocol_config.name.clone()),
 		)
 		.unwrap();
-		let block_announce_config = chain_sync.get_block_announce_proto_config(
-			protocol_id.clone(),
-			&fork_id,
-			Roles::from(if config.is_authority { &Role::Authority } else { &Role::Full }),
-			client.info().best_number,
-			client.info().best_hash,
-			client
-				.block_hash(Zero::zero())
-				.ok()
-				.flatten()
-				.expect("Genesis block exists; qed"),
-		);
 
 		let network = NetworkWorker::new(sc_network::config::Params {
 			role: if config.is_authority { Role::Authority } else { Role::Full },
@@ -911,11 +905,13 @@ where
 			chain_sync_service,
 			metrics_registry: None,
 			block_announce_config,
-			block_request_protocol_config,
-			state_request_protocol_config,
-			light_client_request_protocol_config,
-			warp_sync_protocol_config: Some(warp_protocol_config),
-			request_response_protocol_configs: Vec::new(),
+			request_response_protocol_configs: [
+				block_request_protocol_config,
+				state_request_protocol_config,
+				light_client_request_protocol_config,
+				warp_protocol_config,
+			]
+			.to_vec(),
 		})
 		.unwrap();
 
@@ -994,6 +990,7 @@ where
 				return Poll::Pending
 			}
 		}
+
 		Poll::Ready(())
 	}
 

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -856,7 +856,7 @@ where
 		client.clone(),
 		protocol_id.clone(),
 		&config.chain_spec.fork_id().map(ToOwned::to_owned),
-		Roles::from(&config.role.clone()),
+		Roles::from(&config.role),
 		block_announce_validator,
 		config.network.max_parallel_downloads,
 		warp_sync_provider,

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -846,7 +846,7 @@ where
 	};
 
 	let (chain_sync_network_provider, chain_sync_network_handle) = NetworkServiceProvider::new();
-	let (chain_sync, chain_sync_service) = ChainSync::new(
+	let (chain_sync, chain_sync_service, block_announce_config) = ChainSync::new(
 		match config.network.sync_mode {
 			SyncMode::Full => sc_network_common::sync::SyncMode::Full,
 			SyncMode::Fast { skip_proofs, storage_chain_mode } =>
@@ -854,24 +854,17 @@ where
 			SyncMode::Warp => sc_network_common::sync::SyncMode::Warp,
 		},
 		client.clone(),
+		protocol_id.clone(),
+		&config.chain_spec.fork_id().map(ToOwned::to_owned),
+		Roles::from(&config.role.clone()),
 		block_announce_validator,
 		config.network.max_parallel_downloads,
 		warp_sync_provider,
 		chain_sync_network_handle,
+		block_request_protocol_config.name.clone(),
+		state_request_protocol_config.name.clone(),
+		warp_sync_protocol_config.as_ref().map(|config| config.name.clone()),
 	)?;
-
-	let block_announce_config = chain_sync.get_block_announce_proto_config(
-		protocol_id.clone(),
-		&config.chain_spec.fork_id().map(ToOwned::to_owned),
-		Roles::from(&config.role.clone()),
-		client.info().best_number,
-		client.info().best_hash,
-		client
-			.block_hash(Zero::zero())
-			.ok()
-			.flatten()
-			.expect("Genesis block exists; qed"),
-	);
 
 	request_response_protocol_configs.push(config.network.ipfs_server.then(|| {
 		let (handler, protocol_config) = BitswapRequestHandler::new(client.clone());
@@ -896,12 +889,14 @@ where
 		chain_sync_service,
 		metrics_registry: config.prometheus_config.as_ref().map(|config| config.registry.clone()),
 		block_announce_config,
-		block_request_protocol_config,
-		state_request_protocol_config,
-		warp_sync_protocol_config,
-		light_client_request_protocol_config,
 		request_response_protocol_configs: request_response_protocol_configs
 			.into_iter()
+			.chain([
+				Some(block_request_protocol_config),
+				Some(state_request_protocol_config),
+				Some(light_client_request_protocol_config),
+				warp_sync_protocol_config,
+			])
 			.flatten()
 			.collect::<Vec<_>>(),
 	};


### PR DESCRIPTION
This PR moves most of the code related to block requests away from `Protocol`/`Behaviour`/`NetworkWorker` to `ChainSync`. There is still a bit of block request code left relating to incoming peer connection/block announcements but those will be addressed in future PRs.

Resolves https://github.com/paritytech/substrate/issues/12133

polkadot companion: https://github.com/paritytech/polkadot/pull/6319
cumulus companion: https://github.com/paritytech/cumulus/pull/1899