### PR TITLE
Use custom environment for publishing crates

### DIFF
--- a/scripts/ci/gitlab/pipeline/publish.yml
+++ b/scripts/ci/gitlab/pipeline/publish.yml
@@ -211,6 +211,9 @@ update-node-template:
   # to roughly 202 minutes of delay, or 3h and 22 minutes. As such, the job needs to have a much
   # higher timeout than average.
   timeout:                         5h
+  # A custom publishing environment is used for us to be able to set up protected secrets
+  # specifically for it
+  environment: publish-crates
   script:
     - rusty-cachier snapshot create
     - git clone


### PR DESCRIPTION
Using this custom environment will enable us to set protected secrets specifically for it, as opposed to protected secrets for "All" environments, which is looser. See https://docs.gitlab.com/ee/ci/yaml/#environment for context.

![image](https://user-images.githubusercontent.com/77391175/207277498-fcf5aecf-763e-4b2e-a69a-ba3c3b30fecd.png)

