### PR TITLE
OpenGov: Abstentions

### DIFF
--- a/frame/conviction-voting/src/types.rs
+++ b/frame/conviction-voting/src/types.rs
@@ -147,6 +147,15 @@ impl<
 				self.ayes = self.ayes.checked_add(&aye.votes)?;
 				self.nays = self.nays.checked_add(&nay.votes)?;
 			},
+			AccountVote::SplitAbstain { aye, nay, abstain } => {
+				let aye = Conviction::None.votes(aye);
+				let nay = Conviction::None.votes(nay);
+				let abstain = Conviction::None.votes(abstain);
+				self.support =
+					self.support.checked_add(&aye.capital)?.checked_add(&abstain.capital)?;
+				self.ayes = self.ayes.checked_add(&aye.votes)?;
+				self.nays = self.nays.checked_add(&nay.votes)?;
+			},
 		}
 		Some(())
 	}
@@ -168,6 +177,15 @@ impl<
 				let aye = Conviction::None.votes(aye);
 				let nay = Conviction::None.votes(nay);
 				self.support = self.support.checked_sub(&aye.capital)?;
+				self.ayes = self.ayes.checked_sub(&aye.votes)?;
+				self.nays = self.nays.checked_sub(&nay.votes)?;
+			},
+			AccountVote::SplitAbstain { aye, nay, abstain } => {
+				let aye = Conviction::None.votes(aye);
+				let nay = Conviction::None.votes(nay);
+				let abstain = Conviction::None.votes(abstain);
+				self.support =
+					self.support.checked_sub(&aye.capital)?.checked_sub(&abstain.capital)?;
 				self.ayes = self.ayes.checked_sub(&aye.votes)?;
 				self.nays = self.nays.checked_sub(&nay.votes)?;
 			},

--- a/frame/conviction-voting/src/vote.rs
+++ b/frame/conviction-voting/src/vote.rs
@@ -74,6 +74,10 @@ pub enum AccountVote<Balance> {
 	/// A split vote with balances given for both ways, and with no conviction, useful for
 	/// parachains when voting.
 	Split { aye: Balance, nay: Balance },
+	/// A split vote with balances given for both ways as well as abstentions, and with no
+	/// conviction, useful for parachains when voting, other off-chain aggregate accounts and
+	/// individuals who wish to abstain.
+	SplitAbstain { aye: Balance, nay: Balance, abstain: Balance },
 }
 
 impl<Balance: Saturating> AccountVote<Balance> {
@@ -94,6 +98,8 @@ impl<Balance: Saturating> AccountVote<Balance> {
 		match self {
 			AccountVote::Standard { balance, .. } => balance,
 			AccountVote::Split { aye, nay } => aye.saturating_add(nay),
+			AccountVote::SplitAbstain { aye, nay, abstain } =>
+				aye.saturating_add(nay).saturating_add(abstain),
 		}
 	}
 


### PR DESCRIPTION
Introduce abstention to OpenGov (conviction-voting). Takes the form of a new variant in `AccountVote`.

Abstentions are like aye votes in terms of the support, but do not affect the approval, thus allow participants to support the early termination of voting without affecting its result.

In a way it's like saying "I see it and I do not plan on voting".

## TODO

- [x] Add a test