### PR TITLE
Fix missing block number issue on forced canonicalization

### DIFF
--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -1319,7 +1319,6 @@ impl<Block: BlockT> Backend<Block> {
 		let best_canonical = || self.storage.state_db.best_canonical().unwrap_or(0);
 		let info = self.blockchain.info();
 		let best_number: u64 = self.blockchain.info().best_number.saturated_into();
-		let best_hash = info.best_hash;
 
 		while best_number.saturating_sub(best_canonical()) > self.canonicalization_delay {
 			let to_canonicalize = best_canonical() + 1;
@@ -1329,9 +1328,10 @@ impl<Block: BlockT> Backend<Block> {
 				to_canonicalize.saturated_into(),
 			)?
 			.ok_or_else(|| {
+					let best_hash = info.best_hash;
+
 				sp_blockchain::Error::Backend(format!(
-					"Can't canonicalize missing block number #{} when for best block {:?} (#{})",
-					to_canonicalize, best_hash, best_number,
+					"Can't canonicalize missing block number #{to_canonicalize} when for best block {best_hash:?} (#{best_number})",
 				))
 			})?;
 

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -3855,6 +3855,8 @@ pub(crate) mod tests {
 
 		assert_eq!(0, backend.storage.state_db.best_canonical().unwrap());
 
+		// This should not trigger any forced canonicalization as we didn't have imported any best
+		// block by now.
 		let block2 = {
 			let mut op = backend.begin_operation().unwrap();
 			backend.begin_state_operation(&mut op, block1).unwrap();
@@ -3876,6 +3878,8 @@ pub(crate) mod tests {
 
 		assert_eq!(0, backend.storage.state_db.best_canonical().unwrap());
 
+		// This should also not trigger it yet, because we import a best block, but the best block
+		// from the POV of the db is still at `0`.
 		let block3 = {
 			let mut op = backend.begin_operation().unwrap();
 			backend.begin_state_operation(&mut op, block2).unwrap();
@@ -3895,6 +3899,7 @@ pub(crate) mod tests {
 			header.hash()
 		};
 
+		// Now it should kick in.
 		let block4 = {
 			let mut op = backend.begin_operation().unwrap();
 			backend.begin_state_operation(&mut op, block3).unwrap();

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -1331,6 +1331,10 @@ impl<Block: BlockT> Backend<Block> {
 		}
 
 		let best_number = self.blockchain.info().best_number.saturated_into();
+		// If the `best_number` is one off from the current block we are just importing, we can
+		// take the block number of the current block as the best block. Even if this block is not
+		// imported as best block, we know its hash and can canonicalize it if required below.
+		let best_number = if best_number + 1 == number_u64 { number_u64 } else { best_number };
 
 		// We can not canonicalize beyond the `best_number` as setting the best block also sets the
 		// mapping from block number to hash that is required down below. This is just some safety


### PR DESCRIPTION
There is this issue about missing block numbers on forced canonicalization. I looked over the code now 10000 times and there are possible ways this can be triggered, but I don't really know how this is triggered. So, this pr is going to solve the symptom and not the cause. The block number to hash mapping is set when we import a new best block. Forced canonicalization will now stop at the best block and it will canonicalize the other blocks later when the best block moved. As the error reports indicated that this issue mainly happened on major sync, there should not be any forks, so not doing the canonicalization directly shouldn't be that harmful. All known implementations should import all blocks as best block on major sync anyway (I mean somewhere there is the bug, but I didn't yet found it).

I will also do some changes to Cumulus around some potential culprit for this issue.

Closes: https://github.com/paritytech/substrate/issues/12613

