### PR TITLE
Fix reciprocal curve formula comment

### DIFF
--- a/frame/referenda/src/types.rs
+++ b/frame/referenda/src/types.rs
@@ -284,7 +284,7 @@ pub enum Curve {
 	/// `period` before stepping down to `(period * 2, begin - step * 2)`. This pattern continues
 	/// but the `y` component has a lower limit of `end`.
 	SteppedDecreasing { begin: Perbill, end: Perbill, step: Perbill, period: Perbill },
-	/// A recipocal (`K/(x+S)-T`) curve: `factor` is `K` and `x_offset` is `S`, `y_offset` is `T`.
+	/// A recipocal (`K/(x+S)+T`) curve: `factor` is `K` and `x_offset` is `S`, `y_offset` is `T`.
 	Reciprocal { factor: FixedI64, x_offset: FixedI64, y_offset: FixedI64 },
 }
 


### PR DESCRIPTION
If I am not mistaken (which I could very well be), I believe:

```
Self::Reciprocal { factor, x_offset, y_offset } => factor
	.checked_rounding_div(FixedI64::from(x) + *x_offset, Low)
	.map(|yp| (yp + *y_offset).into_clamped_perthing())
	.unwrap_or_else(Perbill::one)
```
and
```
Self::Reciprocal { factor, x_offset, y_offset } => {
	match factor.checked_rounding_div(FixedI64::from_perbill(x).add(*x_offset), Low) {
		Some(yp) => (yp.add(*y_offset)).into_perbill(),
		None => Perbill::one(),
	}
}
```
Translate to the formula `K/(x+S)+T`. Being that this is the only place this formula is described in plain mathematical terms, I think it's important that it's accurate.