### PR TITLE
txpool: TestApi best_block fix

### DIFF
--- a/test-utils/runtime/transaction-pool/src/lib.rs
+++ b/test-utils/runtime/transaction-pool/src/lib.rs
@@ -178,6 +178,18 @@ impl TestApi {
 
 		let mut chain = self.chain.write();
 		chain.block_by_hash.insert(hash, block.clone());
+
+		if is_best_block {
+			chain
+				.block_by_number
+				.entry(*block_number)
+				.or_default()
+				.iter_mut()
+				.for_each(|x| {
+					x.1 = IsBestBlock::No;
+				});
+		}
+
 		chain
 			.block_by_number
 			.entry(*block_number)


### PR DESCRIPTION
This is a minor clean up.

There was a minor bug in `TestApi::add_block`: the best block flag for given number was not cleared when the new best block with the same number was added.

The usage of `is_best_block` argument in `add_block` method in _txpool_ tests were aligned with the `NewBestBlock` event.
