### PR TITLE
frame-support: Introduce `EnsureOriginOrHigherPrivilege`

### DIFF
--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -99,8 +99,8 @@ mod dispatch;
 pub use dispatch::EnsureOneOf;
 pub use dispatch::{
 	AsEnsureOriginWithArg, CallerTrait, EitherOf, EitherOfDiverse, EnsureOrigin,
-	EnsureOriginWithArg, MapSuccess, NeverEnsureOrigin, OriginTrait, TryMapSuccess,
-	UnfilteredDispatchable,
+	EnsureOriginEqualOrHigherPrivilege, EnsureOriginWithArg, MapSuccess, NeverEnsureOrigin, OriginTrait,
+	TryMapSuccess, UnfilteredDispatchable,
 };
 
 mod voting;


### PR DESCRIPTION
This adds a new `EnsureOrigin` implementation that checks if a given origin matches or if the origin is has a higher or equal origin matches or if the origin is has a higher or equal privilege.
