### PR TITLE
Fix state-db pinning

### DIFF
--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -2002,6 +2002,7 @@ impl<Block: BlockT> sc_client_api::backend::Backend<Block> for Backend<Block> {
 				.map_err(sp_blockchain::Error::from_state_db)?;
 			Err(e)
 		} else {
+			self.storage.state_db.sync();
 			Ok(())
 		}
 	}

--- a/client/state-db/src/lib.rs
+++ b/client/state-db/src/lib.rs
@@ -577,7 +577,7 @@ impl<BlockHash: Hash, Key: Hash, D: MetaDb> StateDb<BlockHash, Key, D> {
 		self.db.write().unpin(hash)
 	}
 
-	/// Confirm that all changes made to commit sets are on disk. Allow for temporarily pinned
+	/// Confirm that all changes made to commit sets are on disk. Allows for temporarily pinned
 	/// blocks to be released.
 	pub fn sync(&self) {
 		self.db.write().sync()

--- a/client/state-db/src/lib.rs
+++ b/client/state-db/src/lib.rs
@@ -470,6 +470,10 @@ impl<BlockHash: Hash, Key: Hash, D: MetaDb> StateDbSync<BlockHash, Key, D> {
 		}
 	}
 
+	fn sync(&mut self) {
+		self.non_canonical.sync();
+	}
+
 	pub fn get<DB: NodeDb, Q: ?Sized>(
 		&self,
 		key: &Q,
@@ -571,6 +575,12 @@ impl<BlockHash: Hash, Key: Hash, D: MetaDb> StateDb<BlockHash, Key, D> {
 	/// Allows pruning of specified block.
 	pub fn unpin(&self, hash: &BlockHash) {
 		self.db.write().unpin(hash)
+	}
+
+	/// Confirm that all changes made to commit sets are on disk. Allow for temporarily pinned
+	/// blocks to be released.
+	pub fn sync(&self) {
+		self.db.write().sync()
 	}
 
 	/// Get a value from non-canonical/pruning overlay or the backing DB.

--- a/client/state-db/src/noncanonical.rs
+++ b/client/state-db/src/noncanonical.rs
@@ -350,6 +350,8 @@ impl<BlockHash: Hash, Key: Hash> NonCanonicalOverlay<BlockHash, Key> {
 		self.last_canonicalized.as_ref().map(|&(_, n)| n)
 	}
 
+	/// Confirm that all changes made to commit sets are on disk. Allows for temporarily pinned
+	/// blocks to be released.
 	pub fn sync(&mut self) {
 		let mut pinned = std::mem::take(&mut self.pinned_canonincalized);
 		for hash in pinned.iter() {


### PR DESCRIPTION
A follow up to #12902. Previous PR did not account for the possibility of multiple blocks finalized in a single transaction. This version accumulates all canonicalized changes pinned in memory, until explicitly released with the `sync` function.  Similar to `apply_changes` function that existed before the state-db refactoring. 