### PR TITLE
sc-network-test::Peer: block push methods return hashes vec

### DIFF
--- a/bin/node/bench/src/import.rs
+++ b/bin/node/bench/src/import.rs
@@ -34,7 +34,7 @@ use std::borrow::Cow;
 
 use node_primitives::Block;
 use node_testing::bench::{BenchDb, BlockType, DatabaseType, KeyTypes, Profile};
-use sc_client_api::{backend::Backend, HeaderBackend};
+use sc_client_api::backend::Backend;
 use sp_runtime::generic::BlockId;
 use sp_state_machine::InspectState;
 
@@ -127,15 +127,10 @@ impl core::Benchmark for ImportBenchmark {
 		context.import_block(self.block.clone());
 		let elapsed = start.elapsed();
 
-		let hash = context
-			.client
-			.expect_block_hash_from_id(&BlockId::number(1))
-			.expect("Block 1 was imported; qed");
-
 		// Sanity checks.
 		context
 			.client
-			.state_at(hash)
+			.state_at(self.block.header.hash())
 			.expect("state_at failed for block#1")
 			.inspect_state(|| {
 				match self.block_type {

--- a/client/beefy/src/worker.rs
+++ b/client/beefy/src/worker.rs
@@ -1383,10 +1383,10 @@ pub(crate) mod tests {
 		// generate 2 blocks, try again expect success
 		let (mut best_block_streams, _) = get_beefy_streams(&mut net, keys);
 		let mut best_block_stream = best_block_streams.drain(..).next().unwrap();
-		net.peer(0).push_blocks(2, false);
-		// finalize 1 and 2 without justifications
-		let hashof1 = backend.blockchain().expect_block_hash_from_id(&BlockId::Number(1)).unwrap();
-		let hashof2 = backend.blockchain().expect_block_hash_from_id(&BlockId::Number(2)).unwrap();
+		let hashes = net.peer(0).push_blocks(2, false);
+		// finalize 1 and 2 without justifications (hashes does not contain genesis)
+		let hashof1 = hashes[0];
+		let hashof2 = hashes[1];
 		backend.finalize_block(hashof1, None).unwrap();
 		backend.finalize_block(hashof2, None).unwrap();
 

--- a/client/finality-grandpa/src/tests.rs
+++ b/client/finality-grandpa/src/tests.rs
@@ -649,14 +649,18 @@ fn sync_justifications_on_change_blocks() {
 	net.peer(0).push_blocks(20, false);
 
 	// at block 21 we do add a transition which is instant
-	let hashof21 = net.peer(0).generate_blocks(1, BlockOrigin::File, |builder| {
-		let mut block = builder.build().unwrap().block;
-		add_scheduled_change(
-			&mut block,
-			ScheduledChange { next_authorities: make_ids(peers_b), delay: 0 },
-		);
-		block
-	});
+	let hashof21 = net
+		.peer(0)
+		.generate_blocks(1, BlockOrigin::File, |builder| {
+			let mut block = builder.build().unwrap().block;
+			add_scheduled_change(
+				&mut block,
+				ScheduledChange { next_authorities: make_ids(peers_b), delay: 0 },
+			);
+			block
+		})
+		.pop()
+		.unwrap();
 
 	// add more blocks on top of it (until we have 25)
 	net.peer(0).push_blocks(4, false);
@@ -1384,7 +1388,7 @@ fn grandpa_environment_respects_voting_rules() {
 	let link = peer.data.lock().take().unwrap();
 
 	// add 21 blocks
-	peer.push_blocks(21, false);
+	let hashes = peer.push_blocks(21, false);
 
 	// create an environment with no voting rule restrictions
 	let unrestricted_env = test_environment(&link, None, network_service.clone(), ());
@@ -1437,12 +1441,7 @@ fn grandpa_environment_respects_voting_rules() {
 	);
 
 	// we finalize block 19 with block 21 being the best block
-	let hashof19 = peer
-		.client()
-		.as_client()
-		.expect_block_hash_from_id(&BlockId::Number(19))
-		.unwrap();
-	peer.client().finalize_block(hashof19, None, false).unwrap();
+	peer.client().finalize_block(hashes[18], None, false).unwrap();
 
 	// the 3/4 environment should propose block 21 for voting
 	assert_eq!(
@@ -1466,11 +1465,7 @@ fn grandpa_environment_respects_voting_rules() {
 	);
 
 	// we finalize block 21 with block 21 being the best block
-	let hashof21 = peer
-		.client()
-		.as_client()
-		.expect_block_hash_from_id(&BlockId::Number(21))
-		.unwrap();
+	let hashof21 = hashes[20];
 	peer.client().finalize_block(hashof21, None, false).unwrap();
 
 	// even though the default environment will always try to not vote on the
@@ -1789,20 +1784,23 @@ fn revert_prunes_authority_changes() {
 	// Fork before revert point
 
 	// add more blocks on top of block 23 (until we have 26)
-	let hash = peer.generate_blocks_at(
-		BlockId::Number(23),
-		3,
-		BlockOrigin::File,
-		|builder| {
-			let mut block = builder.build().unwrap().block;
-			block.header.digest_mut().push(DigestItem::Other(vec![1]));
-			block
-		},
-		false,
-		false,
-		true,
-		ForkChoiceStrategy::LongestChain,
-	);
+	let hash = peer
+		.generate_blocks_at(
+			BlockId::Number(23),
+			3,
+			BlockOrigin::File,
+			|builder| {
+				let mut block = builder.build().unwrap().block;
+				block.header.digest_mut().push(DigestItem::Other(vec![1]));
+				block
+			},
+			false,
+			false,
+			true,
+			ForkChoiceStrategy::LongestChain,
+		)
+		.pop()
+		.unwrap();
 	// at block 27 of the fork add an authority transition
 	peer.generate_blocks_at(
 		BlockId::Hash(hash),
@@ -1818,20 +1816,23 @@ fn revert_prunes_authority_changes() {
 	// Fork after revert point
 
 	// add more block on top of block 25 (until we have 28)
-	let hash = peer.generate_blocks_at(
-		BlockId::Number(25),
-		3,
-		BlockOrigin::File,
-		|builder| {
-			let mut block = builder.build().unwrap().block;
-			block.header.digest_mut().push(DigestItem::Other(vec![2]));
-			block
-		},
-		false,
-		false,
-		true,
-		ForkChoiceStrategy::LongestChain,
-	);
+	let hash = peer
+		.generate_blocks_at(
+			BlockId::Number(25),
+			3,
+			BlockOrigin::File,
+			|builder| {
+				let mut block = builder.build().unwrap().block;
+				block.header.digest_mut().push(DigestItem::Other(vec![2]));
+				block
+			},
+			false,
+			false,
+			true,
+			ForkChoiceStrategy::LongestChain,
+		)
+		.pop()
+		.unwrap();
 	// at block 29 of the fork add an authority transition
 	peer.generate_blocks_at(
 		BlockId::Hash(hash),


### PR DESCRIPTION
This commit reworks the block generation/push methods in
sc-network-test::Peer.

Now methods are providing the vector of hashes that were built.

This allows to get rid of redundant `block_hash_from_id` call, as all
hashes are known just after being built.

Similar approach was taken in BeefyTestNet::generate_blocks_and_sync
method.

This PR is part of BlockId::Number refactoring analysis (paritytech/substrate#11292)
