### PR TITLE
Use explicit call indices

### DIFF
--- a/bin/node-template/pallets/template/src/lib.rs
+++ b/bin/node-template/pallets/template/src/lib.rs
@@ -64,6 +64,7 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// An example dispatchable that takes a singles value as a parameter, writes the value to
 		/// storage and emits an event. This function must be dispatched by a signed extrinsic.
+		#[pallet::call_index(0)]
 		#[pallet::weight(10_000 + T::DbWeight::get().writes(1).ref_time())]
 		pub fn do_something(origin: OriginFor<T>, something: u32) -> DispatchResult {
 			// Check that the extrinsic was signed and get the signer.
@@ -81,6 +82,7 @@ pub mod pallet {
 		}
 
 		/// An example dispatchable that may throw a custom error.
+		#[pallet::call_index(1)]
 		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1).ref_time())]
 		pub fn cause_error(origin: OriginFor<T>) -> DispatchResult {
 			let _who = ensure_signed(origin)?;

--- a/frame/alliance/src/lib.rs
+++ b/frame/alliance/src/lib.rs
@@ -503,6 +503,7 @@ pub mod pallet {
 		/// Add a new proposal to be voted on.
 		///
 		/// Must be called by a Fellow.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::propose_proposed(
 			*length_bound, // B
 			T::MaxFellows::get(), // M
@@ -524,6 +525,7 @@ pub mod pallet {
 		/// Add an aye or nay vote for the sender to the given proposal.
 		///
 		/// Must be called by a Fellow.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::vote(T::MaxFellows::get()))]
 		pub fn vote(
 			origin: OriginFor<T>,
@@ -541,6 +543,7 @@ pub mod pallet {
 		/// Close a vote that is either approved, disapproved, or whose voting period has ended.
 		///
 		/// Must be called by a Fellow.
+		#[pallet::call_index(2)]
 		#[pallet::weight({
 			let b = *length_bound;
 			let m = T::MaxFellows::get();
@@ -573,6 +576,7 @@ pub mod pallet {
 		/// The Alliance must be empty, and the call must provide some founding members.
 		///
 		/// Must be called by the Root origin.
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::init_members(
 			fellows.len() as u32,
 			allies.len() as u32,
@@ -623,6 +627,7 @@ pub mod pallet {
 		/// Disband the Alliance, remove all active members and unreserve deposits.
 		///
 		/// Witness data must be set.
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::disband(
 			witness.fellow_members,
 			witness.ally_members,
@@ -673,6 +678,7 @@ pub mod pallet {
 		}
 
 		/// Set a new IPFS CID to the alliance rule.
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::set_rule())]
 		pub fn set_rule(origin: OriginFor<T>, rule: Cid) -> DispatchResult {
 			T::AdminOrigin::ensure_origin(origin)?;
@@ -684,6 +690,7 @@ pub mod pallet {
 		}
 
 		/// Make an announcement of a new IPFS CID about alliance issues.
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::announce())]
 		pub fn announce(origin: OriginFor<T>, announcement: Cid) -> DispatchResult {
 			T::AnnouncementOrigin::ensure_origin(origin)?;
@@ -699,6 +706,7 @@ pub mod pallet {
 		}
 
 		/// Remove an announcement.
+		#[pallet::call_index(7)]
 		#[pallet::weight(T::WeightInfo::remove_announcement())]
 		pub fn remove_announcement(origin: OriginFor<T>, announcement: Cid) -> DispatchResult {
 			T::AnnouncementOrigin::ensure_origin(origin)?;
@@ -716,6 +724,7 @@ pub mod pallet {
 		}
 
 		/// Submit oneself for candidacy. A fixed deposit is reserved.
+		#[pallet::call_index(8)]
 		#[pallet::weight(T::WeightInfo::join_alliance())]
 		pub fn join_alliance(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -752,6 +761,7 @@ pub mod pallet {
 
 		/// A Fellow can nominate someone to join the alliance as an Ally. There is no deposit
 		/// required from the nominator or nominee.
+		#[pallet::call_index(9)]
 		#[pallet::weight(T::WeightInfo::nominate_ally())]
 		pub fn nominate_ally(origin: OriginFor<T>, who: AccountIdLookupOf<T>) -> DispatchResult {
 			let nominator = ensure_signed(origin)?;
@@ -776,6 +786,7 @@ pub mod pallet {
 		}
 
 		/// Elevate an Ally to Fellow.
+		#[pallet::call_index(10)]
 		#[pallet::weight(T::WeightInfo::elevate_ally())]
 		pub fn elevate_ally(origin: OriginFor<T>, ally: AccountIdLookupOf<T>) -> DispatchResult {
 			T::MembershipManager::ensure_origin(origin)?;
@@ -792,6 +803,7 @@ pub mod pallet {
 
 		/// As a member, give a retirement notice and start a retirement period required to pass in
 		/// order to retire.
+		#[pallet::call_index(11)]
 		#[pallet::weight(T::WeightInfo::give_retirement_notice())]
 		pub fn give_retirement_notice(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -814,6 +826,7 @@ pub mod pallet {
 		///
 		/// This can only be done once you have called `give_retirement_notice` and the
 		/// `RetirementPeriod` has passed.
+		#[pallet::call_index(12)]
 		#[pallet::weight(T::WeightInfo::retire())]
 		pub fn retire(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -836,6 +849,7 @@ pub mod pallet {
 		}
 
 		/// Kick a member from the Alliance and slash its deposit.
+		#[pallet::call_index(13)]
 		#[pallet::weight(T::WeightInfo::kick_member())]
 		pub fn kick_member(origin: OriginFor<T>, who: AccountIdLookupOf<T>) -> DispatchResult {
 			T::MembershipManager::ensure_origin(origin)?;
@@ -853,6 +867,7 @@ pub mod pallet {
 		}
 
 		/// Add accounts or websites to the list of unscrupulous items.
+		#[pallet::call_index(14)]
 		#[pallet::weight(T::WeightInfo::add_unscrupulous_items(items.len() as u32, T::MaxWebsiteUrlLength::get()))]
 		pub fn add_unscrupulous_items(
 			origin: OriginFor<T>,
@@ -882,6 +897,7 @@ pub mod pallet {
 		}
 
 		/// Deem some items no longer unscrupulous.
+		#[pallet::call_index(15)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::remove_unscrupulous_items(
 			items.len() as u32, T::MaxWebsiteUrlLength::get()
 		))]
@@ -907,6 +923,7 @@ pub mod pallet {
 		/// Close a vote that is either approved, disapproved, or whose voting period has ended.
 		///
 		/// Must be called by a Fellow.
+		#[pallet::call_index(16)]
 		#[pallet::weight({
 			let b = *length_bound;
 			let m = T::MaxFellows::get();
@@ -934,6 +951,7 @@ pub mod pallet {
 		/// Abdicate one's position as a voting member and just be an Ally. May be used by Fellows
 		/// who do not want to leave the Alliance but do not have the capacity to participate
 		/// operationally for some time.
+		#[pallet::call_index(17)]
 		#[pallet::weight(T::WeightInfo::abdicate_fellow_status())]
 		pub fn abdicate_fellow_status(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -563,6 +563,7 @@ pub mod pallet {
 		/// Emits `Created` event when successful.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::create())]
 		pub fn create(
 			origin: OriginFor<T>,
@@ -620,6 +621,7 @@ pub mod pallet {
 		/// Emits `ForceCreated` event when successful.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::force_create())]
 		pub fn force_create(
 			origin: OriginFor<T>,
@@ -645,6 +647,7 @@ pub mod pallet {
 		///   asset.
 		///
 		/// The asset class must be frozen before calling `start_destroy`.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::start_destroy())]
 		pub fn start_destroy(origin: OriginFor<T>, id: T::AssetIdParameter) -> DispatchResult {
 			let maybe_check_owner = match T::ForceOrigin::try_origin(origin) {
@@ -667,6 +670,7 @@ pub mod pallet {
 		///   asset.
 		///
 		/// Each call emits the `Event::DestroyedAccounts` event.
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::destroy_accounts(T::RemoveItemsLimit::get()))]
 		pub fn destroy_accounts(
 			origin: OriginFor<T>,
@@ -690,6 +694,7 @@ pub mod pallet {
 		///   asset.
 		///
 		/// Each call emits the `Event::DestroyedApprovals` event.
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::destroy_approvals(T::RemoveItemsLimit::get()))]
 		pub fn destroy_approvals(
 			origin: OriginFor<T>,
@@ -711,6 +716,7 @@ pub mod pallet {
 		///   asset.
 		///
 		/// Each successful call emits the `Event::Destroyed` event.
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::finish_destroy())]
 		pub fn finish_destroy(origin: OriginFor<T>, id: T::AssetIdParameter) -> DispatchResult {
 			let _ = ensure_signed(origin)?;
@@ -730,6 +736,7 @@ pub mod pallet {
 		///
 		/// Weight: `O(1)`
 		/// Modes: Pre-existing balance of `beneficiary`; Account pre-existence of `beneficiary`.
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::mint())]
 		pub fn mint(
 			origin: OriginFor<T>,
@@ -759,6 +766,7 @@ pub mod pallet {
 		///
 		/// Weight: `O(1)`
 		/// Modes: Post-existence of `who`; Pre & post Zombie-status of `who`.
+		#[pallet::call_index(7)]
 		#[pallet::weight(T::WeightInfo::burn())]
 		pub fn burn(
 			origin: OriginFor<T>,
@@ -793,6 +801,7 @@ pub mod pallet {
 		/// Weight: `O(1)`
 		/// Modes: Pre-existence of `target`; Post-existence of sender; Account pre-existence of
 		/// `target`.
+		#[pallet::call_index(8)]
 		#[pallet::weight(T::WeightInfo::transfer())]
 		pub fn transfer(
 			origin: OriginFor<T>,
@@ -826,6 +835,7 @@ pub mod pallet {
 		/// Weight: `O(1)`
 		/// Modes: Pre-existence of `target`; Post-existence of sender; Account pre-existence of
 		/// `target`.
+		#[pallet::call_index(9)]
 		#[pallet::weight(T::WeightInfo::transfer_keep_alive())]
 		pub fn transfer_keep_alive(
 			origin: OriginFor<T>,
@@ -860,6 +870,7 @@ pub mod pallet {
 		/// Weight: `O(1)`
 		/// Modes: Pre-existence of `dest`; Post-existence of `source`; Account pre-existence of
 		/// `dest`.
+		#[pallet::call_index(10)]
 		#[pallet::weight(T::WeightInfo::force_transfer())]
 		pub fn force_transfer(
 			origin: OriginFor<T>,
@@ -887,6 +898,7 @@ pub mod pallet {
 		/// Emits `Frozen`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(11)]
 		#[pallet::weight(T::WeightInfo::freeze())]
 		pub fn freeze(
 			origin: OriginFor<T>,
@@ -923,6 +935,7 @@ pub mod pallet {
 		/// Emits `Thawed`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(12)]
 		#[pallet::weight(T::WeightInfo::thaw())]
 		pub fn thaw(
 			origin: OriginFor<T>,
@@ -958,6 +971,7 @@ pub mod pallet {
 		/// Emits `Frozen`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(13)]
 		#[pallet::weight(T::WeightInfo::freeze_asset())]
 		pub fn freeze_asset(origin: OriginFor<T>, id: T::AssetIdParameter) -> DispatchResult {
 			let origin = ensure_signed(origin)?;
@@ -984,6 +998,7 @@ pub mod pallet {
 		/// Emits `Thawed`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(14)]
 		#[pallet::weight(T::WeightInfo::thaw_asset())]
 		pub fn thaw_asset(origin: OriginFor<T>, id: T::AssetIdParameter) -> DispatchResult {
 			let origin = ensure_signed(origin)?;
@@ -1011,6 +1026,7 @@ pub mod pallet {
 		/// Emits `OwnerChanged`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(15)]
 		#[pallet::weight(T::WeightInfo::transfer_ownership())]
 		pub fn transfer_ownership(
 			origin: OriginFor<T>,
@@ -1054,6 +1070,7 @@ pub mod pallet {
 		/// Emits `TeamChanged`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(16)]
 		#[pallet::weight(T::WeightInfo::set_team())]
 		pub fn set_team(
 			origin: OriginFor<T>,
@@ -1098,6 +1115,7 @@ pub mod pallet {
 		/// Emits `MetadataSet`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(17)]
 		#[pallet::weight(T::WeightInfo::set_metadata(name.len() as u32, symbol.len() as u32))]
 		pub fn set_metadata(
 			origin: OriginFor<T>,
@@ -1122,6 +1140,7 @@ pub mod pallet {
 		/// Emits `MetadataCleared`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(18)]
 		#[pallet::weight(T::WeightInfo::clear_metadata())]
 		pub fn clear_metadata(origin: OriginFor<T>, id: T::AssetIdParameter) -> DispatchResult {
 			let origin = ensure_signed(origin)?;
@@ -1153,6 +1172,7 @@ pub mod pallet {
 		/// Emits `MetadataSet`.
 		///
 		/// Weight: `O(N + S)` where N and S are the length of the name and symbol respectively.
+		#[pallet::call_index(19)]
 		#[pallet::weight(T::WeightInfo::force_set_metadata(name.len() as u32, symbol.len() as u32))]
 		pub fn force_set_metadata(
 			origin: OriginFor<T>,
@@ -1204,6 +1224,7 @@ pub mod pallet {
 		/// Emits `MetadataCleared`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(20)]
 		#[pallet::weight(T::WeightInfo::force_clear_metadata())]
 		pub fn force_clear_metadata(
 			origin: OriginFor<T>,
@@ -1243,6 +1264,7 @@ pub mod pallet {
 		/// Emits `AssetStatusChanged` with the identity of the asset.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(21)]
 		#[pallet::weight(T::WeightInfo::force_asset_status())]
 		pub fn force_asset_status(
 			origin: OriginFor<T>,
@@ -1299,6 +1321,7 @@ pub mod pallet {
 		/// Emits `ApprovedTransfer` on success.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(22)]
 		#[pallet::weight(T::WeightInfo::approve_transfer())]
 		pub fn approve_transfer(
 			origin: OriginFor<T>,
@@ -1325,6 +1348,7 @@ pub mod pallet {
 		/// Emits `ApprovalCancelled` on success.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(23)]
 		#[pallet::weight(T::WeightInfo::cancel_approval())]
 		pub fn cancel_approval(
 			origin: OriginFor<T>,
@@ -1361,6 +1385,7 @@ pub mod pallet {
 		/// Emits `ApprovalCancelled` on success.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(24)]
 		#[pallet::weight(T::WeightInfo::force_cancel_approval())]
 		pub fn force_cancel_approval(
 			origin: OriginFor<T>,
@@ -1410,6 +1435,7 @@ pub mod pallet {
 		/// Emits `TransferredApproved` on success.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(25)]
 		#[pallet::weight(T::WeightInfo::transfer_approved())]
 		pub fn transfer_approved(
 			origin: OriginFor<T>,
@@ -1434,6 +1460,7 @@ pub mod pallet {
 		/// - `id`: The identifier of the asset for the account to be created.
 		///
 		/// Emits `Touched` event when successful.
+		#[pallet::call_index(26)]
 		#[pallet::weight(T::WeightInfo::mint())]
 		pub fn touch(origin: OriginFor<T>, id: T::AssetIdParameter) -> DispatchResult {
 			let id: T::AssetId = id.into();
@@ -1448,6 +1475,7 @@ pub mod pallet {
 		/// - `allow_burn`: If `true` then assets may be destroyed in order to complete the refund.
 		///
 		/// Emits `Refunded` event when successful.
+		#[pallet::call_index(27)]
 		#[pallet::weight(T::WeightInfo::mint())]
 		pub fn refund(
 			origin: OriginFor<T>,

--- a/frame/atomic-swap/src/lib.rs
+++ b/frame/atomic-swap/src/lib.rs
@@ -243,6 +243,7 @@ pub mod pallet {
 		/// - `duration`: Locked duration of the atomic swap. For safety reasons, it is recommended
 		///   that the revealer uses a shorter duration than the counterparty, to prevent the
 		///   situation where the revealer reveals the proof too late around the end block.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::DbWeight::get().reads_writes(1, 1).ref_time().saturating_add(40_000_000))]
 		pub fn create_swap(
 			origin: OriginFor<T>,
@@ -278,6 +279,7 @@ pub mod pallet {
 		/// - `proof`: Revealed proof of the claim.
 		/// - `action`: Action defined in the swap, it must match the entry in blockchain. Otherwise
 		///   the operation fails. This is used for weight calculation.
+		#[pallet::call_index(1)]
 		#[pallet::weight(
 			T::DbWeight::get().reads_writes(1, 1)
 				.saturating_add(action.weight())
@@ -318,6 +320,7 @@ pub mod pallet {
 		///
 		/// - `target`: Target of the original atomic swap.
 		/// - `hashed_proof`: Hashed proof of the original atomic swap.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::DbWeight::get().reads_writes(1, 1).ref_time().saturating_add(40_000_000))]
 		pub fn cancel_swap(
 			origin: OriginFor<T>,

--- a/frame/authorship/src/lib.rs
+++ b/frame/authorship/src/lib.rs
@@ -237,6 +237,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Provide a set of uncles.
+		#[pallet::call_index(0)]
 		#[pallet::weight((0, DispatchClass::Mandatory))]
 		pub fn set_uncles(origin: OriginFor<T>, new_uncles: Vec<T::Header>) -> DispatchResult {
 			ensure_none(origin)?;

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -403,6 +403,7 @@ pub mod pallet {
 		/// the equivocation proof and validate the given key ownership proof
 		/// against the extracted offender. If both are valid, the offence will
 		/// be reported.
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::report_equivocation(
 			key_owner_proof.validator_count(),
 		))]
@@ -424,6 +425,7 @@ pub mod pallet {
 		/// block authors will call it (validated in `ValidateUnsigned`), as such
 		/// if the block author is defined it will be defined as the equivocation
 		/// reporter.
+		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config>::WeightInfo::report_equivocation(
 			key_owner_proof.validator_count(),
 		))]
@@ -445,6 +447,7 @@ pub mod pallet {
 		/// the next call to `enact_epoch_change`. The config will be activated one epoch after.
 		/// Multiple calls to this method will replace any existing planned config change that had
 		/// not been enacted yet.
+		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config>::WeightInfo::plan_config_change())]
 		pub fn plan_config_change(
 			origin: OriginFor<T>,

--- a/frame/bags-list/src/lib.rs
+++ b/frame/bags-list/src/lib.rs
@@ -224,6 +224,7 @@ pub mod pallet {
 		/// `ScoreProvider`.
 		///
 		/// If `dislocated` does not exists, it returns an error.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::rebag_non_terminal().max(T::WeightInfo::rebag_terminal()))]
 		pub fn rebag(origin: OriginFor<T>, dislocated: AccountIdLookupOf<T>) -> DispatchResult {
 			ensure_signed(origin)?;
@@ -242,6 +243,7 @@ pub mod pallet {
 		/// Only works if
 		/// - both nodes are within the same bag,
 		/// - and `origin` has a greater `Score` than `lighter`.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::put_in_front_of())]
 		pub fn put_in_front_of(
 			origin: OriginFor<T>,

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -282,6 +282,7 @@ pub mod pallet {
 		/// ---------------------------------
 		/// - Origin account is already in memory, so no DB operations for them.
 		/// # </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::transfer())]
 		pub fn transfer(
 			origin: OriginFor<T>,
@@ -307,6 +308,7 @@ pub mod pallet {
 		/// it will reset the account nonce (`frame_system::AccountNonce`).
 		///
 		/// The dispatch origin for this call is `root`.
+		#[pallet::call_index(1)]
 		#[pallet::weight(
 			T::WeightInfo::set_balance_creating() // Creates a new account.
 				.max(T::WeightInfo::set_balance_killing()) // Kills an existing account.
@@ -360,6 +362,7 @@ pub mod pallet {
 		/// - Same as transfer, but additional read and write because the source account is not
 		///   assumed to be in the overlay.
 		/// # </weight>
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::force_transfer())]
 		pub fn force_transfer(
 			origin: OriginFor<T>,
@@ -385,6 +388,7 @@ pub mod pallet {
 		/// 99% of the time you want [`transfer`] instead.
 		///
 		/// [`transfer`]: struct.Pallet.html#method.transfer
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::transfer_keep_alive())]
 		pub fn transfer_keep_alive(
 			origin: OriginFor<T>,
@@ -414,6 +418,7 @@ pub mod pallet {
 		///   keep the sender account alive (true). # <weight>
 		/// - O(1). Just like transfer, but reading the user's transferable balance first.
 		///   #</weight>
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::transfer_all())]
 		pub fn transfer_all(
 			origin: OriginFor<T>,
@@ -432,6 +437,7 @@ pub mod pallet {
 		/// Unreserve some balance from a user by force.
 		///
 		/// Can only be called by ROOT.
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::force_unreserve())]
 		pub fn force_unreserve(
 			origin: OriginFor<T>,

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -51,6 +51,7 @@ mod pallet_test {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(0)]
 		pub fn set_value(origin: OriginFor<T>, n: u32) -> DispatchResult {
 			let _sender = ensure_signed(origin)?;
@@ -58,12 +59,14 @@ mod pallet_test {
 			Ok(())
 		}
 
+		#[pallet::call_index(1)]
 		#[pallet::weight(0)]
 		pub fn dummy(origin: OriginFor<T>, _n: u32) -> DispatchResult {
 			let _sender = ensure_none(origin)?;
 			Ok(())
 		}
 
+		#[pallet::call_index(2)]
 		#[pallet::weight(0)]
 		pub fn always_error(_origin: OriginFor<T>) -> DispatchResult {
 			return Err("I always fail".into())

--- a/frame/benchmarking/src/tests_instance.rs
+++ b/frame/benchmarking/src/tests_instance.rs
@@ -61,6 +61,7 @@ mod pallet_test {
 	where
 		<T as OtherConfig>::OtherEvent: Into<<T as Config<I>>::RuntimeEvent>,
 	{
+		#[pallet::call_index(0)]
 		#[pallet::weight(0)]
 		pub fn set_value(origin: OriginFor<T>, n: u32) -> DispatchResult {
 			let _sender = ensure_signed(origin)?;
@@ -68,6 +69,7 @@ mod pallet_test {
 			Ok(())
 		}
 
+		#[pallet::call_index(1)]
 		#[pallet::weight(0)]
 		pub fn dummy(origin: OriginFor<T>, _n: u32) -> DispatchResult {
 			let _sender = ensure_none(origin)?;

--- a/frame/bounties/src/lib.rs
+++ b/frame/bounties/src/lib.rs
@@ -333,6 +333,7 @@ pub mod pallet {
 		/// - `fee`: The curator fee.
 		/// - `value`: The total payment amount of this bounty, curator fee included.
 		/// - `description`: The description of this bounty.
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::propose_bounty(description.len() as u32))]
 		pub fn propose_bounty(
 			origin: OriginFor<T>,
@@ -352,6 +353,7 @@ pub mod pallet {
 		/// # <weight>
 		/// - O(1).
 		/// # </weight>
+		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::approve_bounty())]
 		pub fn approve_bounty(
 			origin: OriginFor<T>,
@@ -383,6 +385,7 @@ pub mod pallet {
 		/// # <weight>
 		/// - O(1).
 		/// # </weight>
+		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::propose_curator())]
 		pub fn propose_curator(
 			origin: OriginFor<T>,
@@ -432,6 +435,7 @@ pub mod pallet {
 		/// # <weight>
 		/// - O(1).
 		/// # </weight>
+		#[pallet::call_index(3)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::unassign_curator())]
 		pub fn unassign_curator(
 			origin: OriginFor<T>,
@@ -517,6 +521,7 @@ pub mod pallet {
 		/// # <weight>
 		/// - O(1).
 		/// # </weight>
+		#[pallet::call_index(4)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::accept_curator())]
 		pub fn accept_curator(
 			origin: OriginFor<T>,
@@ -559,6 +564,7 @@ pub mod pallet {
 		/// # <weight>
 		/// - O(1).
 		/// # </weight>
+		#[pallet::call_index(5)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::award_bounty())]
 		pub fn award_bounty(
 			origin: OriginFor<T>,
@@ -606,6 +612,7 @@ pub mod pallet {
 		/// # <weight>
 		/// - O(1).
 		/// # </weight>
+		#[pallet::call_index(6)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::claim_bounty())]
 		pub fn claim_bounty(
 			origin: OriginFor<T>,
@@ -669,6 +676,7 @@ pub mod pallet {
 		/// # <weight>
 		/// - O(1).
 		/// # </weight>
+		#[pallet::call_index(7)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::close_bounty_proposed()
 			.max(<T as Config<I>>::WeightInfo::close_bounty_active()))]
 		pub fn close_bounty(
@@ -760,6 +768,7 @@ pub mod pallet {
 		/// # <weight>
 		/// - O(1).
 		/// # </weight>
+		#[pallet::call_index(8)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::extend_bounty_expiry())]
 		pub fn extend_bounty_expiry(
 			origin: OriginFor<T>,

--- a/frame/child-bounties/src/lib.rs
+++ b/frame/child-bounties/src/lib.rs
@@ -237,6 +237,7 @@ pub mod pallet {
 		/// - `parent_bounty_id`: Index of parent bounty for which child-bounty is being added.
 		/// - `value`: Value for executing the proposal.
 		/// - `description`: Text description for the child-bounty.
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::add_child_bounty(description.len() as u32))]
 		pub fn add_child_bounty(
 			origin: OriginFor<T>,
@@ -311,6 +312,7 @@ pub mod pallet {
 		/// - `child_bounty_id`: Index of child bounty.
 		/// - `curator`: Address of child-bounty curator.
 		/// - `fee`: payment fee to child-bounty curator for execution.
+		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config>::WeightInfo::propose_curator())]
 		pub fn propose_curator(
 			origin: OriginFor<T>,
@@ -380,6 +382,7 @@ pub mod pallet {
 		///
 		/// - `parent_bounty_id`: Index of parent bounty.
 		/// - `child_bounty_id`: Index of child bounty.
+		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config>::WeightInfo::accept_curator())]
 		pub fn accept_curator(
 			origin: OriginFor<T>,
@@ -456,6 +459,7 @@ pub mod pallet {
 		///
 		/// - `parent_bounty_id`: Index of parent bounty.
 		/// - `child_bounty_id`: Index of child bounty.
+		#[pallet::call_index(3)]
 		#[pallet::weight(<T as Config>::WeightInfo::unassign_curator())]
 		pub fn unassign_curator(
 			origin: OriginFor<T>,
@@ -570,6 +574,7 @@ pub mod pallet {
 		/// - `parent_bounty_id`: Index of parent bounty.
 		/// - `child_bounty_id`: Index of child bounty.
 		/// - `beneficiary`: Beneficiary account.
+		#[pallet::call_index(4)]
 		#[pallet::weight(<T as Config>::WeightInfo::award_child_bounty())]
 		pub fn award_child_bounty(
 			origin: OriginFor<T>,
@@ -636,6 +641,7 @@ pub mod pallet {
 		///
 		/// - `parent_bounty_id`: Index of parent bounty.
 		/// - `child_bounty_id`: Index of child bounty.
+		#[pallet::call_index(5)]
 		#[pallet::weight(<T as Config>::WeightInfo::claim_child_bounty())]
 		pub fn claim_child_bounty(
 			origin: OriginFor<T>,
@@ -745,6 +751,7 @@ pub mod pallet {
 		///
 		/// - `parent_bounty_id`: Index of parent bounty.
 		/// - `child_bounty_id`: Index of child bounty.
+		#[pallet::call_index(6)]
 		#[pallet::weight(<T as Config>::WeightInfo::close_child_bounty_added()
 			.max(<T as Config>::WeightInfo::close_child_bounty_active()))]
 		pub fn close_child_bounty(

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -372,6 +372,7 @@ pub mod pallet {
 		///   - `P` storage mutations (codec `O(M)`) for updating the votes for each proposal
 		///   - 1 storage write (codec `O(1)`) for deleting the old `prime` and setting the new one
 		/// # </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight((
 			T::WeightInfo::set_members(
 				*old_count, // M
@@ -429,6 +430,7 @@ pub mod pallet {
 		/// - DB: 1 read (codec `O(M)`) + DB access of `proposal`
 		/// - 1 event
 		/// # </weight>
+		#[pallet::call_index(1)]
 		#[pallet::weight((
 			T::WeightInfo::execute(
 				*length_bound, // B
@@ -492,6 +494,7 @@ pub mod pallet {
 		///       - 1 storage write `Voting` (codec `O(M)`)
 		///   - 1 event
 		/// # </weight>
+		#[pallet::call_index(2)]
 		#[pallet::weight((
 			if *threshold < 2 {
 				T::WeightInfo::propose_execute(
@@ -557,6 +560,7 @@ pub mod pallet {
 		///   - 1 storage mutation `Voting` (codec `O(M)`)
 		/// - 1 event
 		/// # </weight>
+		#[pallet::call_index(3)]
 		#[pallet::weight((T::WeightInfo::vote(T::MaxMembers::get()), DispatchClass::Operational))]
 		pub fn vote(
 			origin: OriginFor<T>,
@@ -610,6 +614,7 @@ pub mod pallet {
 		///  - any mutations done while executing `proposal` (`P1`)
 		/// - up to 3 events
 		/// # </weight>
+		#[pallet::call_index(4)]
 		#[pallet::weight((
 			{
 				let b = *length_bound;
@@ -653,6 +658,7 @@ pub mod pallet {
 		/// * Reads: Proposals
 		/// * Writes: Voting, Proposals, ProposalOf
 		/// # </weight>
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::disapprove_proposal(T::MaxProposals::get()))]
 		pub fn disapprove_proposal(
 			origin: OriginFor<T>,
@@ -695,6 +701,7 @@ pub mod pallet {
 		///  - any mutations done while executing `proposal` (`P1`)
 		/// - up to 3 events
 		/// # </weight>
+		#[pallet::call_index(6)]
 		#[pallet::weight((
 			{
 				let b = *length_bound;

--- a/frame/collective/src/tests.rs
+++ b/frame/collective/src/tests.rs
@@ -69,6 +69,7 @@ mod mock_democracy {
 
 		#[pallet::call]
 		impl<T: Config> Pallet<T> {
+			#[pallet::call_index(0)]
 			#[pallet::weight(0)]
 			pub fn external_propose_majority(origin: OriginFor<T>) -> DispatchResult {
 				T::ExternalMajorityOrigin::ensure_origin(origin)?;

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -385,6 +385,7 @@ pub mod pallet {
 		<BalanceOf<T> as HasCompact>::Type: Clone + Eq + PartialEq + Debug + TypeInfo + Encode,
 	{
 		/// Deprecated version if [`Self::call`] for use in an in-storage `Call`.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::call().saturating_add(<Pallet<T>>::compat_weight(*gas_limit)))]
 		#[allow(deprecated)]
 		#[deprecated(note = "1D weight is used in this extrinsic, please migrate to `call`")]
@@ -407,6 +408,7 @@ pub mod pallet {
 		}
 
 		/// Deprecated version if [`Self::instantiate_with_code`] for use in an in-storage `Call`.
+		#[pallet::call_index(1)]
 		#[pallet::weight(
 			T::WeightInfo::instantiate_with_code(code.len() as u32, salt.len() as u32)
 			.saturating_add(<Pallet<T>>::compat_weight(*gas_limit))
@@ -436,6 +438,7 @@ pub mod pallet {
 		}
 
 		/// Deprecated version if [`Self::instantiate`] for use in an in-storage `Call`.
+		#[pallet::call_index(2)]
 		#[pallet::weight(
 			T::WeightInfo::instantiate(salt.len() as u32).saturating_add(<Pallet<T>>::compat_weight(*gas_limit))
 		)]
@@ -481,6 +484,7 @@ pub mod pallet {
 		/// To avoid this situation a constructor could employ access control so that it can
 		/// only be instantiated by permissioned entities. The same is true when uploading
 		/// through [`Self::instantiate_with_code`].
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::upload_code(code.len() as u32))]
 		pub fn upload_code(
 			origin: OriginFor<T>,
@@ -497,6 +501,7 @@ pub mod pallet {
 		///
 		/// A code can only be removed by its original uploader (its owner) and only if it is
 		/// not used by any contract.
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::remove_code())]
 		pub fn remove_code(
 			origin: OriginFor<T>,
@@ -518,6 +523,7 @@ pub mod pallet {
 		/// This does **not** change the address of the contract in question. This means
 		/// that the contract address is no longer derived from its code hash after calling
 		/// this dispatchable.
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::set_code())]
 		pub fn set_code(
 			origin: OriginFor<T>,
@@ -563,6 +569,7 @@ pub mod pallet {
 		/// * If the account is a regular account, any value will be transferred.
 		/// * If no account exists and the call value is not less than `existential_deposit`,
 		/// a regular account will be created and any value will be transferred.
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::call().saturating_add(*gas_limit))]
 		pub fn call(
 			origin: OriginFor<T>,
@@ -619,6 +626,7 @@ pub mod pallet {
 		/// - The smart-contract account is created at the computed address.
 		/// - The `value` is transferred to the new account.
 		/// - The `deploy` function is executed in the context of the newly-created account.
+		#[pallet::call_index(7)]
 		#[pallet::weight(
 			T::WeightInfo::instantiate_with_code(code.len() as u32, salt.len() as u32)
 			.saturating_add(*gas_limit)
@@ -661,6 +669,7 @@ pub mod pallet {
 		/// This function is identical to [`Self::instantiate_with_code`] but without the
 		/// code deployment step. Instead, the `code_hash` of an on-chain deployed wasm binary
 		/// must be supplied.
+		#[pallet::call_index(8)]
 		#[pallet::weight(
 			T::WeightInfo::instantiate(salt.len() as u32).saturating_add(*gas_limit)
 		)]

--- a/frame/conviction-voting/src/lib.rs
+++ b/frame/conviction-voting/src/lib.rs
@@ -208,6 +208,7 @@ pub mod pallet {
 		/// - `vote`: The vote configuration.
 		///
 		/// Weight: `O(R)` where R is the number of polls the voter has voted on.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::vote_new().max(T::WeightInfo::vote_existing()))]
 		pub fn vote(
 			origin: OriginFor<T>,
@@ -243,6 +244,7 @@ pub mod pallet {
 		///   voted on. Weight is initially charged as if maximum votes, but is refunded later.
 		// NOTE: weight must cover an incorrect voting of origin with max votes, this is ensure
 		// because a valid delegation cover decoding a direct voting with max votes.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::delegate(T::MaxVotes::get()))]
 		pub fn delegate(
 			origin: OriginFor<T>,
@@ -274,6 +276,7 @@ pub mod pallet {
 		///   voted on. Weight is initially charged as if maximum votes, but is refunded later.
 		// NOTE: weight must cover an incorrect voting of origin with max votes, this is ensure
 		// because a valid delegation cover decoding a direct voting with max votes.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::undelegate(T::MaxVotes::get().into()))]
 		pub fn undelegate(
 			origin: OriginFor<T>,
@@ -293,6 +296,7 @@ pub mod pallet {
 		/// - `target`: The account to remove the lock on.
 		///
 		/// Weight: `O(R)` with R number of vote of target.
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::unlock())]
 		pub fn unlock(
 			origin: OriginFor<T>,
@@ -334,6 +338,7 @@ pub mod pallet {
 		///
 		/// Weight: `O(R + log R)` where R is the number of polls that `target` has voted on.
 		///   Weight is calculated for the maximum number of vote.
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::remove_vote())]
 		pub fn remove_vote(
 			origin: OriginFor<T>,
@@ -360,6 +365,7 @@ pub mod pallet {
 		///
 		/// Weight: `O(R + log R)` where R is the number of polls that `target` has voted on.
 		///   Weight is calculated for the maximum number of vote.
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::remove_other_vote())]
 		pub fn remove_other_vote(
 			origin: OriginFor<T>,

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -549,6 +549,7 @@ pub mod pallet {
 		/// - `value`: The amount of deposit (must be at least `MinimumDeposit`).
 		///
 		/// Emits `Proposed`.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::propose())]
 		pub fn propose(
 			origin: OriginFor<T>,
@@ -591,6 +592,7 @@ pub mod pallet {
 		/// must have funds to cover the deposit, equal to the original deposit.
 		///
 		/// - `proposal`: The index of the proposal to second.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::second())]
 		pub fn second(
 			origin: OriginFor<T>,
@@ -616,6 +618,7 @@ pub mod pallet {
 		///
 		/// - `ref_index`: The index of the referendum to vote for.
 		/// - `vote`: The vote configuration.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::vote_new().max(T::WeightInfo::vote_existing()))]
 		pub fn vote(
 			origin: OriginFor<T>,
@@ -634,6 +637,7 @@ pub mod pallet {
 		/// -`ref_index`: The index of the referendum to cancel.
 		///
 		/// Weight: `O(1)`.
+		#[pallet::call_index(3)]
 		#[pallet::weight((T::WeightInfo::emergency_cancel(), DispatchClass::Operational))]
 		pub fn emergency_cancel(
 			origin: OriginFor<T>,
@@ -656,6 +660,7 @@ pub mod pallet {
 		/// The dispatch origin of this call must be `ExternalOrigin`.
 		///
 		/// - `proposal_hash`: The preimage hash of the proposal.
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::external_propose())]
 		pub fn external_propose(
 			origin: OriginFor<T>,
@@ -684,6 +689,7 @@ pub mod pallet {
 		/// pre-scheduled `external_propose` call.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::external_propose_majority())]
 		pub fn external_propose_majority(
 			origin: OriginFor<T>,
@@ -705,6 +711,7 @@ pub mod pallet {
 		/// pre-scheduled `external_propose` call.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::external_propose_default())]
 		pub fn external_propose_default(
 			origin: OriginFor<T>,
@@ -731,6 +738,7 @@ pub mod pallet {
 		/// Emits `Started`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(7)]
 		#[pallet::weight(T::WeightInfo::fast_track())]
 		pub fn fast_track(
 			origin: OriginFor<T>,
@@ -783,6 +791,7 @@ pub mod pallet {
 		/// Emits `Vetoed`.
 		///
 		/// Weight: `O(V + log(V))` where V is number of `existing vetoers`
+		#[pallet::call_index(8)]
 		#[pallet::weight(T::WeightInfo::veto_external())]
 		pub fn veto_external(origin: OriginFor<T>, proposal_hash: H256) -> DispatchResult {
 			let who = T::VetoOrigin::ensure_origin(origin)?;
@@ -817,6 +826,7 @@ pub mod pallet {
 		/// - `ref_index`: The index of the referendum to cancel.
 		///
 		/// # Weight: `O(1)`.
+		#[pallet::call_index(9)]
 		#[pallet::weight(T::WeightInfo::cancel_referendum())]
 		pub fn cancel_referendum(
 			origin: OriginFor<T>,
@@ -849,6 +859,7 @@ pub mod pallet {
 		///   voted on. Weight is charged as if maximum votes.
 		// NOTE: weight must cover an incorrect voting of origin with max votes, this is ensure
 		// because a valid delegation cover decoding a direct voting with max votes.
+		#[pallet::call_index(10)]
 		#[pallet::weight(T::WeightInfo::delegate(T::MaxVotes::get()))]
 		pub fn delegate(
 			origin: OriginFor<T>,
@@ -877,6 +888,7 @@ pub mod pallet {
 		///   voted on. Weight is charged as if maximum votes.
 		// NOTE: weight must cover an incorrect voting of origin with max votes, this is ensure
 		// because a valid delegation cover decoding a direct voting with max votes.
+		#[pallet::call_index(11)]
 		#[pallet::weight(T::WeightInfo::undelegate(T::MaxVotes::get()))]
 		pub fn undelegate(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
@@ -889,6 +901,7 @@ pub mod pallet {
 		/// The dispatch origin of this call must be _Root_.
 		///
 		/// Weight: `O(1)`.
+		#[pallet::call_index(12)]
 		#[pallet::weight(T::WeightInfo::clear_public_proposals())]
 		pub fn clear_public_proposals(origin: OriginFor<T>) -> DispatchResult {
 			ensure_root(origin)?;
@@ -903,6 +916,7 @@ pub mod pallet {
 		/// - `target`: The account to remove the lock on.
 		///
 		/// Weight: `O(R)` with R number of vote of target.
+		#[pallet::call_index(13)]
 		#[pallet::weight(T::WeightInfo::unlock_set(T::MaxVotes::get()).max(T::WeightInfo::unlock_remove(T::MaxVotes::get())))]
 		pub fn unlock(origin: OriginFor<T>, target: AccountIdLookupOf<T>) -> DispatchResult {
 			ensure_signed(origin)?;
@@ -938,6 +952,7 @@ pub mod pallet {
 		///
 		/// Weight: `O(R + log R)` where R is the number of referenda that `target` has voted on.
 		///   Weight is calculated for the maximum number of vote.
+		#[pallet::call_index(14)]
 		#[pallet::weight(T::WeightInfo::remove_vote(T::MaxVotes::get()))]
 		pub fn remove_vote(origin: OriginFor<T>, index: ReferendumIndex) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -959,6 +974,7 @@ pub mod pallet {
 		///
 		/// Weight: `O(R + log R)` where R is the number of referenda that `target` has voted on.
 		///   Weight is calculated for the maximum number of vote.
+		#[pallet::call_index(15)]
 		#[pallet::weight(T::WeightInfo::remove_other_vote(T::MaxVotes::get()))]
 		pub fn remove_other_vote(
 			origin: OriginFor<T>,
@@ -987,6 +1003,7 @@ pub mod pallet {
 		///
 		/// Weight: `O(p)` (though as this is an high-privilege dispatch, we assume it has a
 		///   reasonable value).
+		#[pallet::call_index(16)]
 		#[pallet::weight((T::WeightInfo::blacklist(), DispatchClass::Operational))]
 		pub fn blacklist(
 			origin: OriginFor<T>,
@@ -1036,6 +1053,7 @@ pub mod pallet {
 		/// - `prop_index`: The index of the proposal to cancel.
 		///
 		/// Weight: `O(p)` where `p = PublicProps::<T>::decode_len()`
+		#[pallet::call_index(17)]
 		#[pallet::weight(T::WeightInfo::cancel_proposal())]
 		pub fn cancel_proposal(
 			origin: OriginFor<T>,

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -892,6 +892,7 @@ pub mod pallet {
 		/// putting their authoring reward at risk.
 		///
 		/// No deposit or reward is associated with this submission.
+		#[pallet::call_index(0)]
 		#[pallet::weight((
 			T::WeightInfo::submit_unsigned(
 				witness.voters,
@@ -941,6 +942,7 @@ pub mod pallet {
 		/// Dispatch origin must be aligned with `T::ForceOrigin`.
 		///
 		/// This check can be turned off by setting the value to `None`.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::DbWeight::get().writes(1))]
 		pub fn set_minimum_untrusted_score(
 			origin: OriginFor<T>,
@@ -959,6 +961,7 @@ pub mod pallet {
 		/// The solution is not checked for any feasibility and is assumed to be trustworthy, as any
 		/// feasibility check itself can in principle cause the election process to fail (due to
 		/// memory/weight constrains).
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::DbWeight::get().reads_writes(1, 1))]
 		pub fn set_emergency_election_result(
 			origin: OriginFor<T>,
@@ -996,6 +999,7 @@ pub mod pallet {
 		///
 		/// A deposit is reserved and recorded for the solution. Based on the outcome, the solution
 		/// might be rewarded, slashed, or get all or a part of the deposit back.
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::submit())]
 		pub fn submit(
 			origin: OriginFor<T>,
@@ -1065,6 +1069,7 @@ pub mod pallet {
 		///
 		/// This can only be called when [`Phase::Emergency`] is enabled, as an alternative to
 		/// calling [`Call::set_emergency_election_result`].
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::DbWeight::get().reads_writes(1, 1))]
 		pub fn governance_fallback(
 			origin: OriginFor<T>,

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -309,6 +309,7 @@ pub mod pallet {
 		/// # <weight>
 		/// We assume the maximum weight among all 3 cases: vote_equal, vote_more and vote_less.
 		/// # </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight(
 			T::WeightInfo::vote_more(votes.len() as u32)
 			.max(T::WeightInfo::vote_less(votes.len() as u32))
@@ -371,6 +372,7 @@ pub mod pallet {
 		/// This removes the lock and returns the deposit.
 		///
 		/// The dispatch origin of this call must be signed and be a voter.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::remove_voter())]
 		pub fn remove_voter(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -394,6 +396,7 @@ pub mod pallet {
 		/// # <weight>
 		/// The number of current candidates must be provided as witness data.
 		/// # </weight>
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::submit_candidacy(*candidate_count))]
 		pub fn submit_candidacy(
 			origin: OriginFor<T>,
@@ -438,6 +441,7 @@ pub mod pallet {
 		/// # <weight>
 		/// The type of renouncing must be provided as witness data.
 		/// # </weight>
+		#[pallet::call_index(3)]
 		#[pallet::weight(match *renouncing {
 			Renouncing::Candidate(count) => T::WeightInfo::renounce_candidacy_candidate(count),
 			Renouncing::Member => T::WeightInfo::renounce_candidacy_members(),
@@ -500,6 +504,7 @@ pub mod pallet {
 		/// If we have a replacement, we use a small weight. Else, since this is a root call and
 		/// will go into phragmen, we assume full block for now.
 		/// # </weight>
+		#[pallet::call_index(4)]
 		#[pallet::weight(if *rerun_election {
 			T::WeightInfo::remove_member_without_replacement()
 		} else {
@@ -535,6 +540,7 @@ pub mod pallet {
 		/// # <weight>
 		/// The total number of voters and those that are defunct must be provided as witness data.
 		/// # </weight>
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::clean_defunct_voters(*_num_voters, *_num_defunct))]
 		pub fn clean_defunct_voters(
 			origin: OriginFor<T>,

--- a/frame/examples/basic/src/lib.rs
+++ b/frame/examples/basic/src/lib.rs
@@ -497,6 +497,7 @@ pub mod pallet {
 		//
 		// The weight for this extrinsic we rely on the auto-generated `WeightInfo` from the
 		// benchmark toolchain.
+		#[pallet::call_index(0)]
 		#[pallet::weight(
 			<T as pallet::Config>::WeightInfo::accumulate_dummy()
 		)]
@@ -541,6 +542,7 @@ pub mod pallet {
 		//
 		// The weight for this extrinsic we use our own weight object `WeightForSetDummy` to
 		// determine its weight
+		#[pallet::call_index(1)]
 		#[pallet::weight(WeightForSetDummy::<T>(<BalanceOf<T>>::from(100u32)))]
 		pub fn set_dummy(
 			origin: OriginFor<T>,

--- a/frame/examples/offchain-worker/src/lib.rs
+++ b/frame/examples/offchain-worker/src/lib.rs
@@ -229,6 +229,7 @@ pub mod pallet {
 		/// working and receives (and provides) meaningful data.
 		/// This example is not focused on correctness of the oracle itself, but rather its
 		/// purpose is to showcase offchain worker capabilities.
+		#[pallet::call_index(0)]
 		#[pallet::weight(0)]
 		pub fn submit_price(origin: OriginFor<T>, price: u32) -> DispatchResultWithPostInfo {
 			// Retrieve sender of the transaction.
@@ -254,6 +255,7 @@ pub mod pallet {
 		///
 		/// This example is not focused on correctness of the oracle itself, but rather its
 		/// purpose is to showcase offchain worker capabilities.
+		#[pallet::call_index(1)]
 		#[pallet::weight(0)]
 		pub fn submit_price_unsigned(
 			origin: OriginFor<T>,
@@ -270,6 +272,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(2)]
 		#[pallet::weight(0)]
 		pub fn submit_price_unsigned_with_signed_payload(
 			origin: OriginFor<T>,

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -674,6 +674,7 @@ mod tests {
 
 		#[pallet::call]
 		impl<T: Config> Pallet<T> {
+			#[pallet::call_index(0)]
 			#[pallet::weight(100)]
 			pub fn some_function(origin: OriginFor<T>) -> DispatchResult {
 				// NOTE: does not make any different.
@@ -681,36 +682,42 @@ mod tests {
 				Ok(())
 			}
 
+			#[pallet::call_index(1)]
 			#[pallet::weight((200, DispatchClass::Operational))]
 			pub fn some_root_operation(origin: OriginFor<T>) -> DispatchResult {
 				frame_system::ensure_root(origin)?;
 				Ok(())
 			}
 
+			#[pallet::call_index(2)]
 			#[pallet::weight(0)]
 			pub fn some_unsigned_message(origin: OriginFor<T>) -> DispatchResult {
 				frame_system::ensure_none(origin)?;
 				Ok(())
 			}
 
+			#[pallet::call_index(3)]
 			#[pallet::weight(0)]
 			pub fn allowed_unsigned(origin: OriginFor<T>) -> DispatchResult {
 				frame_system::ensure_root(origin)?;
 				Ok(())
 			}
 
+			#[pallet::call_index(4)]
 			#[pallet::weight(0)]
 			pub fn unallowed_unsigned(origin: OriginFor<T>) -> DispatchResult {
 				frame_system::ensure_root(origin)?;
 				Ok(())
 			}
 
+			#[pallet::call_index(5)]
 			#[pallet::weight((0, DispatchClass::Mandatory))]
 			pub fn inherent_call(origin: OriginFor<T>) -> DispatchResult {
 				frame_system::ensure_none(origin)?;
 				Ok(())
 			}
 
+			#[pallet::call_index(6)]
 			#[pallet::weight(0)]
 			pub fn calculate_storage_root(_origin: OriginFor<T>) -> DispatchResult {
 				let root = sp_io::storage::root(sp_runtime::StateVersion::V1);

--- a/frame/fast-unstake/src/lib.rs
+++ b/frame/fast-unstake/src/lib.rs
@@ -228,6 +228,7 @@ pub mod pallet {
 		/// If the check fails, the stash remains chilled and waiting for being unbonded as in with
 		/// the normal staking system, but they lose part of their unbonding chunks due to consuming
 		/// the chain's resources.
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::register_fast_unstake())]
 		pub fn register_fast_unstake(origin: OriginFor<T>) -> DispatchResult {
 			let ctrl = ensure_signed(origin)?;
@@ -257,6 +258,7 @@ pub mod pallet {
 		/// Note that the associated stash is still fully unbonded and chilled as a consequence of
 		/// calling `register_fast_unstake`. This should probably be followed by a call to
 		/// `Staking::rebond`.
+		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config>::WeightInfo::deregister())]
 		pub fn deregister(origin: OriginFor<T>) -> DispatchResult {
 			let ctrl = ensure_signed(origin)?;
@@ -282,6 +284,7 @@ pub mod pallet {
 		/// Control the operation of this pallet.
 		///
 		/// Dispatch origin must be signed by the [`Config::ControlOrigin`].
+		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config>::WeightInfo::control())]
 		pub fn control(origin: OriginFor<T>, unchecked_eras_to_check: EraIndex) -> DispatchResult {
 			let _ = T::ControlOrigin::ensure_origin(origin)?;

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -193,6 +193,7 @@ pub mod pallet {
 		/// equivocation proof and validate the given key ownership proof
 		/// against the extracted offender. If both are valid, the offence
 		/// will be reported.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::report_equivocation(key_owner_proof.validator_count()))]
 		pub fn report_equivocation(
 			origin: OriginFor<T>,
@@ -213,6 +214,7 @@ pub mod pallet {
 		/// block authors will call it (validated in `ValidateUnsigned`), as such
 		/// if the block author is defined it will be defined as the equivocation
 		/// reporter.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::report_equivocation(key_owner_proof.validator_count()))]
 		pub fn report_equivocation_unsigned(
 			origin: OriginFor<T>,
@@ -240,6 +242,7 @@ pub mod pallet {
 		/// block of all validators of the new authority set.
 		///
 		/// Only callable by root.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::note_stalled())]
 		pub fn note_stalled(
 			origin: OriginFor<T>,

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -284,6 +284,7 @@ pub mod pallet {
 		/// - One storage mutation (codec `O(R)`).
 		/// - One event.
 		/// # </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::add_registrar(T::MaxRegistrars::get()))]
 		pub fn add_registrar(
 			origin: OriginFor<T>,
@@ -329,6 +330,7 @@ pub mod pallet {
 		/// - One storage mutation (codec-read `O(X' + R)`, codec-write `O(X + R)`).
 		/// - One event.
 		/// # </weight>
+		#[pallet::call_index(1)]
 		#[pallet::weight( T::WeightInfo::set_identity(
 			T::MaxRegistrars::get(), // R
 			T::MaxAdditionalFields::get(), // X
@@ -404,6 +406,7 @@ pub mod pallet {
 		// N storage items for N sub accounts. Right now the weight on this function
 		// is a large overestimate due to the fact that it could potentially write
 		// to 2 x T::MaxSubAccounts::get().
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::set_subs_old(T::MaxSubAccounts::get()) // P: Assume max sub accounts removed.
 			.saturating_add(T::WeightInfo::set_subs_new(subs.len() as u32)) // S: Assume all subs are new.
 		)]
@@ -475,6 +478,7 @@ pub mod pallet {
 		/// - `2` storage reads and `S + 2` storage deletions.
 		/// - One event.
 		/// # </weight>
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::clear_identity(
 			T::MaxRegistrars::get(), // R
 			T::MaxSubAccounts::get(), // S
@@ -526,6 +530,7 @@ pub mod pallet {
 		/// - Storage: 1 read `O(R)`, 1 mutate `O(X + R)`.
 		/// - One event.
 		/// # </weight>
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::request_judgement(
 			T::MaxRegistrars::get(), // R
 			T::MaxAdditionalFields::get(), // X
@@ -588,6 +593,7 @@ pub mod pallet {
 		/// - One storage mutation `O(R + X)`.
 		/// - One event
 		/// # </weight>
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::cancel_request(
 			T::MaxRegistrars::get(), // R
 			T::MaxAdditionalFields::get(), // X
@@ -636,6 +642,7 @@ pub mod pallet {
 		/// - One storage mutation `O(R)`.
 		/// - Benchmark: 7.315 + R * 0.329 µs (min squares analysis)
 		/// # </weight>
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::set_fee(T::MaxRegistrars::get()))] // R
 		pub fn set_fee(
 			origin: OriginFor<T>,
@@ -674,6 +681,7 @@ pub mod pallet {
 		/// - One storage mutation `O(R)`.
 		/// - Benchmark: 8.823 + R * 0.32 µs (min squares analysis)
 		/// # </weight>
+		#[pallet::call_index(7)]
 		#[pallet::weight(T::WeightInfo::set_account_id(T::MaxRegistrars::get()))] // R
 		pub fn set_account_id(
 			origin: OriginFor<T>,
@@ -713,6 +721,7 @@ pub mod pallet {
 		/// - One storage mutation `O(R)`.
 		/// - Benchmark: 7.464 + R * 0.325 µs (min squares analysis)
 		/// # </weight>
+		#[pallet::call_index(8)]
 		#[pallet::weight(T::WeightInfo::set_fields(T::MaxRegistrars::get()))] // R
 		pub fn set_fields(
 			origin: OriginFor<T>,
@@ -761,6 +770,7 @@ pub mod pallet {
 		/// - Storage: 1 read `O(R)`, 1 mutate `O(R + X)`.
 		/// - One event.
 		/// # </weight>
+		#[pallet::call_index(9)]
 		#[pallet::weight(T::WeightInfo::provide_judgement(
 			T::MaxRegistrars::get(), // R
 			T::MaxAdditionalFields::get(), // X
@@ -834,6 +844,7 @@ pub mod pallet {
 		/// - `S + 2` storage mutations.
 		/// - One event.
 		/// # </weight>
+		#[pallet::call_index(10)]
 		#[pallet::weight(T::WeightInfo::kill_identity(
 			T::MaxRegistrars::get(), // R
 			T::MaxSubAccounts::get(), // S
@@ -874,6 +885,7 @@ pub mod pallet {
 		///
 		/// The dispatch origin for this call must be _Signed_ and the sender must have a registered
 		/// sub identity of `sub`.
+		#[pallet::call_index(11)]
 		#[pallet::weight(T::WeightInfo::add_sub(T::MaxSubAccounts::get()))]
 		pub fn add_sub(
 			origin: OriginFor<T>,
@@ -909,6 +921,7 @@ pub mod pallet {
 		///
 		/// The dispatch origin for this call must be _Signed_ and the sender must have a registered
 		/// sub identity of `sub`.
+		#[pallet::call_index(12)]
 		#[pallet::weight(T::WeightInfo::rename_sub(T::MaxSubAccounts::get()))]
 		pub fn rename_sub(
 			origin: OriginFor<T>,
@@ -930,6 +943,7 @@ pub mod pallet {
 		///
 		/// The dispatch origin for this call must be _Signed_ and the sender must have a registered
 		/// sub identity of `sub`.
+		#[pallet::call_index(13)]
 		#[pallet::weight(T::WeightInfo::remove_sub(T::MaxSubAccounts::get()))]
 		pub fn remove_sub(origin: OriginFor<T>, sub: AccountIdLookupOf<T>) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
@@ -959,6 +973,7 @@ pub mod pallet {
 		///
 		/// NOTE: This should not normally be used, but is provided in the case that the non-
 		/// controller of an account is maliciously registered as a sub-account.
+		#[pallet::call_index(14)]
 		#[pallet::weight(T::WeightInfo::quit_sub(T::MaxSubAccounts::get()))]
 		pub fn quit_sub(origin: OriginFor<T>) -> DispatchResult {
 			let sender = ensure_signed(origin)?;

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -474,6 +474,7 @@ pub mod pallet {
 		/// # </weight>
 		// NOTE: the weight includes the cost of validate_unsigned as it is part of the cost to
 		// import block with such an extrinsic.
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::validate_unsigned_and_then_heartbeat(
 			heartbeat.validators_len as u32,
 			heartbeat.network_state.external_addresses.len() as u32,

--- a/frame/indices/src/lib.rs
+++ b/frame/indices/src/lib.rs
@@ -98,6 +98,7 @@ pub mod pallet {
 		/// -------------------
 		/// - DB Weight: 1 Read/Write (Accounts)
 		/// # </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::claim())]
 		pub fn claim(origin: OriginFor<T>, index: T::AccountIndex) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -131,6 +132,7 @@ pub mod pallet {
 		///    - Reads: Indices Accounts, System Account (recipient)
 		///    - Writes: Indices Accounts, System Account (recipient)
 		/// # </weight>
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::transfer())]
 		pub fn transfer(
 			origin: OriginFor<T>,
@@ -171,6 +173,7 @@ pub mod pallet {
 		/// -------------------
 		/// - DB Weight: 1 Read/Write (Accounts)
 		/// # </weight>
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::free())]
 		pub fn free(origin: OriginFor<T>, index: T::AccountIndex) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -207,6 +210,7 @@ pub mod pallet {
 		///    - Reads: Indices Accounts, System Account (original owner)
 		///    - Writes: Indices Accounts, System Account (original owner)
 		/// # </weight>
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::force_transfer())]
 		pub fn force_transfer(
 			origin: OriginFor<T>,
@@ -245,6 +249,7 @@ pub mod pallet {
 		/// -------------------
 		/// - DB Weight: 1 Read/Write (Accounts)
 		/// # </weight>
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::freeze())]
 		pub fn freeze(origin: OriginFor<T>, index: T::AccountIndex) -> DispatchResult {
 			let who = ensure_signed(origin)?;

--- a/frame/lottery/src/lib.rs
+++ b/frame/lottery/src/lib.rs
@@ -296,6 +296,7 @@ pub mod pallet {
 		/// should listen for the `TicketBought` event.
 		///
 		/// This extrinsic must be called by a signed origin.
+		#[pallet::call_index(0)]
 		#[pallet::weight(
 			T::WeightInfo::buy_ticket()
 				.saturating_add(call.get_dispatch_info().weight)
@@ -317,6 +318,7 @@ pub mod pallet {
 		/// provided by this pallet, which uses storage to determine the valid calls.
 		///
 		/// This extrinsic must be called by the Manager origin.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::set_calls(calls.len() as u32))]
 		pub fn set_calls(
 			origin: OriginFor<T>,
@@ -344,6 +346,7 @@ pub mod pallet {
 		/// * `length`: How long the lottery should run for starting at the current block.
 		/// * `delay`: How long after the lottery end we should wait before picking a winner.
 		/// * `repeat`: If the lottery should repeat when completed.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::start_lottery())]
 		pub fn start_lottery(
 			origin: OriginFor<T>,
@@ -376,6 +379,7 @@ pub mod pallet {
 		/// The lottery will continue to run to completion.
 		///
 		/// This extrinsic must be called by the `ManagerOrigin`.
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::stop_repeat())]
 		pub fn stop_repeat(origin: OriginFor<T>) -> DispatchResult {
 			T::ManagerOrigin::ensure_origin(origin)?;

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -166,6 +166,7 @@ pub mod pallet {
 		/// Add a member `who` to the set.
 		///
 		/// May only be called from `T::AddOrigin`.
+		#[pallet::call_index(0)]
 		#[pallet::weight(50_000_000)]
 		pub fn add_member(origin: OriginFor<T>, who: AccountIdLookupOf<T>) -> DispatchResult {
 			T::AddOrigin::ensure_origin(origin)?;
@@ -188,6 +189,7 @@ pub mod pallet {
 		/// Remove a member `who` from the set.
 		///
 		/// May only be called from `T::RemoveOrigin`.
+		#[pallet::call_index(1)]
 		#[pallet::weight(50_000_000)]
 		pub fn remove_member(origin: OriginFor<T>, who: AccountIdLookupOf<T>) -> DispatchResult {
 			T::RemoveOrigin::ensure_origin(origin)?;
@@ -211,6 +213,7 @@ pub mod pallet {
 		/// May only be called from `T::SwapOrigin`.
 		///
 		/// Prime membership is *not* passed from `remove` to `add`, if extant.
+		#[pallet::call_index(2)]
 		#[pallet::weight(50_000_000)]
 		pub fn swap_member(
 			origin: OriginFor<T>,
@@ -244,6 +247,7 @@ pub mod pallet {
 		/// pass `members` pre-sorted.
 		///
 		/// May only be called from `T::ResetOrigin`.
+		#[pallet::call_index(3)]
 		#[pallet::weight(50_000_000)]
 		pub fn reset_members(origin: OriginFor<T>, members: Vec<T::AccountId>) -> DispatchResult {
 			T::ResetOrigin::ensure_origin(origin)?;
@@ -266,6 +270,7 @@ pub mod pallet {
 		/// May only be called from `Signed` origin of a current member.
 		///
 		/// Prime membership is passed from the origin account to `new`, if extant.
+		#[pallet::call_index(4)]
 		#[pallet::weight(50_000_000)]
 		pub fn change_key(origin: OriginFor<T>, new: AccountIdLookupOf<T>) -> DispatchResult {
 			let remove = ensure_signed(origin)?;
@@ -300,6 +305,7 @@ pub mod pallet {
 		/// Set the prime member. Must be a current member.
 		///
 		/// May only be called from `T::PrimeOrigin`.
+		#[pallet::call_index(5)]
 		#[pallet::weight(50_000_000)]
 		pub fn set_prime(origin: OriginFor<T>, who: AccountIdLookupOf<T>) -> DispatchResult {
 			T::PrimeOrigin::ensure_origin(origin)?;
@@ -313,6 +319,7 @@ pub mod pallet {
 		/// Remove the prime member if it exists.
 		///
 		/// May only be called from `T::PrimeOrigin`.
+		#[pallet::call_index(6)]
 		#[pallet::weight(50_000_000)]
 		pub fn clear_prime(origin: OriginFor<T>) -> DispatchResult {
 			T::PrimeOrigin::ensure_origin(origin)?;

--- a/frame/message-queue/src/lib.rs
+++ b/frame/message-queue/src/lib.rs
@@ -574,6 +574,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Remove a page which has no more messages remaining to be processed or is stale.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::reap_page())]
 		pub fn reap_page(
 			origin: OriginFor<T>,
@@ -594,6 +595,7 @@ pub mod pallet {
 		///   of the message.
 		///
 		/// Benchmark complexity considerations: O(index + weight_limit).
+		#[pallet::call_index(1)]
 		#[pallet::weight(
 			T::WeightInfo::execute_overweight_page_updated().max(
 			T::WeightInfo::execute_overweight_page_removed()).saturating_add(*weight_limit)

--- a/frame/multisig/src/lib.rs
+++ b/frame/multisig/src/lib.rs
@@ -272,6 +272,7 @@ pub mod pallet {
 		/// - DB Weight: None
 		/// - Plus Call Weight
 		/// # </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight({
 			let dispatch_info = call.get_dispatch_info();
 			(
@@ -365,6 +366,7 @@ pub mod pallet {
 		///     - Writes: Multisig Storage, [Caller Account]
 		/// - Plus Call Weight
 		/// # </weight>
+		#[pallet::call_index(1)]
 		#[pallet::weight({
 			let s = other_signatories.len() as u32;
 			let z = call.using_encoded(|d| d.len()) as u32;
@@ -428,6 +430,7 @@ pub mod pallet {
 		///     - Read: Multisig Storage, [Caller Account]
 		///     - Write: Multisig Storage, [Caller Account]
 		/// # </weight>
+		#[pallet::call_index(2)]
 		#[pallet::weight({
 			let s = other_signatories.len() as u32;
 
@@ -480,6 +483,7 @@ pub mod pallet {
 		///     - Read: Multisig Storage, [Caller Account], Refund Account
 		///     - Write: Multisig Storage, [Caller Account], Refund Account
 		/// # </weight>
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::cancel_as_multi(other_signatories.len() as u32))]
 		pub fn cancel_as_multi(
 			origin: OriginFor<T>,

--- a/frame/nicks/src/lib.rs
+++ b/frame/nicks/src/lib.rs
@@ -135,6 +135,7 @@ pub mod pallet {
 		/// - One storage read/write.
 		/// - One event.
 		/// # </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight(50_000_000)]
 		pub fn set_name(origin: OriginFor<T>, name: Vec<u8>) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
@@ -167,6 +168,7 @@ pub mod pallet {
 		/// - One storage read/write.
 		/// - One event.
 		/// # </weight>
+		#[pallet::call_index(1)]
 		#[pallet::weight(70_000_000)]
 		pub fn clear_name(origin: OriginFor<T>) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
@@ -193,6 +195,7 @@ pub mod pallet {
 		/// - One storage read/write.
 		/// - One event.
 		/// # </weight>
+		#[pallet::call_index(2)]
 		#[pallet::weight(70_000_000)]
 		pub fn kill_name(origin: OriginFor<T>, target: AccountIdLookupOf<T>) -> DispatchResult {
 			T::ForceOrigin::ensure_origin(origin)?;
@@ -220,6 +223,7 @@ pub mod pallet {
 		/// - One storage read/write.
 		/// - One event.
 		/// # </weight>
+		#[pallet::call_index(3)]
 		#[pallet::weight(70_000_000)]
 		pub fn force_name(
 			origin: OriginFor<T>,

--- a/frame/nis/src/lib.rs
+++ b/frame/nis/src/lib.rs
@@ -520,6 +520,7 @@ pub mod pallet {
 		///
 		/// Complexities:
 		/// - `Queues[duration].len()` (just take max).
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::place_bid_max())]
 		pub fn place_bid(
 			origin: OriginFor<T>,
@@ -581,6 +582,7 @@ pub mod pallet {
 		///
 		/// - `amount`: The amount of the previous bid.
 		/// - `duration`: The duration of the previous bid.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::retract_bid(T::MaxQueueLen::get()))]
 		pub fn retract_bid(
 			origin: OriginFor<T>,
@@ -615,6 +617,7 @@ pub mod pallet {
 		/// Ensure we have sufficient funding for all potential payouts.
 		///
 		/// - `origin`: Must be accepted by `FundOrigin`.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::fund_deficit())]
 		pub fn fund_deficit(origin: OriginFor<T>) -> DispatchResult {
 			T::FundOrigin::ensure_origin(origin)?;
@@ -636,6 +639,7 @@ pub mod pallet {
 		/// - `index`: The index of the receipt.
 		/// - `portion`: If `Some`, then only the given portion of the receipt should be thawed. If
 		///   `None`, then all of it should be.
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::thaw())]
 		pub fn thaw(
 			origin: OriginFor<T>,

--- a/frame/node-authorization/src/lib.rs
+++ b/frame/node-authorization/src/lib.rs
@@ -210,6 +210,7 @@ pub mod pallet {
 		/// May only be called from `T::AddOrigin`.
 		///
 		/// - `node`: identifier of the node.
+		#[pallet::call_index(0)]
 		#[pallet::weight((T::WeightInfo::add_well_known_node(), DispatchClass::Operational))]
 		pub fn add_well_known_node(
 			origin: OriginFor<T>,
@@ -239,6 +240,7 @@ pub mod pallet {
 		/// May only be called from `T::RemoveOrigin`.
 		///
 		/// - `node`: identifier of the node.
+		#[pallet::call_index(1)]
 		#[pallet::weight((T::WeightInfo::remove_well_known_node(), DispatchClass::Operational))]
 		pub fn remove_well_known_node(origin: OriginFor<T>, node: PeerId) -> DispatchResult {
 			T::RemoveOrigin::ensure_origin(origin)?;
@@ -264,6 +266,7 @@ pub mod pallet {
 		///
 		/// - `remove`: the node which will be moved out from the list.
 		/// - `add`: the node which will be put in the list.
+		#[pallet::call_index(2)]
 		#[pallet::weight((T::WeightInfo::swap_well_known_node(), DispatchClass::Operational))]
 		pub fn swap_well_known_node(
 			origin: OriginFor<T>,
@@ -300,6 +303,7 @@ pub mod pallet {
 		/// May only be called from `T::ResetOrigin`.
 		///
 		/// - `nodes`: the new nodes for the allow list.
+		#[pallet::call_index(3)]
 		#[pallet::weight((T::WeightInfo::reset_well_known_nodes(), DispatchClass::Operational))]
 		pub fn reset_well_known_nodes(
 			origin: OriginFor<T>,
@@ -318,6 +322,7 @@ pub mod pallet {
 		/// PeerId, so claim it right away!
 		///
 		/// - `node`: identifier of the node.
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::claim_node())]
 		pub fn claim_node(origin: OriginFor<T>, node: PeerId) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
@@ -335,6 +340,7 @@ pub mod pallet {
 		/// needs to reach consensus among the network participants.
 		///
 		/// - `node`: identifier of the node.
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::remove_claim())]
 		pub fn remove_claim(origin: OriginFor<T>, node: PeerId) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
@@ -355,6 +361,7 @@ pub mod pallet {
 		///
 		/// - `node`: identifier of the node.
 		/// - `owner`: new owner of the node.
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::transfer_node())]
 		pub fn transfer_node(
 			origin: OriginFor<T>,
@@ -378,6 +385,7 @@ pub mod pallet {
 		///
 		/// - `node`: identifier of the node.
 		/// - `connections`: additonal nodes from which the connections are allowed.
+		#[pallet::call_index(7)]
 		#[pallet::weight(T::WeightInfo::add_connections())]
 		pub fn add_connections(
 			origin: OriginFor<T>,
@@ -412,6 +420,7 @@ pub mod pallet {
 		///
 		/// - `node`: identifier of the node.
 		/// - `connections`: additonal nodes from which the connections are not allowed anymore.
+		#[pallet::call_index(8)]
 		#[pallet::weight(T::WeightInfo::remove_connections())]
 		pub fn remove_connections(
 			origin: OriginFor<T>,

--- a/frame/nomination-pools/src/lib.rs
+++ b/frame/nomination-pools/src/lib.rs
@@ -1506,6 +1506,7 @@ pub mod pallet {
 		/// * This call will *not* dust the member account, so the member must have at least
 		///   `existential deposit + amount` in their account.
 		/// * Only a pool with [`PoolState::Open`] can be joined
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::join())]
 		pub fn join(
 			origin: OriginFor<T>,
@@ -1563,6 +1564,7 @@ pub mod pallet {
 		// NOTE: this transaction is implemented with the sole purpose of readability and
 		// correctness, not optimization. We read/write several storage items multiple times instead
 		// of just once, in the spirit reusing code.
+		#[pallet::call_index(1)]
 		#[pallet::weight(
 			T::WeightInfo::bond_extra_transfer()
 			.max(T::WeightInfo::bond_extra_reward())
@@ -1605,6 +1607,7 @@ pub mod pallet {
 		///
 		/// The member will earn rewards pro rata based on the members stake vs the sum of the
 		/// members in the pools stake. Rewards do not "expire".
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::claim_payout())]
 		pub fn claim_payout(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -1644,6 +1647,7 @@ pub mod pallet {
 		/// [`Call::pool_withdraw_unbonded`] can be called to try and minimize unlocking chunks. If
 		/// there are too many unlocking chunks, the result of this call will likely be the
 		/// `NoMoreChunks` error from the staking system.
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::unbond())]
 		pub fn unbond(
 			origin: OriginFor<T>,
@@ -1719,6 +1723,7 @@ pub mod pallet {
 		/// can be cleared by withdrawing. In the case there are too many unlocking chunks, the user
 		/// would probably see an error like `NoMoreChunks` emitted from the staking system when
 		/// they attempt to unbond.
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::pool_withdraw_unbonded(*num_slashing_spans))]
 		pub fn pool_withdraw_unbonded(
 			origin: OriginFor<T>,
@@ -1753,6 +1758,7 @@ pub mod pallet {
 		/// # Note
 		///
 		/// If the target is the depositor, the pool will be destroyed.
+		#[pallet::call_index(5)]
 		#[pallet::weight(
 			T::WeightInfo::withdraw_unbonded_kill(*num_slashing_spans)
 		)]
@@ -1874,6 +1880,7 @@ pub mod pallet {
 		///
 		/// In addition to `amount`, the caller will transfer the existential deposit; so the caller
 		/// needs at have at least `amount + existential_deposit` transferrable.
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::create())]
 		pub fn create(
 			origin: OriginFor<T>,
@@ -1898,6 +1905,7 @@ pub mod pallet {
 		///
 		/// same as `create` with the inclusion of
 		/// * `pool_id` - `A valid PoolId.
+		#[pallet::call_index(7)]
 		#[pallet::weight(T::WeightInfo::create())]
 		pub fn create_with_pool_id(
 			origin: OriginFor<T>,
@@ -1922,6 +1930,7 @@ pub mod pallet {
 		///
 		/// This directly forward the call to the staking pallet, on behalf of the pool bonded
 		/// account.
+		#[pallet::call_index(8)]
 		#[pallet::weight(T::WeightInfo::nominate(validators.len() as u32))]
 		pub fn nominate(
 			origin: OriginFor<T>,
@@ -1944,6 +1953,7 @@ pub mod pallet {
 		/// 1. signed by the state toggler, or the root role of the pool,
 		/// 2. if the pool conditions to be open are NOT met (as described by `ok_to_be_open`), and
 		///    then the state of the pool can be permissionlessly changed to `Destroying`.
+		#[pallet::call_index(9)]
 		#[pallet::weight(T::WeightInfo::set_state())]
 		pub fn set_state(
 			origin: OriginFor<T>,
@@ -1972,6 +1982,7 @@ pub mod pallet {
 		///
 		/// The dispatch origin of this call must be signed by the state toggler, or the root role
 		/// of the pool.
+		#[pallet::call_index(10)]
 		#[pallet::weight(T::WeightInfo::set_metadata(metadata.len() as u32))]
 		pub fn set_metadata(
 			origin: OriginFor<T>,
@@ -2003,6 +2014,7 @@ pub mod pallet {
 		/// * `max_pools` - Set [`MaxPools`].
 		/// * `max_members` - Set [`MaxPoolMembers`].
 		/// * `max_members_per_pool` - Set [`MaxPoolMembersPerPool`].
+		#[pallet::call_index(11)]
 		#[pallet::weight(T::WeightInfo::set_configs())]
 		pub fn set_configs(
 			origin: OriginFor<T>,
@@ -2039,6 +2051,7 @@ pub mod pallet {
 		///
 		/// It emits an event, notifying UIs of the role change. This event is quite relevant to
 		/// most pool members and they should be informed of changes to pool roles.
+		#[pallet::call_index(12)]
 		#[pallet::weight(T::WeightInfo::update_roles())]
 		pub fn update_roles(
 			origin: OriginFor<T>,
@@ -2091,6 +2104,7 @@ pub mod pallet {
 		///
 		/// This directly forward the call to the staking pallet, on behalf of the pool bonded
 		/// account.
+		#[pallet::call_index(13)]
 		#[pallet::weight(T::WeightInfo::chill())]
 		pub fn chill(origin: OriginFor<T>, pool_id: PoolId) -> DispatchResult {
 			let who = ensure_signed(origin)?;

--- a/frame/preimage/src/lib.rs
+++ b/frame/preimage/src/lib.rs
@@ -153,6 +153,7 @@ pub mod pallet {
 		///
 		/// If the preimage was previously requested, no fees or deposits are taken for providing
 		/// the preimage. Otherwise, a deposit is taken proportional to the size of the preimage.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::note_preimage(bytes.len() as u32))]
 		pub fn note_preimage(origin: OriginFor<T>, bytes: Vec<u8>) -> DispatchResultWithPostInfo {
 			// We accept a signed origin which will pay a deposit, or a root origin where a deposit
@@ -172,6 +173,7 @@ pub mod pallet {
 		///
 		/// - `hash`: The hash of the preimage to be removed from the store.
 		/// - `len`: The length of the preimage of `hash`.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::unnote_preimage())]
 		pub fn unnote_preimage(origin: OriginFor<T>, hash: T::Hash) -> DispatchResult {
 			let maybe_sender = Self::ensure_signed_or_manager(origin)?;
@@ -182,6 +184,7 @@ pub mod pallet {
 		///
 		/// If the preimage requests has already been provided on-chain, we unreserve any deposit
 		/// a user may have paid, and take the control of the preimage out of their hands.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::request_preimage())]
 		pub fn request_preimage(origin: OriginFor<T>, hash: T::Hash) -> DispatchResult {
 			T::ManagerOrigin::ensure_origin(origin)?;
@@ -192,6 +195,7 @@ pub mod pallet {
 		/// Clear a previously made request for a preimage.
 		///
 		/// NOTE: THIS MUST NOT BE CALLED ON `hash` MORE TIMES THAN `request_preimage`.
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::unrequest_preimage())]
 		pub fn unrequest_preimage(origin: OriginFor<T>, hash: T::Hash) -> DispatchResult {
 			T::ManagerOrigin::ensure_origin(origin)?;

--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -191,6 +191,7 @@ pub mod pallet {
 		/// - `real`: The account that the proxy will make a call on behalf of.
 		/// - `force_proxy_type`: Specify the exact proxy type to be used and checked for this call.
 		/// - `call`: The call to be made by the `real` account.
+		#[pallet::call_index(0)]
 		#[pallet::weight({
 			let di = call.get_dispatch_info();
 			(T::WeightInfo::proxy(T::MaxProxies::get())
@@ -224,6 +225,7 @@ pub mod pallet {
 		/// - `proxy_type`: The permissions allowed for this proxy account.
 		/// - `delay`: The announcement period required of the initial proxy. Will generally be
 		/// zero.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::add_proxy(T::MaxProxies::get()))]
 		pub fn add_proxy(
 			origin: OriginFor<T>,
@@ -243,6 +245,7 @@ pub mod pallet {
 		/// Parameters:
 		/// - `proxy`: The account that the `caller` would like to remove as a proxy.
 		/// - `proxy_type`: The permissions currently enabled for the removed proxy account.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::remove_proxy(T::MaxProxies::get()))]
 		pub fn remove_proxy(
 			origin: OriginFor<T>,
@@ -261,6 +264,7 @@ pub mod pallet {
 		///
 		/// WARNING: This may be called on accounts created by `pure`, however if done, then
 		/// the unreserved fees will be inaccessible. **All access to this account will be lost.**
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::remove_proxies(T::MaxProxies::get()))]
 		pub fn remove_proxies(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -288,6 +292,7 @@ pub mod pallet {
 		/// same sender, with the same parameters.
 		///
 		/// Fails if there are insufficient funds to pay for deposit.
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::create_pure(T::MaxProxies::get()))]
 		pub fn create_pure(
 			origin: OriginFor<T>,
@@ -335,6 +340,7 @@ pub mod pallet {
 		///
 		/// Fails with `NoPermission` in case the caller is not a previously created pure
 		/// account whose `pure` call has corresponding parameters.
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::kill_pure(T::MaxProxies::get()))]
 		pub fn kill_pure(
 			origin: OriginFor<T>,
@@ -372,6 +378,7 @@ pub mod pallet {
 		/// Parameters:
 		/// - `real`: The account that the proxy will make a call on behalf of.
 		/// - `call_hash`: The hash of the call to be made by the `real` account.
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::announce(T::MaxPending::get(), T::MaxProxies::get()))]
 		pub fn announce(
 			origin: OriginFor<T>,
@@ -421,6 +428,7 @@ pub mod pallet {
 		/// Parameters:
 		/// - `real`: The account that the proxy will make a call on behalf of.
 		/// - `call_hash`: The hash of the call to be made by the `real` account.
+		#[pallet::call_index(7)]
 		#[pallet::weight(T::WeightInfo::remove_announcement(
 			T::MaxPending::get(),
 			T::MaxProxies::get()
@@ -447,6 +455,7 @@ pub mod pallet {
 		/// Parameters:
 		/// - `delegate`: The account that previously announced the call.
 		/// - `call_hash`: The hash of the call to be made.
+		#[pallet::call_index(8)]
 		#[pallet::weight(T::WeightInfo::reject_announcement(
 			T::MaxPending::get(),
 			T::MaxProxies::get()
@@ -476,6 +485,7 @@ pub mod pallet {
 		/// - `real`: The account that the proxy will make a call on behalf of.
 		/// - `force_proxy_type`: Specify the exact proxy type to be used and checked for this call.
 		/// - `call`: The call to be made by the `real` account.
+		#[pallet::call_index(9)]
 		#[pallet::weight({
 			let di = call.get_dispatch_info();
 			(T::WeightInfo::proxy_announced(T::MaxPending::get(), T::MaxProxies::get())

--- a/frame/ranked-collective/src/lib.rs
+++ b/frame/ranked-collective/src/lib.rs
@@ -470,6 +470,7 @@ pub mod pallet {
 		/// - `rank`: The rank to give the new member.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::add_member())]
 		pub fn add_member(origin: OriginFor<T>, who: AccountIdLookupOf<T>) -> DispatchResult {
 			let _ = T::PromoteOrigin::ensure_origin(origin)?;
@@ -483,6 +484,7 @@ pub mod pallet {
 		/// - `who`: Account of existing member.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::promote_member(0))]
 		pub fn promote_member(origin: OriginFor<T>, who: AccountIdLookupOf<T>) -> DispatchResult {
 			let max_rank = T::PromoteOrigin::ensure_origin(origin)?;
@@ -497,6 +499,7 @@ pub mod pallet {
 		/// - `who`: Account of existing member of rank greater than zero.
 		///
 		/// Weight: `O(1)`, less if the member's index is highest in its rank.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::demote_member(0))]
 		pub fn demote_member(origin: OriginFor<T>, who: AccountIdLookupOf<T>) -> DispatchResult {
 			let max_rank = T::DemoteOrigin::ensure_origin(origin)?;
@@ -528,6 +531,7 @@ pub mod pallet {
 		/// - `min_rank`: The rank of the member or greater.
 		///
 		/// Weight: `O(min_rank)`.
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::remove_member(*min_rank as u32))]
 		pub fn remove_member(
 			origin: OriginFor<T>,
@@ -562,6 +566,7 @@ pub mod pallet {
 		/// fee.
 		///
 		/// Weight: `O(1)`, less if there was no previous vote on the poll by the member.
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::vote())]
 		pub fn vote(
 			origin: OriginFor<T>,
@@ -618,6 +623,7 @@ pub mod pallet {
 		/// Transaction fees are waived if the operation is successful.
 		///
 		/// Weight `O(max)` (less if there are fewer items to remove than `max`).
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::cleanup_poll(*max))]
 		pub fn cleanup_poll(
 			origin: OriginFor<T>,

--- a/frame/recovery/src/lib.rs
+++ b/frame/recovery/src/lib.rs
@@ -374,6 +374,7 @@ pub mod pallet {
 		/// Parameters:
 		/// - `account`: The recovered account you want to make a call on-behalf-of.
 		/// - `call`: The call you want to make with the recovered account.
+		#[pallet::call_index(0)]
 		#[pallet::weight({
 			let dispatch_info = call.get_dispatch_info();
 			(
@@ -403,6 +404,7 @@ pub mod pallet {
 		/// Parameters:
 		/// - `lost`: The "lost account" to be recovered.
 		/// - `rescuer`: The "rescuer account" which can call as the lost account.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::set_recovered())]
 		pub fn set_recovered(
 			origin: OriginFor<T>,
@@ -437,6 +439,7 @@ pub mod pallet {
 		///   friends.
 		/// - `delay_period`: The number of blocks after a recovery attempt is initialized that
 		///   needs to pass before the account can be recovered.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::create_recovery(friends.len() as u32))]
 		pub fn create_recovery(
 			origin: OriginFor<T>,
@@ -488,6 +491,7 @@ pub mod pallet {
 		/// Parameters:
 		/// - `account`: The lost account that you want to recover. This account needs to be
 		///   recoverable (i.e. have a recovery configuration).
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::initiate_recovery())]
 		pub fn initiate_recovery(
 			origin: OriginFor<T>,
@@ -532,6 +536,7 @@ pub mod pallet {
 		///
 		/// The combination of these two parameters must point to an active recovery
 		/// process.
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::vouch_recovery(T::MaxFriends::get()))]
 		pub fn vouch_recovery(
 			origin: OriginFor<T>,
@@ -575,6 +580,7 @@ pub mod pallet {
 		/// Parameters:
 		/// - `account`: The lost account that you want to claim has been successfully recovered by
 		///   you.
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::claim_recovery(T::MaxFriends::get()))]
 		pub fn claim_recovery(
 			origin: OriginFor<T>,
@@ -622,6 +628,7 @@ pub mod pallet {
 		///
 		/// Parameters:
 		/// - `rescuer`: The account trying to rescue this recoverable account.
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::close_recovery(T::MaxFriends::get()))]
 		pub fn close_recovery(
 			origin: OriginFor<T>,
@@ -659,6 +666,7 @@ pub mod pallet {
 		///
 		/// The dispatch origin for this call must be _Signed_ and must be a
 		/// recoverable account (i.e. has a recovery configuration).
+		#[pallet::call_index(7)]
 		#[pallet::weight(T::WeightInfo::remove_recovery(T::MaxFriends::get()))]
 		pub fn remove_recovery(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -681,6 +689,7 @@ pub mod pallet {
 		///
 		/// Parameters:
 		/// - `account`: The recovered account you are able to call on-behalf-of.
+		#[pallet::call_index(8)]
 		#[pallet::weight(T::WeightInfo::cancel_recovered())]
 		pub fn cancel_recovered(
 			origin: OriginFor<T>,

--- a/frame/referenda/src/lib.rs
+++ b/frame/referenda/src/lib.rs
@@ -397,6 +397,7 @@ pub mod pallet {
 		/// - `enactment_moment`: The moment that the proposal should be enacted.
 		///
 		/// Emits `Submitted`.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::submit())]
 		pub fn submit(
 			origin: OriginFor<T>,
@@ -444,6 +445,7 @@ pub mod pallet {
 		///   posted.
 		///
 		/// Emits `DecisionDepositPlaced`.
+		#[pallet::call_index(1)]
 		#[pallet::weight(ServiceBranch::max_weight_of_deposit::<T, I>())]
 		pub fn place_decision_deposit(
 			origin: OriginFor<T>,
@@ -471,6 +473,7 @@ pub mod pallet {
 		///   refunded.
 		///
 		/// Emits `DecisionDepositRefunded`.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::refund_decision_deposit())]
 		pub fn refund_decision_deposit(
 			origin: OriginFor<T>,
@@ -500,6 +503,7 @@ pub mod pallet {
 		/// - `index`: The index of the referendum to be cancelled.
 		///
 		/// Emits `Cancelled`.
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::cancel())]
 		pub fn cancel(origin: OriginFor<T>, index: ReferendumIndex) -> DispatchResult {
 			T::CancelOrigin::ensure_origin(origin)?;
@@ -524,6 +528,7 @@ pub mod pallet {
 		/// - `index`: The index of the referendum to be cancelled.
 		///
 		/// Emits `Killed` and `DepositSlashed`.
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::kill())]
 		pub fn kill(origin: OriginFor<T>, index: ReferendumIndex) -> DispatchResult {
 			T::KillOrigin::ensure_origin(origin)?;
@@ -544,6 +549,7 @@ pub mod pallet {
 		///
 		/// - `origin`: must be `Root`.
 		/// - `index`: the referendum to be advanced.
+		#[pallet::call_index(5)]
 		#[pallet::weight(ServiceBranch::max_weight_of_nudge::<T, I>())]
 		pub fn nudge_referendum(
 			origin: OriginFor<T>,
@@ -570,6 +576,7 @@ pub mod pallet {
 		/// `DecidingCount` is not yet updated. This means that we should either:
 		/// - begin deciding another referendum (and leave `DecidingCount` alone); or
 		/// - decrement `DecidingCount`.
+		#[pallet::call_index(6)]
 		#[pallet::weight(OneFewerDecidingBranch::max_weight::<T, I>())]
 		pub fn one_fewer_deciding(
 			origin: OriginFor<T>,
@@ -603,6 +610,7 @@ pub mod pallet {
 		///   refunded.
 		///
 		/// Emits `SubmissionDepositRefunded`.
+		#[pallet::call_index(7)]
 		#[pallet::weight(T::WeightInfo::refund_submission_deposit())]
 		pub fn refund_submission_deposit(
 			origin: OriginFor<T>,

--- a/frame/remark/src/lib.rs
+++ b/frame/remark/src/lib.rs
@@ -62,6 +62,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Index and store data off chain.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::store(remark.len() as u32))]
 		pub fn store(origin: OriginFor<T>, remark: Vec<u8>) -> DispatchResultWithPostInfo {
 			ensure!(!remark.is_empty(), Error::<T>::Empty);

--- a/frame/root-offences/src/lib.rs
+++ b/frame/root-offences/src/lib.rs
@@ -81,6 +81,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Allows the `root`, for example sudo to create an offence.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::DbWeight::get().reads(2))]
 		pub fn create_offence(
 			origin: OriginFor<T>,

--- a/frame/root-testing/src/lib.rs
+++ b/frame/root-testing/src/lib.rs
@@ -45,6 +45,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// A dispatch that will fill the block weight up to the given ratio.
+		#[pallet::call_index(0)]
 		#[pallet::weight(*_ratio * T::BlockWeights::get().max_block)]
 		pub fn fill_block(origin: OriginFor<T>, _ratio: Perbill) -> DispatchResult {
 			ensure_root(origin)?;

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -297,6 +297,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Anonymously schedule a task.
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::schedule(T::MaxScheduledPerBlock::get()))]
 		pub fn schedule(
 			origin: OriginFor<T>,
@@ -318,6 +319,7 @@ pub mod pallet {
 		}
 
 		/// Cancel an anonymously scheduled task.
+		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config>::WeightInfo::cancel(T::MaxScheduledPerBlock::get()))]
 		pub fn cancel(origin: OriginFor<T>, when: T::BlockNumber, index: u32) -> DispatchResult {
 			T::ScheduleOrigin::ensure_origin(origin.clone())?;
@@ -327,6 +329,7 @@ pub mod pallet {
 		}
 
 		/// Schedule a named task.
+		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_named(T::MaxScheduledPerBlock::get()))]
 		pub fn schedule_named(
 			origin: OriginFor<T>,
@@ -350,6 +353,7 @@ pub mod pallet {
 		}
 
 		/// Cancel a named scheduled task.
+		#[pallet::call_index(3)]
 		#[pallet::weight(<T as Config>::WeightInfo::cancel_named(T::MaxScheduledPerBlock::get()))]
 		pub fn cancel_named(origin: OriginFor<T>, id: TaskName) -> DispatchResult {
 			T::ScheduleOrigin::ensure_origin(origin.clone())?;
@@ -363,6 +367,7 @@ pub mod pallet {
 		/// # <weight>
 		/// Same as [`schedule`].
 		/// # </weight>
+		#[pallet::call_index(4)]
 		#[pallet::weight(<T as Config>::WeightInfo::schedule(T::MaxScheduledPerBlock::get()))]
 		pub fn schedule_after(
 			origin: OriginFor<T>,
@@ -388,6 +393,7 @@ pub mod pallet {
 		/// # <weight>
 		/// Same as [`schedule_named`](Self::schedule_named).
 		/// # </weight>
+		#[pallet::call_index(5)]
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_named(T::MaxScheduledPerBlock::get()))]
 		pub fn schedule_named_after(
 			origin: OriginFor<T>,

--- a/frame/scheduler/src/mock.rs
+++ b/frame/scheduler/src/mock.rs
@@ -72,6 +72,7 @@ pub mod logger {
 	where
 		<T as frame_system::Config>::RuntimeOrigin: OriginTrait<PalletsOrigin = OriginCaller>,
 	{
+		#[pallet::call_index(0)]
 		#[pallet::weight(*weight)]
 		pub fn log(origin: OriginFor<T>, i: u32, weight: Weight) -> DispatchResult {
 			Self::deposit_event(Event::Logged(i, weight));
@@ -81,6 +82,7 @@ pub mod logger {
 			Ok(())
 		}
 
+		#[pallet::call_index(1)]
 		#[pallet::weight(*weight)]
 		pub fn log_without_filter(origin: OriginFor<T>, i: u32, weight: Weight) -> DispatchResult {
 			Self::deposit_event(Event::Logged(i, weight));

--- a/frame/scored-pool/src/lib.rs
+++ b/frame/scored-pool/src/lib.rs
@@ -311,6 +311,7 @@ pub mod pallet {
 		///
 		/// The `index` parameter of this function must be set to
 		/// the index of the transactor in the `Pool`.
+		#[pallet::call_index(0)]
 		#[pallet::weight(0)]
 		pub fn submit_candidacy(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -340,6 +341,7 @@ pub mod pallet {
 		///
 		/// The `index` parameter of this function must be set to
 		/// the index of the transactor in the `Pool`.
+		#[pallet::call_index(1)]
 		#[pallet::weight(0)]
 		pub fn withdraw_candidacy(origin: OriginFor<T>, index: u32) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -358,6 +360,7 @@ pub mod pallet {
 		///
 		/// The `index` parameter of this function must be set to
 		/// the index of `dest` in the `Pool`.
+		#[pallet::call_index(2)]
 		#[pallet::weight(0)]
 		pub fn kick(
 			origin: OriginFor<T>,
@@ -382,6 +385,7 @@ pub mod pallet {
 		///
 		/// The `index` parameter of this function must be set to
 		/// the index of the `dest` in the `Pool`.
+		#[pallet::call_index(3)]
 		#[pallet::weight(0)]
 		pub fn score(
 			origin: OriginFor<T>,
@@ -421,6 +425,7 @@ pub mod pallet {
 		/// (this happens each `Period`).
 		///
 		/// May only be called from root.
+		#[pallet::call_index(4)]
 		#[pallet::weight(0)]
 		pub fn change_member_count(origin: OriginFor<T>, count: u32) -> DispatchResult {
 			ensure_root(origin)?;

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -595,6 +595,7 @@ pub mod pallet {
 		/// - DbReads per key id: `KeyOwner`
 		/// - DbWrites per key id: `KeyOwner`
 		/// # </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::set_keys())]
 		pub fn set_keys(origin: OriginFor<T>, keys: T::Keys, proof: Vec<u8>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -620,6 +621,7 @@ pub mod pallet {
 		/// - DbWrites: `NextKeys`, `origin account`
 		/// - DbWrites per key id: `KeyOwner`
 		/// # </weight>
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::purge_keys())]
 		pub fn purge_keys(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;

--- a/frame/society/src/lib.rs
+++ b/frame/society/src/lib.rs
@@ -711,6 +711,7 @@ pub mod pallet {
 		///
 		/// Total Complexity: O(M + B + C + logM + logB + X)
 		/// # </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::BlockWeights::get().max_block / 10)]
 		pub fn bid(origin: OriginFor<T>, value: BalanceOf<T, I>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -750,6 +751,7 @@ pub mod pallet {
 		///
 		/// Total Complexity: O(B + X)
 		/// # </weight>
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::BlockWeights::get().max_block / 10)]
 		pub fn unbid(origin: OriginFor<T>, pos: u32) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -822,6 +824,7 @@ pub mod pallet {
 		///
 		/// Total Complexity: O(M + B + C + logM + logB + X)
 		/// # </weight>
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::BlockWeights::get().max_block / 10)]
 		pub fn vouch(
 			origin: OriginFor<T>,
@@ -873,6 +876,7 @@ pub mod pallet {
 		///
 		/// Total Complexity: O(B)
 		/// # </weight>
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::BlockWeights::get().max_block / 10)]
 		pub fn unvouch(origin: OriginFor<T>, pos: u32) -> DispatchResult {
 			let voucher = ensure_signed(origin)?;
@@ -914,6 +918,7 @@ pub mod pallet {
 		///
 		/// Total Complexity: O(M + logM + C)
 		/// # </weight>
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::BlockWeights::get().max_block / 10)]
 		pub fn vote(
 			origin: OriginFor<T>,
@@ -950,6 +955,7 @@ pub mod pallet {
 		///
 		/// Total Complexity: O(M + logM)
 		/// # </weight>
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::BlockWeights::get().max_block / 10)]
 		pub fn defender_vote(origin: OriginFor<T>, approve: bool) -> DispatchResult {
 			let voter = ensure_signed(origin)?;
@@ -984,6 +990,7 @@ pub mod pallet {
 		///
 		/// Total Complexity: O(M + logM + P + X)
 		/// # </weight>
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::BlockWeights::get().max_block / 10)]
 		pub fn payout(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -1026,6 +1033,7 @@ pub mod pallet {
 		///
 		/// Total Complexity: O(1)
 		/// # </weight>
+		#[pallet::call_index(7)]
 		#[pallet::weight(T::BlockWeights::get().max_block / 10)]
 		pub fn found(
 			origin: OriginFor<T>,
@@ -1060,6 +1068,7 @@ pub mod pallet {
 		///
 		/// Total Complexity: O(1)
 		/// # </weight>
+		#[pallet::call_index(8)]
 		#[pallet::weight(T::BlockWeights::get().max_block / 10)]
 		pub fn unfound(origin: OriginFor<T>) -> DispatchResult {
 			let founder = ensure_signed(origin)?;
@@ -1105,6 +1114,7 @@ pub mod pallet {
 		///
 		/// Total Complexity: O(M + logM + B)
 		/// # </weight>
+		#[pallet::call_index(9)]
 		#[pallet::weight(T::BlockWeights::get().max_block / 10)]
 		pub fn judge_suspended_member(
 			origin: OriginFor<T>,
@@ -1182,6 +1192,7 @@ pub mod pallet {
 		///
 		/// Total Complexity: O(M + logM + B + X)
 		/// # </weight>
+		#[pallet::call_index(10)]
 		#[pallet::weight(T::BlockWeights::get().max_block / 10)]
 		pub fn judge_suspended_candidate(
 			origin: OriginFor<T>,
@@ -1255,6 +1266,7 @@ pub mod pallet {
 		///
 		/// Total Complexity: O(1)
 		/// # </weight>
+		#[pallet::call_index(11)]
 		#[pallet::weight(T::BlockWeights::get().max_block / 10)]
 		pub fn set_max_members(origin: OriginFor<T>, max: u32) -> DispatchResult {
 			ensure_root(origin)?;

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -831,6 +831,7 @@ pub mod pallet {
 		/// unless the `origin` falls below _existential deposit_ and gets removed as dust.
 		/// ------------------
 		/// # </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::bond())]
 		pub fn bond(
 			origin: OriginFor<T>,
@@ -900,6 +901,7 @@ pub mod pallet {
 		/// - Independent of the arguments. Insignificant complexity.
 		/// - O(1).
 		/// # </weight>
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::bond_extra())]
 		pub fn bond_extra(
 			origin: OriginFor<T>,
@@ -953,6 +955,7 @@ pub mod pallet {
 		/// Emits `Unbonded`.
 		///
 		/// See also [`Call::withdraw_unbonded`].
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::unbond())]
 		pub fn unbond(
 			origin: OriginFor<T>,
@@ -1032,6 +1035,7 @@ pub mod pallet {
 		/// Complexity O(S) where S is the number of slashing spans to remove
 		/// NOTE: Weight annotation is the kill scenario, we refund otherwise.
 		/// # </weight>
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::withdraw_unbonded_kill(*num_slashing_spans))]
 		pub fn withdraw_unbonded(
 			origin: OriginFor<T>,
@@ -1079,6 +1083,7 @@ pub mod pallet {
 		/// Effects will be felt at the beginning of the next era.
 		///
 		/// The dispatch origin for this call must be _Signed_ by the controller, not the stash.
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::validate())]
 		pub fn validate(origin: OriginFor<T>, prefs: ValidatorPrefs) -> DispatchResult {
 			let controller = ensure_signed(origin)?;
@@ -1122,6 +1127,7 @@ pub mod pallet {
 		/// which is capped at CompactAssignments::LIMIT (T::MaxNominations).
 		/// - Both the reads and writes follow a similar pattern.
 		/// # </weight>
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::nominate(targets.len() as u32))]
 		pub fn nominate(
 			origin: OriginFor<T>,
@@ -1190,6 +1196,7 @@ pub mod pallet {
 		/// - Contains one read.
 		/// - Writes are limited to the `origin` account key.
 		/// # </weight>
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::chill())]
 		pub fn chill(origin: OriginFor<T>) -> DispatchResult {
 			let controller = ensure_signed(origin)?;
@@ -1214,6 +1221,7 @@ pub mod pallet {
 		///     - Read: Ledger
 		///     - Write: Payee
 		/// # </weight>
+		#[pallet::call_index(7)]
 		#[pallet::weight(T::WeightInfo::set_payee())]
 		pub fn set_payee(
 			origin: OriginFor<T>,
@@ -1242,6 +1250,7 @@ pub mod pallet {
 		/// - Read: Bonded, Ledger New Controller, Ledger Old Controller
 		/// - Write: Bonded, Ledger New Controller, Ledger Old Controller
 		/// # </weight>
+		#[pallet::call_index(8)]
 		#[pallet::weight(T::WeightInfo::set_controller())]
 		pub fn set_controller(
 			origin: OriginFor<T>,
@@ -1270,6 +1279,7 @@ pub mod pallet {
 		/// Weight: O(1)
 		/// Write: Validator Count
 		/// # </weight>
+		#[pallet::call_index(9)]
 		#[pallet::weight(T::WeightInfo::set_validator_count())]
 		pub fn set_validator_count(
 			origin: OriginFor<T>,
@@ -1294,6 +1304,7 @@ pub mod pallet {
 		/// # <weight>
 		/// Same as [`Self::set_validator_count`].
 		/// # </weight>
+		#[pallet::call_index(10)]
 		#[pallet::weight(T::WeightInfo::set_validator_count())]
 		pub fn increase_validator_count(
 			origin: OriginFor<T>,
@@ -1319,6 +1330,7 @@ pub mod pallet {
 		/// # <weight>
 		/// Same as [`Self::set_validator_count`].
 		/// # </weight>
+		#[pallet::call_index(11)]
 		#[pallet::weight(T::WeightInfo::set_validator_count())]
 		pub fn scale_validator_count(origin: OriginFor<T>, factor: Percent) -> DispatchResult {
 			ensure_root(origin)?;
@@ -1349,6 +1361,7 @@ pub mod pallet {
 		/// - Weight: O(1)
 		/// - Write: ForceEra
 		/// # </weight>
+		#[pallet::call_index(12)]
 		#[pallet::weight(T::WeightInfo::force_no_eras())]
 		pub fn force_no_eras(origin: OriginFor<T>) -> DispatchResult {
 			ensure_root(origin)?;
@@ -1372,6 +1385,7 @@ pub mod pallet {
 		/// - Weight: O(1)
 		/// - Write ForceEra
 		/// # </weight>
+		#[pallet::call_index(13)]
 		#[pallet::weight(T::WeightInfo::force_new_era())]
 		pub fn force_new_era(origin: OriginFor<T>) -> DispatchResult {
 			ensure_root(origin)?;
@@ -1382,6 +1396,7 @@ pub mod pallet {
 		/// Set the validators who cannot be slashed (if any).
 		///
 		/// The dispatch origin must be Root.
+		#[pallet::call_index(14)]
 		#[pallet::weight(T::WeightInfo::set_invulnerables(invulnerables.len() as u32))]
 		pub fn set_invulnerables(
 			origin: OriginFor<T>,
@@ -1395,6 +1410,7 @@ pub mod pallet {
 		/// Force a current staker to become completely unstaked, immediately.
 		///
 		/// The dispatch origin must be Root.
+		#[pallet::call_index(15)]
 		#[pallet::weight(T::WeightInfo::force_unstake(*num_slashing_spans))]
 		pub fn force_unstake(
 			origin: OriginFor<T>,
@@ -1420,6 +1436,7 @@ pub mod pallet {
 		/// The election process starts multiple blocks before the end of the era.
 		/// If this is called just before a new era is triggered, the election process may not
 		/// have enough blocks to get a result.
+		#[pallet::call_index(16)]
 		#[pallet::weight(T::WeightInfo::force_new_era_always())]
 		pub fn force_new_era_always(origin: OriginFor<T>) -> DispatchResult {
 			ensure_root(origin)?;
@@ -1432,6 +1449,7 @@ pub mod pallet {
 		/// Can be called by the `T::SlashCancelOrigin`.
 		///
 		/// Parameters: era and indices of the slashes for that era to kill.
+		#[pallet::call_index(17)]
 		#[pallet::weight(T::WeightInfo::cancel_deferred_slash(slash_indices.len() as u32))]
 		pub fn cancel_deferred_slash(
 			origin: OriginFor<T>,
@@ -1477,6 +1495,7 @@ pub mod pallet {
 		///   NOTE: weights are assuming that payouts are made to alive stash account (Staked).
 		///   Paying even a dead controller is cheaper weight-wise. We don't do any refunds here.
 		/// # </weight>
+		#[pallet::call_index(18)]
 		#[pallet::weight(T::WeightInfo::payout_stakers_alive_staked(
 			T::MaxNominatorRewardedPerValidator::get()
 		))]
@@ -1498,6 +1517,7 @@ pub mod pallet {
 		/// - Bounded by `MaxUnlockingChunks`.
 		/// - Storage changes: Can't increase storage, only decrease it.
 		/// # </weight>
+		#[pallet::call_index(19)]
 		#[pallet::weight(T::WeightInfo::rebond(T::MaxUnlockingChunks::get() as u32))]
 		pub fn rebond(
 			origin: OriginFor<T>,
@@ -1542,6 +1562,7 @@ pub mod pallet {
 		/// It can be called by anyone, as long as `stash` meets the above requirements.
 		///
 		/// Refunds the transaction fees upon successful execution.
+		#[pallet::call_index(20)]
 		#[pallet::weight(T::WeightInfo::reap_stash(*num_slashing_spans))]
 		pub fn reap_stash(
 			origin: OriginFor<T>,
@@ -1574,6 +1595,7 @@ pub mod pallet {
 		///
 		/// Note: Making this call only makes sense if you first set the validator preferences to
 		/// block any further nominations.
+		#[pallet::call_index(21)]
 		#[pallet::weight(T::WeightInfo::kick(who.len() as u32))]
 		pub fn kick(origin: OriginFor<T>, who: Vec<AccountIdLookupOf<T>>) -> DispatchResult {
 			let controller = ensure_signed(origin)?;
@@ -1621,6 +1643,7 @@ pub mod pallet {
 		/// to kick people under the new limits, `chill_other` should be called.
 		// We assume the worst case for this call is either: all items are set or all items are
 		// removed.
+		#[pallet::call_index(22)]
 		#[pallet::weight(
 			T::WeightInfo::set_staking_configs_all_set()
 				.max(T::WeightInfo::set_staking_configs_all_remove())
@@ -1681,6 +1704,7 @@ pub mod pallet {
 		///
 		/// This can be helpful if bond requirements are updated, and we need to remove old users
 		/// who do not satisfy these requirements.
+		#[pallet::call_index(23)]
 		#[pallet::weight(T::WeightInfo::chill_other())]
 		pub fn chill_other(origin: OriginFor<T>, controller: T::AccountId) -> DispatchResult {
 			// Anyone can call this function.
@@ -1743,6 +1767,7 @@ pub mod pallet {
 		/// Force a validator to have at least the minimum commission. This will not affect a
 		/// validator who already has a commission greater than or equal to the minimum. Any account
 		/// can call this.
+		#[pallet::call_index(24)]
 		#[pallet::weight(T::WeightInfo::force_apply_min_commission())]
 		pub fn force_apply_min_commission(
 			origin: OriginFor<T>,

--- a/frame/state-trie-migration/src/lib.rs
+++ b/frame/state-trie-migration/src/lib.rs
@@ -546,6 +546,7 @@ pub mod pallet {
 		/// Control the automatic migration.
 		///
 		/// The dispatch origin of this call must be [`Config::ControlOrigin`].
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::DbWeight::get().reads_writes(1, 1))]
 		pub fn control_auto_migration(
 			origin: OriginFor<T>,
@@ -577,6 +578,7 @@ pub mod pallet {
 		/// Based on the documentation of [`MigrationTask::migrate_until_exhaustion`], the
 		/// recommended way of doing this is to pass a `limit` that only bounds `count`, as the
 		/// `size` limit can always be overwritten.
+		#[pallet::call_index(1)]
 		#[pallet::weight(
 			// the migration process
 			Pallet::<T>::dynamic_weight(limits.item, * real_size_upper)
@@ -648,6 +650,7 @@ pub mod pallet {
 		///
 		/// This does not affect the global migration process tracker ([`MigrationProcess`]), and
 		/// should only be used in case any keys are leftover due to a bug.
+		#[pallet::call_index(2)]
 		#[pallet::weight(
 			T::WeightInfo::migrate_custom_top_success()
 				.max(T::WeightInfo::migrate_custom_top_fail())
@@ -704,6 +707,7 @@ pub mod pallet {
 		///
 		/// This does not affect the global migration process tracker ([`MigrationProcess`]), and
 		/// should only be used in case any keys are leftover due to a bug.
+		#[pallet::call_index(3)]
 		#[pallet::weight(
 			T::WeightInfo::migrate_custom_child_success()
 				.max(T::WeightInfo::migrate_custom_child_fail())
@@ -764,6 +768,7 @@ pub mod pallet {
 		}
 
 		/// Set the maximum limit of the signed migration.
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::DbWeight::get().reads_writes(1, 1))]
 		pub fn set_signed_max_limits(
 			origin: OriginFor<T>,
@@ -783,6 +788,7 @@ pub mod pallet {
 		///
 		/// In case you mess things up, you can also, in principle, use this to reset the migration
 		/// process.
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::DbWeight::get().reads_writes(1, 1))]
 		pub fn force_set_progress(
 			origin: OriginFor<T>,

--- a/frame/sudo/src/lib.rs
+++ b/frame/sudo/src/lib.rs
@@ -148,6 +148,7 @@ pub mod pallet {
 		/// - One DB write (event).
 		/// - Weight of derivative `call` execution + 10,000.
 		/// # </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight({
 			let dispatch_info = call.get_dispatch_info();
 			(dispatch_info.weight, dispatch_info.class)
@@ -176,6 +177,7 @@ pub mod pallet {
 		/// - O(1).
 		/// - The weight of this call is defined by the caller.
 		/// # </weight>
+		#[pallet::call_index(1)]
 		#[pallet::weight((*_weight, call.get_dispatch_info().class))]
 		pub fn sudo_unchecked_weight(
 			origin: OriginFor<T>,
@@ -202,6 +204,7 @@ pub mod pallet {
 		/// - Limited storage reads.
 		/// - One DB change.
 		/// # </weight>
+		#[pallet::call_index(2)]
 		#[pallet::weight(0)]
 		pub fn set_key(
 			origin: OriginFor<T>,
@@ -229,6 +232,7 @@ pub mod pallet {
 		/// - One DB write (event).
 		/// - Weight of derivative `call` execution + 10,000.
 		/// # </weight>
+		#[pallet::call_index(3)]
 		#[pallet::weight({
 			let dispatch_info = call.get_dispatch_info();
 			(

--- a/frame/sudo/src/mock.rs
+++ b/frame/sudo/src/mock.rs
@@ -49,6 +49,7 @@ pub mod logger {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(*weight)]
 		pub fn privileged_i32_log(
 			origin: OriginFor<T>,
@@ -62,6 +63,7 @@ pub mod logger {
 			Ok(().into())
 		}
 
+		#[pallet::call_index(1)]
 		#[pallet::weight(*weight)]
 		pub fn non_privileged_log(
 			origin: OriginFor<T>,

--- a/frame/support/procedural/src/pallet/parse/call.rs
+++ b/frame/support/procedural/src/pallet/parse/call.rs
@@ -235,6 +235,10 @@ impl CallDef {
 					_ => unreachable!("checked during creation of the let binding"),
 				};
 
+				if call_idx_attrs.is_empty() {
+					return Err(syn::Error::new(method.sig.span(), "Missing call_index"));
+				}
+
 				if call_idx_attrs.len() > 1 {
 					let msg = "Invalid pallet::call, too many call_index attributes given";
 					return Err(syn::Error::new(method.sig.span(), msg))

--- a/frame/support/procedural/src/pallet/parse/call.rs
+++ b/frame/support/procedural/src/pallet/parse/call.rs
@@ -235,10 +235,6 @@ impl CallDef {
 					_ => unreachable!("checked during creation of the let binding"),
 				};
 
-				if call_idx_attrs.is_empty() {
-					return Err(syn::Error::new(method.sig.span(), "Missing call_index"));
-				}
-
 				if call_idx_attrs.len() > 1 {
 					let msg = "Invalid pallet::call, too many call_index attributes given";
 					return Err(syn::Error::new(method.sig.span(), msg))

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -192,6 +192,7 @@ pub mod pallet {
 		T::AccountId: From<SomeType1> + From<SomeType3> + SomeAssociation1,
 	{
 		/// Doc comment put in metadata
+		#[pallet::call_index(0)]
 		#[pallet::weight(Weight::from_ref_time(*_foo as u64))]
 		pub fn foo(
 			origin: OriginFor<T>,
@@ -206,6 +207,7 @@ pub mod pallet {
 		}
 
 		/// Doc comment put in metadata
+		#[pallet::call_index(1)]
 		#[pallet::weight(1)]
 		pub fn foo_storage_layer(
 			_origin: OriginFor<T>,
@@ -220,6 +222,7 @@ pub mod pallet {
 		}
 
 		// Test for DispatchResult return type
+		#[pallet::call_index(2)]
 		#[pallet::weight(1)]
 		pub fn foo_no_post_info(_origin: OriginFor<T>) -> DispatchResult {
 			Ok(())

--- a/frame/support/test/tests/pallet_compatibility.rs
+++ b/frame/support/test/tests/pallet_compatibility.rs
@@ -141,6 +141,7 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T::Balance as Into<u64>>::into(new_value.clone()))]
 		pub fn set_dummy(
 			origin: OriginFor<T>,

--- a/frame/support/test/tests/pallet_compatibility_instance.rs
+++ b/frame/support/test/tests/pallet_compatibility_instance.rs
@@ -127,6 +127,7 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config<I>, I: 'static> Pallet<T, I> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T::Balance as Into<u64>>::into(new_value.clone()))]
 		pub fn set_dummy(
 			origin: OriginFor<T>,

--- a/frame/support/test/tests/pallet_instance.rs
+++ b/frame/support/test/tests/pallet_instance.rs
@@ -82,6 +82,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		/// Doc comment put in metadata
+		#[pallet::call_index(0)]
 		#[pallet::weight(Weight::from_ref_time(*_foo as u64))]
 		pub fn foo(
 			origin: OriginFor<T>,
@@ -93,6 +94,7 @@ pub mod pallet {
 		}
 
 		/// Doc comment put in metadata
+		#[pallet::call_index(1)]
 		#[pallet::weight(1)]
 		pub fn foo_storage_layer(
 			origin: OriginFor<T>,

--- a/frame/support/test/tests/storage_layers.rs
+++ b/frame/support/test/tests/storage_layers.rs
@@ -46,6 +46,7 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(1)]
 		pub fn set_value(_origin: OriginFor<T>, value: u32) -> DispatchResult {
 			Value::<T>::put(value);

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -372,6 +372,7 @@ pub mod pallet {
 		/// # <weight>
 		/// - `O(1)`
 		/// # </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::SystemWeightInfo::remark(_remark.len() as u32))]
 		pub fn remark(origin: OriginFor<T>, _remark: Vec<u8>) -> DispatchResultWithPostInfo {
 			ensure_signed_or_root(origin)?;
@@ -379,6 +380,7 @@ pub mod pallet {
 		}
 
 		/// Set the number of pages in the WebAssembly environment's heap.
+		#[pallet::call_index(1)]
 		#[pallet::weight((T::SystemWeightInfo::set_heap_pages(), DispatchClass::Operational))]
 		pub fn set_heap_pages(origin: OriginFor<T>, pages: u64) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
@@ -399,6 +401,7 @@ pub mod pallet {
 		/// The weight of this function is dependent on the runtime, but generally this is very
 		/// expensive. We will treat this as a full block.
 		/// # </weight>
+		#[pallet::call_index(2)]
 		#[pallet::weight((T::BlockWeights::get().max_block, DispatchClass::Operational))]
 		pub fn set_code(origin: OriginFor<T>, code: Vec<u8>) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
@@ -416,6 +419,7 @@ pub mod pallet {
 		/// - 1 event.
 		/// The weight of this function is dependent on the runtime. We will treat this as a full
 		/// block. # </weight>
+		#[pallet::call_index(3)]
 		#[pallet::weight((T::BlockWeights::get().max_block, DispatchClass::Operational))]
 		pub fn set_code_without_checks(
 			origin: OriginFor<T>,
@@ -427,6 +431,7 @@ pub mod pallet {
 		}
 
 		/// Set some items of storage.
+		#[pallet::call_index(4)]
 		#[pallet::weight((
 			T::SystemWeightInfo::set_storage(items.len() as u32),
 			DispatchClass::Operational,
@@ -443,6 +448,7 @@ pub mod pallet {
 		}
 
 		/// Kill some items from storage.
+		#[pallet::call_index(5)]
 		#[pallet::weight((
 			T::SystemWeightInfo::kill_storage(keys.len() as u32),
 			DispatchClass::Operational,
@@ -459,6 +465,7 @@ pub mod pallet {
 		///
 		/// **NOTE:** We rely on the Root origin to provide us the number of subkeys under
 		/// the prefix we are removing to accurately calculate the weight of this function.
+		#[pallet::call_index(6)]
 		#[pallet::weight((
 			T::SystemWeightInfo::kill_prefix(_subkeys.saturating_add(1)),
 			DispatchClass::Operational,
@@ -474,6 +481,7 @@ pub mod pallet {
 		}
 
 		/// Make some on-chain remark and emit event.
+		#[pallet::call_index(7)]
 		#[pallet::weight(T::SystemWeightInfo::remark_with_event(remark.len() as u32))]
 		pub fn remark_with_event(
 			origin: OriginFor<T>,

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -198,6 +198,7 @@ pub mod pallet {
 		///   `on_finalize`)
 		/// - 1 event handler `on_timestamp_set`. Must be `O(1)`.
 		/// # </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight((
 			T::WeightInfo::set(),
 			DispatchClass::Mandatory

--- a/frame/tips/src/lib.rs
+++ b/frame/tips/src/lib.rs
@@ -235,6 +235,7 @@ pub mod pallet {
 		/// - DbReads: `Reasons`, `Tips`
 		/// - DbWrites: `Reasons`, `Tips`
 		/// # </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::report_awesome(reason.len() as u32))]
 		pub fn report_awesome(
 			origin: OriginFor<T>,
@@ -292,6 +293,7 @@ pub mod pallet {
 		/// - DbReads: `Tips`, `origin account`
 		/// - DbWrites: `Reasons`, `Tips`, `origin account`
 		/// # </weight>
+		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::retract_tip())]
 		pub fn retract_tip(origin: OriginFor<T>, hash: T::Hash) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -330,6 +332,7 @@ pub mod pallet {
 		/// - DbReads: `Tippers`, `Reasons`
 		/// - DbWrites: `Reasons`, `Tips`
 		/// # </weight>
+		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::tip_new(reason.len() as u32, T::Tippers::max_len() as u32))]
 		pub fn tip_new(
 			origin: OriginFor<T>,
@@ -384,6 +387,7 @@ pub mod pallet {
 		/// - DbReads: `Tippers`, `Tips`
 		/// - DbWrites: `Tips`
 		/// # </weight>
+		#[pallet::call_index(3)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::tip(T::Tippers::max_len() as u32))]
 		pub fn tip(
 			origin: OriginFor<T>,
@@ -417,6 +421,7 @@ pub mod pallet {
 		/// - DbReads: `Tips`, `Tippers`, `tip finder`
 		/// - DbWrites: `Reasons`, `Tips`, `Tippers`, `tip finder`
 		/// # </weight>
+		#[pallet::call_index(4)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::close_tip(T::Tippers::max_len() as u32))]
 		pub fn close_tip(origin: OriginFor<T>, hash: T::Hash) -> DispatchResult {
 			ensure_signed(origin)?;
@@ -443,6 +448,7 @@ pub mod pallet {
 		///   `T` is charged as upper bound given by `ContainsLengthBound`.
 		///   The actual cost depends on the implementation of `T::Tippers`.
 		/// # </weight>
+		#[pallet::call_index(5)]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::slash_tip(T::Tippers::max_len() as u32))]
 		pub fn slash_tip(origin: OriginFor<T>, hash: T::Hash) -> DispatchResult {
 			T::RejectOrigin::ensure_origin(origin)?;

--- a/frame/transaction-storage/src/lib.rs
+++ b/frame/transaction-storage/src/lib.rs
@@ -188,6 +188,7 @@ pub mod pallet {
 		/// - n*log(n) of data size, as all data is pushed to an in-memory trie.
 		/// Additionally contains a DB write.
 		/// # </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::store(data.len() as u32))]
 		pub fn store(origin: OriginFor<T>, data: Vec<u8>) -> DispatchResult {
 			ensure!(data.len() > 0, Error::<T>::EmptyTransaction);
@@ -236,6 +237,7 @@ pub mod pallet {
 		/// # <weight>
 		/// - Constant.
 		/// # </weight>
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::renew())]
 		pub fn renew(
 			origin: OriginFor<T>,
@@ -281,6 +283,7 @@ pub mod pallet {
 		/// There's a DB read for each transaction.
 		/// Here we assume a maximum of 100 probed transactions.
 		/// # </weight>
+		#[pallet::call_index(2)]
 		#[pallet::weight((T::WeightInfo::check_proof_max(), DispatchClass::Mandatory))]
 		pub fn check_proof(
 			origin: OriginFor<T>,

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -350,6 +350,7 @@ pub mod pallet {
 		/// - DbReads: `ProposalCount`, `origin account`
 		/// - DbWrites: `ProposalCount`, `Proposals`, `origin account`
 		/// # </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::propose_spend())]
 		pub fn propose_spend(
 			origin: OriginFor<T>,
@@ -380,6 +381,7 @@ pub mod pallet {
 		/// - DbReads: `Proposals`, `rejected proposer account`
 		/// - DbWrites: `Proposals`, `rejected proposer account`
 		/// # </weight>
+		#[pallet::call_index(1)]
 		#[pallet::weight((T::WeightInfo::reject_proposal(), DispatchClass::Operational))]
 		pub fn reject_proposal(
 			origin: OriginFor<T>,
@@ -410,6 +412,7 @@ pub mod pallet {
 		/// - DbReads: `Proposals`, `Approvals`
 		/// - DbWrite: `Approvals`
 		/// # </weight>
+		#[pallet::call_index(2)]
 		#[pallet::weight((T::WeightInfo::approve_proposal(T::MaxApprovals::get()), DispatchClass::Operational))]
 		pub fn approve_proposal(
 			origin: OriginFor<T>,
@@ -431,6 +434,7 @@ pub mod pallet {
 		///
 		/// NOTE: For record-keeping purposes, the proposer is deemed to be equivalent to the
 		/// beneficiary.
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::spend())]
 		pub fn spend(
 			origin: OriginFor<T>,
@@ -472,6 +476,7 @@ pub mod pallet {
 		/// - `ProposalNotApproved`: The `proposal_id` supplied was not found in the approval queue,
 		/// i.e., the proposal has not been approved. This could also mean the proposal does not
 		/// exist altogether, thus there is no way it would have been approved in the first place.
+		#[pallet::call_index(4)]
 		#[pallet::weight((T::WeightInfo::remove_approval(), DispatchClass::Operational))]
 		pub fn remove_approval(
 			origin: OriginFor<T>,

--- a/frame/uniques/src/lib.rs
+++ b/frame/uniques/src/lib.rs
@@ -449,6 +449,7 @@ pub mod pallet {
 		/// Emits `Created` event when successful.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::create())]
 		pub fn create(
 			origin: OriginFor<T>,
@@ -485,6 +486,7 @@ pub mod pallet {
 		/// Emits `ForceCreated` event when successful.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::force_create())]
 		pub fn force_create(
 			origin: OriginFor<T>,
@@ -520,6 +522,7 @@ pub mod pallet {
 		/// - `n = witness.items`
 		/// - `m = witness.item_metadatas`
 		/// - `a = witness.attributes`
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::destroy(
 			witness.items,
  			witness.item_metadatas,
@@ -555,6 +558,7 @@ pub mod pallet {
 		/// Emits `Issued` event when successful.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::mint())]
 		pub fn mint(
 			origin: OriginFor<T>,
@@ -584,6 +588,7 @@ pub mod pallet {
 		///
 		/// Weight: `O(1)`
 		/// Modes: `check_owner.is_some()`.
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::burn())]
 		pub fn burn(
 			origin: OriginFor<T>,
@@ -622,6 +627,7 @@ pub mod pallet {
 		/// Emits `Transferred`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::transfer())]
 		pub fn transfer(
 			origin: OriginFor<T>,
@@ -658,6 +664,7 @@ pub mod pallet {
 		/// is not permitted to call it.
 		///
 		/// Weight: `O(items.len())`
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::redeposit(items.len() as u32))]
 		pub fn redeposit(
 			origin: OriginFor<T>,
@@ -718,6 +725,7 @@ pub mod pallet {
 		/// Emits `Frozen`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(7)]
 		#[pallet::weight(T::WeightInfo::freeze())]
 		pub fn freeze(
 			origin: OriginFor<T>,
@@ -749,6 +757,7 @@ pub mod pallet {
 		/// Emits `Thawed`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(8)]
 		#[pallet::weight(T::WeightInfo::thaw())]
 		pub fn thaw(
 			origin: OriginFor<T>,
@@ -779,6 +788,7 @@ pub mod pallet {
 		/// Emits `CollectionFrozen`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(9)]
 		#[pallet::weight(T::WeightInfo::freeze_collection())]
 		pub fn freeze_collection(
 			origin: OriginFor<T>,
@@ -806,6 +816,7 @@ pub mod pallet {
 		/// Emits `CollectionThawed`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(10)]
 		#[pallet::weight(T::WeightInfo::thaw_collection())]
 		pub fn thaw_collection(
 			origin: OriginFor<T>,
@@ -835,6 +846,7 @@ pub mod pallet {
 		/// Emits `OwnerChanged`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(11)]
 		#[pallet::weight(T::WeightInfo::transfer_ownership())]
 		pub fn transfer_ownership(
 			origin: OriginFor<T>,
@@ -883,6 +895,7 @@ pub mod pallet {
 		/// Emits `TeamChanged`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(12)]
 		#[pallet::weight(T::WeightInfo::set_team())]
 		pub fn set_team(
 			origin: OriginFor<T>,
@@ -923,6 +936,7 @@ pub mod pallet {
 		/// Emits `ApprovedTransfer` on success.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(13)]
 		#[pallet::weight(T::WeightInfo::approve_transfer())]
 		pub fn approve_transfer(
 			origin: OriginFor<T>,
@@ -976,6 +990,7 @@ pub mod pallet {
 		/// Emits `ApprovalCancelled` on success.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(14)]
 		#[pallet::weight(T::WeightInfo::cancel_approval())]
 		pub fn cancel_approval(
 			origin: OriginFor<T>,
@@ -1028,6 +1043,7 @@ pub mod pallet {
 		/// Emits `ItemStatusChanged` with the identity of the item.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(15)]
 		#[pallet::weight(T::WeightInfo::force_item_status())]
 		pub fn force_item_status(
 			origin: OriginFor<T>,
@@ -1077,6 +1093,7 @@ pub mod pallet {
 		/// Emits `AttributeSet`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(16)]
 		#[pallet::weight(T::WeightInfo::set_attribute())]
 		pub fn set_attribute(
 			origin: OriginFor<T>,
@@ -1139,6 +1156,7 @@ pub mod pallet {
 		/// Emits `AttributeCleared`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(17)]
 		#[pallet::weight(T::WeightInfo::clear_attribute())]
 		pub fn clear_attribute(
 			origin: OriginFor<T>,
@@ -1188,6 +1206,7 @@ pub mod pallet {
 		/// Emits `MetadataSet`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(18)]
 		#[pallet::weight(T::WeightInfo::set_metadata())]
 		pub fn set_metadata(
 			origin: OriginFor<T>,
@@ -1250,6 +1269,7 @@ pub mod pallet {
 		/// Emits `MetadataCleared`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(19)]
 		#[pallet::weight(T::WeightInfo::clear_metadata())]
 		pub fn clear_metadata(
 			origin: OriginFor<T>,
@@ -1299,6 +1319,7 @@ pub mod pallet {
 		/// Emits `CollectionMetadataSet`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(20)]
 		#[pallet::weight(T::WeightInfo::set_collection_metadata())]
 		pub fn set_collection_metadata(
 			origin: OriginFor<T>,
@@ -1356,6 +1377,7 @@ pub mod pallet {
 		/// Emits `CollectionMetadataCleared`.
 		///
 		/// Weight: `O(1)`
+		#[pallet::call_index(21)]
 		#[pallet::weight(T::WeightInfo::clear_collection_metadata())]
 		pub fn clear_collection_metadata(
 			origin: OriginFor<T>,
@@ -1392,6 +1414,7 @@ pub mod pallet {
 		///   ownership transferal.
 		///
 		/// Emits `OwnershipAcceptanceChanged`.
+		#[pallet::call_index(22)]
 		#[pallet::weight(T::WeightInfo::set_accept_ownership())]
 		pub fn set_accept_ownership(
 			origin: OriginFor<T>,
@@ -1428,6 +1451,7 @@ pub mod pallet {
 		/// - `max_supply`: The maximum amount of items a collection could have.
 		///
 		/// Emits `CollectionMaxSupplySet` event when successful.
+		#[pallet::call_index(23)]
 		#[pallet::weight(T::WeightInfo::set_collection_max_supply())]
 		pub fn set_collection_max_supply(
 			origin: OriginFor<T>,
@@ -1467,6 +1491,7 @@ pub mod pallet {
 		///
 		/// Emits `ItemPriceSet` on success if the price is not `None`.
 		/// Emits `ItemPriceRemoved` on success if the price is `None`.
+		#[pallet::call_index(24)]
 		#[pallet::weight(T::WeightInfo::set_price())]
 		pub fn set_price(
 			origin: OriginFor<T>,
@@ -1489,6 +1514,7 @@ pub mod pallet {
 		/// - `bid_price`: The price the sender is willing to pay.
 		///
 		/// Emits `ItemBought` on success.
+		#[pallet::call_index(25)]
 		#[pallet::weight(T::WeightInfo::buy_item())]
 		#[transactional]
 		pub fn buy_item(

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -181,6 +181,7 @@ pub mod pallet {
 		/// `BatchInterrupted` event is deposited, along with the number of successful calls made
 		/// and the error of the failed call. If all were successful, then the `BatchCompleted`
 		/// event is deposited.
+		#[pallet::call_index(0)]
 		#[pallet::weight({
 			let dispatch_infos = calls.iter().map(|call| call.get_dispatch_info()).collect::<Vec<_>>();
 			let dispatch_weight = dispatch_infos.iter()
@@ -254,6 +255,7 @@ pub mod pallet {
 		/// NOTE: Prior to version *12, this was called `as_limited_sub`.
 		///
 		/// The dispatch origin for this call must be _Signed_.
+		#[pallet::call_index(1)]
 		#[pallet::weight({
 			let dispatch_info = call.get_dispatch_info();
 			(
@@ -302,6 +304,7 @@ pub mod pallet {
 		/// # <weight>
 		/// - Complexity: O(C) where C is the number of calls to be batched.
 		/// # </weight>
+		#[pallet::call_index(2)]
 		#[pallet::weight({
 			let dispatch_infos = calls.iter().map(|call| call.get_dispatch_info()).collect::<Vec<_>>();
 			let dispatch_weight = dispatch_infos.iter()
@@ -377,6 +380,7 @@ pub mod pallet {
 		/// - One DB write (event).
 		/// - Weight of derivative `call` execution + T::WeightInfo::dispatch_as().
 		/// # </weight>
+		#[pallet::call_index(3)]
 		#[pallet::weight({
 			let dispatch_info = call.get_dispatch_info();
 			(
@@ -414,6 +418,7 @@ pub mod pallet {
 		/// # <weight>
 		/// - Complexity: O(C) where C is the number of calls to be batched.
 		/// # </weight>
+		#[pallet::call_index(4)]
 		#[pallet::weight({
 			let dispatch_infos = calls.iter().map(|call| call.get_dispatch_info()).collect::<Vec<_>>();
 			let dispatch_weight = dispatch_infos.iter()
@@ -481,6 +486,7 @@ pub mod pallet {
 		/// Root origin to specify the weight of the call.
 		///
 		/// The dispatch origin for this call must be _Root_.
+		#[pallet::call_index(5)]
 		#[pallet::weight((*_weight, call.get_dispatch_info().class))]
 		pub fn with_weight(
 			origin: OriginFor<T>,

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -53,11 +53,13 @@ pub mod example {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(*_weight)]
 		pub fn noop(_origin: OriginFor<T>, _weight: Weight) -> DispatchResult {
 			Ok(())
 		}
 
+		#[pallet::call_index(1)]
 		#[pallet::weight(*_start_weight)]
 		pub fn foobar(
 			origin: OriginFor<T>,
@@ -78,6 +80,7 @@ pub mod example {
 			}
 		}
 
+		#[pallet::call_index(2)]
 		#[pallet::weight(0)]
 		pub fn big_variant(_origin: OriginFor<T>, _arg: [u8; 400]) -> DispatchResult {
 			Ok(())
@@ -105,6 +108,7 @@ mod mock_democracy {
 
 		#[pallet::call]
 		impl<T: Config> Pallet<T> {
+			#[pallet::call_index(3)]
 			#[pallet::weight(0)]
 			pub fn external_propose_majority(origin: OriginFor<T>) -> DispatchResult {
 				T::ExternalMajorityOrigin::ensure_origin(origin)?;

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -303,6 +303,7 @@ pub mod pallet {
 		///     - Reads: Vesting Storage, Balances Locks, [Sender Account]
 		///     - Writes: Vesting Storage, Balances Locks, [Sender Account]
 		/// # </weight>
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::vest_locked(MaxLocksOf::<T>::get(), T::MAX_VESTING_SCHEDULES)
 			.max(T::WeightInfo::vest_unlocked(MaxLocksOf::<T>::get(), T::MAX_VESTING_SCHEDULES))
 		)]
@@ -326,6 +327,7 @@ pub mod pallet {
 		///     - Reads: Vesting Storage, Balances Locks, Target Account
 		///     - Writes: Vesting Storage, Balances Locks, Target Account
 		/// # </weight>
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::vest_other_locked(MaxLocksOf::<T>::get(), T::MAX_VESTING_SCHEDULES)
 			.max(T::WeightInfo::vest_other_unlocked(MaxLocksOf::<T>::get(), T::MAX_VESTING_SCHEDULES))
 		)]
@@ -352,6 +354,7 @@ pub mod pallet {
 		///     - Reads: Vesting Storage, Balances Locks, Target Account, [Sender Account]
 		///     - Writes: Vesting Storage, Balances Locks, Target Account, [Sender Account]
 		/// # </weight>
+		#[pallet::call_index(2)]
 		#[pallet::weight(
 			T::WeightInfo::vested_transfer(MaxLocksOf::<T>::get(), T::MAX_VESTING_SCHEDULES)
 		)]
@@ -383,6 +386,7 @@ pub mod pallet {
 		///     - Reads: Vesting Storage, Balances Locks, Target Account, Source Account
 		///     - Writes: Vesting Storage, Balances Locks, Target Account, Source Account
 		/// # </weight>
+		#[pallet::call_index(3)]
 		#[pallet::weight(
 			T::WeightInfo::force_vested_transfer(MaxLocksOf::<T>::get(), T::MAX_VESTING_SCHEDULES)
 		)]
@@ -417,6 +421,7 @@ pub mod pallet {
 		///
 		/// - `schedule1_index`: index of the first schedule to merge.
 		/// - `schedule2_index`: index of the second schedule to merge.
+		#[pallet::call_index(4)]
 		#[pallet::weight(
 			T::WeightInfo::not_unlocking_merge_schedules(MaxLocksOf::<T>::get(), T::MAX_VESTING_SCHEDULES)
 			.max(T::WeightInfo::unlocking_merge_schedules(MaxLocksOf::<T>::get(), T::MAX_VESTING_SCHEDULES))

--- a/frame/whitelist/src/lib.rs
+++ b/frame/whitelist/src/lib.rs
@@ -119,6 +119,7 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::whitelist_call())]
 		pub fn whitelist_call(origin: OriginFor<T>, call_hash: PreimageHash) -> DispatchResult {
 			T::WhitelistOrigin::ensure_origin(origin)?;
@@ -136,6 +137,7 @@ pub mod pallet {
 			Ok(())
 		}
 
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::remove_whitelisted_call())]
 		pub fn remove_whitelisted_call(
 			origin: OriginFor<T>,
@@ -152,6 +154,7 @@ pub mod pallet {
 			Ok(())
 		}
 
+		#[pallet::call_index(2)]
 		#[pallet::weight(
 			T::WeightInfo::dispatch_whitelisted_call(*call_encoded_len)
 				.saturating_add(*call_weight_witness)
@@ -190,6 +193,7 @@ pub mod pallet {
 			Ok(actual_weight.into())
 		}
 
+		#[pallet::call_index(3)]
 		#[pallet::weight({
 			let call_weight = call.get_dispatch_info().weight;
 			let call_len = call.encoded_size() as u32;


### PR DESCRIPTION
Starting with frame-system…  
Probably all pallets should have them.  

Context:
Explicit call indices are important for governance, since governance votes on a `(pallet, call)` index pair.  
Having explicit indices will make it harder to accidentally change then.

Follow up for warning on missing `call_index`: https://github.com/paritytech/substrate/pull/12894