### PR TITLE
Add `with_weight` extrinsic

### DIFF
--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -474,6 +474,23 @@ pub mod pallet {
 			let base_weight = T::WeightInfo::batch(calls_len as u32);
 			Ok(Some(base_weight.saturating_add(weight)).into())
 		}
+
+		/// Dispatch a function call with a specified weight.
+		///
+		/// This function does not check the weight of the call, and instead allows the
+		/// Root origin to specify the weight of the call.
+		///
+		/// The dispatch origin for this call must be _Root_.
+		#[pallet::weight((*_weight, call.get_dispatch_info().class))]
+		pub fn with_weight(
+			origin: OriginFor<T>,
+			call: Box<<T as Config>::RuntimeCall>,
+			_weight: Weight,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+			let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Root.into());
+			res.map(|_| ()).map_err(|e| e.error)
+		}
 	}
 }
 

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -901,3 +901,22 @@ fn batch_all_works_with_council_origin() {
 		));
 	})
 }
+
+#[test]
+fn with_weight_works() {
+	new_test_ext().execute_with(|| {
+		let upgrade_code_call =
+			Box::new(RuntimeCall::System(frame_system::Call::set_code_without_checks {
+				code: vec![],
+			}));
+		let with_weight_call = Call::<Test>::with_weight {
+			call: upgrade_code_call,
+			weight: Weight::from_parts(123, 456),
+		};
+		assert_eq!(with_weight_call.get_dispatch_info().weight, Weight::from_parts(123, 456));
+		assert_eq!(
+			with_weight_call.get_dispatch_info().class,
+			frame_support::dispatch::DispatchClass::Operational
+		);
+	})
+}

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -909,10 +909,18 @@ fn with_weight_works() {
 			Box::new(RuntimeCall::System(frame_system::Call::set_code_without_checks {
 				code: vec![],
 			}));
+		// Weight before is max.
+		assert_eq!(upgrade_code_call.get_dispatch_info().weight, Weight::MAX);
+		assert_eq!(
+			upgrade_code_call.get_dispatch_info().class,
+			frame_support::dispatch::DispatchClass::Operational
+		);
+
 		let with_weight_call = Call::<Test>::with_weight {
 			call: upgrade_code_call,
 			weight: Weight::from_parts(123, 456),
 		};
+		// Weight after is set by Root.
 		assert_eq!(with_weight_call.get_dispatch_info().weight, Weight::from_parts(123, 456));
 		assert_eq!(
 			with_weight_call.get_dispatch_info().class,


### PR DESCRIPTION
This adds a new utility function `with_weight` that allows Root origin to override the weight of any function call.