### PR TITLE
Make Gov2 Curve::threshold fn public

### DIFF
--- a/frame/referenda/src/types.rs
+++ b/frame/referenda/src/types.rs
@@ -409,7 +409,7 @@ impl Curve {
 	}
 
 	/// Determine the `y` value for the given `x` value.
-	pub(crate) fn threshold(&self, x: Perbill) -> Perbill {
+	pub fn threshold(&self, x: Perbill) -> Perbill {
 		match self {
 			Self::LinearDecreasing { length, floor, ceil } =>
 				*ceil - (x.min(*length).saturating_div(*length, Down) * (*ceil - *floor)),


### PR DESCRIPTION
`Curve::threshold` function returns the `y` value for a given `x` value on the Gov2 Curve object. This PR changes its visibility from `pub(crate)` to `pub`.

Moonbeam is using this function to chart and compare approval/support curves. Currently we have copied pasted the function definition https://github.com/4meta5/gov2-curve-plotter/blob/main/src/curve.rs#L179-L202 but would prefer to call it directly which requires making it public.
