### PR TITLE
return error instead of expect in `feasibility_check`

### DIFF
--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -1552,7 +1552,7 @@ impl<T: Config> Pallet<T> {
 		// Size of winners in miner solution is equal to `desired_targets` <= `MaxWinners`.
 		let supports = supports
 			.try_into()
-			.defensive_map_err(|_| FeasibilityError::BoundedConversionFailed);
+			.defensive_map_err(|_| FeasibilityError::BoundedConversionFailed)?;
 		Ok(ReadySolution { supports, compute, score })
 	}
 

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -237,7 +237,7 @@ use frame_election_provider_support::{
 use frame_support::{
 	dispatch::DispatchClass,
 	ensure,
-	traits::{Currency, Get, OnUnbalanced, ReservableCurrency},
+	traits::{Currency, DefensiveResult, Get, OnUnbalanced, ReservableCurrency},
 	weights::Weight,
 	DefaultNoBound, EqNoBound, PartialEqNoBound,
 };
@@ -551,7 +551,6 @@ pub enum FeasibilityError {
 	///
 	/// Should never happen under correct configurations.
 	BoundedConversionFailed,
-
 }
 
 impl From<sp_npos_elections::Error> for FeasibilityError {
@@ -565,10 +564,7 @@ pub use pallet::*;
 pub mod pallet {
 	use super::*;
 	use frame_election_provider_support::{InstantElectionProvider, NposSolver};
-	use frame_support::{
-		pallet_prelude::*,
-		traits::{DefensiveResult, EstimateCallFee},
-	};
+	use frame_support::{pallet_prelude::*, traits::EstimateCallFee};
 	use frame_system::pallet_prelude::*;
 
 	#[pallet::config]
@@ -1554,7 +1550,9 @@ impl<T: Config> Pallet<T> {
 		ensure!(known_score == score, FeasibilityError::InvalidScore);
 
 		// Size of winners in miner solution is equal to `desired_targets` <= `MaxWinners`.
-		let supports = supports.try_into().defensive_map_err(|_| FeasibilityError::BoundedConversionFailed);
+		let supports = supports
+			.try_into()
+			.defensive_map_err(|_| FeasibilityError::BoundedConversionFailed);
 		Ok(ReadySolution { supports, compute, score })
 	}
 

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -547,6 +547,11 @@ pub enum FeasibilityError {
 	UntrustedScoreTooLow,
 	/// Data Provider returned too many desired targets
 	TooManyDesiredTargets,
+	/// Conversion into bounded types failed.
+	///
+	/// Should never happen under correct configurations.
+	BoundedConversionFailed,
+	
 }
 
 impl From<sp_npos_elections::Error> for FeasibilityError {
@@ -1549,7 +1554,7 @@ impl<T: Config> Pallet<T> {
 		ensure!(known_score == score, FeasibilityError::InvalidScore);
 
 		// Size of winners in miner solution is equal to `desired_targets` <= `MaxWinners`.
-		let supports = supports.try_into().expect("checked desired_targets <= MaxWinners; qed");
+		let supports = supports.try_into().map_err(|_| FeasibilityError::BoundedConversionFailed);
 		Ok(ReadySolution { supports, compute, score })
 	}
 

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -551,7 +551,7 @@ pub enum FeasibilityError {
 	///
 	/// Should never happen under correct configurations.
 	BoundedConversionFailed,
-	
+
 }
 
 impl From<sp_npos_elections::Error> for FeasibilityError {
@@ -1554,7 +1554,7 @@ impl<T: Config> Pallet<T> {
 		ensure!(known_score == score, FeasibilityError::InvalidScore);
 
 		// Size of winners in miner solution is equal to `desired_targets` <= `MaxWinners`.
-		let supports = supports.try_into().map_err(|_| FeasibilityError::BoundedConversionFailed);
+		let supports = supports.try_into().defensive_map_err(|_| FeasibilityError::BoundedConversionFailed);
 		Ok(ReadySolution { supports, compute, score })
 	}
 

--- a/frame/fast-unstake/src/migrations.rs
+++ b/frame/fast-unstake/src/migrations.rs
@@ -39,6 +39,9 @@ pub mod v1 {
 			);
 
 			if current == 1 && onchain == 0 {
+				// update the version nonetheless.
+				current.put::<Pallet<T>>();
+
 				// if a head exists, then we put them back into the queue.
 				if Head::<T>::exists() {
 					if let Some((stash, _, deposit)) =
@@ -55,8 +58,6 @@ pub mod v1 {
 				} else {
 					T::DbWeight::get().reads(2)
 				}
-
-				current.put::<Pallet<T>>();
 			} else {
 				log!(info, "Migration did not execute. This probably should be removed");
 				T::DbWeight::get().reads(1)

--- a/frame/fast-unstake/src/migrations.rs
+++ b/frame/fast-unstake/src/migrations.rs
@@ -48,7 +48,6 @@ pub mod v1 {
 						.defensive()
 					{
 						Queue::<T>::insert(stash, deposit);
-						current.put::<Pallet<T>>();
 					} else {
 						// not much we can do here -- head is already deleted.
 					}
@@ -56,6 +55,8 @@ pub mod v1 {
 				} else {
 					T::DbWeight::get().reads(2)
 				}
+
+				current.put::<Pallet<T>>();
 			} else {
 				log!(info, "Migration did not execute. This probably should be removed");
 				T::DbWeight::get().reads(1)


### PR DESCRIPTION
we have multiple runtime and configuration checks to believe that this error won't happen, but since this code path is reachable by `on_initialize`, defensively returning an error is better.