### PR TITLE
Enabled improved panic error reporting by default

### DIFF
--- a/client/executor/runtime-test/Cargo.toml
+++ b/client/executor/runtime-test/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 paste = "1.0.6"
 sp-core = { version = "7.0.0", default-features = false, path = "../../../primitives/core" }
-sp-io = { version = "7.0.0", default-features = false, features = ["improved_panic_error_reporting"], path = "../../../primitives/io" }
+sp-io = { version = "7.0.0", default-features = false, path = "../../../primitives/io" }
 sp-runtime = { version = "7.0.0", default-features = false, path = "../../../primitives/runtime" }
 sp-sandbox = { version = "0.10.0-dev", default-features = false, path = "../../../primitives/sandbox" }
 sp-std = { version = "5.0.0", default-features = false, path = "../../../primitives/std" }

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -70,22 +70,3 @@ with-tracing = [
 disable_panic_handler = []
 disable_oom = []
 disable_allocator = []
-
-# This feature flag controls the runtime's behavior when encountering
-# a panic or when it runs out of memory, improving the diagnostics.
-#
-# When enabled the runtime will marshal the relevant error message
-# to the host through the `PanicHandler::abort_on_panic` runtime interface.
-# This gives the caller direct programmatic access to the error message.
-#
-# When disabled the error message will only be printed out in the
-# logs, with the caller receving a generic "wasm `unreachable` instruction executed"
-# error message.
-#
-# This has no effect if both `disable_panic_handler` and `disable_oom`
-# are enabled.
-#
-# WARNING: Enabling this feature flag requires the `PanicHandler::abort_on_panic`
-#          host function to be supported by the host. Do *not* enable it for your
-#          runtime without first upgrading your host client!
-improved_panic_error_reporting = []

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -1687,30 +1687,14 @@ mod allocator_impl {
 #[no_mangle]
 pub fn panic(info: &core::panic::PanicInfo) -> ! {
 	let message = sp_std::alloc::format!("{}", info);
-	#[cfg(feature = "improved_panic_error_reporting")]
-	{
-		panic_handler::abort_on_panic(&message);
-	}
-	#[cfg(not(feature = "improved_panic_error_reporting"))]
-	{
-		logging::log(LogLevel::Error, "runtime", message.as_bytes());
-		core::arch::wasm32::unreachable();
-	}
+	panic_handler::abort_on_panic(&message);
 }
 
 /// A default OOM handler for WASM environment.
 #[cfg(all(not(feature = "disable_oom"), not(feature = "std")))]
 #[alloc_error_handler]
 pub fn oom(_: core::alloc::Layout) -> ! {
-	#[cfg(feature = "improved_panic_error_reporting")]
-	{
-		panic_handler::abort_on_panic("Runtime memory exhausted.");
-	}
-	#[cfg(not(feature = "improved_panic_error_reporting"))]
-	{
-		logging::log(LogLevel::Error, "runtime", b"Runtime memory exhausted. Aborting");
-		core::arch::wasm32::unreachable();
-	}
+	panic_handler::abort_on_panic("Runtime memory exhausted.");
 }
 
 /// Type alias for Externalities implementation used in tests.


### PR DESCRIPTION
This PR will make it so that any runtime built with require the `abort_on_panic` host function first introduced in https://github.com/paritytech/substrate/pull/10741.

(This still needs PRs for `polkadot` and `cumulus` bumping the version of `substrate` they use for this to take effect; I'll make the relevant PRs after this one gets merged, as I don't really want to deal with the jankiness of companions if I don't have to.)