### PR TITLE
Referendum decision period quantization

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -808,7 +808,7 @@ impl pallet_conviction_voting::Config for Runtime {
 
 parameter_types! {
 	pub const AlarmInterval: BlockNumber = 1;
-	pub const MinAlarmInterval: BlockNumber = 1;
+	pub const MinAlarmPeriod: BlockNumber = 1;
 	pub const SubmissionDeposit: Balance = 100 * DOLLARS;
 	pub const UndecidingTimeout: BlockNumber = 28 * DAYS;
 }
@@ -871,7 +871,7 @@ impl pallet_referenda::Config for Runtime {
 	type MaxQueued = ConstU32<100>;
 	type UndecidingTimeout = UndecidingTimeout;
 	type AlarmInterval = AlarmInterval;
-	type MinAlarmInterval = MinAlarmInterval;
+	type MinAlarmPeriod = MinAlarmPeriod;
 	type Tracks = TracksInfo;
 	type Preimages = Preimage;
 }
@@ -892,6 +892,7 @@ impl pallet_referenda::Config<pallet_referenda::Instance2> for Runtime {
 	type MaxQueued = ConstU32<100>;
 	type UndecidingTimeout = UndecidingTimeout;
 	type AlarmInterval = AlarmInterval;
+	type MinAlarmPeriod = MinAlarmPeriod;
 	type Tracks = TracksInfo;
 	type Preimages = Preimage;
 }

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -808,6 +808,7 @@ impl pallet_conviction_voting::Config for Runtime {
 
 parameter_types! {
 	pub const AlarmInterval: BlockNumber = 1;
+	pub const MinAlarmInterval: BlockNumber = 1;
 	pub const SubmissionDeposit: Balance = 100 * DOLLARS;
 	pub const UndecidingTimeout: BlockNumber = 28 * DAYS;
 }
@@ -870,6 +871,7 @@ impl pallet_referenda::Config for Runtime {
 	type MaxQueued = ConstU32<100>;
 	type UndecidingTimeout = UndecidingTimeout;
 	type AlarmInterval = AlarmInterval;
+	type MinAlarmInterval = MinAlarmInterval;
 	type Tracks = TracksInfo;
 	type Preimages = Preimage;
 }

--- a/frame/referenda/src/mock.rs
+++ b/frame/referenda/src/mock.rs
@@ -124,7 +124,8 @@ impl pallet_balances::Config for Test {
 	type WeightInfo = ();
 }
 parameter_types! {
-	pub static AlarmInterval: u64 = 2;
+	pub static AlarmInterval: u64 = 1;
+	pub static MinAlarmInterval: u64 = 1;
 }
 ord_parameter_types! {
 	pub const One: u64 = 1;
@@ -226,6 +227,7 @@ impl Config for Test {
 	type MaxQueued = ConstU32<3>;
 	type UndecidingTimeout = ConstU64<20>;
 	type AlarmInterval = AlarmInterval;
+	type MinAlarmPeriod = MinAlarmInterval;
 	type Tracks = TestTracksInfo;
 	type Preimages = Preimage;
 }

--- a/frame/referenda/src/mock.rs
+++ b/frame/referenda/src/mock.rs
@@ -124,7 +124,7 @@ impl pallet_balances::Config for Test {
 	type WeightInfo = ();
 }
 parameter_types! {
-	pub static AlarmInterval: u64 = 1;
+	pub static AlarmInterval: u64 = 2;
 }
 ord_parameter_types! {
 	pub const One: u64 = 1;

--- a/frame/referenda/src/mock.rs
+++ b/frame/referenda/src/mock.rs
@@ -125,7 +125,7 @@ impl pallet_balances::Config for Test {
 }
 parameter_types! {
 	pub static AlarmInterval: u64 = 1;
-	pub static MinAlarmInterval: u64 = 1;
+	pub static MinAlarmPeriod: u64 = 1;
 }
 ord_parameter_types! {
 	pub const One: u64 = 1;
@@ -227,7 +227,7 @@ impl Config for Test {
 	type MaxQueued = ConstU32<3>;
 	type UndecidingTimeout = ConstU64<20>;
 	type AlarmInterval = AlarmInterval;
-	type MinAlarmPeriod = MinAlarmInterval;
+	type MinAlarmPeriod = MinAlarmPeriod;
 	type Tracks = TestTracksInfo;
 	type Preimages = Preimage;
 }


### PR DESCRIPTION
Right now if `AlarmInterval` set to > 1, the time for alarm will be calculated to the past, and scheduler will fail.

This PR fixes it. 