### PR TITLE
pallet-contracts migration pre-upgrade fix for v8

### DIFF
--- a/frame/contracts/src/migration.rs
+++ b/frame/contracts/src/migration.rs
@@ -69,7 +69,7 @@ impl<T: Config> OnRuntimeUpgrade for Migration<T> {
 	fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
 		let version = <Pallet<T>>::on_chain_storage_version();
 
-		if version < 8 {
+		if version == 7 {
 			v8::pre_upgrade::<T>()?;
 		}
 

--- a/frame/contracts/src/migration.rs
+++ b/frame/contracts/src/migration.rs
@@ -69,7 +69,7 @@ impl<T: Config> OnRuntimeUpgrade for Migration<T> {
 	fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
 		let version = <Pallet<T>>::on_chain_storage_version();
 
-		if version == 8 {
+		if version < 8 {
 			v8::pre_upgrade::<T>()?;
 		}
 


### PR DESCRIPTION
Make sure to only run pallet-contracts `v8 pre-upgrade` check if versions is  **7**.

This is a trivial change and only affect `try-runtime` checks for `pallet-contracts`.