### PR TITLE
Custom origin for staking pallet calls

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -565,7 +565,7 @@ impl pallet_staking::Config for Runtime {
 	type BondingDuration = BondingDuration;
 	type SlashDeferDuration = SlashDeferDuration;
 	/// A super-majority of the council can cancel the slash.
-	type StakingAdminOrigin = EitherOfDiverse<
+	type AdminOrigin = EitherOfDiverse<
 		EnsureRoot<AccountId>,
 		pallet_collective::EnsureProportionAtLeast<AccountId, CouncilCollective, 3, 4>,
 	>;

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -565,7 +565,7 @@ impl pallet_staking::Config for Runtime {
 	type BondingDuration = BondingDuration;
 	type SlashDeferDuration = SlashDeferDuration;
 	/// A super-majority of the council can cancel the slash.
-	type SlashCancelOrigin = EitherOfDiverse<
+	type StakingAdminOrigin = EitherOfDiverse<
 		EnsureRoot<AccountId>,
 		pallet_collective::EnsureProportionAtLeast<AccountId, CouncilCollective, 3, 4>,
 	>;

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -195,7 +195,7 @@ impl pallet_staking::Config for Test {
 	type SessionsPerEra = SessionsPerEra;
 	type BondingDuration = BondingDuration;
 	type SlashDeferDuration = SlashDeferDuration;
-	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type SessionInterface = Self;
 	type UnixTime = pallet_timestamp::Pallet<Test>;
 	type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -195,7 +195,7 @@ impl pallet_staking::Config for Test {
 	type SessionsPerEra = SessionsPerEra;
 	type BondingDuration = BondingDuration;
 	type SlashDeferDuration = SlashDeferDuration;
-	type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type SessionInterface = Self;
 	type UnixTime = pallet_timestamp::Pallet<Test>;
 	type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;

--- a/frame/fast-unstake/src/mock.rs
+++ b/frame/fast-unstake/src/mock.rs
@@ -140,7 +140,7 @@ impl pallet_staking::Config for Runtime {
 	type Reward = ();
 	type SessionsPerEra = ();
 	type SlashDeferDuration = ();
-	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BondingDuration = BondingDuration;
 	type SessionInterface = ();
 	type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;

--- a/frame/fast-unstake/src/mock.rs
+++ b/frame/fast-unstake/src/mock.rs
@@ -140,7 +140,7 @@ impl pallet_staking::Config for Runtime {
 	type Reward = ();
 	type SessionsPerEra = ();
 	type SlashDeferDuration = ();
-	type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BondingDuration = BondingDuration;
 	type SessionInterface = ();
 	type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -199,7 +199,7 @@ impl pallet_staking::Config for Test {
 	type SessionsPerEra = SessionsPerEra;
 	type BondingDuration = BondingDuration;
 	type SlashDeferDuration = ();
-	type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type SessionInterface = Self;
 	type UnixTime = pallet_timestamp::Pallet<Test>;
 	type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -199,7 +199,7 @@ impl pallet_staking::Config for Test {
 	type SessionsPerEra = SessionsPerEra;
 	type BondingDuration = BondingDuration;
 	type SlashDeferDuration = ();
-	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type SessionInterface = Self;
 	type UnixTime = pallet_timestamp::Pallet<Test>;
 	type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;

--- a/frame/nomination-pools/benchmarking/src/mock.rs
+++ b/frame/nomination-pools/benchmarking/src/mock.rs
@@ -102,7 +102,7 @@ impl pallet_staking::Config for Runtime {
 	type Reward = ();
 	type SessionsPerEra = ();
 	type SlashDeferDuration = ();
-	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BondingDuration = ConstU32<3>;
 	type SessionInterface = ();
 	type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;

--- a/frame/nomination-pools/benchmarking/src/mock.rs
+++ b/frame/nomination-pools/benchmarking/src/mock.rs
@@ -102,7 +102,7 @@ impl pallet_staking::Config for Runtime {
 	type Reward = ();
 	type SessionsPerEra = ();
 	type SlashDeferDuration = ();
-	type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BondingDuration = ConstU32<3>;
 	type SessionInterface = ();
 	type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;

--- a/frame/nomination-pools/test-staking/src/mock.rs
+++ b/frame/nomination-pools/test-staking/src/mock.rs
@@ -116,7 +116,7 @@ impl pallet_staking::Config for Runtime {
 	type Reward = ();
 	type SessionsPerEra = ();
 	type SlashDeferDuration = ();
-	type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BondingDuration = BondingDuration;
 	type SessionInterface = ();
 	type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;

--- a/frame/nomination-pools/test-staking/src/mock.rs
+++ b/frame/nomination-pools/test-staking/src/mock.rs
@@ -116,7 +116,7 @@ impl pallet_staking::Config for Runtime {
 	type Reward = ();
 	type SessionsPerEra = ();
 	type SlashDeferDuration = ();
-	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BondingDuration = BondingDuration;
 	type SessionInterface = ();
 	type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -173,7 +173,7 @@ impl pallet_staking::Config for Test {
 	type Reward = ();
 	type SessionsPerEra = ();
 	type SlashDeferDuration = ();
-	type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BondingDuration = ();
 	type SessionInterface = Self;
 	type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -173,7 +173,7 @@ impl pallet_staking::Config for Test {
 	type Reward = ();
 	type SessionsPerEra = ();
 	type SlashDeferDuration = ();
-	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BondingDuration = ();
 	type SessionInterface = Self;
 	type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;

--- a/frame/root-offences/src/mock.rs
+++ b/frame/root-offences/src/mock.rs
@@ -184,7 +184,7 @@ impl pallet_staking::Config for Test {
 	type Reward = ();
 	type SessionsPerEra = SessionsPerEra;
 	type SlashDeferDuration = SlashDeferDuration;
-	type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BondingDuration = BondingDuration;
 	type SessionInterface = Self;
 	type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;

--- a/frame/root-offences/src/mock.rs
+++ b/frame/root-offences/src/mock.rs
@@ -184,7 +184,7 @@ impl pallet_staking::Config for Test {
 	type Reward = ();
 	type SessionsPerEra = SessionsPerEra;
 	type SlashDeferDuration = SlashDeferDuration;
-	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BondingDuration = BondingDuration;
 	type SessionInterface = Self;
 	type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -167,7 +167,7 @@ impl pallet_staking::Config for Test {
 	type Reward = ();
 	type SessionsPerEra = ();
 	type SlashDeferDuration = ();
-	type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BondingDuration = ();
 	type SessionInterface = Self;
 	type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -167,7 +167,7 @@ impl pallet_staking::Config for Test {
 	type Reward = ();
 	type SessionsPerEra = ();
 	type SlashDeferDuration = ();
-	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BondingDuration = ();
 	type SessionInterface = Self;
 	type EraPayout = pallet_staking::ConvertCurve<RewardCurve>;

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -292,7 +292,7 @@ impl crate::pallet::pallet::Config for Test {
 	type Reward = MockReward;
 	type SessionsPerEra = SessionsPerEra;
 	type SlashDeferDuration = SlashDeferDuration;
-	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BondingDuration = BondingDuration;
 	type SessionInterface = Self;
 	type EraPayout = ConvertCurve<RewardCurve>;

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -292,7 +292,7 @@ impl crate::pallet::pallet::Config for Test {
 	type Reward = MockReward;
 	type SessionsPerEra = SessionsPerEra;
 	type SlashDeferDuration = SlashDeferDuration;
-	type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type StakingAdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type BondingDuration = BondingDuration;
 	type SessionInterface = Self;
 	type EraPayout = ConvertCurve<RewardCurve>;

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -183,7 +183,10 @@ pub mod pallet {
 		#[pallet::constant]
 		type SlashDeferDuration: Get<EraIndex>;
 
-		/// The origin which can cancel a deferred slash. Root can always do this.
+		/// The origin which can manage critical staking operations.
+		///
+		/// Set of operations that needs StakingAdminOrigin: `set_config`, changing validator count,
+		/// force era changes, `force_unstake`, `cancel_deferred_slash`.
 		type StakingAdminOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
 		/// Interface for interacting with a session pallet.
@@ -1278,7 +1281,7 @@ pub mod pallet {
 
 		/// Sets the ideal number of validators.
 		///
-		/// The dispatch origin must be Root.
+		/// The dispatch origin must be `T::StakingAdminOrigin`.
 		///
 		/// # <weight>
 		/// Weight: O(1)
@@ -1304,7 +1307,7 @@ pub mod pallet {
 		/// Increments the ideal number of validators upto maximum of
 		/// `ElectionProviderBase::MaxWinners`.
 		///
-		/// The dispatch origin must be Root.
+		/// The dispatch origin must be `T::StakingAdminOrigin`.
 		///
 		/// # <weight>
 		/// Same as [`Self::set_validator_count`].
@@ -1330,7 +1333,7 @@ pub mod pallet {
 		/// Scale up the ideal number of validators by a factor upto maximum of
 		/// `ElectionProviderBase::MaxWinners`.
 		///
-		/// The dispatch origin must be Root.
+		/// The dispatch origin must be `T::StakingAdminOrigin`.
 		///
 		/// # <weight>
 		/// Same as [`Self::set_validator_count`].
@@ -1353,7 +1356,7 @@ pub mod pallet {
 
 		/// Force there to be no new eras indefinitely.
 		///
-		/// The dispatch origin must be Root.
+		/// The dispatch origin must be `T::StakingAdminOrigin`.
 		///
 		/// # Warning
 		///
@@ -1377,7 +1380,7 @@ pub mod pallet {
 		/// Force there to be a new era at the end of the next session. After this, it will be
 		/// reset to normal (non-forced) behaviour.
 		///
-		/// The dispatch origin must be Root.
+		/// The dispatch origin must be `T::StakingAdminOrigin`.
 		///
 		/// # Warning
 		///
@@ -1414,7 +1417,7 @@ pub mod pallet {
 
 		/// Force a current staker to become completely unstaked, immediately.
 		///
-		/// The dispatch origin must be Root.
+		/// The dispatch origin must be `T::StakingAdminOrigin`.
 		#[pallet::call_index(15)]
 		#[pallet::weight(T::WeightInfo::force_unstake(*num_slashing_spans))]
 		pub fn force_unstake(
@@ -1434,7 +1437,7 @@ pub mod pallet {
 
 		/// Force there to be a new era at the end of sessions indefinitely.
 		///
-		/// The dispatch origin must be Root.
+		/// The dispatch origin must be `T::StakingAdminOrigin`.
 		///
 		/// # Warning
 		///
@@ -1451,7 +1454,7 @@ pub mod pallet {
 
 		/// Cancel enactment of a deferred slash.
 		///
-		/// Can be called by the `T::SlashCancelOrigin`.
+		/// Can be called by the `T::StakingAdminOrigin`.
 		///
 		/// Parameters: era and indices of the slashes for that era to kill.
 		#[pallet::call_index(17)]
@@ -1642,7 +1645,7 @@ pub mod pallet {
 		/// * `min_commission`: The minimum amount of commission that each validators must maintain.
 		///   This is checked only upon calling `validate`. Existing validators are not affected.
 		///
-		/// RuntimeOrigin must be Root to call this function.
+		/// RuntimeOrigin must be `T::StakingAdminOrigin` to call this function.
 		///
 		/// NOTE: Existing nominators and validators will not be affected by this update.
 		/// to kick people under the new limits, `chill_other` should be called.

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -185,9 +185,9 @@ pub mod pallet {
 
 		/// The origin which can manage critical staking operations.
 		///
-		/// Set of operations that needs StakingAdminOrigin: `set_config`, changing validator count,
+		/// Set of operations that needs AdminOrigin: `set_config`, changing validator count,
 		/// force era changes, `force_unstake`, `cancel_deferred_slash`.
-		type StakingAdminOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+		type AdminOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
 		/// Interface for interacting with a session pallet.
 		type SessionInterface: SessionInterface<Self::AccountId>;
@@ -1281,7 +1281,7 @@ pub mod pallet {
 
 		/// Sets the ideal number of validators.
 		///
-		/// The dispatch origin must be `T::StakingAdminOrigin`.
+		/// The dispatch origin must be `T::AdminOrigin`.
 		///
 		/// # <weight>
 		/// Weight: O(1)
@@ -1293,7 +1293,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			#[pallet::compact] new: u32,
 		) -> DispatchResult {
-			T::StakingAdminOrigin::ensure_origin(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 			// ensure new validator count does not exceed maximum winners
 			// support by election provider.
 			ensure!(
@@ -1307,7 +1307,7 @@ pub mod pallet {
 		/// Increments the ideal number of validators upto maximum of
 		/// `ElectionProviderBase::MaxWinners`.
 		///
-		/// The dispatch origin must be `T::StakingAdminOrigin`.
+		/// The dispatch origin must be `T::AdminOrigin`.
 		///
 		/// # <weight>
 		/// Same as [`Self::set_validator_count`].
@@ -1318,7 +1318,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			#[pallet::compact] additional: u32,
 		) -> DispatchResult {
-			T::StakingAdminOrigin::ensure_origin(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 			let old = ValidatorCount::<T>::get();
 			let new = old.checked_add(additional).ok_or(ArithmeticError::Overflow)?;
 			ensure!(
@@ -1333,7 +1333,7 @@ pub mod pallet {
 		/// Scale up the ideal number of validators by a factor upto maximum of
 		/// `ElectionProviderBase::MaxWinners`.
 		///
-		/// The dispatch origin must be `T::StakingAdminOrigin`.
+		/// The dispatch origin must be `T::AdminOrigin`.
 		///
 		/// # <weight>
 		/// Same as [`Self::set_validator_count`].
@@ -1341,7 +1341,7 @@ pub mod pallet {
 		#[pallet::call_index(11)]
 		#[pallet::weight(T::WeightInfo::set_validator_count())]
 		pub fn scale_validator_count(origin: OriginFor<T>, factor: Percent) -> DispatchResult {
-			T::StakingAdminOrigin::ensure_origin(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 			let old = ValidatorCount::<T>::get();
 			let new = old.checked_add(factor.mul_floor(old)).ok_or(ArithmeticError::Overflow)?;
 
@@ -1356,7 +1356,7 @@ pub mod pallet {
 
 		/// Force there to be no new eras indefinitely.
 		///
-		/// The dispatch origin must be `T::StakingAdminOrigin`.
+		/// The dispatch origin must be `T::AdminOrigin`.
 		///
 		/// # Warning
 		///
@@ -1372,7 +1372,7 @@ pub mod pallet {
 		#[pallet::call_index(12)]
 		#[pallet::weight(T::WeightInfo::force_no_eras())]
 		pub fn force_no_eras(origin: OriginFor<T>) -> DispatchResult {
-			T::StakingAdminOrigin::ensure_origin(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 			ForceEra::<T>::put(Forcing::ForceNone);
 			Ok(())
 		}
@@ -1380,7 +1380,7 @@ pub mod pallet {
 		/// Force there to be a new era at the end of the next session. After this, it will be
 		/// reset to normal (non-forced) behaviour.
 		///
-		/// The dispatch origin must be `T::StakingAdminOrigin`.
+		/// The dispatch origin must be `T::AdminOrigin`.
 		///
 		/// # Warning
 		///
@@ -1396,7 +1396,7 @@ pub mod pallet {
 		#[pallet::call_index(13)]
 		#[pallet::weight(T::WeightInfo::force_new_era())]
 		pub fn force_new_era(origin: OriginFor<T>) -> DispatchResult {
-			T::StakingAdminOrigin::ensure_origin(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 			ForceEra::<T>::put(Forcing::ForceNew);
 			Ok(())
 		}
@@ -1417,7 +1417,7 @@ pub mod pallet {
 
 		/// Force a current staker to become completely unstaked, immediately.
 		///
-		/// The dispatch origin must be `T::StakingAdminOrigin`.
+		/// The dispatch origin must be `T::AdminOrigin`.
 		#[pallet::call_index(15)]
 		#[pallet::weight(T::WeightInfo::force_unstake(*num_slashing_spans))]
 		pub fn force_unstake(
@@ -1425,7 +1425,7 @@ pub mod pallet {
 			stash: T::AccountId,
 			num_slashing_spans: u32,
 		) -> DispatchResult {
-			T::StakingAdminOrigin::ensure_origin(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 
 			// Remove all staking-related information.
 			Self::kill_stash(&stash, num_slashing_spans)?;
@@ -1437,7 +1437,7 @@ pub mod pallet {
 
 		/// Force there to be a new era at the end of sessions indefinitely.
 		///
-		/// The dispatch origin must be `T::StakingAdminOrigin`.
+		/// The dispatch origin must be `T::AdminOrigin`.
 		///
 		/// # Warning
 		///
@@ -1447,14 +1447,14 @@ pub mod pallet {
 		#[pallet::call_index(16)]
 		#[pallet::weight(T::WeightInfo::force_new_era_always())]
 		pub fn force_new_era_always(origin: OriginFor<T>) -> DispatchResult {
-			T::StakingAdminOrigin::ensure_origin(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 			ForceEra::<T>::put(Forcing::ForceAlways);
 			Ok(())
 		}
 
 		/// Cancel enactment of a deferred slash.
 		///
-		/// Can be called by the `T::StakingAdminOrigin`.
+		/// Can be called by the `T::AdminOrigin`.
 		///
 		/// Parameters: era and indices of the slashes for that era to kill.
 		#[pallet::call_index(17)]
@@ -1464,7 +1464,7 @@ pub mod pallet {
 			era: EraIndex,
 			slash_indices: Vec<u32>,
 		) -> DispatchResult {
-			T::StakingAdminOrigin::ensure_origin(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 
 			ensure!(!slash_indices.is_empty(), Error::<T>::EmptyTargets);
 			ensure!(is_sorted_and_unique(&slash_indices), Error::<T>::NotSortedAndUnique);
@@ -1645,7 +1645,7 @@ pub mod pallet {
 		/// * `min_commission`: The minimum amount of commission that each validators must maintain.
 		///   This is checked only upon calling `validate`. Existing validators are not affected.
 		///
-		/// RuntimeOrigin must be `T::StakingAdminOrigin` to call this function.
+		/// RuntimeOrigin must be `T::AdminOrigin` to call this function.
 		///
 		/// NOTE: Existing nominators and validators will not be affected by this update.
 		/// to kick people under the new limits, `chill_other` should be called.
@@ -1665,7 +1665,7 @@ pub mod pallet {
 			chill_threshold: ConfigOp<Percent>,
 			min_commission: ConfigOp<Perbill>,
 		) -> DispatchResult {
-			T::StakingAdminOrigin::ensure_origin(origin)?;
+			T::AdminOrigin::ensure_origin(origin)?;
 
 			macro_rules! config_op_exp {
 				($storage:ty, $op:ident) => {

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -184,7 +184,7 @@ pub mod pallet {
 		type SlashDeferDuration: Get<EraIndex>;
 
 		/// The origin which can cancel a deferred slash. Root can always do this.
-		type SlashCancelOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+		type StakingAdminOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
 		/// Interface for interacting with a session pallet.
 		type SessionInterface: SessionInterface<Self::AccountId>;
@@ -1290,7 +1290,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			#[pallet::compact] new: u32,
 		) -> DispatchResult {
-			ensure_root(origin)?;
+			T::StakingAdminOrigin::ensure_origin(origin)?;
 			// ensure new validator count does not exceed maximum winners
 			// support by election provider.
 			ensure!(
@@ -1315,7 +1315,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			#[pallet::compact] additional: u32,
 		) -> DispatchResult {
-			ensure_root(origin)?;
+			T::StakingAdminOrigin::ensure_origin(origin)?;
 			let old = ValidatorCount::<T>::get();
 			let new = old.checked_add(additional).ok_or(ArithmeticError::Overflow)?;
 			ensure!(
@@ -1338,7 +1338,7 @@ pub mod pallet {
 		#[pallet::call_index(11)]
 		#[pallet::weight(T::WeightInfo::set_validator_count())]
 		pub fn scale_validator_count(origin: OriginFor<T>, factor: Percent) -> DispatchResult {
-			ensure_root(origin)?;
+			T::StakingAdminOrigin::ensure_origin(origin)?;
 			let old = ValidatorCount::<T>::get();
 			let new = old.checked_add(factor.mul_floor(old)).ok_or(ArithmeticError::Overflow)?;
 
@@ -1369,7 +1369,7 @@ pub mod pallet {
 		#[pallet::call_index(12)]
 		#[pallet::weight(T::WeightInfo::force_no_eras())]
 		pub fn force_no_eras(origin: OriginFor<T>) -> DispatchResult {
-			ensure_root(origin)?;
+			T::StakingAdminOrigin::ensure_origin(origin)?;
 			ForceEra::<T>::put(Forcing::ForceNone);
 			Ok(())
 		}
@@ -1393,7 +1393,7 @@ pub mod pallet {
 		#[pallet::call_index(13)]
 		#[pallet::weight(T::WeightInfo::force_new_era())]
 		pub fn force_new_era(origin: OriginFor<T>) -> DispatchResult {
-			ensure_root(origin)?;
+			T::StakingAdminOrigin::ensure_origin(origin)?;
 			ForceEra::<T>::put(Forcing::ForceNew);
 			Ok(())
 		}
@@ -1422,7 +1422,7 @@ pub mod pallet {
 			stash: T::AccountId,
 			num_slashing_spans: u32,
 		) -> DispatchResult {
-			ensure_root(origin)?;
+			T::StakingAdminOrigin::ensure_origin(origin)?;
 
 			// Remove all staking-related information.
 			Self::kill_stash(&stash, num_slashing_spans)?;
@@ -1444,7 +1444,7 @@ pub mod pallet {
 		#[pallet::call_index(16)]
 		#[pallet::weight(T::WeightInfo::force_new_era_always())]
 		pub fn force_new_era_always(origin: OriginFor<T>) -> DispatchResult {
-			ensure_root(origin)?;
+			T::StakingAdminOrigin::ensure_origin(origin)?;
 			ForceEra::<T>::put(Forcing::ForceAlways);
 			Ok(())
 		}
@@ -1461,7 +1461,7 @@ pub mod pallet {
 			era: EraIndex,
 			slash_indices: Vec<u32>,
 		) -> DispatchResult {
-			T::SlashCancelOrigin::ensure_origin(origin)?;
+			T::StakingAdminOrigin::ensure_origin(origin)?;
 
 			ensure!(!slash_indices.is_empty(), Error::<T>::EmptyTargets);
 			ensure!(is_sorted_and_unique(&slash_indices), Error::<T>::NotSortedAndUnique);
@@ -1662,7 +1662,7 @@ pub mod pallet {
 			chill_threshold: ConfigOp<Percent>,
 			min_commission: ConfigOp<Perbill>,
 		) -> DispatchResult {
-			ensure_root(origin)?;
+			T::StakingAdminOrigin::ensure_origin(origin)?;
 
 			macro_rules! config_op_exp {
 				($storage:ty, $op:ident) => {


### PR DESCRIPTION
Fixes https://github.com/paritytech/substrate/issues/12930
polkadot companion: https://github.com/paritytech/polkadot/pull/6444

I have left `set_invulnerables` to still require root origin since it seems not something that should ever need to be set unless during the initial phase of a chain. Please correct me if this assumption is incorrect. 