### PR TITLE
improve ocw validator/collator CLI description

### DIFF
--- a/client/cli/src/arg_enums.rs
+++ b/client/cli/src/arg_enums.rs
@@ -233,7 +233,7 @@ pub enum OffchainWorkerEnabled {
 	/// Never enable the offchain worker.
 	Never,
 	/// Only enable the offchain worker when running as a validator (or collator, if this is a parachain node).
-	WhenValidating,
+	WhenAuthority,
 }
 
 /// Syncing mode.

--- a/client/cli/src/arg_enums.rs
+++ b/client/cli/src/arg_enums.rs
@@ -232,7 +232,7 @@ pub enum OffchainWorkerEnabled {
 	Always,
 	/// Never enable the offchain worker.
 	Never,
-	/// Only enable the offchain worker when running as validator.
+	/// Only enable the offchain worker when running as a validator (or collator, if this is a parachain node).
 	WhenValidating,
 }
 

--- a/client/cli/src/arg_enums.rs
+++ b/client/cli/src/arg_enums.rs
@@ -232,7 +232,8 @@ pub enum OffchainWorkerEnabled {
 	Always,
 	/// Never enable the offchain worker.
 	Never,
-	/// Only enable the offchain worker when running as a validator (or collator, if this is a parachain node).
+	/// Only enable the offchain worker when running as a validator (or collator, if this is a
+	/// parachain node).
 	WhenAuthority,
 }
 

--- a/client/cli/src/params/offchain_worker_params.rs
+++ b/client/cli/src/params/offchain_worker_params.rs
@@ -40,7 +40,7 @@ pub struct OffchainWorkerParams {
 		value_name = "ENABLED",
 		value_enum,
 		ignore_case = true,
-		default_value_t = OffchainWorkerEnabled::WhenValidating
+		default_value_t = OffchainWorkerEnabled::WhenAuthority
 	)]
 	pub enabled: OffchainWorkerEnabled,
 
@@ -56,10 +56,10 @@ impl OffchainWorkerParams {
 	/// Load spec to `Configuration` from `OffchainWorkerParams` and spec factory.
 	pub fn offchain_worker(&self, role: &Role) -> error::Result<OffchainWorkerConfig> {
 		let enabled = match (&self.enabled, role) {
-			(OffchainWorkerEnabled::WhenValidating, Role::Authority { .. }) => true,
+			(OffchainWorkerEnabled::WhenAuthority, Role::Authority { .. }) => true,
 			(OffchainWorkerEnabled::Always, _) => true,
 			(OffchainWorkerEnabled::Never, _) => false,
-			(OffchainWorkerEnabled::WhenValidating, _) => false,
+			(OffchainWorkerEnabled::WhenAuthority, _) => false,
 		};
 
 		let indexing_enabled = self.indexing_enabled;


### PR DESCRIPTION
There's many instances on the substrate/cumulus stack where the `Validator` term is used when `Collator` should hold the actual meaning. Unfortunately, it's not trivial to solve many of those cases, because of the way that the dependencies of substrate and cumulus are set up.

In case of this CLI argument for OCWs, I propose improving the description string, at least so that the reader has some context to avoid misleading interpretations.

This PR has similar motivations to https://github.com/paritytech/substrate/issues/12933