### PR TITLE
txpool: don't validate block transactions if the pool is empty

### DIFF
--- a/client/transaction-pool/src/graph/pool.rs
+++ b/client/transaction-pool/src/graph/pool.rs
@@ -271,7 +271,7 @@ impl<B: ChainApi> Pool<B> {
 				// if it's not found in the pool query the runtime at parent block
 				// to get validity info and tags that the extrinsic provides.
 				None => {
-					// Avoid validating block txs if the pool is empty (substrate/issues #12903)
+					// Avoid validating block txs if the pool is empty
 					if !self.validated_pool.status().is_empty() {
 						let validity = self
 							.validated_pool
@@ -287,7 +287,7 @@ impl<B: ChainApi> Pool<B> {
 							future_tags.extend(validity.provides);
 						}
 					} else {
-						log::trace!( target: "txpool", "txpool is empty, skipping validation for block {:?}", at);
+						log::trace!(target: "txpool", "txpool is empty, skipping validation for block {at:?}");
 					}
 				},
 			}

--- a/client/transaction-pool/src/graph/pool.rs
+++ b/client/transaction-pool/src/graph/pool.rs
@@ -271,14 +271,23 @@ impl<B: ChainApi> Pool<B> {
 				// if it's not found in the pool query the runtime at parent block
 				// to get validity info and tags that the extrinsic provides.
 				None => {
-					let validity = self
-						.validated_pool
-						.api()
-						.validate_transaction(parent, TransactionSource::InBlock, extrinsic.clone())
-						.await;
+					// Avoid validating block txs if the pool is empty (substrate/issues #12903)
+					if !self.validated_pool.status().is_empty() {
+						let validity = self
+							.validated_pool
+							.api()
+							.validate_transaction(
+								parent,
+								TransactionSource::InBlock,
+								extrinsic.clone(),
+							)
+							.await;
 
-					if let Ok(Ok(validity)) = validity {
-						future_tags.extend(validity.provides);
+						if let Ok(Ok(validity)) = validity {
+							future_tags.extend(validity.provides);
+						}
+					} else {
+						log::trace!( target: "txpool", "txpool is empty, skipping validation for block {:?}", at);
 					}
 				},
 			}


### PR DESCRIPTION
Fix shall prevent from wasting the CPU during the major sync. Block
transaction don't need to be re-validated when the txpool is empty.

Part of: #12903
