### PR TITLE
Trace response payload in default `jsonrpsee` middleware

### DIFF
--- a/client/rpc-servers/src/middleware.rs
+++ b/client/rpc-servers/src/middleware.rs
@@ -206,7 +206,7 @@ impl RpcMiddleware {
 	/// Called once the JSON-RPC request is finished and response is sent to the output buffer.
 	fn on_response(&self, result: &str, started_at: std::time::Instant) {
 		log::trace!(target: "rpc_metrics", "[{}] on_response started_at={:?}", self.transport_label, started_at);
-		log::trace!(target: "extra_rpc_metrics", "[{}] result={:?}", self.transport_label, result);
+		log::trace!(target: "rpc_metrics::extra", "[{}] result={:?}", self.transport_label, result);
 		self.metrics.requests_finished.with_label_values(&[self.transport_label]).inc();
 	}
 }

--- a/client/rpc-servers/src/middleware.rs
+++ b/client/rpc-servers/src/middleware.rs
@@ -204,8 +204,9 @@ impl RpcMiddleware {
 	}
 
 	/// Called once the JSON-RPC request is finished and response is sent to the output buffer.
-	fn on_response(&self, _result: &str, started_at: std::time::Instant) {
+	fn on_response(&self, result: &str, started_at: std::time::Instant) {
 		log::trace!(target: "rpc_metrics", "[{}] on_response started_at={:?}", self.transport_label, started_at);
+		log::trace!(target: "extra_rpc_metrics", "[{}] result={:?}", self.transport_label, result);
 		self.metrics.requests_finished.with_label_values(&[self.transport_label]).inc();
 	}
 }


### PR DESCRIPTION
Add `rpc_metrics::extra` target to log rpc response payloads in the default middleware.
