### PR TITLE
Require rust-features check

### DIFF
--- a/client/offchain/src/api.rs
+++ b/client/offchain/src/api.rs
@@ -300,7 +300,7 @@ pub(crate) struct AsyncApi {
 }
 
 impl AsyncApi {
-	/// Creates new Offchain extensions API implementation an the asynchronous processing part.
+	/// Creates new Offchain extensions API implementation and the asynchronous processing part.
 	pub fn new(
 		network_provider: Arc<dyn NetworkProvider + Send + Sync>,
 		is_validator: bool,

--- a/scripts/ci/gitlab/pipeline/check.yml
+++ b/scripts/ci/gitlab/pipeline/check.yml
@@ -38,6 +38,7 @@ test-dependency-rules:
 test-rust-features:
   stage:                           check
   extends:
+    - .docker-env
     - .test-refs-no-trigger-prs-only
   script:
     - git clone

--- a/scripts/ci/gitlab/pipeline/check.yml
+++ b/scripts/ci/gitlab/pipeline/check.yml
@@ -38,9 +38,7 @@ test-dependency-rules:
 test-rust-features:
   stage:                           check
   extends:
-    - .kubernetes-env
     - .test-refs-no-trigger-prs-only
-  allow_failure:                   true
   script:
     - git clone
         --depth=1

--- a/scripts/ci/gitlab/pipeline/check.yml
+++ b/scripts/ci/gitlab/pipeline/check.yml
@@ -38,7 +38,7 @@ test-dependency-rules:
 test-rust-features:
   stage:                           check
   extends:
-    - .docker-env
+    - .kubernetes-env
     - .test-refs-no-trigger-prs-only
   script:
     - git clone


### PR DESCRIPTION
Changes:  
- Require the rust-feature check not to fail anymore. There were no hiccups so far, should be fine to require.
- Move the rust-feature check to docker executor since it is a bit slower than anticipated. PS: Does not speed it up…