### PR TITLE
contracts: Improve contract address derivation

### DIFF
--- a/frame/contracts/proc-macro/src/lib.rs
+++ b/frame/contracts/proc-macro/src/lib.rs
@@ -404,11 +404,7 @@ fn expand_impls(def: &mut EnvDef) -> TokenStream2 {
 	let dummy_impls = expand_functions(def, false, quote! { () });
 
 	quote! {
-		impl<'a, E> crate::wasm::Environment<crate::wasm::runtime::Runtime<'a, E>> for Env
-		where
-			E: Ext,
-			<E::T as ::frame_system::Config>::AccountId:
-				::sp_core::crypto::UncheckedFrom<<E::T as ::frame_system::Config>::Hash> + ::core::convert::AsRef<[::core::primitive::u8]>,
+		impl<'a, E: Ext> crate::wasm::Environment<crate::wasm::runtime::Runtime<'a, E>> for Env
 		{
 			fn define(store: &mut ::wasmi::Store<crate::wasm::Runtime<E>>, linker: &mut ::wasmi::Linker<crate::wasm::Runtime<E>>, allow_unstable: bool) -> Result<(), ::wasmi::errors::LinkerError> {
 				#impls

--- a/frame/contracts/src/benchmarking/code.rs
+++ b/frame/contracts/src/benchmarking/code.rs
@@ -26,7 +26,6 @@
 
 use crate::{Config, Determinism};
 use frame_support::traits::Get;
-use sp_core::crypto::UncheckedFrom;
 use sp_runtime::traits::Hash;
 use sp_std::{borrow::ToOwned, prelude::*};
 use wasm_instrument::{
@@ -105,11 +104,7 @@ pub struct ImportedMemory {
 }
 
 impl ImportedMemory {
-	pub fn max<T: Config>() -> Self
-	where
-		T: Config,
-		T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
-	{
+	pub fn max<T: Config>() -> Self {
 		let pages = max_pages::<T>();
 		Self { min_pages: pages, max_pages: pages }
 	}
@@ -130,11 +125,7 @@ pub struct WasmModule<T: Config> {
 	pub memory: Option<ImportedMemory>,
 }
 
-impl<T: Config> From<ModuleDefinition> for WasmModule<T>
-where
-	T: Config,
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
-{
+impl<T: Config> From<ModuleDefinition> for WasmModule<T> {
 	fn from(def: ModuleDefinition) -> Self {
 		// internal functions start at that offset.
 		let func_offset = u32::try_from(def.imported_functions.len()).unwrap();
@@ -259,11 +250,7 @@ where
 	}
 }
 
-impl<T: Config> WasmModule<T>
-where
-	T: Config,
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
-{
+impl<T: Config> WasmModule<T> {
 	/// Uses the supplied wasm module and instruments it when requested.
 	pub fn instrumented(code: &[u8], inject_gas: bool, inject_stack: bool) -> Self {
 		let module = {
@@ -533,11 +520,7 @@ pub mod body {
 }
 
 /// The maximum amount of pages any contract is allowed to have according to the current `Schedule`.
-pub fn max_pages<T: Config>() -> u32
-where
-	T: Config,
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
-{
+pub fn max_pages<T: Config>() -> u32 {
 	T::Schedule::get().limits.memory_pages
 }
 

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -1792,8 +1792,9 @@ benchmarks! {
 		}
 	}
 
-	seal_instantiate_per_transfer_salt_kb {
+	seal_instantiate_per_transfer_input_salt_kb {
 		let t in 0 .. 1;
+		let i in 0 .. (code::max_pages::<T>() - 1) * 64;
 		let s in 0 .. (code::max_pages::<T>() - 1) * 64;
 		let callee_code = WasmModule::<T>::dummy();
 		let hash = callee_code.hash;
@@ -1861,14 +1862,14 @@ benchmarks! {
 				Regular(Instruction::I64Const(0)), // gas
 				Regular(Instruction::I32Const(value_offset as i32)), // value_ptr
 				Regular(Instruction::I32Const(value_len as i32)), // value_len
-				Regular(Instruction::I32Const(0)), // input_data_ptr
-				Regular(Instruction::I32Const(0)), // input_data_len
+				Counter(salt_offset as u32, salt_len as u32), // input_data_ptr
+				Regular(Instruction::I32Const((i * 1024) as i32)), // input_data_ptr_len
 				Regular(Instruction::I32Const((addr_len_offset + addr_len) as i32)), // address_ptr
 				Regular(Instruction::I32Const(addr_len_offset as i32)), // address_len_ptr
 				Regular(Instruction::I32Const(SENTINEL as i32)), // output_ptr
 				Regular(Instruction::I32Const(0)), // output_len_ptr
 				Counter(salt_offset as u32, salt_len as u32), // salt_ptr
-				Regular(Instruction::I32Const((s * 1024).max(salt_len as u32) as i32)), // salt_len
+				Regular(Instruction::I32Const((s * 1024) as i32)), // salt_len
 				Regular(Instruction::Call(0)),
 				Regular(Instruction::I32Eqz),
 				Regular(Instruction::If(BlockType::NoResult)),

--- a/frame/contracts/src/benchmarking/sandbox.rs
+++ b/frame/contracts/src/benchmarking/sandbox.rs
@@ -20,7 +20,6 @@
 /// ! environment that provides the seal interface as imported functions.
 use super::{code::WasmModule, Config};
 use crate::wasm::{Environment, PrefabWasmModule};
-use sp_core::crypto::UncheckedFrom;
 use wasmi::{errors::LinkerError, Func, Linker, StackLimits, Store};
 
 /// Minimal execution environment without any imported functions.
@@ -36,11 +35,7 @@ impl Sandbox {
 	}
 }
 
-impl<T: Config> From<&WasmModule<T>> for Sandbox
-where
-	T: Config,
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
-{
+impl<T: Config> From<&WasmModule<T>> for Sandbox {
 	/// Creates an instance from the supplied module and supplies as much memory
 	/// to the instance as the module declares as imported.
 	fn from(module: &WasmModule<T>) -> Self {

--- a/frame/contracts/src/chain_extension.rs
+++ b/frame/contracts/src/chain_extension.rs
@@ -83,7 +83,6 @@ use sp_std::{marker::PhantomData, vec::Vec};
 pub use crate::{exec::Ext, Config};
 pub use frame_system::Config as SysConfig;
 pub use pallet_contracts_primitives::ReturnFlags;
-pub use sp_core::crypto::UncheckedFrom;
 
 /// Result that returns a [`DispatchError`] on error.
 pub type Result<T> = sp_std::result::Result<T, DispatchError>;
@@ -114,10 +113,7 @@ pub trait ChainExtension<C: Config> {
 	/// In case of `Err` the contract execution is immediately suspended and the passed error
 	/// is returned to the caller. Otherwise the value of [`RetVal`] determines the exit
 	/// behaviour.
-	fn call<E>(&mut self, env: Environment<E, InitState>) -> Result<RetVal>
-	where
-		E: Ext<T = C>,
-		<E::T as SysConfig>::AccountId: UncheckedFrom<<E::T as SysConfig>::Hash> + AsRef<[u8]>;
+	fn call<E: Ext<T = C>>(&mut self, env: Environment<E, InitState>) -> Result<RetVal>;
 
 	/// Determines whether chain extensions are enabled for this chain.
 	///
@@ -153,11 +149,7 @@ pub trait RegisteredChainExtension<C: Config>: ChainExtension<C> {
 #[impl_trait_for_tuples::impl_for_tuples(10)]
 #[tuple_types_custom_trait_bound(RegisteredChainExtension<C>)]
 impl<C: Config> ChainExtension<C> for Tuple {
-	fn call<E>(&mut self, mut env: Environment<E, InitState>) -> Result<RetVal>
-	where
-		E: Ext<T = C>,
-		<E::T as SysConfig>::AccountId: UncheckedFrom<<E::T as SysConfig>::Hash> + AsRef<[u8]>,
-	{
+	fn call<E: Ext<T = C>>(&mut self, mut env: Environment<E, InitState>) -> Result<RetVal> {
 		for_tuples!(
 			#(
 				if (Tuple::ID == env.ext_id()) && Tuple::enabled() {
@@ -205,10 +197,7 @@ pub struct Environment<'a, 'b, E: Ext, S: State> {
 }
 
 /// Functions that are available in every state of this type.
-impl<'a, 'b, E: Ext, S: State> Environment<'a, 'b, E, S>
-where
-	<E::T as SysConfig>::AccountId: UncheckedFrom<<E::T as SysConfig>::Hash> + AsRef<[u8]>,
-{
+impl<'a, 'b, E: Ext, S: State> Environment<'a, 'b, E, S> {
 	/// The function id within the `id` passed by a contract.
 	///
 	/// It returns the two least significant bytes of the `id` passed by a contract as the other
@@ -326,10 +315,7 @@ impl<'a, 'b, E: Ext, S: PrimOut> Environment<'a, 'b, E, S> {
 }
 
 /// Functions to use the input arguments as pointer to a buffer.
-impl<'a, 'b, E: Ext, S: BufIn> Environment<'a, 'b, E, S>
-where
-	<E::T as SysConfig>::AccountId: UncheckedFrom<<E::T as SysConfig>::Hash> + AsRef<[u8]>,
-{
+impl<'a, 'b, E: Ext, S: BufIn> Environment<'a, 'b, E, S> {
 	/// Reads `min(max_len, in_len)` from contract memory.
 	///
 	/// This does **not** charge any weight. The caller must make sure that the an
@@ -401,10 +387,7 @@ where
 }
 
 /// Functions to use the output arguments as pointer to a buffer.
-impl<'a, 'b, E: Ext, S: BufOut> Environment<'a, 'b, E, S>
-where
-	<E::T as SysConfig>::AccountId: UncheckedFrom<<E::T as SysConfig>::Hash> + AsRef<[u8]>,
-{
+impl<'a, 'b, E: Ext, S: BufOut> Environment<'a, 'b, E, S> {
 	/// Write the supplied buffer to contract memory.
 	///
 	/// If the contract supplied buffer is smaller than the passed `buffer` an `Err` is returned.

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -18,8 +18,8 @@
 use crate::{
 	gas::GasMeter,
 	storage::{self, Storage, WriteOutcome},
-	BalanceOf, CodeHash, Config, ContractInfo, ContractInfoOf, Determinism, Error, Event, Nonce,
-	Pallet as Contracts, Schedule,
+	AddressGenerator, BalanceOf, CodeHash, Config, ContractInfo, ContractInfoOf, Determinism,
+	Error, Event, Nonce, Pallet as Contracts, Schedule,
 };
 use frame_support::{
 	crypto::ecdsa::ECDSAExt,
@@ -32,7 +32,7 @@ use frame_support::{
 use frame_system::RawOrigin;
 use pallet_contracts_primitives::ExecReturnValue;
 use smallvec::{Array, SmallVec};
-use sp_core::{crypto::UncheckedFrom, ecdsa::Public as ECDSAPublic};
+use sp_core::ecdsa::Public as ECDSAPublic;
 use sp_io::{crypto::secp256k1_ecdsa_recover_compressed, hashing::blake2_256};
 use sp_runtime::traits::{Convert, Hash};
 use sp_std::{marker::PhantomData, mem, prelude::*};
@@ -475,6 +475,8 @@ enum FrameArgs<'a, T: Config, E> {
 		executable: E,
 		/// A salt used in the contract address deriviation of the new contract.
 		salt: &'a [u8],
+		/// The input data is used in the contract address deriviation of the new contract.
+		input_data: &'a [u8],
 	},
 }
 
@@ -596,7 +598,6 @@ impl<T: Config> CachedContract<T> {
 impl<'a, T, E> Stack<'a, T, E>
 where
 	T: Config,
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
 	E: Executable<T>,
 {
 	/// Create and run a new call stack by calling into `dest`.
@@ -660,6 +661,7 @@ where
 				nonce: <Nonce<T>>::get().wrapping_add(1),
 				executable,
 				salt,
+				input_data: input_data.as_ref(),
 			},
 			origin,
 			gas_meter,
@@ -742,9 +744,13 @@ where
 
 					(dest, contract, executable, delegate_caller, ExportedFunction::Call, None)
 				},
-				FrameArgs::Instantiate { sender, nonce, executable, salt } => {
-					let account_id =
-						<Contracts<T>>::contract_address(&sender, executable.code_hash(), salt);
+				FrameArgs::Instantiate { sender, nonce, executable, salt, input_data } => {
+					let account_id = T::AddressGenerator::generate_address(
+						&sender,
+						executable.code_hash(),
+						input_data,
+						salt,
+					);
 					let trie_id = Storage::<T>::generate_trie_id(&account_id, nonce);
 					let contract =
 						Storage::<T>::new_contract(&account_id, trie_id, *executable.code_hash())?;
@@ -1080,7 +1086,6 @@ where
 impl<'a, T, E> Ext for Stack<'a, T, E>
 where
 	T: Config,
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
 	E: Executable<T>,
 {
 	type T = T;
@@ -1167,6 +1172,7 @@ where
 				nonce,
 				executable,
 				salt,
+				input_data: input_data.as_ref(),
 			},
 			value,
 			gas_limit,

--- a/frame/contracts/src/gas.rs
+++ b/frame/contracts/src/gas.rs
@@ -23,7 +23,6 @@ use frame_support::{
 	weights::Weight,
 	DefaultNoBound,
 };
-use sp_core::crypto::UncheckedFrom;
 use sp_runtime::traits::Zero;
 use sp_std::marker::PhantomData;
 
@@ -86,10 +85,7 @@ pub struct GasMeter<T: Config> {
 	tokens: Vec<ErasedToken>,
 }
 
-impl<T: Config> GasMeter<T>
-where
-	T::AccountId: UncheckedFrom<<T as frame_system::Config>::Hash> + AsRef<[u8]>,
-{
+impl<T: Config> GasMeter<T> {
 	pub fn new(gas_limit: Weight) -> Self {
 		GasMeter {
 			gas_limit,

--- a/frame/contracts/src/storage/meter.rs
+++ b/frame/contracts/src/storage/meter.rs
@@ -29,7 +29,6 @@ use frame_support::{
 	DefaultNoBound, RuntimeDebugNoBound,
 };
 use pallet_contracts_primitives::StorageDeposit as Deposit;
-use sp_core::crypto::UncheckedFrom;
 use sp_runtime::{
 	traits::{Saturating, Zero},
 	FixedPointNumber, FixedU128,
@@ -255,7 +254,6 @@ impl<T: Config> Default for Contribution<T> {
 impl<T, E, S> RawMeter<T, E, S>
 where
 	T: Config,
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
 	E: Ext<T>,
 	S: State,
 {
@@ -325,7 +323,6 @@ where
 impl<T, E> RawMeter<T, E, Root>
 where
 	T: Config,
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
 	E: Ext<T>,
 {
 	/// Create new storage meter for the specified `origin` and `limit`.
@@ -361,7 +358,6 @@ where
 impl<T, E> RawMeter<T, E, Nested>
 where
 	T: Config,
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
 	E: Ext<T>,
 {
 	/// Try to charge the `diff` from the meter. Fails if this would exceed the original limit.
@@ -441,11 +437,7 @@ where
 	}
 }
 
-impl<T> Ext<T> for ReservingExt
-where
-	T: Config,
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
-{
+impl<T: Config> Ext<T> for ReservingExt {
 	fn check_limit(
 		origin: &T::AccountId,
 		limit: Option<BalanceOf<T>>,

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -19,7 +19,7 @@ use self::test_utils::hash;
 use crate::{
 	chain_extension::{
 		ChainExtension, Environment, Ext, InitState, RegisteredChainExtension,
-		Result as ExtensionResult, RetVal, ReturnFlags, SysConfig, UncheckedFrom,
+		Result as ExtensionResult, RetVal, ReturnFlags, SysConfig,
 	},
 	exec::{FixSizedKey, Frame},
 	storage::Storage,
@@ -174,7 +174,6 @@ impl ChainExtension<Test> for TestExtension {
 	fn call<E>(&mut self, env: Environment<E, InitState>) -> ExtensionResult<RetVal>
 	where
 		E: Ext<T = Test>,
-		<E::T as SysConfig>::AccountId: UncheckedFrom<<E::T as SysConfig>::Hash> + AsRef<[u8]>,
 	{
 		let func_id = env.func_id();
 		let id = env.ext_id() as u32 | func_id as u32;
@@ -219,7 +218,6 @@ impl ChainExtension<Test> for RevertingExtension {
 	fn call<E>(&mut self, _env: Environment<E, InitState>) -> ExtensionResult<RetVal>
 	where
 		E: Ext<T = Test>,
-		<E::T as SysConfig>::AccountId: UncheckedFrom<<E::T as SysConfig>::Hash> + AsRef<[u8]>,
 	{
 		Ok(RetVal::Diverging { flags: ReturnFlags::REVERT, data: vec![0x4B, 0x1D] })
 	}
@@ -237,7 +235,6 @@ impl ChainExtension<Test> for DisabledExtension {
 	fn call<E>(&mut self, _env: Environment<E, InitState>) -> ExtensionResult<RetVal>
 	where
 		E: Ext<T = Test>,
-		<E::T as SysConfig>::AccountId: UncheckedFrom<<E::T as SysConfig>::Hash> + AsRef<[u8]>,
 	{
 		panic!("Disabled chain extensions are never called")
 	}
@@ -255,7 +252,6 @@ impl ChainExtension<Test> for TempStorageExtension {
 	fn call<E>(&mut self, env: Environment<E, InitState>) -> ExtensionResult<RetVal>
 	where
 		E: Ext<T = Test>,
-		<E::T as SysConfig>::AccountId: UncheckedFrom<<E::T as SysConfig>::Hash> + AsRef<[u8]>,
 	{
 		let func_id = env.func_id();
 		match func_id {
@@ -542,16 +538,19 @@ fn instantiate_and_call_and_deposit_event() {
 		initialize_block(2);
 
 		// Check at the end to get hash on error easily
-		assert_ok!(Contracts::instantiate(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			value,
 			GAS_LIMIT,
 			None,
-			code_hash,
+			Code::Existing(code_hash),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 		assert!(ContractInfoOf::<Test>::contains_key(&addr));
 
 		assert_eq!(
@@ -621,21 +620,24 @@ fn instantiate_and_call_and_deposit_event() {
 
 #[test]
 fn deposit_event_max_value_limit() {
-	let (wasm, code_hash) = compile_module::<Test>("event_size").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("event_size").unwrap();
 
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		// Create
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			30_000,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Call contract with allowed storage value.
 		assert_ok!(Contracts::call(
@@ -664,21 +666,24 @@ fn deposit_event_max_value_limit() {
 
 #[test]
 fn run_out_of_gas() {
-	let (wasm, code_hash) = compile_module::<Test>("run_out_of_gas").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("run_out_of_gas").unwrap();
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			100 * min_balance,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Call the contract with a fixed gas limit. It must run out of gas because it just
 		// loops forever.
@@ -711,18 +716,21 @@ fn instantiate_unique_trie_id() {
 			Determinism::Deterministic,
 		)
 		.unwrap();
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
 
 		// Instantiate the contract and store its trie id for later comparison.
-		assert_ok!(Contracts::instantiate(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			0,
 			GAS_LIMIT,
 			None,
-			code_hash,
+			Code::Existing(code_hash),
 			vec![],
 			vec![],
-		));
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 		let trie_id = get_contract(&addr).trie_id;
 
 		// Try to instantiate it again without termination should yield an error.
@@ -767,21 +775,24 @@ fn instantiate_unique_trie_id() {
 
 #[test]
 fn storage_max_value_limit() {
-	let (wasm, code_hash) = compile_module::<Test>("storage_size").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("storage_size").unwrap();
 
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		// Create
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			30_000,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 		get_contract(&addr);
 
 		// Call contract with allowed storage value.
@@ -811,34 +822,46 @@ fn storage_max_value_limit() {
 
 #[test]
 fn deploy_and_call_other_contract() {
-	let (caller_wasm, caller_code_hash) = compile_module::<Test>("caller_contract").unwrap();
+	let (caller_wasm, _caller_code_hash) = compile_module::<Test>("caller_contract").unwrap();
 	let (callee_wasm, callee_code_hash) = compile_module::<Test>("return_with_data").unwrap();
-	let caller_addr = Contracts::contract_address(&ALICE, &caller_code_hash, &[]);
-	let callee_addr = Contracts::contract_address(&caller_addr, &callee_code_hash, &[]);
 
 	ExtBuilder::default().existential_deposit(500).build().execute_with(|| {
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 
 		// Create
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let caller_addr = Contracts::bare_instantiate(
+			ALICE,
 			100_000,
 			GAS_LIMIT,
 			None,
-			caller_wasm,
+			Code::Upload(caller_wasm),
 			vec![],
 			vec![],
-		));
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
+		Contracts::bare_instantiate(
+			ALICE,
 			100_000,
 			GAS_LIMIT,
 			None,
-			callee_wasm,
+			Code::Upload(callee_wasm),
 			0u32.to_le_bytes().encode(),
 			vec![42],
-		));
+			false,
+		)
+		.result
+		.unwrap();
+
+		let callee_addr = Contracts::contract_address(
+			&caller_addr,
+			&callee_code_hash,
+			&[0, 1, 34, 51, 68, 85, 102, 119],
+			&[],
+		);
 
 		// Drop previous events
 		initialize_block(2);
@@ -938,23 +961,26 @@ fn deploy_and_call_other_contract() {
 
 #[test]
 fn delegate_call() {
-	let (caller_wasm, caller_code_hash) = compile_module::<Test>("delegate_call").unwrap();
+	let (caller_wasm, _caller_code_hash) = compile_module::<Test>("delegate_call").unwrap();
 	let (callee_wasm, callee_code_hash) = compile_module::<Test>("delegate_call_lib").unwrap();
-	let caller_addr = Contracts::contract_address(&ALICE, &caller_code_hash, &[]);
 
 	ExtBuilder::default().existential_deposit(500).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 
 		// Instantiate the 'caller'
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let caller_addr = Contracts::bare_instantiate(
+			ALICE,
 			300_000,
 			GAS_LIMIT,
 			None,
-			caller_wasm,
+			Code::Upload(caller_wasm),
 			vec![],
 			vec![],
-		));
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 		// Only upload 'callee' code
 		assert_ok!(Contracts::upload_code(
 			RuntimeOrigin::signed(ALICE),
@@ -976,21 +1002,24 @@ fn delegate_call() {
 
 #[test]
 fn cannot_self_destruct_through_draning() {
-	let (wasm, code_hash) = compile_module::<Test>("drain").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("drain").unwrap();
 	ExtBuilder::default().existential_deposit(200).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 
 		// Instantiate the BOB contract.
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			1_000,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Check that the BOB contract has been instantiated.
 		get_contract(&addr);
@@ -1016,22 +1045,25 @@ fn cannot_self_destruct_through_draning() {
 
 #[test]
 fn cannot_self_destruct_through_storage_refund_after_price_change() {
-	let (wasm, code_hash) = compile_module::<Test>("store").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("store").unwrap();
 	ExtBuilder::default().existential_deposit(200).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 
 		// Instantiate the BOB contract.
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			0,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Check that the BOB contract has been instantiated and has the minimum balance
 		assert_eq!(get_contract(&addr).total_deposit(), min_balance);
@@ -1072,21 +1104,24 @@ fn cannot_self_destruct_through_storage_refund_after_price_change() {
 
 #[test]
 fn cannot_self_destruct_by_refund_after_slash() {
-	let (wasm, code_hash) = compile_module::<Test>("store").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("store").unwrap();
 	ExtBuilder::default().existential_deposit(500).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			0,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// create 100 more reserved balance
 		assert_ok!(Contracts::call(
@@ -1155,21 +1190,24 @@ fn cannot_self_destruct_by_refund_after_slash() {
 
 #[test]
 fn cannot_self_destruct_while_live() {
-	let (wasm, code_hash) = compile_module::<Test>("self_destruct").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("self_destruct").unwrap();
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 
 		// Instantiate the BOB contract.
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			100_000,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Check that the BOB contract has been instantiated.
 		get_contract(&addr);
@@ -1201,16 +1239,19 @@ fn self_destruct_works() {
 		let _ = Balances::deposit_creating(&DJANGO, 1_000_000);
 
 		// Instantiate the BOB contract.
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			100_000,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Check that the BOB contract has been instantiated.
 		get_contract(&addr);
@@ -1289,36 +1330,32 @@ fn self_destruct_works() {
 #[test]
 fn destroy_contract_and_transfer_funds() {
 	let (callee_wasm, callee_code_hash) = compile_module::<Test>("self_destruct").unwrap();
-	let (caller_wasm, caller_code_hash) = compile_module::<Test>("destroy_and_transfer").unwrap();
+	let (caller_wasm, _caller_code_hash) = compile_module::<Test>("destroy_and_transfer").unwrap();
 
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
-		// Create
+		// Create code hash for bob to instantiate
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
-			200_000,
-			GAS_LIMIT,
-			None,
-			callee_wasm,
-			vec![],
-			vec![42]
-		));
+		Contracts::bare_upload_code(ALICE, callee_wasm, None, Determinism::Deterministic).unwrap();
 
 		// This deploys the BOB contract, which in turn deploys the CHARLIE contract during
 		// construction.
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr_bob = Contracts::bare_instantiate(
+			ALICE,
 			200_000,
 			GAS_LIMIT,
 			None,
-			caller_wasm,
+			Code::Upload(caller_wasm),
 			callee_code_hash.as_ref().to_vec(),
 			vec![],
-		));
-		let addr_bob = Contracts::contract_address(&ALICE, &caller_code_hash, &[]);
-		let addr_charlie = Contracts::contract_address(&addr_bob, &callee_code_hash, &[0x47, 0x11]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Check that the CHARLIE contract has been instantiated.
+		let addr_charlie =
+			Contracts::contract_address(&addr_bob, &callee_code_hash, &[], &[0x47, 0x11]);
 		get_contract(&addr_charlie);
 
 		// Call BOB, which calls CHARLIE, forcing CHARLIE to self-destruct.
@@ -1360,22 +1397,25 @@ fn cannot_self_destruct_in_constructor() {
 
 #[test]
 fn crypto_hashes() {
-	let (wasm, code_hash) = compile_module::<Test>("crypto_hashes").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("crypto_hashes").unwrap();
 
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 
 		// Instantiate the CRYPTO_HASHES contract.
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			100_000,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 		// Perform the call.
 		let input = b"_DEAD_BEEF";
 		use sp_io::hashing::*;
@@ -1418,21 +1458,24 @@ fn crypto_hashes() {
 
 #[test]
 fn transfer_return_code() {
-	let (wasm, code_hash) = compile_module::<Test>("transfer_return_code").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("transfer_return_code").unwrap();
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 		let _ = Balances::deposit_creating(&ALICE, 1000 * min_balance);
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		),);
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Contract has only the minimal balance so any transfer will fail.
 		Balances::make_free_balance_be(&addr, min_balance);
@@ -1473,23 +1516,26 @@ fn transfer_return_code() {
 
 #[test]
 fn call_return_code() {
-	let (caller_code, caller_hash) = compile_module::<Test>("call_return_code").unwrap();
-	let (callee_code, callee_hash) = compile_module::<Test>("ok_trap_revert").unwrap();
+	let (caller_code, _caller_hash) = compile_module::<Test>("call_return_code").unwrap();
+	let (callee_code, _callee_hash) = compile_module::<Test>("ok_trap_revert").unwrap();
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 		let _ = Balances::deposit_creating(&ALICE, 1000 * min_balance);
 		let _ = Balances::deposit_creating(&CHARLIE, 1000 * min_balance);
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr_bob = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			caller_code,
+			Code::Upload(caller_code),
 			vec![0],
 			vec![],
-		),);
-		let addr_bob = Contracts::contract_address(&ALICE, &caller_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 		Balances::make_free_balance_be(&addr_bob, min_balance);
 
 		// Contract calls into Django which is no valid contract
@@ -1507,16 +1553,19 @@ fn call_return_code() {
 		.unwrap();
 		assert_return_code!(result, RuntimeReturnCode::NotCallable);
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(CHARLIE),
+		let addr_django = Contracts::bare_instantiate(
+			CHARLIE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			callee_code,
+			Code::Upload(callee_code),
 			vec![0],
 			vec![],
-		),);
-		let addr_django = Contracts::contract_address(&CHARLIE, &callee_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 		Balances::make_free_balance_be(&addr_django, min_balance);
 
 		// Contract has only the minimal balance so any transfer will fail.
@@ -1604,7 +1653,7 @@ fn call_return_code() {
 
 #[test]
 fn instantiate_return_code() {
-	let (caller_code, caller_hash) = compile_module::<Test>("instantiate_return_code").unwrap();
+	let (caller_code, _caller_hash) = compile_module::<Test>("instantiate_return_code").unwrap();
 	let (callee_code, callee_hash) = compile_module::<Test>("ok_trap_revert").unwrap();
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let min_balance = <Test as Config>::Currency::minimum_balance();
@@ -1620,18 +1669,21 @@ fn instantiate_return_code() {
 			callee_code,
 			vec![],
 			vec![],
-		),);
+		));
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			caller_code,
+			Code::Upload(caller_code),
 			vec![],
 			vec![],
-		),);
-		let addr = Contracts::contract_address(&ALICE, &caller_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Contract has only the minimal balance so any transfer will fail.
 		Balances::make_free_balance_be(&addr, min_balance);
@@ -1740,20 +1792,23 @@ fn disabled_chain_extension_wont_deploy() {
 
 #[test]
 fn disabled_chain_extension_errors_on_call() {
-	let (code, hash) = compile_module::<Test>("chain_extension").unwrap();
+	let (code, _hash) = compile_module::<Test>("chain_extension").unwrap();
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 		let _ = Balances::deposit_creating(&ALICE, 1000 * min_balance);
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			code,
+			Code::Upload(code),
 			vec![],
 			vec![],
-		),);
-		let addr = Contracts::contract_address(&ALICE, &hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 		TestExtension::disable();
 		assert_err_ignore_postinfo!(
 			Contracts::call(RuntimeOrigin::signed(ALICE), addr.clone(), 0, GAS_LIMIT, None, vec![],),
@@ -1764,20 +1819,23 @@ fn disabled_chain_extension_errors_on_call() {
 
 #[test]
 fn chain_extension_works() {
-	let (code, hash) = compile_module::<Test>("chain_extension").unwrap();
+	let (code, _hash) = compile_module::<Test>("chain_extension").unwrap();
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 		let _ = Balances::deposit_creating(&ALICE, 1000 * min_balance);
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			code,
+			Code::Upload(code),
 			vec![],
 			vec![],
-		),);
-		let addr = Contracts::contract_address(&ALICE, &hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// 0 = read input buffer and pass it through as output
 		let input: Vec<u8> = ExtensionInput { extension_id: 0, func_id: 0, extra: &[99] }.into();
@@ -1900,20 +1958,23 @@ fn chain_extension_works() {
 
 #[test]
 fn chain_extension_temp_storage_works() {
-	let (code, hash) = compile_module::<Test>("chain_extension_temp_storage").unwrap();
+	let (code, _hash) = compile_module::<Test>("chain_extension_temp_storage").unwrap();
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 		let _ = Balances::deposit_creating(&ALICE, 1000 * min_balance);
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			code,
+			Code::Upload(code),
 			vec![],
 			vec![],
-		),);
-		let addr = Contracts::contract_address(&ALICE, &hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Call func 0 and func 1 back to back.
 		let stop_recursion = 0u8;
@@ -1942,22 +2003,25 @@ fn chain_extension_temp_storage_works() {
 
 #[test]
 fn lazy_removal_works() {
-	let (code, hash) = compile_module::<Test>("self_destruct").unwrap();
+	let (code, _hash) = compile_module::<Test>("self_destruct").unwrap();
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 		let _ = Balances::deposit_creating(&ALICE, 1000 * min_balance);
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			code,
+			Code::Upload(code),
 			vec![],
 			vec![],
-		),);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
-		let addr = Contracts::contract_address(&ALICE, &hash, &[]);
 		let info = get_contract(&addr);
 		let trie = &info.child_trie_info();
 
@@ -2009,24 +2073,27 @@ fn lazy_removal_on_full_queue_works_on_initialize() {
 
 #[test]
 fn lazy_batch_removal_works() {
-	let (code, hash) = compile_module::<Test>("self_destruct").unwrap();
+	let (code, _hash) = compile_module::<Test>("self_destruct").unwrap();
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 		let _ = Balances::deposit_creating(&ALICE, 1000 * min_balance);
 		let mut tries: Vec<child::ChildInfo> = vec![];
 
 		for i in 0..3u8 {
-			assert_ok!(Contracts::instantiate_with_code(
-				RuntimeOrigin::signed(ALICE),
+			let addr = Contracts::bare_instantiate(
+				ALICE,
 				min_balance * 100,
 				GAS_LIMIT,
 				None,
-				code.clone(),
+				Code::Upload(code.clone()),
 				vec![],
 				vec![i],
-			),);
+				false,
+			)
+			.result
+			.unwrap()
+			.account_id;
 
-			let addr = Contracts::contract_address(&ALICE, &hash, &[i]);
 			let info = get_contract(&addr);
 			let trie = &info.child_trie_info();
 
@@ -2062,7 +2129,7 @@ fn lazy_batch_removal_works() {
 
 #[test]
 fn lazy_removal_partial_remove_works() {
-	let (code, hash) = compile_module::<Test>("self_destruct").unwrap();
+	let (code, _hash) = compile_module::<Test>("self_destruct").unwrap();
 
 	// We create a contract with some extra keys above the weight limit
 	let extra_keys = 7u32;
@@ -2078,17 +2145,20 @@ fn lazy_removal_partial_remove_works() {
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 		let _ = Balances::deposit_creating(&ALICE, 1000 * min_balance);
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			code,
+			Code::Upload(code),
 			vec![],
 			vec![],
-		),);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
-		let addr = Contracts::contract_address(&ALICE, &hash, &[]);
 		let info = get_contract(&addr);
 
 		// Put value into the contracts child trie
@@ -2185,22 +2255,25 @@ fn lazy_removal_does_no_run_on_full_queue_and_full_block() {
 
 #[test]
 fn lazy_removal_does_no_run_on_low_remaining_weight() {
-	let (code, hash) = compile_module::<Test>("self_destruct").unwrap();
+	let (code, _hash) = compile_module::<Test>("self_destruct").unwrap();
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 		let _ = Balances::deposit_creating(&ALICE, 1000 * min_balance);
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			code,
+			Code::Upload(code),
 			vec![],
 			vec![],
-		),);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
-		let addr = Contracts::contract_address(&ALICE, &hash, &[]);
 		let info = get_contract(&addr);
 		let trie = &info.child_trie_info();
 
@@ -2249,7 +2322,7 @@ fn lazy_removal_does_no_run_on_low_remaining_weight() {
 
 #[test]
 fn lazy_removal_does_not_use_all_weight() {
-	let (code, hash) = compile_module::<Test>("self_destruct").unwrap();
+	let (code, _hash) = compile_module::<Test>("self_destruct").unwrap();
 
 	let weight_limit = Weight::from_ref_time(5_000_000_000);
 	let mut ext = ExtBuilder::default().existential_deposit(50).build();
@@ -2258,17 +2331,20 @@ fn lazy_removal_does_not_use_all_weight() {
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 		let _ = Balances::deposit_creating(&ALICE, 1000 * min_balance);
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			code,
+			Code::Upload(code),
 			vec![],
 			vec![],
-		),);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
-		let addr = Contracts::contract_address(&ALICE, &hash, &[]);
 		let info = get_contract(&addr);
 		let (weight_per_key, max_keys) = Storage::<Test>::deletion_budget(1, weight_limit);
 
@@ -2333,22 +2409,24 @@ fn lazy_removal_does_not_use_all_weight() {
 
 #[test]
 fn deletion_queue_full() {
-	let (code, hash) = compile_module::<Test>("self_destruct").unwrap();
+	let (code, _hash) = compile_module::<Test>("self_destruct").unwrap();
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 		let _ = Balances::deposit_creating(&ALICE, 1000 * min_balance);
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			code,
+			Code::Upload(code),
 			vec![],
 			vec![],
-		),);
-
-		let addr = Contracts::contract_address(&ALICE, &hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// fill the deletion queue up until its limit
 		Storage::<Test>::fill_queue_with_dummies();
@@ -2372,42 +2450,49 @@ fn refcounter() {
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 
 		// Create two contracts with the same code and check that they do in fact share it.
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr0 = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			wasm.clone(),
+			Code::Upload(wasm.clone()),
 			vec![],
 			vec![0],
-		));
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
+		let addr1 = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			wasm.clone(),
+			Code::Upload(wasm.clone()),
 			vec![],
 			vec![1],
-		));
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 		assert_refcount!(code_hash, 2);
 
 		// Sharing should also work with the usual instantiate call
-		assert_ok!(Contracts::instantiate(
-			RuntimeOrigin::signed(ALICE),
+		let addr2 = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			code_hash,
+			Code::Existing(code_hash),
 			vec![],
 			vec![2],
-		));
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 		assert_refcount!(code_hash, 3);
-
-		// addresses of all three existing contracts
-		let addr0 = Contracts::contract_address(&ALICE, &code_hash, &[0]);
-		let addr1 = Contracts::contract_address(&ALICE, &code_hash, &[1]);
-		let addr2 = Contracts::contract_address(&ALICE, &code_hash, &[2]);
 
 		// Terminating one contract should decrement the refcount
 		assert_ok!(Contracts::call(
@@ -2460,17 +2545,19 @@ fn reinstrument_does_charge() {
 		let zero = 0u32.to_le_bytes().encode();
 		let code_len = wasm.len() as u32;
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			zero.clone(),
 			vec![],
-		));
-
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Call the contract two times without reinstrument
 
@@ -2530,20 +2617,23 @@ fn reinstrument_does_charge() {
 
 #[test]
 fn debug_message_works() {
-	let (wasm, code_hash) = compile_module::<Test>("debug_message_works").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("debug_message_works").unwrap();
 
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			30_000,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		),);
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 		let result = Contracts::bare_call(
 			ALICE,
 			addr,
@@ -2562,20 +2652,23 @@ fn debug_message_works() {
 
 #[test]
 fn debug_message_logging_disabled() {
-	let (wasm, code_hash) = compile_module::<Test>("debug_message_logging_disabled").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("debug_message_logging_disabled").unwrap();
 
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			30_000,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		),);
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 		// disable logging by passing `false`
 		let result = Contracts::bare_call(
 			ALICE,
@@ -2596,20 +2689,23 @@ fn debug_message_logging_disabled() {
 
 #[test]
 fn debug_message_invalid_utf8() {
-	let (wasm, code_hash) = compile_module::<Test>("debug_message_invalid_utf8").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("debug_message_invalid_utf8").unwrap();
 
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			30_000,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		),);
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 		let result = Contracts::bare_call(
 			ALICE,
 			addr,
@@ -2626,34 +2722,40 @@ fn debug_message_invalid_utf8() {
 
 #[test]
 fn gas_estimation_nested_call_fixed_limit() {
-	let (caller_code, caller_hash) = compile_module::<Test>("call_with_limit").unwrap();
-	let (callee_code, callee_hash) = compile_module::<Test>("dummy").unwrap();
+	let (caller_code, _caller_hash) = compile_module::<Test>("call_with_limit").unwrap();
+	let (callee_code, _callee_hash) = compile_module::<Test>("dummy").unwrap();
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 		let _ = Balances::deposit_creating(&ALICE, 1000 * min_balance);
 		let _ = Balances::deposit_creating(&CHARLIE, 1000 * min_balance);
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr_caller = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			caller_code,
+			Code::Upload(caller_code),
 			vec![],
 			vec![0],
-		),);
-		let addr_caller = Contracts::contract_address(&ALICE, &caller_hash, &[0]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr_callee = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			callee_code,
+			Code::Upload(callee_code),
 			vec![],
 			vec![1],
-		),);
-		let addr_callee = Contracts::contract_address(&ALICE, &callee_hash, &[1]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		let input: Vec<u8> = AsRef::<[u8]>::as_ref(&addr_callee)
 			.iter()
@@ -2697,34 +2799,40 @@ fn gas_estimation_nested_call_fixed_limit() {
 #[test]
 fn gas_estimation_call_runtime() {
 	use codec::Decode;
-	let (caller_code, caller_hash) = compile_module::<Test>("call_runtime").unwrap();
-	let (callee_code, callee_hash) = compile_module::<Test>("dummy").unwrap();
+	let (caller_code, _caller_hash) = compile_module::<Test>("call_runtime").unwrap();
+	let (callee_code, _callee_hash) = compile_module::<Test>("dummy").unwrap();
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 		let _ = Balances::deposit_creating(&ALICE, 1000 * min_balance);
 		let _ = Balances::deposit_creating(&CHARLIE, 1000 * min_balance);
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr_caller = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			caller_code,
+			Code::Upload(caller_code),
 			vec![],
 			vec![0],
-		),);
-		let addr_caller = Contracts::contract_address(&ALICE, &caller_hash, &[0]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr_callee = Contracts::bare_instantiate(
+			ALICE,
 			min_balance * 100,
 			GAS_LIMIT,
 			None,
-			callee_code,
+			Code::Upload(callee_code),
 			vec![],
 			vec![1],
-		),);
-		let addr_callee = Contracts::contract_address(&ALICE, &callee_hash, &[1]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Call something trivial with a huge gas limit so that we can observe the effects
 		// of pre-charging. This should create a difference between consumed and required.
@@ -2769,22 +2877,25 @@ fn gas_estimation_call_runtime() {
 
 #[test]
 fn ecdsa_recover() {
-	let (wasm, code_hash) = compile_module::<Test>("ecdsa_recover").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("ecdsa_recover").unwrap();
 
 	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 
 		// Instantiate the ecdsa_recover contract.
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			100_000,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		#[rustfmt::skip]
 		let signature: [u8; 65] = [
@@ -3071,16 +3182,19 @@ fn instantiate_with_zero_balance_works() {
 		initialize_block(2);
 
 		// Instantiate the BOB contract.
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			0,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Check that the BOB contract has been instantiated.
 		get_contract(&addr);
@@ -3164,16 +3278,19 @@ fn instantiate_with_below_existential_deposit_works() {
 		initialize_block(2);
 
 		// Instantiate the BOB contract.
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			50,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Check that the BOB contract has been instantiated.
 		get_contract(&addr);
@@ -3257,21 +3374,24 @@ fn instantiate_with_below_existential_deposit_works() {
 
 #[test]
 fn storage_deposit_works() {
-	let (wasm, code_hash) = compile_module::<Test>("multi_store").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("multi_store").unwrap();
 	ExtBuilder::default().existential_deposit(200).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 		let mut deposit = <Test as Config>::Currency::minimum_balance();
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			0,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Drop previous events
 		initialize_block(2);
@@ -3412,16 +3532,19 @@ fn set_code_extrinsic() {
 	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			0,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		assert_ok!(Contracts::upload_code(
 			RuntimeOrigin::signed(ALICE),
@@ -3489,21 +3612,24 @@ fn set_code_extrinsic() {
 
 #[test]
 fn call_after_killed_account_needs_funding() {
-	let (wasm, code_hash) = compile_module::<Test>("dummy").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("dummy").unwrap();
 	ExtBuilder::default().existential_deposit(200).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			700,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Drop previous events
 		initialize_block(2);
@@ -3790,21 +3916,23 @@ fn set_code_hash() {
 	let (wasm, code_hash) = compile_module::<Test>("set_code_hash").unwrap();
 	let (new_wasm, new_code_hash) = compile_module::<Test>("new_set_code_hash_contract").unwrap();
 
-	let contract_addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
-
 	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 
 		// Instantiate the 'caller'
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let contract_addr = Contracts::bare_instantiate(
+			ALICE,
 			300_000,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 		// upload new code
 		assert_ok!(Contracts::upload_code(
 			RuntimeOrigin::signed(ALICE),
@@ -3881,22 +4009,25 @@ fn set_code_hash() {
 
 #[test]
 fn storage_deposit_limit_is_enforced() {
-	let (wasm, code_hash) = compile_module::<Test>("store").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("store").unwrap();
 	ExtBuilder::default().existential_deposit(200).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 
 		// Instantiate the BOB contract.
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			0,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Check that the BOB contract has been instantiated and has the minimum balance
 		assert_eq!(get_contract(&addr).total_deposit(), min_balance);
@@ -3919,33 +4050,39 @@ fn storage_deposit_limit_is_enforced() {
 
 #[test]
 fn storage_deposit_limit_is_enforced_late() {
-	let (wasm_caller, code_hash_caller) =
+	let (wasm_caller, _code_hash_caller) =
 		compile_module::<Test>("create_storage_and_call").unwrap();
-	let (wasm_callee, code_hash_callee) = compile_module::<Test>("store").unwrap();
+	let (wasm_callee, _code_hash_callee) = compile_module::<Test>("store").unwrap();
 	ExtBuilder::default().existential_deposit(200).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 
 		// Create both contracts: Constructors do nothing.
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr_caller = Contracts::bare_instantiate(
+			ALICE,
 			0,
 			GAS_LIMIT,
 			None,
-			wasm_caller,
+			Code::Upload(wasm_caller),
 			vec![],
 			vec![],
-		));
-		let addr_caller = Contracts::contract_address(&ALICE, &code_hash_caller, &[]);
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
+		let addr_callee = Contracts::bare_instantiate(
+			ALICE,
 			0,
 			GAS_LIMIT,
 			None,
-			wasm_callee,
+			Code::Upload(wasm_callee),
 			vec![],
 			vec![],
-		));
-		let addr_callee = Contracts::contract_address(&ALICE, &code_hash_callee, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Create 100 bytes of storage with a price of per byte
 		// This is 100 Balance + 2 Balance for the item
@@ -4058,23 +4195,26 @@ fn storage_deposit_limit_is_enforced_late() {
 
 #[test]
 fn deposit_limit_honors_liquidity_restrictions() {
-	let (wasm, code_hash) = compile_module::<Test>("store").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("store").unwrap();
 	ExtBuilder::default().existential_deposit(200).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 		let _ = Balances::deposit_creating(&BOB, 1_000);
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 
 		// Instantiate the BOB contract.
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			0,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Check that the contract has been instantiated and has the minimum balance
 		assert_eq!(get_contract(&addr).total_deposit(), min_balance);
@@ -4099,23 +4239,26 @@ fn deposit_limit_honors_liquidity_restrictions() {
 
 #[test]
 fn deposit_limit_honors_existential_deposit() {
-	let (wasm, code_hash) = compile_module::<Test>("store").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("store").unwrap();
 	ExtBuilder::default().existential_deposit(200).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 		let _ = Balances::deposit_creating(&BOB, 1_000);
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 
 		// Instantiate the BOB contract.
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			0,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Check that the contract has been instantiated and has the minimum balance
 		assert_eq!(get_contract(&addr).total_deposit(), min_balance);
@@ -4139,23 +4282,26 @@ fn deposit_limit_honors_existential_deposit() {
 
 #[test]
 fn deposit_limit_honors_min_leftover() {
-	let (wasm, code_hash) = compile_module::<Test>("store").unwrap();
+	let (wasm, _code_hash) = compile_module::<Test>("store").unwrap();
 	ExtBuilder::default().existential_deposit(200).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 		let _ = Balances::deposit_creating(&BOB, 1_000);
 		let min_balance = <Test as Config>::Currency::minimum_balance();
 
 		// Instantiate the BOB contract.
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let addr = Contracts::bare_instantiate(
+			ALICE,
 			0,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
-		let addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// Check that the contract has been instantiated and has the minimum balance
 		assert_eq!(get_contract(&addr).total_deposit(), min_balance);
@@ -4419,21 +4565,24 @@ fn delegate_call_indeterministic_code() {
 
 #[test]
 fn reentrance_count_works_with_call() {
-	let (wasm, code_hash) = compile_module::<Test>("reentrance_count_call").unwrap();
-	let contract_addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
+	let (wasm, _code_hash) = compile_module::<Test>("reentrance_count_call").unwrap();
 
 	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let contract_addr = Contracts::bare_instantiate(
+			ALICE,
 			300_000,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// passing reentrant count to the input
 		let input = 0.encode();
@@ -4456,20 +4605,23 @@ fn reentrance_count_works_with_call() {
 #[test]
 fn reentrance_count_works_with_delegated_call() {
 	let (wasm, code_hash) = compile_module::<Test>("reentrance_count_delegated_call").unwrap();
-	let contract_addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
 
 	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let contract_addr = Contracts::bare_instantiate(
+			ALICE,
 			300_000,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		// adding a callstack height to the input
 		let input = (code_hash, 1).encode();
@@ -4491,36 +4643,40 @@ fn reentrance_count_works_with_delegated_call() {
 
 #[test]
 fn account_reentrance_count_works() {
-	let (wasm, code_hash) = compile_module::<Test>("account_reentrance_count_call").unwrap();
-	let (wasm_reentrance_count, code_hash_reentrance_count) =
+	let (wasm, _code_hash) = compile_module::<Test>("account_reentrance_count_call").unwrap();
+	let (wasm_reentrance_count, _code_hash_reentrance_count) =
 		compile_module::<Test>("reentrance_count_call").unwrap();
 
 	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let contract_addr = Contracts::bare_instantiate(
+			ALICE,
 			300_000,
 			GAS_LIMIT,
 			None,
-			wasm,
+			Code::Upload(wasm),
 			vec![],
 			vec![],
-		));
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
-		assert_ok!(Contracts::instantiate_with_code(
-			RuntimeOrigin::signed(ALICE),
+		let another_contract_addr = Contracts::bare_instantiate(
+			ALICE,
 			300_000,
 			GAS_LIMIT,
 			None,
-			wasm_reentrance_count,
+			Code::Upload(wasm_reentrance_count),
 			vec![],
-			vec![]
-		));
-
-		let contract_addr = Contracts::contract_address(&ALICE, &code_hash, &[]);
-		let another_contract_addr =
-			Contracts::contract_address(&ALICE, &code_hash_reentrance_count, &[]);
+			vec![],
+			false,
+		)
+		.result
+		.unwrap()
+		.account_id;
 
 		let result1 = Contracts::bare_call(
 			ALICE,

--- a/frame/contracts/src/wasm/code_cache.rs
+++ b/frame/contracts/src/wasm/code_cache.rs
@@ -41,7 +41,6 @@ use frame_support::{
 	traits::{Get, ReservableCurrency},
 	WeakBoundedVec,
 };
-use sp_core::crypto::UncheckedFrom;
 use sp_runtime::traits::BadOrigin;
 use sp_std::vec;
 
@@ -49,10 +48,7 @@ use sp_std::vec;
 ///
 /// Increments the refcount of the in-storage `prefab_module` if it already exists in storage
 /// under the specified `code_hash`.
-pub fn store<T: Config>(mut module: PrefabWasmModule<T>, instantiated: bool) -> DispatchResult
-where
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
-{
+pub fn store<T: Config>(mut module: PrefabWasmModule<T>, instantiated: bool) -> DispatchResult {
 	let code_hash = sp_std::mem::take(&mut module.code_hash);
 	<CodeStorage<T>>::mutate(&code_hash, |existing| match existing {
 		Some(existing) => {
@@ -135,10 +131,7 @@ pub fn increment_refcount<T: Config>(code_hash: CodeHash<T>) -> Result<(), Dispa
 }
 
 /// Try to remove code together with all associated information.
-pub fn try_remove<T: Config>(origin: &T::AccountId, code_hash: CodeHash<T>) -> DispatchResult
-where
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
-{
+pub fn try_remove<T: Config>(origin: &T::AccountId, code_hash: CodeHash<T>) -> DispatchResult {
 	<OwnerInfoOf<T>>::try_mutate_exists(&code_hash, |existing| {
 		if let Some(owner_info) = existing {
 			ensure!(owner_info.refcount == 0, <Error<T>>::CodeInUse);
@@ -164,10 +157,7 @@ pub fn load<T: Config>(
 	code_hash: CodeHash<T>,
 	schedule: &Schedule<T>,
 	gas_meter: &mut GasMeter<T>,
-) -> Result<PrefabWasmModule<T>, DispatchError>
-where
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
-{
+) -> Result<PrefabWasmModule<T>, DispatchError> {
 	let max_code_len = T::MaxCodeLen::get();
 	let charged = gas_meter.charge(CodeToken::Load(max_code_len))?;
 
@@ -192,10 +182,7 @@ where
 pub fn reinstrument<T: Config>(
 	prefab_module: &mut PrefabWasmModule<T>,
 	schedule: &Schedule<T>,
-) -> Result<u32, DispatchError>
-where
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
-{
+) -> Result<u32, DispatchError> {
 	let original_code =
 		<PristineCode<T>>::get(&prefab_module.code_hash).ok_or(Error::<T>::CodeNotFound)?;
 	let original_code_len = original_code.len();

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -36,7 +36,7 @@ use crate::{
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::dispatch::{DispatchError, DispatchResult};
-use sp_core::{crypto::UncheckedFrom, Get};
+use sp_core::Get;
 use sp_runtime::RuntimeDebug;
 use sp_std::prelude::*;
 #[cfg(test)]
@@ -140,10 +140,7 @@ impl ExportedFunction {
 	}
 }
 
-impl<T: Config> PrefabWasmModule<T>
-where
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
-{
+impl<T: Config> PrefabWasmModule<T> {
 	/// Create the module by checking and instrumenting `original_code`.
 	///
 	/// This does **not** store the module. For this one need to either call [`Self::store`]
@@ -263,10 +260,7 @@ impl<T: Config> OwnerInfo<T> {
 	}
 }
 
-impl<T: Config> Executable<T> for PrefabWasmModule<T>
-where
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
-{
+impl<T: Config> Executable<T> for PrefabWasmModule<T> {
 	fn from_storage(
 		code_hash: CodeHash<T>,
 		schedule: &Schedule<T>,
@@ -476,7 +470,7 @@ mod tests {
 				salt: salt.to_vec(),
 			});
 			Ok((
-				Contracts::<Test>::contract_address(&ALICE, &code_hash, salt),
+				Contracts::<Test>::contract_address(&ALICE, &code_hash, &data, salt),
 				ExecReturnValue { flags: ReturnFlags::empty(), data: Vec::new() },
 			))
 		}

--- a/frame/contracts/src/wasm/prepare.rs
+++ b/frame/contracts/src/wasm/prepare.rs
@@ -26,7 +26,6 @@ use crate::{
 	AccountIdOf, CodeVec, Config, Error, Schedule,
 };
 use codec::{Encode, MaxEncodedLen};
-use sp_core::crypto::UncheckedFrom;
 use sp_runtime::{traits::Hash, DispatchError};
 use sp_std::prelude::*;
 use wasm_instrument::{
@@ -396,7 +395,6 @@ fn instrument<E, T>(
 where
 	E: Environment<()>,
 	T: Config,
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
 {
 	// Do not enable any features here. Any additional feature needs to be carefully
 	// checked for potential security issues. For example, enabling multi value could lead
@@ -500,7 +498,6 @@ pub fn prepare<E, T>(
 where
 	E: Environment<()>,
 	T: Config,
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
 {
 	let (code, (initial, maximum)) =
 		instrument::<E, T>(original_code.as_ref(), schedule, determinism, try_instantiate)?;
@@ -547,7 +544,6 @@ pub fn reinstrument<E, T>(
 where
 	E: Environment<()>,
 	T: Config,
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
 {
 	instrument::<E, T>(original_code, schedule, determinism, TryInstantiate::Skip)
 		.map_err(|(err, msg)| {

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -29,7 +29,6 @@ use codec::{Decode, DecodeLimit, Encode, MaxEncodedLen};
 use frame_support::{dispatch::DispatchError, ensure, traits::Get, weights::Weight, RuntimeDebug};
 use pallet_contracts_primitives::{ExecReturnValue, ReturnFlags};
 use pallet_contracts_proc_macro::define_env;
-use sp_core::crypto::UncheckedFrom;
 use sp_io::hashing::{blake2_128, blake2_256, keccak_256, sha2_256};
 use sp_runtime::traits::{Bounded, Zero};
 use sp_std::{fmt, prelude::*};
@@ -270,11 +269,7 @@ pub enum RuntimeCosts {
 }
 
 impl RuntimeCosts {
-	fn token<T>(&self, s: &HostFnWeights<T>) -> RuntimeToken
-	where
-		T: Config,
-		T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
-	{
+	fn token<T: Config>(&self, s: &HostFnWeights<T>) -> RuntimeToken {
 		use self::RuntimeCosts::*;
 		let weight = match *self {
 			MeteringBlock(amount) => s.gas.saturating_add(amount),
@@ -375,11 +370,7 @@ struct RuntimeToken {
 	weight: Weight,
 }
 
-impl<T> Token<T> for RuntimeToken
-where
-	T: Config,
-	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
-{
+impl<T: Config> Token<T> for RuntimeToken {
 	fn weight(&self) -> Weight {
 		self.weight
 	}
@@ -463,12 +454,7 @@ pub struct Runtime<'a, E: Ext + 'a> {
 	chain_extension: Option<Box<<E::T as Config>::ChainExtension>>,
 }
 
-impl<'a, E> Runtime<'a, E>
-where
-	E: Ext + 'a,
-	<E::T as frame_system::Config>::AccountId:
-		UncheckedFrom<<E::T as frame_system::Config>::Hash> + AsRef<[u8]>,
-{
+impl<'a, E: Ext + 'a> Runtime<'a, E> {
 	pub fn new(ext: &'a mut E, input_data: Vec<u8>) -> Self {
 		Runtime {
 			ext,


### PR DESCRIPTION
* Add a prefix in order to prevent collisions with other modules
* Include the constructor arguments in the derivation as they change the behavior of a contract
* Remove now obsolete trait bounds (we create the id using `Decode` now)
* Changed instantiate benchmark to check for the influence of input bytes len on runtime (they are hashed now)

The bulk of the changes are within tests where we move away from calling `Pallet::contract_address` where possible and use `Pallet::bare_instantiate` instead which returns the new contracts address.

WIP: Needs benchmarking run