### PR TITLE
[contracts] Adapt storage reading host functions to Weights V2

### DIFF
--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -2928,7 +2928,7 @@ benchmarks! {
 	// configured `Schedule` during benchmark development.
 	// It can be outputed using the following command:
 	// cargo run --manifest-path=bin/node/cli/Cargo.toml --release \
-	//     --features runtime-benchmarks -- benchmark --extra --dev --execution=native \
+	//     --features runtime-benchmarks -- benchmark pallet --extra --dev --execution=native \
 	//     -p pallet_contracts -e print_schedule --no-median-slopes --no-min-squares
 	#[extra]
 	print_schedule {

--- a/frame/contracts/src/gas.rs
+++ b/frame/contracts/src/gas.rs
@@ -157,8 +157,8 @@ where
 	/// Returns `OutOfGas` if there is not enough gas or addition of the specified
 	/// amount of gas has lead to overflow. On success returns `Proceed`.
 	///
-	/// NOTE that amount is always consumed, i.e. if there is not enough gas
-	/// then the counter will be set to zero.
+	/// NOTE that amount isn't consumed if there is not enough gas. This is considered
+	/// safe because we always charge gas before performing any resource-spending action.
 	#[inline]
 	pub fn charge<Tok: Token<T>>(&mut self, token: Tok) -> Result<ChargedAmount, DispatchError> {
 		#[cfg(test)]

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -391,7 +391,7 @@ pub mod pallet {
 	{
 		/// Deprecated version if [`Self::call`] for use in an in-storage `Call`.
 		#[pallet::call_index(0)]
-		#[pallet::weight(T::WeightInfo::call().saturating_add(<Pallet<T>>::compat_weight(*gas_limit)))]
+		#[pallet::weight(T::WeightInfo::call().saturating_add(<Pallet<T>>::compat_weight_limit(*gas_limit)))]
 		#[allow(deprecated)]
 		#[deprecated(note = "1D weight is used in this extrinsic, please migrate to `call`")]
 		pub fn call_old_weight(
@@ -406,7 +406,7 @@ pub mod pallet {
 				origin,
 				dest,
 				value,
-				<Pallet<T>>::compat_weight(gas_limit),
+				<Pallet<T>>::compat_weight_limit(gas_limit),
 				storage_deposit_limit,
 				data,
 			)
@@ -416,7 +416,7 @@ pub mod pallet {
 		#[pallet::call_index(1)]
 		#[pallet::weight(
 			T::WeightInfo::instantiate_with_code(code.len() as u32, salt.len() as u32)
-			.saturating_add(<Pallet<T>>::compat_weight(*gas_limit))
+			.saturating_add(<Pallet<T>>::compat_weight_limit(*gas_limit))
 		)]
 		#[allow(deprecated)]
 		#[deprecated(
@@ -434,7 +434,7 @@ pub mod pallet {
 			Self::instantiate_with_code(
 				origin,
 				value,
-				<Pallet<T>>::compat_weight(gas_limit),
+				<Pallet<T>>::compat_weight_limit(gas_limit),
 				storage_deposit_limit,
 				code,
 				data,
@@ -445,7 +445,7 @@ pub mod pallet {
 		/// Deprecated version if [`Self::instantiate`] for use in an in-storage `Call`.
 		#[pallet::call_index(2)]
 		#[pallet::weight(
-			T::WeightInfo::instantiate(salt.len() as u32).saturating_add(<Pallet<T>>::compat_weight(*gas_limit))
+			T::WeightInfo::instantiate(salt.len() as u32).saturating_add(<Pallet<T>>::compat_weight_limit(*gas_limit))
 		)]
 		#[allow(deprecated)]
 		#[deprecated(note = "1D weight is used in this extrinsic, please migrate to `instantiate`")]
@@ -461,7 +461,7 @@ pub mod pallet {
 			Self::instantiate(
 				origin,
 				value,
-				<Pallet<T>>::compat_weight(gas_limit),
+				<Pallet<T>>::compat_weight_limit(gas_limit),
 				storage_deposit_limit,
 				code_hash,
 				data,
@@ -1231,11 +1231,11 @@ where
 		<T::Currency as Inspect<AccountIdOf<T>>>::minimum_balance()
 	}
 
-	/// Convert a 1D Weight to a 2D weight.
+	/// Convert gas_limit from 1D Weight to a 2D Weight.
 	///
-	/// Used by backwards compatible extrinsics. We cannot just set the proof to zero
-	/// or an old `Call` will just fail.
-	fn compat_weight(gas_limit: OldWeight) -> Weight {
+	/// Used by backwards compatible extrinsics. We cannot just set the proof_size weight limit to zero
+	/// or an old `Call` will just fail with OutOfGas.
+	fn compat_weight_limit(gas_limit: OldWeight) -> Weight {
 		Weight::from(gas_limit).set_proof_size(u64::from(T::MaxCodeLen::get()) * 2)
 	}
 }

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -423,7 +423,7 @@ pub const BOB: AccountId32 = AccountId32::new([2u8; 32]);
 pub const CHARLIE: AccountId32 = AccountId32::new([3u8; 32]);
 pub const DJANGO: AccountId32 = AccountId32::new([4u8; 32]);
 
-pub const GAS_LIMIT: Weight = Weight::from_ref_time(100_000_000_000).set_proof_size(256 * 1024);
+pub const GAS_LIMIT: Weight = Weight::from_ref_time(100_000_000_000).set_proof_size(512 * 1024);
 
 pub struct ExtBuilder {
 	existential_deposit: u64,
@@ -2732,7 +2732,9 @@ fn gas_estimation_call_runtime() {
 		let call = RuntimeCall::Contracts(crate::Call::call {
 			dest: addr_callee,
 			value: 0,
-			gas_limit: GAS_LIMIT.set_ref_time(GAS_LIMIT.ref_time() / 3),
+			gas_limit: GAS_LIMIT
+				.set_ref_time(GAS_LIMIT.ref_time() / 3)
+				.set_proof_size(GAS_LIMIT.proof_size() / 3),
 			storage_deposit_limit: None,
 			data: vec![],
 		});

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -431,7 +431,9 @@ mod tests {
 				events: Default::default(),
 				runtime_calls: Default::default(),
 				schedule: Default::default(),
-				gas_meter: GasMeter::new(Weight::from_ref_time(10_000_000_000)),
+				gas_meter: GasMeter::new(
+					Weight::from_ref_time(10_000_000_000).set_proof_size(10 * 1024 * 1024),
+				),
 				debug_buffer: Default::default(),
 				ecdsa_recover: Default::default(),
 			}

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -277,81 +277,102 @@ impl RuntimeCosts {
 	{
 		use self::RuntimeCosts::*;
 		let weight = match *self {
-			MeteringBlock(amount) => s.gas.saturating_add(amount),
-			CopyFromContract(len) => s.return_per_byte.saturating_mul(len.into()),
-			CopyToContract(len) => s.input_per_byte.saturating_mul(len.into()),
-			Caller => s.caller,
-			IsContract => s.is_contract,
-			CodeHash => s.code_hash,
-			OwnCodeHash => s.own_code_hash,
-			CallerIsOrigin => s.caller_is_origin,
-			Address => s.address,
-			GasLeft => s.gas_left,
-			Balance => s.balance,
-			ValueTransferred => s.value_transferred,
-			MinimumBalance => s.minimum_balance,
-			BlockNumber => s.block_number,
-			Now => s.now,
-			WeightToFee => s.weight_to_fee,
-			InputBase => s.input,
-			Return(len) => s.r#return.saturating_add(s.return_per_byte.saturating_mul(len.into())),
-			Terminate => s.terminate,
-			Random => s.random,
-			DepositEvent { num_topic, len } => s
-				.deposit_event
-				.saturating_add(s.deposit_event_per_topic.saturating_mul(num_topic.into()))
-				.saturating_add(s.deposit_event_per_byte.saturating_mul(len.into())),
-			DebugMessage => s.debug_message,
-			SetStorage { new_bytes, old_bytes } => s
-				.set_storage
-				.saturating_add(s.set_storage_per_new_byte.saturating_mul(new_bytes.into()))
-				.saturating_add(s.set_storage_per_old_byte.saturating_mul(old_bytes.into())),
-			ClearStorage(len) => s
-				.clear_storage
-				.saturating_add(s.clear_storage_per_byte.saturating_mul(len.into())),
-			ContainsStorage(len) => s
-				.contains_storage
-				.saturating_add(s.contains_storage_per_byte.saturating_mul(len.into())),
-			GetStorage(len) =>
+			MeteringBlock(amount) => Weight::from_ref_time(s.gas.saturating_add(amount)),
+			CopyFromContract(len) =>
+				Weight::from_ref_time(s.return_per_byte.saturating_mul(len.into())),
+			CopyToContract(len) =>
+				Weight::from_ref_time(s.input_per_byte.saturating_mul(len.into())),
+			Caller => Weight::from_ref_time(s.caller),
+			IsContract => Weight::from_ref_time(s.is_contract),
+			CodeHash => Weight::from_ref_time(s.code_hash),
+			OwnCodeHash => Weight::from_ref_time(s.own_code_hash),
+			CallerIsOrigin => Weight::from_ref_time(s.caller_is_origin),
+			Address => Weight::from_ref_time(s.address),
+			GasLeft => Weight::from_ref_time(s.gas_left),
+			Balance => Weight::from_ref_time(s.balance),
+			ValueTransferred => Weight::from_ref_time(s.value_transferred),
+			MinimumBalance => Weight::from_ref_time(s.minimum_balance),
+			BlockNumber => Weight::from_ref_time(s.block_number),
+			Now => Weight::from_ref_time(s.now),
+			WeightToFee => Weight::from_ref_time(s.weight_to_fee),
+			InputBase => Weight::from_ref_time(s.input),
+			Return(len) => Weight::from_ref_time(
+				s.r#return.saturating_add(s.return_per_byte.saturating_mul(len.into())),
+			),
+			Terminate => Weight::from_ref_time(s.terminate),
+			Random => Weight::from_ref_time(s.random),
+			DepositEvent { num_topic, len } => Weight::from_ref_time(
+				s.deposit_event
+					.saturating_add(s.deposit_event_per_topic.saturating_mul(num_topic.into()))
+					.saturating_add(s.deposit_event_per_byte.saturating_mul(len.into())),
+			),
+			DebugMessage => Weight::from_ref_time(s.debug_message),
+			SetStorage { new_bytes, old_bytes } => Weight::from_ref_time(
+				s.set_storage
+					.saturating_add(s.set_storage_per_new_byte.saturating_mul(new_bytes.into()))
+					.saturating_add(s.set_storage_per_old_byte.saturating_mul(old_bytes.into())),
+			)
+			.set_proof_size(old_bytes.into()),
+			ClearStorage(len) => Weight::from_ref_time(
+				s.clear_storage
+					.saturating_add(s.clear_storage_per_byte.saturating_mul(len.into())),
+			)
+			.set_proof_size(len.into()),
+			ContainsStorage(len) => Weight::from_ref_time(
+				s.contains_storage
+					.saturating_add(s.contains_storage_per_byte.saturating_mul(len.into())),
+			)
+			.set_proof_size(len.into()),
+			GetStorage(len) => Weight::from_ref_time(
 				s.get_storage.saturating_add(s.get_storage_per_byte.saturating_mul(len.into())),
-			TakeStorage(len) => s
-				.take_storage
-				.saturating_add(s.take_storage_per_byte.saturating_mul(len.into())),
-			Transfer => s.transfer,
-			CallBase => s.call,
-			DelegateCallBase => s.delegate_call,
-			CallSurchargeTransfer => s.call_transfer_surcharge,
-			CallInputCloned(len) => s.call_per_cloned_byte.saturating_mul(len.into()),
-			InstantiateBase { input_data_len, salt_len } => s
-				.instantiate
-				.saturating_add(s.return_per_byte.saturating_mul(input_data_len.into()))
-				.saturating_add(s.instantiate_per_salt_byte.saturating_mul(salt_len.into())),
-			InstantiateSurchargeTransfer => s.instantiate_transfer_surcharge,
-			HashSha256(len) => s
-				.hash_sha2_256
-				.saturating_add(s.hash_sha2_256_per_byte.saturating_mul(len.into())),
-			HashKeccak256(len) => s
-				.hash_keccak_256
-				.saturating_add(s.hash_keccak_256_per_byte.saturating_mul(len.into())),
-			HashBlake256(len) => s
-				.hash_blake2_256
-				.saturating_add(s.hash_blake2_256_per_byte.saturating_mul(len.into())),
-			HashBlake128(len) => s
-				.hash_blake2_128
-				.saturating_add(s.hash_blake2_128_per_byte.saturating_mul(len.into())),
-			EcdsaRecovery => s.ecdsa_recover,
-			ChainExtension(amount) => amount,
-			CallRuntime(weight) => weight.ref_time(),
-			SetCodeHash => s.set_code_hash,
-			EcdsaToEthAddress => s.ecdsa_to_eth_address,
-			ReentrantCount => s.reentrance_count,
-			AccountEntranceCount => s.account_reentrance_count,
-			InstantationNonce => s.instantiation_nonce,
+			)
+			.set_proof_size(len.into()),
+			TakeStorage(len) => Weight::from_ref_time(
+				s.take_storage
+					.saturating_add(s.take_storage_per_byte.saturating_mul(len.into())),
+			)
+			.set_proof_size(len.into()),
+			Transfer => Weight::from_ref_time(s.transfer),
+			CallBase => Weight::from_ref_time(s.call),
+			DelegateCallBase => Weight::from_ref_time(s.delegate_call),
+			CallSurchargeTransfer => Weight::from_ref_time(s.call_transfer_surcharge),
+			CallInputCloned(len) =>
+				Weight::from_ref_time(s.call_per_cloned_byte.saturating_mul(len.into())),
+			InstantiateBase { input_data_len, salt_len } => Weight::from_ref_time(
+				s.instantiate
+					.saturating_add(s.return_per_byte.saturating_mul(input_data_len.into()))
+					.saturating_add(s.instantiate_per_salt_byte.saturating_mul(salt_len.into())),
+			),
+			InstantiateSurchargeTransfer => Weight::from_ref_time(s.instantiate_transfer_surcharge),
+			HashSha256(len) => Weight::from_ref_time(
+				s.hash_sha2_256
+					.saturating_add(s.hash_sha2_256_per_byte.saturating_mul(len.into())),
+			),
+			HashKeccak256(len) => Weight::from_ref_time(
+				s.hash_keccak_256
+					.saturating_add(s.hash_keccak_256_per_byte.saturating_mul(len.into())),
+			),
+			HashBlake256(len) => Weight::from_ref_time(
+				s.hash_blake2_256
+					.saturating_add(s.hash_blake2_256_per_byte.saturating_mul(len.into())),
+			),
+			HashBlake128(len) => Weight::from_ref_time(
+				s.hash_blake2_128
+					.saturating_add(s.hash_blake2_128_per_byte.saturating_mul(len.into())),
+			),
+			EcdsaRecovery => Weight::from_ref_time(s.ecdsa_recover),
+			ChainExtension(amount) => Weight::from_ref_time(amount),
+			CallRuntime(weight) => weight,
+			SetCodeHash => Weight::from_ref_time(s.set_code_hash),
+			EcdsaToEthAddress => Weight::from_ref_time(s.ecdsa_to_eth_address),
+			ReentrantCount => Weight::from_ref_time(s.reentrance_count),
+			AccountEntranceCount => Weight::from_ref_time(s.account_reentrance_count),
+			InstantationNonce => Weight::from_ref_time(s.instantiation_nonce),
 		};
 		RuntimeToken {
 			#[cfg(test)]
 			_created_from: *self,
-			weight: Weight::from_ref_time(weight),
+			weight,
 		}
 	}
 }


### PR DESCRIPTION
Follow up to #12421 

We charge weight for PoV size assuming its 1-to-1 ratio to the size of the storage being read. Until #8652  is shipped we can't have proper benchmarks for it anyways, which also holds us from implementing the Weights V2 compatible versions of 
- `seal_instantiate`
- `seal_call`
- `seal_weight_to_fee` 
- and `seal_gas_left`
