### PR TITLE
ed25519: Don't panic for invalid signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.0.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c66a534cbb46ab4ea03477eae19d5c22c01da8258030280b7bd9d8433fb6ef"
+checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
  "signature",
 ]
@@ -9245,6 +9245,7 @@ name = "sp-io"
 version = "7.0.0"
 dependencies = [
  "bytes",
+ "ed25519",
  "ed25519-dalek",
  "futures",
  "hash-db",

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -38,7 +38,7 @@ tracing-core = { version = "0.1.28", default-features = false}
 # Required for backwards compatibility reason, but only used for verifying when `UseDalekExt` is set.
 ed25519-dalek = { version = "1.0.1", default-features = false, optional = true }
 # Force the usage of ed25519, this is being used in `ed25519-dalek`.
-ed25519 = "1.5.2"
+ed25519 = { version = "1.5.2", optional = true }
 
 [features]
 default = ["std"]
@@ -63,6 +63,8 @@ std = [
 	"futures",
 	"parking_lot",
 	"ed25519-dalek",
+	"ed25519",
+
 ]
 
 with-tracing = [

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -64,7 +64,6 @@ std = [
 	"parking_lot",
 	"ed25519-dalek",
 	"ed25519",
-
 ]
 
 with-tracing = [

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -34,7 +34,11 @@ parking_lot = { version = "0.12.1", optional = true }
 secp256k1 = { version = "0.24.0", features = ["recovery", "global-context"], optional = true }
 tracing = { version = "0.1.29", default-features = false }
 tracing-core = { version = "0.1.28", default-features = false}
+
+# Required for backwards compatibility reason, but only used for verifying when `UseDalekExt` is set.
 ed25519-dalek = { version = "1.0.1", default-features = false, optional = true }
+# Force the usage of ed25519, this is being used in `ed25519-dalek`.
+ed25519 = "1.5.2"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
We should not panic for an invalid signature when the `UseDalekExt` is given.

