### PR TITLE
Reset mmr storage

### DIFF
--- a/frame/merkle-mountain-range/src/lib.rs
+++ b/frame/merkle-mountain-range/src/lib.rs
@@ -122,8 +122,12 @@ pub mod pallet {
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
 
+	/// The current storage version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
 
 	/// This pallet's configuration trait

--- a/frame/merkle-mountain-range/src/lib.rs
+++ b/frame/merkle-mountain-range/src/lib.rs
@@ -69,6 +69,8 @@ pub use sp_mmr_primitives::{
 	self as primitives, utils::NodesUtils, Error, LeafDataProvider, LeafIndex, NodeIndex,
 };
 
+pub mod migrations;
+
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 mod default_weights;

--- a/frame/merkle-mountain-range/src/migrations.rs
+++ b/frame/merkle-mountain-range/src/migrations.rs
@@ -39,17 +39,14 @@ pub mod v1 {
 				current.put::<Pallet<T>>();
 
 				// reset all storage values
-				// TODO: RootHash should be overwritten correctly, but double-check
-				// RootHash::<T>::set();
 				NumberOfLeaves::<T>::set(0);
-				// TODO: find reasonable limit for node clearing
-				let _ = Nodes::<T>::clear(u32::max_value(), None);
+				let res = Nodes::<T>::clear(u32::max_value(), None);
 
-				// TODO: adjust DbWeight
-				T::DbWeight::get().reads_writes(2, 1)
+				// (storage version + Nodes::clear,
+				// storage version write + NumberOfLeaves write + node key removals)
+				T::DbWeight::get().reads_writes(1 + res.loops as u64, 2 + res.unique as u64)
 			} else {
 				log::info!("Migration did not execute. This probably should be removed");
-				// TODO: adjust DbWeight (but reads -> 1 should remain correct)
 				T::DbWeight::get().reads(1)
 			}
 		}

--- a/frame/merkle-mountain-range/src/migrations.rs
+++ b/frame/merkle-mountain-range/src/migrations.rs
@@ -1,0 +1,49 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod v1 {
+	use frame_support::{
+		pallet_prelude::*,
+		traits::{GetStorageVersion, OnRuntimeUpgrade},
+	};
+
+	use crate::*;
+	pub struct MigrateToV1<T>(sp_std::marker::PhantomData<T>);
+	impl<T: Config> OnRuntimeUpgrade for MigrateToV1<T> {
+		fn on_runtime_upgrade() -> Weight {
+			let current = Pallet::<T>::current_storage_version();
+			let onchain = Pallet::<T>::on_chain_storage_version();
+
+			log::info!(
+				"Running migration with current storage version {:?} / onchain {:?}",
+				current,
+				onchain
+			);
+
+			if current == 1 && onchain == 0 {
+
+				current.put::<Pallet<T>>();
+				// TODO: adjust DbWeight
+				T::DbWeight::get().reads_writes(2, 1)
+			} else {
+				log::info!("Migration did not execute. This probably should be removed");
+				// TODO: adjust DbWeight (but reads -> 1 should remain correct)
+				T::DbWeight::get().reads(1)
+			}
+		}
+	}
+}

--- a/frame/merkle-mountain-range/src/migrations.rs
+++ b/frame/merkle-mountain-range/src/migrations.rs
@@ -45,5 +45,17 @@ pub mod v1 {
 				T::DbWeight::get().reads(1)
 			}
 		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+			assert_eq!(Pallet::<T>::on_chain_storage_version(), 0);
+			Ok(Default::default())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(_: Vec<u8>) -> Result<(), &'static str> {
+			assert_eq!(Pallet::<T>::on_chain_storage_version(), 1);
+			Ok(())
+		}
 	}
 }

--- a/frame/merkle-mountain-range/src/migrations.rs
+++ b/frame/merkle-mountain-range/src/migrations.rs
@@ -35,8 +35,16 @@ pub mod v1 {
 			);
 
 			if current == 1 && onchain == 0 {
-
+				// update on-chain storage version
 				current.put::<Pallet<T>>();
+
+				// reset all storage values
+				// TODO: RootHash should be overwritten correctly, but double-check
+				// RootHash::<T>::set();
+				NumberOfLeaves::<T>::set(0);
+				// TODO: find reasonable limit for node clearing
+				let _ = Nodes::<T>::clear(u32::max_value(), None);
+
 				// TODO: adjust DbWeight
 				T::DbWeight::get().reads_writes(2, 1)
 			} else {


### PR DESCRIPTION
This resets mmr storage, as followup to discussion #12864.
It does not touch the offchain db, which will be overwritten, but resets `NumberOfLeaves` and `Nodes`.

I'm ooo atm, so will resume working on this next week and address review comments accumulated in the meantime then.
