### PR TITLE
Sort crates before splitting them into groups (+ some improvements)

### DIFF
--- a/scripts/ci/gitlab/check-each-crate.sh
+++ b/scripts/ci/gitlab/check-each-crate.sh
@@ -21,6 +21,10 @@ readarray -t workspace_crates < <(\
 )
 
 crates_total=${#workspace_crates[*]}
+if [ "$crates_total" -lt 1 ]; then
+  >&2 echo "No crates detected for $PWD"
+  exit 1
+fi
 
 if [ "$crates_total" -lt "$groups_total" ]; then
   # `crates_total / groups_total` would result in 0, so round it up to 1

--- a/scripts/ci/gitlab/check-each-crate.sh
+++ b/scripts/ci/gitlab/check-each-crate.sh
@@ -8,7 +8,7 @@
 set -Eeu -o pipefail
 shopt -s inherit_errexit
 
-set -x
+set -vx
 
 target_group="$1"
 groups_total="$2"
@@ -38,7 +38,9 @@ fi
 group=1
 for ((i=0; i < crates_total; i += crates_per_group)); do
   if [ $group -eq "$target_group" ]; then
-    for crate in "${workspace_crates[@]:$i:$crates_per_group}"; do
+    crates_in_group=("${workspace_crates[@]:$i:$crates_per_group}")
+    printf "crates in the group: ${crates_in_group[*]}" >/dev/null # >/dev/null due to "set -x"
+    for crate in "${crates_in_group[@]}"; do
       cargo check --locked --release -p "$crate"
     done
     break

--- a/scripts/ci/gitlab/check-each-crate.sh
+++ b/scripts/ci/gitlab/check-each-crate.sh
@@ -15,7 +15,8 @@ groups_total="$2"
 
 readarray -t workspace_crates < <(\
   cargo tree --workspace --depth 0 | \
-  awk '{ if (length($1) == 0 || substr($1, 1, 1) == "[") { skip } else { print $1 } }'
+  awk '{ if (length($1) == 0 || substr($1, 1, 1) == "[") { skip } else { print $1 } }' | \
+  sort
 )
 
 crates_total=${#workspace_crates[*]}

--- a/scripts/ci/gitlab/check-each-crate.sh
+++ b/scripts/ci/gitlab/check-each-crate.sh
@@ -14,8 +14,8 @@ target_group="$1"
 groups_total="$2"
 
 readarray -t workspace_crates < <(\
-  cargo tree --workspace --depth 0 --prefix none | \
-  awk '{ if (length($1) == 0 || substr($1, 1, 1) == "[") { skip } else { print $1 } }' | \
+  cargo tree --workspace --depth 0 --prefix none |
+  awk '{ if (length($1) == 0 || substr($1, 1, 1) == "[") { skip } else { print $1 } }' |
   sort |
   uniq
 )

--- a/scripts/ci/gitlab/check-each-crate.sh
+++ b/scripts/ci/gitlab/check-each-crate.sh
@@ -40,7 +40,7 @@ group=1
 for ((i=0; i < crates_total; i += crates_per_group)); do
   if [ $group -eq "$target_group" ]; then
     crates_in_group=("${workspace_crates[@]:$i:$crates_per_group}")
-    printf "crates in the group: ${crates_in_group[*]}" >/dev/null # >/dev/null due to "set -x"
+    echo "crates in the group: ${crates_in_group[*]}" >/dev/null # >/dev/null due to "set -x"
     for crate in "${crates_in_group[@]}"; do
       cargo check --locked --release -p "$crate"
     done

--- a/scripts/ci/gitlab/check-each-crate.sh
+++ b/scripts/ci/gitlab/check-each-crate.sh
@@ -16,8 +16,8 @@ groups_total="$2"
 readarray -t workspace_crates < <(\
   cargo tree --workspace --depth 0 --prefix none | \
   awk '{ if (length($1) == 0 || substr($1, 1, 1) == "[") { skip } else { print $1 } }' | \
-  uniq | \
-  sort
+  sort |
+  uniq
 )
 
 crates_total=${#workspace_crates[*]}

--- a/scripts/ci/gitlab/check-each-crate.sh
+++ b/scripts/ci/gitlab/check-each-crate.sh
@@ -14,8 +14,9 @@ target_group="$1"
 groups_total="$2"
 
 readarray -t workspace_crates < <(\
-  cargo tree --workspace --depth 0 | \
+  cargo tree --workspace --depth 0 --prefix none | \
   awk '{ if (length($1) == 0 || substr($1, 1, 1) == "[") { skip } else { print $1 } }' | \
+  uniq | \
   sort
 )
 


### PR DESCRIPTION
This is useful so that crates always get routed to a specific group for a given version of the source code, which means that jobs for each group can be reliably retried individually to target a specific crate.