### PR TITLE
Update substrate-node-template readme to add ./.local folder

### DIFF
--- a/bin/node-template/README.md
+++ b/bin/node-template/README.md
@@ -208,6 +208,11 @@ A FRAME pallet is compromised of a number of blockchain primitives:
 First, install [Docker](https://docs.docker.com/get-docker/) and
 [Docker Compose](https://docs.docker.com/compose/install/).
 
+Create the following folder before running the following scripts:
+```bash
+mkdir ./.local
+```
+
 Then run the following command to start a single node development chain.
 
 ```bash


### PR DESCRIPTION
Add an instruction in the "Run in Docker" instructions to create that folder (i.e. `mkdir .local`) before running the scripts like `./scripts/docker_run.sh`, otherwise users get the following error when they clone the repo https://github.com/substrate-developer-hub/substrate-node-template and just run `./scripts/docker_run.sh`

```
ERROR: for substrate-node-template_dev_run  Cannot create container for service dev: invalid mount config for type "bind": bind source path does not exist: /Users/me/substrate-node-template/.local

ERROR: for dev  Cannot create container for service dev: invalid mount config for type "bind": bind source path does not exist: /Users/me/substrate-node-template/.local
```

**Alternative 1** create a /.local folder in the readme for users to use.

**Alternative 2** suggest users use the Substrate docker instructions instead so they use https://github.com/paritytech/substrate/blob/master/docker/substrate_builder.Dockerfile, and just tweak the instructions to use the node-template part of it
