### PR TITLE
add numerator and denominator to Rational128 Debug impl

### DIFF
--- a/primitives/arithmetic/src/rational.rs
+++ b/primitives/arithmetic/src/rational.rs
@@ -94,14 +94,14 @@ pub struct Rational128(u128, u128);
 #[cfg(feature = "std")]
 impl sp_std::fmt::Debug for Rational128 {
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
-		write!(f, "Rational128({:.4})", self.0 as f32 / self.1 as f32)
+		write!(f, "Rational128({} / {} ≈ {:.8})", self.0, self.1, self.0 as f64 / self.1 as f64)
 	}
 }
 
 #[cfg(not(feature = "std"))]
 impl sp_std::fmt::Debug for Rational128 {
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
-		write!(f, "Rational128(..)")
+		write!(f, "Rational128({} / {})", self.0, self.1)
 	}
 }
 


### PR DESCRIPTION
This PR adds the numerator and denominator to the `Rational128` `Debug` implementation and increases the number of digits displayed for the float representation. This allows numbers close to zero to be distinguished from zero in the logs.
