### PR TITLE
Safety check scheduler `MaximumWeight`

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -345,6 +345,9 @@ impl pallet_proxy::Config for Runtime {
 parameter_types! {
 	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(80) *
 		RuntimeBlockWeights::get().max_block;
+	// We allow the scheduler to have at most 50% overhead.
+	pub MinAvailableTaskWeight: Weight = Perbill::from_percent(50) *
+		MaximumSchedulerWeight::get();
 }
 
 impl pallet_scheduler::Config for Runtime {
@@ -353,6 +356,7 @@ impl pallet_scheduler::Config for Runtime {
 	type PalletsOrigin = OriginCaller;
 	type RuntimeCall = RuntimeCall;
 	type MaximumWeight = MaximumSchedulerWeight;
+	type MinAvailableTaskWeight = MinAvailableTaskWeight;
 	type ScheduleOrigin = EnsureRoot<AccountId>;
 	type MaxScheduledPerBlock = ConstU32<512>;
 	type WeightInfo = pallet_scheduler::weights::SubstrateWeight<Runtime>;

--- a/frame/democracy/src/tests.rs
+++ b/frame/democracy/src/tests.rs
@@ -109,6 +109,9 @@ impl frame_system::Config for Test {
 }
 parameter_types! {
 	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(80) * BlockWeights::get().max_block;
+	// We allow the scheduler to have at most 50% overhead.
+	pub MinAvailableTaskWeight: Weight = Perbill::from_percent(50) *
+		MaximumSchedulerWeight::get();
 }
 
 impl pallet_preimage::Config for Test {
@@ -126,6 +129,7 @@ impl pallet_scheduler::Config for Test {
 	type PalletsOrigin = OriginCaller;
 	type RuntimeCall = RuntimeCall;
 	type MaximumWeight = MaximumSchedulerWeight;
+	type MinAvailableTaskWeight = MinAvailableTaskWeight;
 	type ScheduleOrigin = EnsureRoot<u64>;
 	type MaxScheduledPerBlock = ConstU32<100>;
 	type WeightInfo = ();

--- a/frame/referenda/src/mock.rs
+++ b/frame/referenda/src/mock.rs
@@ -100,12 +100,20 @@ impl pallet_preimage::Config for Test {
 	type BaseDeposit = ();
 	type ByteDeposit = ();
 }
+
+parameter_types! {
+	// We allow the scheduler to have at most 50% overhead.
+	pub MinAvailableTaskWeight: Weight = Perbill::from_percent(50) *
+		MaxWeight::get();
+}
+
 impl pallet_scheduler::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
 	type PalletsOrigin = OriginCaller;
 	type RuntimeCall = RuntimeCall;
 	type MaximumWeight = MaxWeight;
+	type MinAvailableTaskWeight = MinAvailableTaskWeight;
 	type ScheduleOrigin = EnsureRoot<u64>;
 	type MaxScheduledPerBlock = ConstU32<100>;
 	type WeightInfo = ();

--- a/frame/scheduler/src/mock.rs
+++ b/frame/scheduler/src/mock.rs
@@ -208,6 +208,9 @@ impl WeightInfo for TestWeightInfo {
 parameter_types! {
 	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(80) *
 		BlockWeights::get().max_block;
+	// We allow the scheduler to have at most 50% overhead.
+	pub MinAvailableTaskWeight: Weight = Perbill::from_percent(50) *
+		MaximumSchedulerWeight::get();
 }
 
 impl Config for Test {
@@ -216,6 +219,7 @@ impl Config for Test {
 	type PalletsOrigin = OriginCaller;
 	type RuntimeCall = RuntimeCall;
 	type MaximumWeight = MaximumSchedulerWeight;
+	type MinAvailableTaskWeight = MinAvailableTaskWeight;
 	type ScheduleOrigin = EitherOfDiverse<EnsureRoot<u64>, EnsureSignedBy<One, u64>>;
 	type MaxScheduledPerBlock = ConstU32<10>;
 	type WeightInfo = TestWeightInfo;


### PR DESCRIPTION
Adds a config item `MinAvailableTaskWeight` and checks that in each block at least one task of such weight can be dispatched.  
This is important to ensure that runtime upgrades work since #11637 will over-estimate the PoV size quite a lot.

TODO once approved:
- [ ] Companions