### PR TITLE
API for registering inactive funds

### DIFF
--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -156,12 +156,12 @@
 #[macro_use]
 mod tests;
 mod benchmarking;
+pub mod migration;
 mod tests_composite;
 mod tests_local;
 #[cfg(test)]
 mod tests_reentrancy;
 pub mod weights;
-pub mod migration;
 
 pub use self::imbalances::{NegativeImbalance, PositiveImbalance};
 use codec::{Codec, Decode, Encode, MaxEncodedLen};
@@ -502,7 +502,8 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn inactive_issuance)]
 	#[pallet::whitelist_storage]
-	pub type InactiveIssuance<T: Config<I>, I: 'static = ()> = StorageValue<_, T::Balance, ValueQuery>;
+	pub type InactiveIssuance<T: Config<I>, I: 'static = ()> =
+		StorageValue<_, T::Balance, ValueQuery>;
 
 	/// The Balances pallet example of storing the balance of an account.
 	///

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1440,15 +1440,15 @@ where
 	}
 
 	fn active_issuance() -> Self::Balance {
-		<Self as fungibles::Inspect>::active_issuance()
+		<Self as fungible::Inspect<T::AccountId>>::active_issuance()
 	}
 
 	fn deactivate(amount: Self::Balance) {
-		<Self as fungibles::Transfer>::deactivate(amount);
+		<Self as fungible::Transfer<T::AccountId>>::deactivate(amount);
 	}
 
 	fn reactivate(amount: Self::Balance) {
-		<Self as fungibles::Transfer>::reactivate(amount);
+		<Self as fungible::Transfer<T::AccountId>>::reactivate(amount);
 	}
 
 	fn minimum_balance() -> Self::Balance {

--- a/frame/balances/src/migration.rs
+++ b/frame/balances/src/migration.rs
@@ -15,12 +15,13 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
-use frame_support::{storage_alias, Twox64Concat, traits::OnRuntimeUpgrade, weights::Weight};
-use frame_support::pallet_prelude::*;
+use frame_support::{pallet_prelude::*, traits::OnRuntimeUpgrade, weights::Weight};
 
 // NOTE: This must be used alongside any accounts whose balances are expected to be inactive.
 // Generally this will be used for the XCM teleport checking account.
-pub struct MigrateToTrackInactive<T: Config, A: Get<T::AccountId>>(sp_std::marker::PhantomData<(T, A)>);
+pub struct MigrateToTrackInactive<T: Config, A: Get<T::AccountId>>(
+	sp_std::marker::PhantomData<(T, A)>,
+);
 impl<T: Config, A: Get<T::AccountId>> OnRuntimeUpgrade for MigrateToTrackInactive<T, A> {
 	fn on_runtime_upgrade() -> Weight {
 		let current_version = Pallet::<T>::current_storage_version();

--- a/frame/balances/src/migration.rs
+++ b/frame/balances/src/migration.rs
@@ -1,0 +1,50 @@
+// Copyright 2017-2020 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+use frame_support::{storage_alias, Twox64Concat, traits::OnRuntimeUpgrade, weights::Weight};
+use frame_support::pallet_prelude::*;
+
+// NOTE: This must be used alongside any accounts whose balances are expected to be inactive.
+// Generally this will be used for the XCM teleport checking account.
+pub struct MigrateToTrackInactive<T: Config, A: Get<T::AccountId>>(sp_std::marker::PhantomData<(T, A)>);
+impl<T: Config, A: Get<T::AccountId>> OnRuntimeUpgrade for MigrateToTrackInactive<T, A> {
+	fn on_runtime_upgrade() -> Weight {
+		let current_version = Pallet::<T>::current_storage_version();
+		let onchain_version = Pallet::<T>::on_chain_storage_version();
+
+		if onchain_version == 0 && current_version == 1 {
+			let b = Pallet::<T>::total_balance(&A::get());
+			Pallet::<T>::deactivate(b);
+			current_version.put::<Pallet<T>>();
+			log::info!(target: "runtime::balances", "Storage to version {:?}", current_version);
+			T::DbWeight::get().reads_writes(3, 3)
+		} else {
+			log::info!(target: "runtime::balances",  "Migration did not execute. This probably should be removed");
+			T::DbWeight::get().reads(1)
+		}
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+		Ok(vec![])
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(total: Vec<u8>) -> Result<(), &'static str> {
+		Ok(())
+	}
+}

--- a/frame/balances/src/migration.rs
+++ b/frame/balances/src/migration.rs
@@ -17,7 +17,7 @@
 use super::*;
 use frame_support::{pallet_prelude::*, traits::OnRuntimeUpgrade, weights::Weight};
 
-// NOTE: This must be used alongside any accounts whose balances are expected to be inactive.
+// NOTE: This must be used alongside the account whose balance is expected to be inactive.
 // Generally this will be used for the XCM teleport checking account.
 pub struct MigrateToTrackInactive<T: Config, A: Get<T::AccountId>>(
 	sp_std::marker::PhantomData<(T, A)>,
@@ -35,7 +35,7 @@ impl<T: Config, A: Get<T::AccountId>> OnRuntimeUpgrade for MigrateToTrackInactiv
 			T::DbWeight::get().reads_writes(3, 3)
 		} else {
 			log::info!(target: "runtime::balances",  "Migration did not execute. This probably should be removed");
-			T::DbWeight::get().reads(1)
+			T::DbWeight::get().reads(2)
 		}
 	}
 

--- a/frame/support/src/traits/tokens/currency.rs
+++ b/frame/support/src/traits/tokens/currency.rs
@@ -59,6 +59,16 @@ pub trait Currency<AccountId> {
 	/// The total amount of issuance in the system.
 	fn total_issuance() -> Self::Balance;
 
+	/// The total amount of issuance in the system excluding those which are controlled by the
+	/// system.
+	fn active_issuance() -> Self::Balance { Self::total_issuance() }
+
+	/// Reduce the active issuance by some amount.
+	fn deactivate(_: Self::Balance) {}
+
+	/// Increase the active issuance by some amount, up to the outstanding amount reduced.
+	fn reactivate(_: Self::Balance) {}
+
 	/// The minimum balance any single account may have. This is equivalent to the `Balances`
 	/// module's `ExistentialDeposit`.
 	fn minimum_balance() -> Self::Balance;
@@ -209,6 +219,15 @@ pub struct TotalIssuanceOf<C: Currency<A>, A>(sp_std::marker::PhantomData<(C, A)
 impl<C: Currency<A>, A> Get<C::Balance> for TotalIssuanceOf<C, A> {
 	fn get() -> C::Balance {
 		C::total_issuance()
+	}
+}
+
+/// A non-const `Get` implementation parameterised by a `Currency` impl which provides the result
+/// of `active_issuance`.
+pub struct ActiveIssuanceOf<C: Currency<A>, A>(sp_std::marker::PhantomData<(C, A)>);
+impl<C: Currency<A>, A> Get<C::Balance> for ActiveIssuanceOf<C, A> {
+	fn get() -> C::Balance {
+		C::active_issuance()
 	}
 }
 

--- a/frame/support/src/traits/tokens/currency.rs
+++ b/frame/support/src/traits/tokens/currency.rs
@@ -61,7 +61,9 @@ pub trait Currency<AccountId> {
 
 	/// The total amount of issuance in the system excluding those which are controlled by the
 	/// system.
-	fn active_issuance() -> Self::Balance { Self::total_issuance() }
+	fn active_issuance() -> Self::Balance {
+		Self::total_issuance()
+	}
 
 	/// Reduce the active issuance by some amount.
 	fn deactivate(_: Self::Balance) {}

--- a/frame/support/src/traits/tokens/fungible.rs
+++ b/frame/support/src/traits/tokens/fungible.rs
@@ -40,6 +40,10 @@ pub trait Inspect<AccountId> {
 	/// The total amount of issuance in the system.
 	fn total_issuance() -> Self::Balance;
 
+	/// The total amount of issuance in the system excluding those which are controlled by the
+	/// system.
+	fn active_issuance() -> Self::Balance { Self::total_issuance() }
+
 	/// The minimum balance any single account may have.
 	fn minimum_balance() -> Self::Balance;
 
@@ -120,6 +124,12 @@ pub trait Transfer<AccountId>: Inspect<AccountId> {
 		amount: Self::Balance,
 		keep_alive: bool,
 	) -> Result<Self::Balance, DispatchError>;
+
+	/// Reduce the active issuance by some amount.
+	fn deactivate(_: Self::Balance) {}
+
+	/// Increase the active issuance by some amount, up to the outstanding amount reduced.
+	fn reactivate(_: Self::Balance) {}
 }
 
 /// Trait for inspecting a fungible asset which can be reserved.
@@ -213,6 +223,9 @@ impl<
 	fn total_issuance() -> Self::Balance {
 		<F as fungibles::Inspect<AccountId>>::total_issuance(A::get())
 	}
+	fn active_issuance() -> Self::Balance {
+		<F as fungibles::Inspect<AccountId>>::active_issuance(A::get())
+	}
 	fn minimum_balance() -> Self::Balance {
 		<F as fungibles::Inspect<AccountId>>::minimum_balance(A::get())
 	}
@@ -257,6 +270,12 @@ impl<
 		keep_alive: bool,
 	) -> Result<Self::Balance, DispatchError> {
 		<F as fungibles::Transfer<AccountId>>::transfer(A::get(), source, dest, amount, keep_alive)
+	}
+	fn deactivate(amount: Self::Balance) {
+		<F as fungibles::Transfer<AccountId>>::deactivate(A::get(), amount)
+	}
+	fn reactivate(amount: Self::Balance) {
+		<F as fungibles::Transfer<AccountId>>::reactivate(A::get(), amount)
 	}
 }
 

--- a/frame/support/src/traits/tokens/fungible.rs
+++ b/frame/support/src/traits/tokens/fungible.rs
@@ -42,7 +42,9 @@ pub trait Inspect<AccountId> {
 
 	/// The total amount of issuance in the system excluding those which are controlled by the
 	/// system.
-	fn active_issuance() -> Self::Balance { Self::total_issuance() }
+	fn active_issuance() -> Self::Balance {
+		Self::total_issuance()
+	}
 
 	/// The minimum balance any single account may have.
 	fn minimum_balance() -> Self::Balance;

--- a/frame/support/src/traits/tokens/fungibles.rs
+++ b/frame/support/src/traits/tokens/fungibles.rs
@@ -46,6 +46,10 @@ pub trait Inspect<AccountId> {
 	/// The total amount of issuance in the system.
 	fn total_issuance(asset: Self::AssetId) -> Self::Balance;
 
+	/// The total amount of issuance in the system excluding those which are controlled by the
+	/// system.
+	fn active_issuance(asset: Self::AssetId) -> Self::Balance { Self::total_issuance(asset) }
+
 	/// The minimum balance any single account may have.
 	fn minimum_balance(asset: Self::AssetId) -> Self::Balance;
 
@@ -177,6 +181,12 @@ pub trait Transfer<AccountId>: Inspect<AccountId> {
 		amount: Self::Balance,
 		keep_alive: bool,
 	) -> Result<Self::Balance, DispatchError>;
+
+	/// Reduce the active issuance by some amount.
+	fn deactivate(_: Self::AssetId, _: Self::Balance) {}
+
+	/// Increase the active issuance by some amount, up to the outstanding amount reduced.
+	fn reactivate(_: Self::AssetId, _: Self::Balance) {}
 }
 
 /// Trait for inspecting a set of named fungible assets which can be placed on hold.

--- a/frame/support/src/traits/tokens/fungibles.rs
+++ b/frame/support/src/traits/tokens/fungibles.rs
@@ -48,7 +48,9 @@ pub trait Inspect<AccountId> {
 
 	/// The total amount of issuance in the system excluding those which are controlled by the
 	/// system.
-	fn active_issuance(asset: Self::AssetId) -> Self::Balance { Self::total_issuance(asset) }
+	fn active_issuance(asset: Self::AssetId) -> Self::Balance {
+		Self::total_issuance(asset)
+	}
 
 	/// The minimum balance any single account may have.
 	fn minimum_balance(asset: Self::AssetId) -> Self::Balance;

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -138,7 +138,6 @@ pub mod pallet {
 	use super::*;
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
-	use sp_runtime::traits::CheckedSub;
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]

--- a/primitives/wasm-interface/src/lib.rs
+++ b/primitives/wasm-interface/src/lib.rs
@@ -627,48 +627,6 @@ impl_into_and_from_value! {
 	i64, I64,
 }
 
-/// Something that can write a primitive to wasm memory location.
-pub trait WritePrimitive<T: PointerType> {
-	/// Write the given value `t` to the given memory location `ptr`.
-	fn write_primitive(&mut self, ptr: Pointer<T>, t: T) -> Result<()>;
-}
-
-impl WritePrimitive<u32> for &mut dyn FunctionContext {
-	fn write_primitive(&mut self, ptr: Pointer<u32>, t: u32) -> Result<()> {
-		let r = t.to_le_bytes();
-		self.write_memory(ptr.cast(), &r)
-	}
-}
-
-impl WritePrimitive<u64> for &mut dyn FunctionContext {
-	fn write_primitive(&mut self, ptr: Pointer<u64>, t: u64) -> Result<()> {
-		let r = t.to_le_bytes();
-		self.write_memory(ptr.cast(), &r)
-	}
-}
-
-/// Something that can read a primitive from a wasm memory location.
-pub trait ReadPrimitive<T: PointerType> {
-	/// Read a primitive from the given memory location `ptr`.
-	fn read_primitive(&self, ptr: Pointer<T>) -> Result<T>;
-}
-
-impl ReadPrimitive<u32> for &mut dyn FunctionContext {
-	fn read_primitive(&self, ptr: Pointer<u32>) -> Result<u32> {
-		let mut r = [0u8; 4];
-		self.read_memory_into(ptr.cast(), &mut r)?;
-		Ok(u32::from_le_bytes(r))
-	}
-}
-
-impl ReadPrimitive<u64> for &mut dyn FunctionContext {
-	fn read_primitive(&self, ptr: Pointer<u64>) -> Result<u64> {
-		let mut r = [0u8; 8];
-		self.read_memory_into(ptr.cast(), &mut r)?;
-		Ok(u64::from_le_bytes(r))
-	}
-}
-
 /// Typed value that can be returned from a function.
 ///
 /// Basically a `TypedValue` plus `Unit`, for functions which return nothing.


### PR DESCRIPTION
Introduces `ActiveIssuanceOf` which is the total issuance not including the treasury funds and any other funds marked as inactive with `deactivate`. This should generally be used rather than `TotalIssuance`.

Balances pallet provides a migration which can be used to mark accounts with inactive funds (which, after the upgrade, we assume will be kept up to date with `deactivate` and `reactivate`). For chains with XCM, *this should be used to mark the **Checking Account** when upgraded.*