### PR TITLE
Safe desired targets call

### DIFF
--- a/frame/election-provider-multi-phase/src/benchmarking.rs
+++ b/frame/election-provider-multi-phase/src/benchmarking.rs
@@ -269,7 +269,7 @@ frame_benchmarking::benchmarks! {
 		set_up_data_provider::<T>(v, t);
 		let targets = T::DataProvider::electable_targets(None)?;
 		let voters = T::DataProvider::electing_voters(None)?;
-		let desired_targets = <T as ElectionProviderBase>::desired_targets_checked()?;
+		let desired_targets = T::DataProvider::desired_targets()?;
 		assert!(<MultiPhase<T>>::snapshot().is_none());
 	}: {
 		<MultiPhase::<T>>::create_snapshot_internal(targets, voters, desired_targets)

--- a/frame/election-provider-multi-phase/src/benchmarking.rs
+++ b/frame/election-provider-multi-phase/src/benchmarking.rs
@@ -269,7 +269,7 @@ frame_benchmarking::benchmarks! {
 		set_up_data_provider::<T>(v, t);
 		let targets = T::DataProvider::electable_targets(None)?;
 		let voters = T::DataProvider::electing_voters(None)?;
-		let desired_targets = T::DataProvider::desired_targets()?;
+		let desired_targets = <T as ElectionProviderBase>::desired_targets_checked()?;
 		assert!(<MultiPhase<T>>::snapshot().is_none());
 	}: {
 		<MultiPhase::<T>>::create_snapshot_internal(targets, voters, desired_targets)

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -1410,7 +1410,7 @@ impl<T: Config> Pallet<T> {
 		}
 
 		let desired_targets =
-			<T as ElectionProviderBase>::desired_targets_checked().map_err(|e| ElectionError::DataProvider(e))?;
+			<Pallet<T> as ElectionProviderBase>::desired_targets_checked().map_err(|e| ElectionError::DataProvider(e))?;
 
 		Ok((targets, voters, desired_targets))
 	}

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -1409,21 +1409,8 @@ impl<T: Config> Pallet<T> {
 			return Err(ElectionError::DataProvider("Snapshot too big for submission."))
 		}
 
-		let mut desired_targets =
-			T::DataProvider::desired_targets().map_err(ElectionError::DataProvider)?;
-
-		// If `desired_targets` > `targets.len()`, cap `desired_targets` to that
-		// level and emit a warning
-		let max_desired_targets: u32 = (targets.len() as u32).min(T::MaxWinners::get());
-		if desired_targets > max_desired_targets {
-			log!(
-				warn,
-				"desired_targets: {} > targets.len(): {}, capping desired_targets",
-				desired_targets,
-				max_desired_targets
-			);
-			desired_targets = max_desired_targets;
-		}
+		let desired_targets =
+			<T as ElectionProviderBase>::desired_targets_checked().map_err(|e| ElectionError::DataProvider(e))?;
 
 		Ok((targets, voters, desired_targets))
 	}

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -1409,8 +1409,8 @@ impl<T: Config> Pallet<T> {
 			return Err(ElectionError::DataProvider("Snapshot too big for submission."))
 		}
 
-		let desired_targets =
-			<Pallet<T> as ElectionProviderBase>::desired_targets_checked().map_err(|e| ElectionError::DataProvider(e))?;
+		let desired_targets = <Pallet<T> as ElectionProviderBase>::desired_targets_checked()
+			.map_err(|e| ElectionError::DataProvider(e))?;
 
 		Ok((targets, voters, desired_targets))
 	}

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -1409,8 +1409,21 @@ impl<T: Config> Pallet<T> {
 			return Err(ElectionError::DataProvider("Snapshot too big for submission."))
 		}
 
-		let desired_targets = <Pallet<T> as ElectionProviderBase>::desired_targets_checked()
+		let mut desired_targets = <Pallet<T> as ElectionProviderBase>::desired_targets_checked()
 			.map_err(|e| ElectionError::DataProvider(e))?;
+
+		// If `desired_targets` > `targets.len()`, cap `desired_targets` to that level and emit a
+		// warning
+		let max_desired_targets: u32 = targets.len() as u32;
+		if desired_targets > max_desired_targets {
+			log!(
+				warn,
+				"desired_targets: {} > targets.len(): {}, capping desired_targets",
+				desired_targets,
+				max_desired_targets
+			);
+			desired_targets = max_desired_targets;
+		}
 
 		Ok((targets, voters, desired_targets))
 	}

--- a/frame/election-provider-multi-phase/src/signed.rs
+++ b/frame/election-provider-multi-phase/src/signed.rs
@@ -594,10 +594,12 @@ mod tests {
 			DesiredTargets::set(4);
 			MaxWinners::set(3);
 
-			let (_, _, actual_desired_targets) = MultiPhase::create_snapshot_external().unwrap();
-
-			// snapshot is created with min of desired_targets and MaxWinners
-			assert_eq!(actual_desired_targets, 3);
+			// snapshot not created because data provider returned an unexpected number of
+			// desired_targets
+			assert_noop!(
+				MultiPhase::create_snapshot_external(),
+				ElectionError::DataProvider("desired_targets must not be greater than MaxWinners."),
+			);
 		})
 	}
 

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -391,7 +391,7 @@ pub trait ElectionProviderBase {
 				if desired_targets <= Self::MaxWinners::get() {
 					Ok(desired_targets)
 				} else {
-					Err("desired_targets should not be greater than MaxWinners")
+					Err("desired_targets must not be greater than MaxWinners.")
 				},
 			Err(e) => Err(e),
 		}

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -386,15 +386,13 @@ pub trait ElectionProviderBase {
 	/// checked call to `Self::DataProvider::desired_targets()` ensuring the value never exceeds
 	/// [`Self::MaxWinners`].
 	fn desired_targets_checked() -> data_provider::Result<u32> {
-		match Self::DataProvider::desired_targets() {
-			Ok(desired_targets) =>
-				if desired_targets <= Self::MaxWinners::get() {
-					Ok(desired_targets)
-				} else {
-					Err("desired_targets must not be greater than MaxWinners.")
-				},
-			Err(e) => Err(e),
-		}
+		Self::DataProvider::desired_targets().and_then(|desired_targets| {
+			if desired_targets <= Self::MaxWinners::get() {
+				Ok(desired_targets)
+			} else {
+				Err("desired_targets must not be greater than MaxWinners.")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
`ElectionProvider` expects `ElectionDataProvider` to return a `desired_targets` value that is not larger than the `MaxWinners` supported by the `ElectionProvider`. This is a little opaque rule for the `ElectionDataProvider` to be aware of. This PR tries to better communicate this rule by exposing a `desired_targets_checked` method to the trait `ElectionProvider` which verifies the above condition.

Fixes https://github.com/paritytech/substrate/issues/12756