### PR TITLE
Add debug info in assert_has_event and assert_last_event

### DIFF
--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1501,9 +1501,7 @@ impl<T: Config> Pallet<T> {
 		let events = Self::events();
 		assert!(
 			events.iter().any(|record| record.event == event),
-			"expected event {:?} not found in events {:?}",
-			event,
-			events
+			"expected event {event:?} not found in events {events:?}",
 		);
 	}
 
@@ -1513,8 +1511,7 @@ impl<T: Config> Pallet<T> {
 		let last_event = Self::events().last().expect("events expected").event.clone();
 		assert_eq!(
 			last_event, event,
-			"expected event {:?} is not equal to the last event {:?}",
-			event, last_event
+			"expected event {event:?} is not equal to the last event {last_event:?}",
 		);
 	}
 

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1498,13 +1498,24 @@ impl<T: Config> Pallet<T> {
 	/// Assert the given `event` exists.
 	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
 	pub fn assert_has_event(event: T::RuntimeEvent) {
-		assert!(Self::events().iter().any(|record| record.event == event))
+		let events = Self::events();
+		assert!(
+			events.iter().any(|record| record.event == event),
+			"expected event {:?} not found in events {:?}",
+			event,
+			events
+		);
 	}
 
 	/// Assert the last event equal to the given `event`.
 	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
 	pub fn assert_last_event(event: T::RuntimeEvent) {
-		assert_eq!(Self::events().last().expect("events expected").event, event);
+		let last_event = Self::events().last().expect("events expected").event.clone();
+		assert_eq!(
+			last_event, event,
+			"expected event {:?} is not equal to the last event {:?}",
+			event, last_event
+		);
 	}
 
 	/// Return the chain's current runtime version.


### PR DESCRIPTION
The original error only had a panic(`panicked at 'assertion failed: Self::events().iter().any(|record| record.event == event)`), and there was no intuitive debug information. 

A custom panic message is now added to help with debugging.


