### PR TITLE
*: update `rand` to v0.8.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,15 +376,12 @@ dependencies = [
  "async-trait",
  "fnv",
  "futures",
- "futures-timer",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-block-builder",
- "sc-chain-spec",
  "sc-client-api",
  "sc-consensus",
- "sc-finality-grandpa",
  "sc-keystore",
  "sc-network",
  "sc-network-common",
@@ -425,7 +422,6 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-rpc",
- "sc-utils",
  "serde",
  "serde_json",
  "sp-beefy",
@@ -1904,13 +1900,10 @@ dependencies = [
  "frame-system",
  "gethostname",
  "handlebars",
- "hash-db",
  "itertools",
- "kvdb",
  "lazy_static",
  "linked-hash-map",
  "log",
- "memory-db",
  "parity-scale-codec",
  "rand 0.8.5",
  "rand_pcg",
@@ -1923,7 +1916,6 @@ dependencies = [
  "sc-sysinfo",
  "serde",
  "serde_json",
- "serde_nanos",
  "sp-api",
  "sp-blockchain",
  "sp-core",
@@ -1936,7 +1928,6 @@ dependencies = [
  "sp-std",
  "sp-storage",
  "sp-trie",
- "tempfile",
  "thiserror",
  "thousands",
 ]
@@ -2029,18 +2020,15 @@ dependencies = [
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
 dependencies = [
- "env_logger",
  "frame-support",
  "futures",
  "log",
  "pallet-elections-phragmen",
  "parity-scale-codec",
  "serde",
- "serde_json",
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-version",
  "substrate-rpc-client",
  "tokio",
  "tracing-subscriber 0.3.16",
@@ -2383,7 +2371,6 @@ dependencies = [
  "git2",
  "num-format",
  "pallet-staking",
- "sp-io",
 ]
 
 [[package]]
@@ -3917,7 +3904,6 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-io",
  "sp-mmr-primitives",
  "sp-runtime",
  "sp-tracing",
@@ -7197,9 +7183,7 @@ dependencies = [
 name = "sc-chain-spec"
 version = "4.0.0-dev"
 dependencies = [
- "impl-trait-for-tuples",
  "memmap2",
- "parity-scale-codec",
  "sc-chain-spec-derive",
  "sc-network-common",
  "sc-telemetry",
@@ -7266,7 +7250,6 @@ version = "4.0.0-dev"
 dependencies = [
  "fnv",
  "futures",
- "hash-db",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -7284,7 +7267,6 @@ dependencies = [
  "sp-state-machine",
  "sp-storage",
  "sp-test-primitives",
- "sp-trie",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime",
  "thiserror",
@@ -7409,7 +7391,6 @@ dependencies = [
  "sc-network-test",
  "sc-telemetry",
  "schnorrkel",
- "serde",
  "sp-api",
  "sp-application-crypto",
  "sp-block-builder",
@@ -7420,13 +7401,11 @@ dependencies = [
  "sp-consensus-vrf",
  "sp-core",
  "sp-inherents",
- "sp-io",
  "sp-keyring",
  "sp-keystore",
  "sp-runtime",
  "sp-timestamp",
  "sp-tracing",
- "sp-version",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "thiserror",
@@ -7555,7 +7534,6 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "substrate-test-runtime-client",
- "thiserror",
 ]
 
 [[package]]
@@ -7673,7 +7651,6 @@ dependencies = [
  "sc-chain-spec",
  "sc-client-api",
  "sc-consensus",
- "sc-keystore",
  "sc-network",
  "sc-network-common",
  "sc-network-gossip",
@@ -7713,7 +7690,6 @@ dependencies = [
  "sc-finality-grandpa",
  "sc-rpc",
  "serde",
- "serde_json",
  "sp-blockchain",
  "sp-core",
  "sp-finality-grandpa",
@@ -7734,7 +7710,6 @@ dependencies = [
  "log",
  "sc-client-api",
  "sc-network-common",
- "sc-transaction-pool-api",
  "sp-blockchain",
  "sp-runtime",
 ]
@@ -8044,9 +8019,7 @@ dependencies = [
  "assert_matches",
  "env_logger",
  "futures",
- "hash-db",
  "jsonrpsee",
- "lazy_static",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -8080,11 +8053,8 @@ dependencies = [
 name = "sc-rpc-api"
 version = "0.10.0-dev"
 dependencies = [
- "futures",
  "jsonrpsee",
- "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
  "sc-chain-spec",
  "sc-transaction-pool-api",
  "scale-info",
@@ -8093,7 +8063,6 @@ dependencies = [
  "sp-core",
  "sp-rpc",
  "sp-runtime",
- "sp-tracing",
  "sp-version",
  "thiserror",
 ]
@@ -8102,7 +8071,6 @@ dependencies = [
 name = "sc-rpc-server"
 version = "4.0.0-dev"
 dependencies = [
- "futures",
  "http",
  "jsonrpsee",
  "log",
@@ -8252,7 +8220,6 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "sc-client-api",
  "sp-core",
 ]
 
@@ -8626,15 +8593,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_nanos"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44969a61f5d316be20a42ff97816efb3b407a924d06824c3d8a49fa8450de0e"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "sha-1"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8994,7 +8952,6 @@ version = "0.10.0-dev"
 dependencies = [
  "async-trait",
  "futures",
- "futures-timer",
  "log",
  "parity-scale-codec",
  "sp-core",
@@ -9064,8 +9021,6 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic",
- "sp-runtime",
  "sp-std",
  "sp-timestamp",
 ]
@@ -9090,7 +9045,6 @@ dependencies = [
  "base58",
  "bitflags",
  "blake2",
- "byteorder",
  "criterion",
  "dyn-clonable",
  "ed25519-zebra",
@@ -9102,7 +9056,6 @@ dependencies = [
  "libsecp256k1",
  "log",
  "merlin",
- "num-traits",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "primitive-types",
@@ -9126,7 +9079,6 @@ dependencies = [
  "substrate-bip39",
  "thiserror",
  "tiny-bip39",
- "wasmi 0.13.0",
  "zeroize",
 ]
 
@@ -9218,11 +9170,9 @@ dependencies = [
  "bytes",
  "ed25519-dalek",
  "futures",
- "hash-db",
  "libsecp256k1",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
  "secp256k1",
  "sp-core",
  "sp-externalities",
@@ -9232,7 +9182,6 @@ dependencies = [
  "sp-std",
  "sp-tracing",
  "sp-trie",
- "sp-wasm-interface",
  "tracing",
  "tracing-core",
 ]
@@ -9487,7 +9436,6 @@ dependencies = [
  "assert_matches",
  "hash-db",
  "log",
- "num-traits",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "pretty_assertions",
@@ -9502,7 +9450,6 @@ dependencies = [
  "thiserror",
  "tracing",
  "trie-db",
- "trie-root",
 ]
 
 [[package]]
@@ -9540,7 +9487,6 @@ dependencies = [
  "futures-timer",
  "log",
  "parity-scale-codec",
- "sp-api",
  "sp-inherents",
  "sp-runtime",
  "sp-std",
@@ -9651,7 +9597,6 @@ dependencies = [
 name = "sp-weights"
 version = "4.0.0"
 dependencies = [
- "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -9826,7 +9771,6 @@ version = "3.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
- "futures",
  "jsonrpsee",
  "parity-scale-codec",
  "sc-rpc-api",
@@ -9848,11 +9792,9 @@ dependencies = [
  "jsonrpsee",
  "log",
  "parity-scale-codec",
- "sc-client-api",
  "sc-rpc-api",
  "sc-transaction-pool",
  "sc-transaction-pool-api",
- "serde_json",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
@@ -9867,7 +9809,6 @@ dependencies = [
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
 dependencies = [
- "futures-util",
  "hyper",
  "log",
  "prometheus",
@@ -9902,10 +9843,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-std",
  "sp-trie",
  "trie-db",
 ]
@@ -10626,7 +10565,6 @@ dependencies = [
  "hex",
  "log",
  "parity-scale-codec",
- "sc-chain-spec",
  "sc-cli",
  "sc-executor",
  "sc-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,7 +1913,7 @@ dependencies = [
  "memory-db",
  "parity-scale-codec",
  "rand 0.8.5",
- "rand_pcg 0.3.1",
+ "rand_pcg",
  "sc-block-builder",
  "sc-cli",
  "sc-client-api",
@@ -1965,7 +1965,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
- "rand 0.7.3",
+ "rand 0.8.5",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
@@ -2422,10 +2422,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4196,7 +4194,7 @@ dependencies = [
  "node-primitives",
  "node-testing",
  "parity-db",
- "rand 0.7.3",
+ "rand 0.8.5",
  "sc-basic-authorship",
  "sc-client-api",
  "sc-transaction-pool",
@@ -5029,7 +5027,7 @@ dependencies = [
  "parity-scale-codec",
  "pretty_assertions",
  "rand 0.8.5",
- "rand_pcg 0.3.1",
+ "rand_pcg",
  "scale-info",
  "serde",
  "smallvec",
@@ -5117,7 +5115,7 @@ dependencies = [
  "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "rand 0.7.3",
+ "rand 0.8.5",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
@@ -5126,7 +5124,6 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-tracing",
- "static_assertions",
  "strum",
 ]
 
@@ -5799,7 +5796,7 @@ dependencies = [
  "pallet-staking-reward-curve",
  "pallet-timestamp",
  "parity-scale-codec",
- "rand 0.7.3",
+ "rand 0.8.5",
  "scale-info",
  "sp-core",
  "sp-io",
@@ -6238,20 +6235,20 @@ checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "pbkdf2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
-dependencies = [
- "crypto-mac 0.8.0",
-]
-
-[[package]]
-name = "pbkdf2"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
 dependencies = [
  "crypto-mac 0.11.1",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -6713,7 +6710,6 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
- "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -6723,7 +6719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.0",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.2",
 ]
 
@@ -6739,9 +6735,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.2",
@@ -6780,15 +6776,6 @@ name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
 ]
@@ -7150,7 +7137,7 @@ dependencies = [
  "prost",
  "prost-build",
  "quickcheck",
- "rand 0.7.3",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-network-common",
  "sp-api",
@@ -7246,7 +7233,7 @@ dependencies = [
  "log",
  "names",
  "parity-scale-codec",
- "rand 0.7.3",
+ "rand 0.8.5",
  "regex",
  "rpassword",
  "sc-client-api",
@@ -7775,25 +7762,19 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "asynchronous-codec",
- "bitflags",
  "bytes",
- "cid",
  "either",
  "fnv",
- "fork-tree",
  "futures",
  "futures-timer",
  "ip_network",
  "libp2p",
- "linked-hash-map",
- "linked_hash_set",
  "log",
  "lru",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "pin-project",
- "prost",
- "rand 0.7.3",
+ "rand 0.8.5",
  "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
@@ -7846,7 +7827,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "unsigned-varint",
- "void",
 ]
 
 [[package]]
@@ -7961,7 +7941,7 @@ dependencies = [
  "libp2p",
  "log",
  "parking_lot 0.12.1",
- "rand 0.7.3",
+ "rand 0.8.5",
  "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
@@ -7987,7 +7967,6 @@ version = "0.10.0-dev"
 dependencies = [
  "array-bytes",
  "futures",
- "hex",
  "libp2p",
  "log",
  "parity-scale-codec",
@@ -8016,7 +7995,7 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "rand 0.7.3",
+ "rand 0.8.5",
  "sc-block-builder",
  "sc-client-api",
  "sc-client-db",
@@ -8044,7 +8023,7 @@ dependencies = [
  "futures",
  "libp2p",
  "log",
- "rand 0.7.3",
+ "rand 0.8.5",
  "sc-utils",
  "serde_json",
  "wasm-timer",
@@ -8174,13 +8153,12 @@ dependencies = [
  "exit-future",
  "futures",
  "futures-timer",
- "hash-db",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "pin-project",
- "rand 0.7.3",
+ "rand 0.8.5",
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
@@ -8208,19 +8186,15 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-api",
- "sp-application-crypto",
- "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
  "sp-externalities",
- "sp-inherents",
  "sp-keystore",
  "sp-runtime",
  "sp-session",
  "sp-state-machine",
  "sp-storage",
- "sp-tracing",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
  "sp-trie",
@@ -8259,9 +8233,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-externalities",
  "sp-io",
- "sp-panic-handler",
  "sp-runtime",
  "sp-state-machine",
  "sp-storage",
@@ -8309,8 +8281,8 @@ dependencies = [
  "futures",
  "libc",
  "log",
- "rand 0.7.3",
- "rand_pcg 0.2.1",
+ "rand 0.8.5",
+ "rand_pcg",
  "regex",
  "sc-telemetry",
  "serde",
@@ -8331,7 +8303,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.1",
  "pin-project",
- "rand 0.7.3",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "thiserror",
@@ -8929,11 +8901,10 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "primitive-types",
- "rand 0.7.3",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "sp-core",
- "sp-debug-derive",
  "sp-std",
  "static_assertions",
 ]
@@ -9135,7 +9106,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "primitive-types",
- "rand 0.7.3",
+ "rand 0.8.5",
  "regex",
  "scale-info",
  "schnorrkel",
@@ -9325,7 +9296,7 @@ name = "sp-npos-elections"
 version = "4.0.0-dev"
 dependencies = [
  "parity-scale-codec",
- "rand 0.7.3",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "sp-arithmetic",
@@ -9386,7 +9357,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "paste",
- "rand 0.7.3",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "serde_json",
@@ -9520,7 +9491,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "pretty_assertions",
- "rand 0.7.3",
+ "rand 0.8.5",
  "smallvec",
  "sp-core",
  "sp-externalities",
@@ -10252,17 +10223,17 @@ dependencies = [
 
 [[package]]
 name = "tiny-bip39"
-version = "0.8.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc59cb9dfc85bb312c3a78fd6aa8a8582e310b0fa885d5bb877f6dcc601839d"
+checksum = "62cc94d358b5a1e84a5cb9109f559aa3c4d634d2b1b4de3d0fa4adc7c78e2861"
 dependencies = [
  "anyhow",
- "hmac 0.8.1",
+ "hmac 0.12.1",
  "once_cell",
- "pbkdf2 0.4.0",
- "rand 0.7.3",
+ "pbkdf2 0.11.0",
+ "rand 0.8.5",
  "rustc-hash",
- "sha2 0.9.8",
+ "sha2 0.10.2",
  "thiserror",
  "unicode-normalization",
  "wasm-bindgen",
@@ -10751,9 +10722,9 @@ checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.17"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]

--- a/bin/node/bench/Cargo.toml
+++ b/bin/node/bench/Cargo.toml
@@ -36,7 +36,7 @@ sp-tracing = { version = "6.0.0", path = "../../../primitives/tracing" }
 hash-db = "0.15.2"
 tempfile = "3.1.0"
 fs_extra = "1"
-rand = { version = "0.7.2", features = ["small_rng"] }
+rand = { version = "0.8.5", features = ["small_rng"] }
 lazy_static = "1.4.0"
 parity-db = "0.4.2"
 sc-transaction-pool = { version = "4.0.0-dev", path = "../../../client/transaction-pool" }

--- a/client/api/Cargo.toml
+++ b/client/api/Cargo.toml
@@ -19,7 +19,6 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 ] }
 fnv = "1.0.6"
 futures = "0.3.21"
-hash-db = { version = "0.15.2", default-features = false }
 log = "0.4.17"
 parking_lot = "0.12.1"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", path = "../../utils/prometheus" }
@@ -36,7 +35,6 @@ sp-keystore = { version = "0.13.0", default-features = false, path = "../../prim
 sp-runtime = { version = "7.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-state-machine = { version = "0.13.0", path = "../../primitives/state-machine" }
 sp-storage = { version = "7.0.0", path = "../../primitives/storage" }
-sp-trie = { version = "7.0.0", path = "../../primitives/trie" }
 
 [dev-dependencies]
 thiserror = "1.0.30"

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -24,7 +24,7 @@ ip_network = "0.4.1"
 libp2p = { version = "0.49.0", default-features = false, features = ["kad"] }
 log = "0.4.17"
 prost = "0.11"
-rand = "0.7.2"
+rand = "0.8.5"
 thiserror = "1.0"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", path = "../../utils/prometheus" }
 sc-client-api = { version = "4.0.0-dev", path = "../api" }

--- a/client/beefy/Cargo.toml
+++ b/client/beefy/Cargo.toml
@@ -14,17 +14,14 @@ async-trait = "0.1.57"
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 fnv = "1.0.6"
 futures = "0.3"
-futures-timer = "3.0.1"
 log = "0.4"
 parking_lot = "0.12.1"
 thiserror = "1.0"
 wasm-timer = "0.2.5"
 beefy-primitives = { version = "4.0.0-dev", path = "../../primitives/beefy", package = "sp-beefy" }
 prometheus = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", path = "../../utils/prometheus" }
-sc-chain-spec = { version = "4.0.0-dev", path = "../../client/chain-spec" }
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sc-consensus = { version = "0.10.0-dev", path = "../consensus/common" }
-sc-finality-grandpa = { version = "0.10.0-dev", path = "../../client/finality-grandpa" }
 sc-keystore = { version = "4.0.0-dev", path = "../keystore" }
 sc-network = { version = "0.10.0-dev", path = "../network" }
 sc-network-common = { version = "0.10.0-dev", path = "../network/common" }

--- a/client/beefy/rpc/Cargo.toml
+++ b/client/beefy/rpc/Cargo.toml
@@ -19,7 +19,6 @@ thiserror = "1.0"
 beefy-gadget = { version = "4.0.0-dev", path = "../." }
 beefy-primitives = { version = "4.0.0-dev", path = "../../../primitives/beefy", package = "sp-beefy" }
 sc-rpc = { version = "4.0.0-dev", path = "../../rpc" }
-sc-utils = { version = "4.0.0-dev", path = "../../utils" }
 sp-core = { version = "7.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "7.0.0", path = "../../../primitives/runtime" }
 

--- a/client/chain-spec/Cargo.toml
+++ b/client/chain-spec/Cargo.toml
@@ -13,8 +13,6 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0" }
-impl-trait-for-tuples = "0.2.2"
 memmap2 = "0.5.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.85"

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -22,13 +22,13 @@ libp2p = "0.49.0"
 log = "0.4.17"
 names = { version = "0.13.0", default-features = false }
 parity-scale-codec = "3.0.0"
-rand = "0.7.3"
+rand = "0.8.5"
 regex = "1.6.0"
 rpassword = "7.0.0"
 serde = "1.0.136"
 serde_json = "1.0.85"
 thiserror = "1.0.30"
-tiny-bip39 = "0.8.2"
+tiny-bip39 = "1.0.0"
 tokio = { version = "1.22.0", features = ["signal", "rt-multi-thread", "parking_lot"] }
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sc-client-db = { version = "0.10.0-dev", default-features = false, path = "../db" }

--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -24,7 +24,6 @@ num-rational = "0.4.1"
 num-traits = "0.2.8"
 parking_lot = "0.12.1"
 schnorrkel = { version = "0.9.1", features = ["preaudit_deprecated"] }
-serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0"
 fork-tree = { version = "3.0.0", path = "../../../utils/fork-tree" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", path = "../../../utils/prometheus" }
@@ -44,10 +43,8 @@ sp-consensus-slots = { version = "0.10.0-dev", path = "../../../primitives/conse
 sp-consensus-vrf = { version = "0.10.0-dev", path = "../../../primitives/consensus/vrf" }
 sp-core = { version = "7.0.0", path = "../../../primitives/core" }
 sp-inherents = { version = "4.0.0-dev", path = "../../../primitives/inherents" }
-sp-io = { version = "7.0.0", path = "../../../primitives/io" }
 sp-keystore = { version = "0.13.0", path = "../../../primitives/keystore" }
 sp-runtime = { version = "7.0.0", path = "../../../primitives/runtime" }
-sp-version = { version = "5.0.0", path = "../../../primitives/version" }
 
 [dev-dependencies]
 rand_chacha = "0.2.2"

--- a/client/consensus/slots/Cargo.toml
+++ b/client/consensus/slots/Cargo.toml
@@ -19,7 +19,6 @@ codec = { package = "parity-scale-codec", version = "3.0.0" }
 futures = "0.3.21"
 futures-timer = "3.0.1"
 log = "0.4.17"
-thiserror = "1.0.30"
 sc-client-api = { version = "4.0.0-dev", path = "../../api" }
 sc-consensus = { version = "0.10.0-dev", path = "../../../client/consensus/common" }
 sc-telemetry = { version = "4.0.0-dev", path = "../../telemetry" }

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -37,7 +37,7 @@ sp-trie = { version = "7.0.0", path = "../../primitives/trie" }
 [dev-dependencies]
 criterion = "0.3.3"
 kvdb-rocksdb = "0.17.0"
-rand = "0.8.4"
+rand = "0.8.5"
 tempfile = "3.1.0"
 quickcheck = { version = "1.0.3", default-features = false }
 kitchensink-runtime = { path = "../../bin/node/runtime" }

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -24,7 +24,7 @@ futures-timer = "3.0.1"
 log = "0.4.17"
 parity-scale-codec = { version = "3.0.0", features = ["derive"] }
 parking_lot = "0.12.1"
-rand = "0.8.4"
+rand = "0.8.5"
 serde_json = "1.0.85"
 thiserror = "1.0"
 fork-tree = { version = "3.0.0", path = "../../utils/fork-tree" }

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -33,7 +33,6 @@ sc-block-builder = { version = "0.10.0-dev", path = "../block-builder" }
 sc-chain-spec = { version = "4.0.0-dev", path = "../../client/chain-spec" }
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sc-consensus = { version = "0.10.0-dev", path = "../consensus/common" }
-sc-keystore = { version = "4.0.0-dev", path = "../keystore" }
 sc-network = { version = "0.10.0-dev", path = "../network" }
 sc-network-gossip = { version = "0.10.0-dev", path = "../network-gossip" }
 sc-network-common = { version = "0.10.0-dev", path = "../network/common" }

--- a/client/finality-grandpa/rpc/Cargo.toml
+++ b/client/finality-grandpa/rpc/Cargo.toml
@@ -16,7 +16,6 @@ jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"]
 log = "0.4.8"
 parity-scale-codec = { version = "3.0.0", features = ["derive"] }
 serde = { version = "1.0.105", features = ["derive"] }
-serde_json = "1.0.50"
 thiserror = "1.0"
 sc-client-api = { version = "4.0.0-dev", path = "../../api" }
 sc-finality-grandpa = { version = "0.10.0-dev", path = "../" }

--- a/client/informant/Cargo.toml
+++ b/client/informant/Cargo.toml
@@ -19,6 +19,5 @@ futures-timer = "3.0.1"
 log = "0.4.17"
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sc-network-common = { version = "0.10.0-dev", path = "../network/common" }
-sc-transaction-pool-api = { version = "4.0.0-dev", path = "../transaction-pool/api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sp-runtime = { version = "7.0.0", path = "../../primitives/runtime" }

--- a/client/merkle-mountain-range/Cargo.toml
+++ b/client/merkle-mountain-range/Cargo.toml
@@ -20,7 +20,6 @@ sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }
 sp-core = { version = "7.0.0", path = "../../primitives/core" }
-sp-io = { version = "7.0.0", path = "../../primitives/io" }
 sp-mmr-primitives = { version = "4.0.0-dev", path = "../../primitives/merkle-mountain-range" }
 sc-offchain = { version = "4.0.0-dev", path = "../offchain" }
 sp-runtime = { version = "7.0.0", path = "../../primitives/runtime" }

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -51,7 +51,6 @@ sp-runtime = { version = "7.0.0", path = "../../primitives/runtime" }
 
 [dev-dependencies]
 assert_matches = "1.3"
-rand = "0.8.5"
 tempfile = "3.1.0"
 tokio = { version = "1.22.0", features = ["macros"] }
 tokio-util = { version = "0.7.4", features = ["compat"] }

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -17,9 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 array-bytes = "4.1"
 async-trait = "0.1"
 asynchronous-codec = "0.6"
-bitflags = "1.3.2"
 bytes = "1"
-cid = "0.8.4"
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 either = "1.5.3"
 fnv = "1.0.6"
@@ -27,21 +25,17 @@ futures = "0.3.21"
 futures-timer = "3.0.2"
 ip_network = "0.4.1"
 libp2p = { version = "0.49.0", features = ["dns", "identify", "kad", "mdns", "mplex", "noise", "ping", "tcp", "tokio", "yamux", "websocket"] }
-linked_hash_set = "0.1.3"
-linked-hash-map = "0.5.4"
 log = "0.4.17"
 lru = "0.8.1"
 parking_lot = "0.12.1"
 pin-project = "1.0.12"
-prost = "0.11"
-rand = "0.7.2"
+rand = "0.8.5"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.85"
 smallvec = "1.8.0"
 thiserror = "1.0"
 unsigned-varint = { version = "0.7.1", features = ["futures", "asynchronous_codec"] }
 zeroize = "1.4.3"
-fork-tree = { version = "3.0.0", path = "../../utils/fork-tree" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", path = "../../utils/prometheus" }
 sc-block-builder = { version = "0.10.0-dev", path = "../block-builder" }
 sc-client-api = { version = "4.0.0-dev", path = "../api" }
@@ -57,7 +51,7 @@ sp-runtime = { version = "7.0.0", path = "../../primitives/runtime" }
 
 [dev-dependencies]
 assert_matches = "1.3"
-rand = "0.7.2"
+rand = "0.8.5"
 tempfile = "3.1.0"
 tokio = { version = "1.22.0", features = ["macros"] }
 tokio-util = { version = "0.7.4", features = ["compat"] }

--- a/client/network/bitswap/Cargo.toml
+++ b/client/network/bitswap/Cargo.toml
@@ -23,7 +23,6 @@ log = "0.4.17"
 prost = "0.11"
 thiserror = "1.0"
 unsigned-varint = { version = "0.7.1", features = ["futures", "asynchronous_codec"] }
-void = "1.0.2"
 sc-client-api = { version = "4.0.0-dev", path = "../../api" }
 sc-network-common = { version = "0.10.0-dev", path = "../common" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }

--- a/client/network/test/Cargo.toml
+++ b/client/network/test/Cargo.toml
@@ -20,7 +20,7 @@ futures-timer = "3.0.1"
 libp2p = { version = "0.49.0", default-features = false }
 log = "0.4.17"
 parking_lot = "0.12.1"
-rand = "0.7.2"
+rand = "0.8.5"
 sc-block-builder = { version = "0.10.0-dev", path = "../../block-builder" }
 sc-client-api = { version = "4.0.0-dev", path = "../../api" }
 sc-consensus = { version = "0.10.0-dev", path = "../../consensus/common" }

--- a/client/network/transactions/Cargo.toml
+++ b/client/network/transactions/Cargo.toml
@@ -16,7 +16,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 array-bytes = "4.1"
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 futures = "0.3.21"
-hex = "0.4.0"
 libp2p = "0.49.0"
 log = "0.4.17"
 pin-project = "1.0.12"

--- a/client/offchain/Cargo.toml
+++ b/client/offchain/Cargo.toml
@@ -25,7 +25,7 @@ libp2p = { version = "0.49.0", default-features = false }
 num_cpus = "1.13"
 once_cell = "1.8"
 parking_lot = "0.12.1"
-rand = "0.7.2"
+rand = "0.8.5"
 threadpool = "1.7"
 tracing = "0.1.29"
 sc-client-api = { version = "4.0.0-dev", path = "../api" }

--- a/client/peerset/Cargo.toml
+++ b/client/peerset/Cargo.toml
@@ -22,4 +22,4 @@ wasm-timer = "0.2"
 sc-utils = { version = "4.0.0-dev", path = "../utils" }
 
 [dev-dependencies]
-rand = "0.7.2"
+rand = "0.8.5"

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -14,9 +14,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
-futures = "0.3.21"
-log = "0.4.17"
-parking_lot = "0.12.1"
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.85"
@@ -26,6 +23,5 @@ sc-transaction-pool-api = { version = "4.0.0-dev", path = "../transaction-pool/a
 sp-core = { version = "7.0.0", path = "../../primitives/core" }
 sp-rpc = { version = "6.0.0", path = "../../primitives/rpc" }
 sp-runtime = { version = "7.0.0", path = "../../primitives/runtime" }
-sp-tracing = { version = "6.0.0", path = "../../primitives/tracing" }
 sp-version = { version = "5.0.0", path = "../../primitives/version" }
 jsonrpsee = { version = "0.16.2", features = ["server", "client-core", "macros"] }

--- a/client/rpc-servers/Cargo.toml
+++ b/client/rpc-servers/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-futures = "0.3.21"
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 log = "0.4.17"
 serde_json = "1.0.85"

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -15,9 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 futures = "0.3.21"
-hash-db = { version = "0.15.2", default-features = false }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
-lazy_static = { version = "1.4.0", optional = true }
 log = "0.4.17"
 parking_lot = "0.12.1"
 serde_json = "1.0.85"
@@ -43,7 +41,6 @@ tokio = { version = "1.22.0", optional = true }
 [dev-dependencies]
 env_logger = "0.9"
 assert_matches = "1.3.0"
-lazy_static = "1.4.0"
 sc-block-builder = { version = "0.10.0-dev", path = "../block-builder" }
 sc-network = { version = "0.10.0-dev", path = "../network" }
 sc-network-common = { version = "0.10.0-dev", path = "../network/common" }
@@ -54,4 +51,4 @@ sp-io = { version = "7.0.0", path = "../../primitives/io" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }
 
 [features]
-test-helpers = ["lazy_static", "tokio"]
+test-helpers = ["tokio"]

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -25,13 +25,12 @@ runtime-benchmarks = ["sc-client-db/runtime-benchmarks"]
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 thiserror = "1.0.30"
 futures = "0.3.21"
-rand = "0.7.3"
+rand = "0.8.5"
 parking_lot = "0.12.1"
 log = "0.4.17"
 futures-timer = "3.0.1"
 exit-future = "0.2.0"
 pin-project = "1.0.12"
-hash-db = "0.15.2"
 serde = "1.0.136"
 serde_json = "1.0.85"
 sc-keystore = { version = "4.0.0-dev", path = "../keystore" }
@@ -45,10 +44,8 @@ sp-core = { version = "7.0.0", path = "../../primitives/core" }
 sp-keystore = { version = "0.13.0", path = "../../primitives/keystore" }
 sp-session = { version = "4.0.0-dev", path = "../../primitives/session" }
 sp-state-machine = { version = "0.13.0", path = "../../primitives/state-machine" }
-sp-application-crypto = { version = "7.0.0", path = "../../primitives/application-crypto" }
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }
 sc-consensus = { version = "0.10.0-dev", path = "../../client/consensus/common" }
-sp-inherents = { version = "4.0.0-dev", path = "../../primitives/inherents" }
 sp-storage = { version = "7.0.0", path = "../../primitives/storage" }
 sc-network = { version = "0.10.0-dev", path = "../network" }
 sc-network-bitswap = { version = "0.10.0-dev", path = "../network/bitswap" }
@@ -70,13 +67,11 @@ sc-rpc-server = { version = "4.0.0-dev", path = "../rpc-servers" }
 sc-rpc = { version = "4.0.0-dev", path = "../rpc" }
 sc-rpc-spec-v2 = { version = "0.10.0-dev", path = "../rpc-spec-v2" }
 sc-block-builder = { version = "0.10.0-dev", path = "../block-builder" }
-sp-block-builder = { version = "4.0.0-dev", path = "../../primitives/block-builder" }
 sc-informant = { version = "0.10.0-dev", path = "../informant" }
 sc-telemetry = { version = "4.0.0-dev", path = "../telemetry" }
 sc-offchain = { version = "4.0.0-dev", path = "../offchain" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.10.0-dev" }
 sc-tracing = { version = "4.0.0-dev", path = "../tracing" }
-sp-tracing = { version = "6.0.0", path = "../../primitives/tracing" }
 sc-sysinfo = { version = "6.0.0-dev", path = "../sysinfo" }
 tracing = "0.1.29"
 tracing-futures = { version = "0.2.4" }

--- a/client/service/test/Cargo.toml
+++ b/client/service/test/Cargo.toml
@@ -33,8 +33,6 @@ sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
 sp-consensus = { version = "0.10.0-dev", path = "../../../primitives/consensus/common" }
 sp-core = { version = "7.0.0", path = "../../../primitives/core" }
-sp-externalities = { version = "0.13.0", path = "../../../primitives/externalities" }
-sp-panic-handler = { version = "5.0.0", path = "../../../primitives/panic-handler" }
 sp-runtime = { version = "7.0.0", path = "../../../primitives/runtime" }
 sp-state-machine = { version = "0.13.0", path = "../../../primitives/state-machine" }
 sp-storage = { version = "7.0.0", path = "../../../primitives/storage" }

--- a/client/state-db/Cargo.toml
+++ b/client/state-db/Cargo.toml
@@ -16,5 +16,4 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 log = "0.4.17"
 parking_lot = "0.12.1"
-sc-client-api = { version = "4.0.0-dev", path = "../api" }
 sp-core = { version = "7.0.0", path = "../../primitives/core" }

--- a/client/sysinfo/Cargo.toml
+++ b/client/sysinfo/Cargo.toml
@@ -17,8 +17,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 futures = "0.3.19"
 libc = "0.2"
 log = "0.4.17"
-rand = "0.7.3"
-rand_pcg = "0.2.1"
+rand = "0.8.5"
+rand_pcg = "0.3.1"
 regex = "1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.85"

--- a/client/telemetry/Cargo.toml
+++ b/client/telemetry/Cargo.toml
@@ -20,7 +20,7 @@ libp2p = { version = "0.49.0", default-features = false, features = ["dns", "tcp
 log = "0.4.17"
 parking_lot = "0.12.1"
 pin-project = "1.0.12"
-rand = "0.7.2"
+rand = "0.8.5"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.85"
 thiserror = "1.0.30"

--- a/client/telemetry/src/node.rs
+++ b/client/telemetry/src/node.rs
@@ -76,7 +76,7 @@ enum NodeSocket<TTrans: Transport> {
 
 impl<TTrans: Transport> NodeSocket<TTrans> {
 	fn wait_reconnect() -> NodeSocket<TTrans> {
-		let random_delay = rand::thread_rng().gen_range(10, 20);
+		let random_delay = rand::thread_rng().gen_range(10..20);
 		let delay = Delay::new(Duration::from_secs(random_delay));
 		log::trace!(target: "telemetry", "Pausing for {} secs before reconnecting", random_delay);
 		NodeSocket::WaitingReconnect(delay)

--- a/frame/election-provider-multi-phase/Cargo.toml
+++ b/frame/election-provider-multi-phase/Cargo.toml
@@ -12,7 +12,6 @@ description = "PALLET two phase election providers"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-static_assertions = "1.1.0"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
 	"derive",
 ] }
@@ -35,12 +34,12 @@ frame-election-provider-support = { version = "4.0.0-dev", default-features = fa
 # Optional imports for benchmarking
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 pallet-election-provider-support-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../election-provider-support/benchmarking", optional = true }
-rand = { version = "0.7.3", default-features = false, features = ["alloc", "small_rng"], optional = true }
+rand = { version = "0.8.5", default-features = false, features = ["alloc", "small_rng"], optional = true }
 strum = { version = "0.24.1",  default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 parking_lot = "0.12.1"
-rand = { version = "0.7.3" }
+rand = "0.8.5"
 sp-core = { version = "7.0.0", default-features = false, path = "../../primitives/core" }
 sp-io = { version = "7.0.0", path = "../../primitives/io" }
 sp-npos-elections = { version = "4.0.0-dev", default-features = false, path = "../../primitives/npos-elections" }

--- a/frame/election-provider-support/Cargo.toml
+++ b/frame/election-provider-support/Cargo.toml
@@ -24,7 +24,7 @@ sp-std = { version = "5.0.0", default-features = false, path = "../../primitives
 sp-core = { version = "7.0.0", default-features = false, path = "../../primitives/core" }
 
 [dev-dependencies]
-rand = "0.8.5"
+rand = { version = "0.8.5", features = ["small_rng"] }
 sp-io = { version = "7.0.0", path = "../../primitives/io" }
 sp-npos-elections = { version = "4.0.0-dev", path = "../../primitives/npos-elections" }
 

--- a/frame/election-provider-support/Cargo.toml
+++ b/frame/election-provider-support/Cargo.toml
@@ -24,7 +24,7 @@ sp-std = { version = "5.0.0", default-features = false, path = "../../primitives
 sp-core = { version = "7.0.0", default-features = false, path = "../../primitives/core" }
 
 [dev-dependencies]
-rand = "0.7.3"
+rand = "0.8.5"
 sp-io = { version = "7.0.0", path = "../../primitives/io" }
 sp-npos-elections = { version = "4.0.0-dev", path = "../../primitives/npos-elections" }
 

--- a/frame/election-provider-support/src/mock.rs
+++ b/frame/election-provider-support/src/mock.rs
@@ -97,7 +97,7 @@ pub fn generate_random_votes(
 		// it's not interesting if a voter chooses 0 or all candidates, so rule those cases out.
 		// also, let's not generate any cases which result in a compact overflow.
 		let n_candidates_chosen =
-			rng.gen_range(1, candidates.len().min(<TestSolution as crate::NposSolution>::LIMIT));
+			rng.gen_range(1..candidates.len().min(<TestSolution as crate::NposSolution>::LIMIT));
 
 		let mut chosen_candidates = Vec::with_capacity(n_candidates_chosen);
 		chosen_candidates.extend(candidates.choose_multiple(&mut rng, n_candidates_chosen));
@@ -106,7 +106,7 @@ pub fn generate_random_votes(
 
 	// always generate a sensible number of winners: elections are uninteresting if nobody wins,
 	// or everybody wins
-	let num_winners = rng.gen_range(1, candidate_count);
+	let num_winners = rng.gen_range(1..candidate_count);
 	let mut winners: HashSet<AccountId> = HashSet::with_capacity(num_winners);
 	winners.extend(candidates.choose_multiple(&mut rng, num_winners));
 	assert_eq!(winners.len(), num_winners);
@@ -123,7 +123,7 @@ pub fn generate_random_votes(
 			let mut available_stake = 1000;
 			let mut stake_distribution = Vec::with_capacity(num_chosen_winners);
 			for _ in 0..num_chosen_winners - 1 {
-				let stake = rng.gen_range(0, available_stake).min(1);
+				let stake = rng.gen_range(0..available_stake).min(1);
 				stake_distribution.push(TestAccuracy::from_perthousand(stake));
 				available_stake -= stake;
 			}

--- a/frame/election-provider-support/src/tests.rs
+++ b/frame/election-provider-support/src/tests.rs
@@ -92,7 +92,7 @@ mod solution_type {
 
 	#[test]
 	fn from_assignment_fail_too_many_voters() {
-		let rng = rand::rngs::SmallRng::seed_from_u64(0);
+		let rng = rand::rngs::SmallRng::seed_from_u64(1);
 
 		// This will produce 24 voters..
 		let (voters, assignments, candidates) = generate_random_votes(10, 25, rng);

--- a/frame/session/benchmarking/Cargo.toml
+++ b/frame/session/benchmarking/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-rand = { version = "0.8.5", default-features = false }
+rand = { version = "0.8.5", default-features = false, features = ["std_rng"] }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../../benchmarking" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system" }

--- a/frame/session/benchmarking/Cargo.toml
+++ b/frame/session/benchmarking/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-rand = { version = "0.7.2", default-features = false }
+rand = { version = "0.8.5", default-features = false }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../../benchmarking" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system" }

--- a/primitives/arithmetic/Cargo.toml
+++ b/primitives/arithmetic/Cargo.toml
@@ -23,14 +23,13 @@ num-traits = { version = "0.2.8", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.136", features = ["derive"], optional = true }
 static_assertions = "1.1.0"
-sp-debug-derive = { version = "5.0.0", default-features = false, path = "../debug-derive" }
 sp-std = { version = "5.0.0", default-features = false, path = "../std" }
 
 [dev-dependencies]
 criterion = "0.3"
 primitive-types = "0.12.0"
 sp-core = { version = "7.0.0", features = ["full_crypto"], path = "../core" }
-rand = "0.7.2"
+rand = "0.8.5"
 
 [features]
 default = ["std"]
@@ -39,7 +38,6 @@ std = [
 	"num-traits/std",
 	"scale-info/std",
 	"serde",
-	"sp-debug-derive/std",
 	"sp-std/std",
 ]
 

--- a/primitives/arithmetic/benches/bench.rs
+++ b/primitives/arithmetic/benches/bench.rs
@@ -21,7 +21,7 @@ use sp_arithmetic::biguint::{BigUint, Single};
 
 fn random_big_uint(size: usize) -> BigUint {
 	let mut rng = rand::thread_rng();
-	let digits: Vec<_> = (0..size).map(|_| rng.gen_range(0, Single::max_value())).collect();
+	let digits: Vec<_> = (0..size).map(|_| rng.gen_range(0..Single::MAX)).collect();
 	BigUint::from_limbs(&digits)
 }
 
@@ -64,7 +64,7 @@ fn bench_division(c: &mut Criterion) {
 		group.throughput(Throughput::Elements(*size));
 		group.bench_with_input(BenchmarkId::from_parameter(size), size, |bencher, &size| {
 			let a = random_big_uint(size as usize);
-			let b = random_big_uint(rand::thread_rng().gen_range(2, size as usize));
+			let b = random_big_uint(rand::thread_rng().gen_range(2..size as usize));
 
 			bencher.iter(|| {
 				let _ = a.clone().div(&b, true);

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -19,7 +19,6 @@ codec = { package = "parity-scale-codec", version = "3.0.0", features = [
 	"derive",
 ] }
 futures = { version = "0.3.21", features = ["thread-pool"] }
-futures-timer = "3.0.1"
 log = "0.4.17"
 thiserror = "1.0.30"
 sp-core = { version = "7.0.0", path = "../../core" }

--- a/primitives/consensus/slots/Cargo.toml
+++ b/primitives/consensus/slots/Cargo.toml
@@ -16,8 +16,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
-sp-arithmetic = { version = "6.0.0", default-features = false, path = "../../arithmetic" }
-sp-runtime = { version = "7.0.0", default-features = false, path = "../../runtime" }
 sp-std = { version = "5.0.0", default-features = false, path = "../../std" }
 sp-timestamp = { version = "4.0.0-dev", default-features = false, path = "../../timestamp" }
 
@@ -27,8 +25,6 @@ std = [
 	"codec/std",
 	"scale-info/std",
 	"serde",
-	"sp-arithmetic/std",
-	"sp-runtime/std",
 	"sp-std/std",
 	"sp-timestamp/std",
 ]

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -27,9 +27,9 @@ wasmi = { version = "0.13", optional = true }
 hash-db = { version = "0.15.2", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 base58 = { version = "0.2.0", optional = true }
-rand = { version = "0.7.3", optional = true, features = ["small_rng"] }
+rand = { version = "0.8.5", optional = true, features = ["small_rng"] }
 substrate-bip39 = { version = "0.4.4", optional = true }
-tiny-bip39 = { version = "0.8.2", optional = true }
+tiny-bip39 = { version = "1.0.0", optional = true }
 regex = { version = "1.6.0", optional = true }
 num-traits = { version = "0.2.8", default-features = false }
 zeroize = { version = "1.4.3", default-features = false }
@@ -62,7 +62,7 @@ sp-runtime-interface = { version = "7.0.0", default-features = false, path = "..
 
 [dev-dependencies]
 sp-serializer = { version = "4.0.0-dev", path = "../serializer" }
-rand = "0.7.2"
+rand = "0.8.5"
 criterion = "0.3.3"
 serde_json = "1.0"
 sp-core-hashing-proc-macro = { version = "5.0.0", path = "./hashing/proc-macro" }

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -20,10 +20,8 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
-byteorder = { version = "1.3.2", default-features = false }
 primitive-types = { version = "0.12.0", default-features = false, features = ["codec", "scale-info"] }
 impl-serde = { version = "0.4.0", optional = true }
-wasmi = { version = "0.13", optional = true }
 hash-db = { version = "0.15.2", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 base58 = { version = "0.2.0", optional = true }
@@ -31,7 +29,6 @@ rand = { version = "0.8.5", optional = true, features = ["small_rng"] }
 substrate-bip39 = { version = "0.4.4", optional = true }
 tiny-bip39 = { version = "1.0.0", optional = true }
 regex = { version = "1.6.0", optional = true }
-num-traits = { version = "0.2.8", default-features = false }
 zeroize = { version = "1.4.3", default-features = false }
 secrecy = { version = "0.8.0", default-features = false }
 lazy_static = { version = "1.4.0", default-features = false, optional = true }
@@ -81,7 +78,6 @@ std = [
 	"full_crypto",
 	"log/std",
 	"thiserror",
-	"wasmi",
 	"lazy_static",
 	"parking_lot",
 	"primitive-types/std",
@@ -101,11 +97,9 @@ std = [
 	"base58",
 	"substrate-bip39",
 	"tiny-bip39",
-	"byteorder/std",
 	"rand",
 	"schnorrkel/std",
 	"regex",
-	"num-traits/std",
 	"secp256k1/std",
 	"secp256k1/global-context",
 	"sp-core-hashing/std",

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -17,20 +17,17 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 bytes = { version = "1.1.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.1.3", default-features = false, features = ["bytes"] }
-hash-db = { version = "0.15.2", default-features = false }
 sp-core = { version = "7.0.0", default-features = false, path = "../core" }
 sp-keystore = { version = "0.13.0", default-features = false, optional = true, path = "../keystore" }
 sp-std = { version = "5.0.0", default-features = false, path = "../std" }
 libsecp256k1 = { version = "0.7", optional = true }
 sp-state-machine = { version = "0.13.0", default-features = false, optional = true, path = "../state-machine" }
-sp-wasm-interface = { version = "7.0.0", path = "../wasm-interface", default-features = false }
 sp-runtime-interface = { version = "7.0.0", default-features = false, path = "../runtime-interface" }
 sp-trie = { version = "7.0.0", default-features = false, optional = true, path = "../trie" }
 sp-externalities = { version = "0.13.0", default-features = false, path = "../externalities" }
 sp-tracing = { version = "6.0.0", default-features = false, path = "../tracing" }
 log = { version = "0.4.17", optional = true }
 futures = { version = "0.3.21", features = ["thread-pool"], optional = true }
-parking_lot = { version = "0.12.1", optional = true }
 secp256k1 = { version = "0.24.0", features = ["recovery", "global-context"], optional = true }
 tracing = { version = "0.1.29", default-features = false }
 tracing-core = { version = "0.1.28", default-features = false}
@@ -45,19 +42,16 @@ std = [
 	"sp-keystore",
 	"codec/std",
 	"sp-std/std",
-	"hash-db/std",
 	"sp-trie/std",
 	"sp-state-machine/std",
 	"libsecp256k1",
 	"secp256k1",
 	"sp-runtime-interface/std",
-	"sp-wasm-interface/std",
 	"sp-tracing/std",
 	"tracing/std",
 	"tracing-core/std",
 	"log",
 	"futures",
-	"parking_lot",
 	"ed25519-dalek",
 ]
 

--- a/primitives/npos-elections/Cargo.toml
+++ b/primitives/npos-elections/Cargo.toml
@@ -22,7 +22,7 @@ sp-runtime = { version = "7.0.0", default-features = false, path = "../runtime" 
 sp-std = { version = "5.0.0", default-features = false, path = "../std" }
 
 [dev-dependencies]
-rand = "0.7.3"
+rand = "0.8.5"
 substrate-test-utils = { version = "4.0.0-dev", path = "../../test-utils" }
 
 [features]

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -20,7 +20,7 @@ hash256-std-hasher = { version = "0.15.2", default-features = false }
 impl-trait-for-tuples = "0.2.2"
 log = { version = "0.4.17", default-features = false }
 paste = "1.0"
-rand = { version = "0.7.2", optional = true }
+rand = { version = "0.8.5", optional = true }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.136", features = ["derive"], optional = true }
 sp-application-crypto = { version = "7.0.0", default-features = false, path = "../application-crypto" }
@@ -31,7 +31,7 @@ sp-std = { version = "5.0.0", default-features = false, path = "../std" }
 sp-weights = { version = "4.0.0", default-features = false, path = "../weights" }
 
 [dev-dependencies]
-rand = "0.7.2"
+rand = "0.8.5"
 serde_json = "1.0.85"
 zstd = { version = "0.11.2", default-features = false }
 sp-api = { version = "4.0.0-dev", path = "../api" }

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -19,7 +19,7 @@ hash-db = { version = "0.15.2", default-features = false }
 log = { version = "0.4.17", optional = true }
 num-traits = { version = "0.2.8", default-features = false }
 parking_lot = { version = "0.12.1", optional = true }
-rand = { version = "0.7.2", optional = true }
+rand = { version = "0.8.5", optional = true }
 smallvec = "1.8.0"
 thiserror = { version = "1.0.30", optional = true }
 tracing = { version = "0.1.29", optional = true }
@@ -33,7 +33,7 @@ sp-trie = { version = "7.0.0", default-features = false, path = "../trie" }
 [dev-dependencies]
 array-bytes = "4.1"
 pretty_assertions = "1.2.1"
-rand = "0.7.2"
+rand = "0.8.5"
 sp-runtime = { version = "7.0.0", path = "../runtime" }
 trie-db = "0.24.0"
 assert_matches = "1.5"

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -17,13 +17,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 hash-db = { version = "0.15.2", default-features = false }
 log = { version = "0.4.17", optional = true }
-num-traits = { version = "0.2.8", default-features = false }
 parking_lot = { version = "0.12.1", optional = true }
 rand = { version = "0.8.5", optional = true }
 smallvec = "1.8.0"
 thiserror = { version = "1.0.30", optional = true }
 tracing = { version = "0.1.29", optional = true }
-trie-root = { version = "0.17.0", default-features = false }
 sp-core = { version = "7.0.0", default-features = false, path = "../core" }
 sp-externalities = { version = "0.13.0", default-features = false, path = "../externalities" }
 sp-panic-handler = { version = "5.0.0", optional = true, path = "../panic-handler" }
@@ -44,7 +42,6 @@ std = [
 	"codec/std",
 	"hash-db/std",
 	"log",
-	"num-traits/std",
 	"parking_lot",
 	"rand",
 	"sp-core/std",
@@ -54,5 +51,4 @@ std = [
 	"sp-trie/std",
 	"thiserror",
 	"tracing",
-	"trie-root/std",
 ]

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -1845,7 +1845,7 @@ mod tests {
 		use rand::{rngs::SmallRng, RngCore, SeedableRng};
 		let mut storage: HashMap<Option<ChildInfo>, BTreeMap<StorageKey, StorageValue>> =
 			Default::default();
-		let mut seed = [0; 16];
+		let mut seed = [0; 32];
 		for i in 0..50u32 {
 			let mut child_infos = Vec::new();
 			let seed_partial = &mut seed[0..4];

--- a/primitives/timestamp/Cargo.toml
+++ b/primitives/timestamp/Cargo.toml
@@ -18,7 +18,6 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 futures-timer = { version = "3.0.2", optional = true }
 log = { version = "0.4.17", optional = true }
 thiserror = { version = "1.0.30", optional = true }
-sp-api = { version = "4.0.0-dev", default-features = false, path = "../api" }
 sp-inherents = { version = "4.0.0-dev", default-features = false, path = "../inherents" }
 sp-runtime = { version = "7.0.0", default-features = false, path = "../runtime" }
 sp-std = { version = "5.0.0", default-features = false, path = "../std" }
@@ -30,7 +29,6 @@ std = [
 	"codec/std",
 	"futures-timer",
 	"log",
-	"sp-api/std",
 	"sp-inherents/std",
 	"sp-runtime/std",
 	"sp-std/std",

--- a/primitives/weights/Cargo.toml
+++ b/primitives/weights/Cargo.toml
@@ -14,7 +14,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-impl-trait-for-tuples = "0.2.2"
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 smallvec = "1.8.0"

--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -19,20 +19,15 @@ clap = { version = "4.0.9", features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 comfy-table = { version = "6.0.0", default-features = false }
 handlebars = "4.2.2"
-hash-db = "0.15.2"
 Inflector = "0.11.4"
 itertools = "0.10.3"
-kvdb = "0.13.0"
 lazy_static = "1.4.0"
 linked-hash-map = "0.5.4"
 log = "0.4.17"
-memory-db = "0.31.0"
 rand = { version = "0.8.4", features = ["small_rng"] }
 rand_pcg = "0.3.1"
 serde = "1.0.136"
 serde_json = "1.0.85"
-serde_nanos = "0.1.2"
-tempfile = "3.2.0"
 thiserror = "1.0.30"
 thousands = "0.2.0"
 frame-benchmarking = { version = "4.0.0-dev", path = "../../../frame/benchmarking" }

--- a/utils/frame/generate-bags/Cargo.toml
+++ b/utils/frame/generate-bags/Cargo.toml
@@ -15,9 +15,6 @@ frame-election-provider-support = { version = "4.0.0-dev", path = "../../../fram
 frame-system = { version = "4.0.0-dev", path = "../../../frame/system" }
 pallet-staking = { version = "4.0.0-dev", path = "../../../frame/staking" }
 
-# primitives
-sp-io = { version = "7.0.0", path = "../../../primitives/io" }
-
 # third party
 chrono = { version = "0.4.19" }
 git2 = { version = "0.14.2", default-features = false }

--- a/utils/frame/remote-externalities/Cargo.toml
+++ b/utils/frame/remote-externalities/Cargo.toml
@@ -13,15 +13,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
-env_logger = "0.9"
 log = "0.4.17"
 serde = "1.0.136"
-serde_json = "1.0"
 frame-support = { version = "4.0.0-dev", optional = true, path = "../../../frame/support" }
 sp-core = { version = "7.0.0", path = "../../../primitives/core" }
 sp-io = { version = "7.0.0", path = "../../../primitives/io" }
 sp-runtime = { version = "7.0.0", path = "../../../primitives/runtime" }
-sp-version = { version = "5.0.0", path = "../../../primitives/version" }
 tokio = { version = "1.22.0", features = ["macros", "rt-multi-thread"] }
 substrate-rpc-client = { path = "../rpc/client" }
 futures = "0.3"

--- a/utils/frame/rpc/state-trie-migration-rpc/Cargo.toml
+++ b/utils/frame/rpc/state-trie-migration-rpc/Cargo.toml
@@ -18,8 +18,6 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 serde = { version = "1", features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 
-sp-std = { path = "../../../../primitives/std" }
-sp-io = { path = "../../../../primitives/io" }
 sp-core = { path = "../../../../primitives/core" }
 sp-state-machine = { path = "../../../../primitives/state-machine" }
 sp-trie = { path = "../../../../primitives/trie" }

--- a/utils/frame/rpc/support/Cargo.toml
+++ b/utils/frame/rpc/support/Cargo.toml
@@ -16,7 +16,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }
-futures = "0.3.21"
 jsonrpsee = { version = "0.16.2", features = ["jsonrpsee-types"] }
 serde = "1"
 frame-support = { version = "4.0.0-dev", path = "../../../../frame/support" }

--- a/utils/frame/rpc/system/Cargo.toml
+++ b/utils/frame/rpc/system/Cargo.toml
@@ -13,13 +13,11 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-serde_json = "1"
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
 futures = "0.3.21"
 log = "0.4.17"
 frame-system-rpc-runtime-api = { version = "4.0.0-dev", path = "../../../../frame/system/rpc/runtime-api" }
-sc-client-api = { version = "4.0.0-dev", path = "../../../../client/api" }
 sc-rpc-api = { version = "0.10.0-dev", path = "../../../../client/rpc-api" }
 sc-transaction-pool-api = { version = "4.0.0-dev", path = "../../../../client/transaction-pool/api" }
 sp-api = { version = "4.0.0-dev", path = "../../../../primitives/api" }

--- a/utils/frame/try-runtime/cli/Cargo.toml
+++ b/utils/frame/try-runtime/cli/Cargo.toml
@@ -13,7 +13,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 remote-externalities = { version = "0.10.0-dev", path = "../../remote-externalities", package = "frame-remote-externalities" }
-sc-chain-spec = { version = "4.0.0-dev", path = "../../../../client/chain-spec" }
 sc-cli = { version = "0.10.0-dev", path = "../../../../client/cli" }
 sc-executor = { version = "0.10.0-dev", path = "../../../../client/executor" }
 sc-service = { version = "0.10.0-dev", default-features = false, path = "../../../../client/service" }

--- a/utils/prometheus/Cargo.toml
+++ b/utils/prometheus/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-futures-util = { version = "0.3.19", default-features = false, features = ["io"] }
 hyper = { version = "0.14.16", default-features = false, features = ["http1", "server", "tcp"] }
 log = "0.4.17"
 prometheus = { version = "0.13.0", default-features = false }


### PR DESCRIPTION
- update `rand` to v0.8.5 (now only `sp-keystore`, `ed25519-dalek` and `schnorrkel` use `rand` v0.7)
- update `tiny-bip39` to v1.0.0
- remove useless dependencies