### PR TITLE
Defensive traits: Ensure doc tests are also working without `debug_assertions`

### DIFF
--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -1353,6 +1353,7 @@ mod test {
 	}
 
 	#[test]
+	#[cfg(debug_assertions)]
 	#[should_panic(expected = "Defensive failure has been triggered!: \"DefensiveMin\"")]
 	fn defensive_min_panics() {
 		10_u32.defensive_min(9_u32);
@@ -1365,6 +1366,7 @@ mod test {
 	}
 
 	#[test]
+	#[cfg(debug_assertions)]
 	#[should_panic(expected = "Defensive failure has been triggered!: \"DefensiveMin strict\"")]
 	fn defensive_strict_min_panics() {
 		9_u32.defensive_strict_min(9_u32);
@@ -1377,6 +1379,7 @@ mod test {
 	}
 
 	#[test]
+	#[cfg(debug_assertions)]
 	#[should_panic(expected = "Defensive failure has been triggered!: \"DefensiveMax\"")]
 	fn defensive_max_panics() {
 		9_u32.defensive_max(10_u32);
@@ -1389,6 +1392,7 @@ mod test {
 	}
 
 	#[test]
+	#[cfg(debug_assertions)]
 	#[should_panic(expected = "Defensive failure has been triggered!: \"DefensiveMax strict\"")]
 	fn defensive_strict_max_panics() {
 		9_u32.defensive_strict_max(9_u32);

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -445,7 +445,7 @@ pub trait DefensiveMin<T> {
 	/// assert_eq!(4, 4_u32.defensive_min(4_u32));
 	/// ```
 	///
-	/// ```should_panic
+	/// ```#[cfg_attr(debug_assertions, should_panic)]
 	/// use frame_support::traits::DefensiveMin;
 	/// // min(4, 3) panics.
 	/// 4_u32.defensive_min(3_u32);
@@ -462,7 +462,7 @@ pub trait DefensiveMin<T> {
 	/// assert_eq!(3, 3_u32.defensive_strict_min(4_u32));
 	/// ```
 	///
-	/// ```should_panic
+	/// ```#[cfg_attr(debug_assertions, should_panic)]
 	/// use frame_support::traits::DefensiveMin;
 	/// // min(4, 4) panics.
 	/// 4_u32.defensive_strict_min(4_u32);
@@ -509,7 +509,7 @@ pub trait DefensiveMax<T> {
 	/// assert_eq!(4, 4_u32.defensive_max(4_u32));
 	/// ```
 	///
-	/// ```should_panic
+	/// ```#[cfg_attr(debug_assertions, should_panic)]
 	/// use frame_support::traits::DefensiveMax;
 	/// // max(4, 5) panics.
 	/// 4_u32.defensive_max(5_u32);
@@ -526,7 +526,7 @@ pub trait DefensiveMax<T> {
 	/// assert_eq!(4, 4_u32.defensive_strict_max(3_u32));
 	/// ```
 	///
-	/// ```should_panic
+	/// ```#[cfg_attr(debug_assertions, should_panic)]
 	/// use frame_support::traits::DefensiveMax;
 	/// // max(4, 4) panics.
 	/// 4_u32.defensive_strict_max(4_u32);


### PR DESCRIPTION

Closes: https://github.com/paritytech/substrate/issues/12940

