### PR TITLE
Add `Weightless` benchmark bailing

### DIFF
--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -1814,12 +1814,10 @@ macro_rules! add_benchmark {
 						$crate::str::from_utf8(benchmark)
 							.expect("benchmark name is always a valid string!")
 					);
-					let dummy = $crate::BenchmarkResult {
+					Some(vec![$crate::BenchmarkResult {
 						components: selected_components.clone(),
 						.. Default::default()
-					};
-					// The linear regression logic needs at least two values.
-					Some(vec![dummy])
+					}])
 				}
 			};
 

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -1814,9 +1814,12 @@ macro_rules! add_benchmark {
 						$crate::str::from_utf8(benchmark)
 							.expect("benchmark name is always a valid string!")
 					);
-					let mut dummy = $crate::BenchmarkResult::default();
-					dummy.components = selected_components.clone();
-					Some(vec![dummy.clone(), dummy.clone()])
+					let dummy = $crate::BenchmarkResult {
+						components: selected_components.clone(),
+						.. Default::default()
+					};
+					// The linear regression logic needs at least two values.
+					Some(vec![dummy])
 				}
 			};
 

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -881,6 +881,13 @@ macro_rules! impl_bench_name_tests {
 										"WARNING: benchmark error skipped - {}",
 										stringify!($name),
 									);
+								},
+								$crate::BenchmarkError::Weightless => {
+									// This is considered a success condition.
+									$crate::log::error!(
+										"WARNING: benchmark weightless skipped - {}",
+										stringify!($name),
+									);
 								}
 							}
 						},
@@ -1640,6 +1647,14 @@ macro_rules! impl_test_function {
 												.expect("benchmark name is always a valid string!"),
 										);
 									}
+									$crate::BenchmarkError::Weightless => {
+										// This is considered a success condition.
+										$crate::log::error!(
+											"WARNING: benchmark weightless skipped - {}",
+											$crate::str::from_utf8(benchmark_name)
+												.expect("benchmark name is always a valid string!"),
+										);
+									}
 								}
 							},
 							Ok(Ok(())) => (),
@@ -1792,6 +1807,16 @@ macro_rules! add_benchmark {
 							.expect("benchmark name is always a valid string!")
 					);
 					None
+				},
+				Err($crate::BenchmarkError::Weightless) => {
+					$crate::log::error!(
+						"WARNING: benchmark weightless skipped - {}",
+						$crate::str::from_utf8(benchmark)
+							.expect("benchmark name is always a valid string!")
+					);
+					let mut dummy = $crate::BenchmarkResult::default();
+					dummy.components = selected_components.clone();
+					Some(vec![dummy.clone(), dummy.clone()])
 				}
 			};
 

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -162,6 +162,11 @@ pub enum BenchmarkError {
 	/// The benchmarking pipeline is allowed to fail here, and we should simply
 	/// skip processing these results.
 	Skip,
+	/// No weight can be determined; set the weight of this call to zero.
+	///
+	/// You can also use `Override` instead, but this is easier to use since `Override` expects the
+	/// correct components to be present.
+	Weightless,
 }
 
 impl From<BenchmarkError> for &'static str {
@@ -170,6 +175,7 @@ impl From<BenchmarkError> for &'static str {
 			BenchmarkError::Stop(s) => s,
 			BenchmarkError::Override(_) => "benchmark override",
 			BenchmarkError::Skip => "benchmark skip",
+			BenchmarkError::Weightless => "benchmark weightless",
 		}
 	}
 }

--- a/frame/bounties/src/benchmarking.rs
+++ b/frame/bounties/src/benchmarking.rs
@@ -21,7 +21,7 @@
 
 use super::*;
 
-use frame_benchmarking::{account, benchmarks_instance_pallet, whitelisted_caller};
+use frame_benchmarking::{account, benchmarks_instance_pallet, whitelisted_caller, BenchmarkError};
 use frame_system::RawOrigin;
 use sp_runtime::traits::Bounded;
 
@@ -31,13 +31,14 @@ use pallet_treasury::Pallet as Treasury;
 const SEED: u32 = 0;
 
 // Create bounties that are approved for use in `on_initialize`.
-fn create_approved_bounties<T: Config<I>, I: 'static>(n: u32) -> Result<(), &'static str> {
+fn create_approved_bounties<T: Config<I>, I: 'static>(n: u32) -> Result<(), BenchmarkError> {
 	for i in 0..n {
 		let (caller, _curator, _fee, value, reason) =
 			setup_bounty::<T, I>(i, T::MaximumReasonLength::get());
 		Bounties::<T, I>::propose_bounty(RawOrigin::Signed(caller).into(), value, reason)?;
 		let bounty_id = BountyCount::<T, I>::get() - 1;
-		let approve_origin = T::ApproveOrigin::successful_origin();
+		let approve_origin =
+			T::SpendOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
 		Bounties::<T, I>::approve_bounty(approve_origin, bounty_id)?;
 	}
 	ensure!(BountyApprovals::<T, I>::get().len() == n as usize, "Not all bounty approved");
@@ -62,13 +63,14 @@ fn setup_bounty<T: Config<I>, I: 'static>(
 }
 
 fn create_bounty<T: Config<I>, I: 'static>(
-) -> Result<(AccountIdLookupOf<T>, BountyIndex), &'static str> {
+) -> Result<(AccountIdLookupOf<T>, BountyIndex), BenchmarkError> {
 	let (caller, curator, fee, value, reason) =
 		setup_bounty::<T, I>(0, T::MaximumReasonLength::get());
 	let curator_lookup = T::Lookup::unlookup(curator.clone());
 	Bounties::<T, I>::propose_bounty(RawOrigin::Signed(caller).into(), value, reason)?;
 	let bounty_id = BountyCount::<T, I>::get() - 1;
-	let approve_origin = T::ApproveOrigin::successful_origin();
+	let approve_origin =
+		T::SpendOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
 	Bounties::<T, I>::approve_bounty(approve_origin.clone(), bounty_id)?;
 	Treasury::<T, I>::on_initialize(T::BlockNumber::zero());
 	Bounties::<T, I>::propose_curator(approve_origin, bounty_id, curator_lookup.clone(), fee)?;
@@ -97,7 +99,7 @@ benchmarks_instance_pallet! {
 		let (caller, curator, fee, value, reason) = setup_bounty::<T, I>(0, T::MaximumReasonLength::get());
 		Bounties::<T, I>::propose_bounty(RawOrigin::Signed(caller).into(), value, reason)?;
 		let bounty_id = BountyCount::<T, I>::get() - 1;
-		let approve_origin = T::SpendOrigin::successful_origin();
+		let approve_origin = T::SpendOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
 	}: _<T::RuntimeOrigin>(approve_origin, bounty_id)
 
 	propose_curator {
@@ -106,10 +108,9 @@ benchmarks_instance_pallet! {
 		let curator_lookup = T::Lookup::unlookup(curator);
 		Bounties::<T, I>::propose_bounty(RawOrigin::Signed(caller).into(), value, reason)?;
 		let bounty_id = BountyCount::<T, I>::get() - 1;
-		let approve_origin = T::SpendOrigin::successful_origin();
-		Bounties::<T, I>::approve_bounty(approve_origin, bounty_id)?;
+		let approve_origin = T::SpendOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
+		Bounties::<T, I>::approve_bounty(approve_origin.clone(), bounty_id)?;
 		Treasury::<T, I>::on_initialize(T::BlockNumber::zero());
-		let approve_origin = T::SpendOrigin::successful_origin();
 	}: _<T::RuntimeOrigin>(approve_origin, bounty_id, curator_lookup, fee)
 
 	// Worst case when curator is inactive and any sender unassigns the curator.
@@ -128,7 +129,7 @@ benchmarks_instance_pallet! {
 		let curator_lookup = T::Lookup::unlookup(curator.clone());
 		Bounties::<T, I>::propose_bounty(RawOrigin::Signed(caller).into(), value, reason)?;
 		let bounty_id = BountyCount::<T, I>::get() - 1;
-		let approve_origin = T::SpendOrigin::successful_origin();
+		let approve_origin = T::SpendOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
 		Bounties::<T, I>::approve_bounty(approve_origin.clone(), bounty_id)?;
 		Treasury::<T, I>::on_initialize(T::BlockNumber::zero());
 		Bounties::<T, I>::propose_curator(approve_origin, bounty_id, curator_lookup, fee)?;


### PR DESCRIPTION
The (child)-bounties benchmark require `SpendOrigin` as dispatch origin. Since `SpendOrigin` is configured to `NeverEnsureOrigin` in Polkadot, it is impossible to make these Calls since no origin instance can be created.  

This MR fixes this by:
- Adding a `Weightless` early return option for benchmarks whose weight will be annotated with 0. It is not completly zero since users still pay the `ExtrinsicBaseWeight` and a length-based fee.
- Using this option in the `bounties` and `child-bounties` benches.

This is a better solution than https://github.com/paritytech/substrate/pull/11562 since there would be a lot of ifs needed otherwise.

TODO:
- [x] Double check that all Polkadot benches still work (https://github.com/paritytech/polkadot/pull/6045)

These are not actually companions but needed to make the CI green:  
Polkadot companion: https://github.com/paritytech/polkadot/pull/6328  
Cumulus companion: https://github.com/paritytech/cumulus/pull/1940