### PR TITLE
`zombienet`: sketch of warp-sync test for validators 

### DIFF
--- a/scripts/ci/gitlab/pipeline/zombienet.yml
+++ b/scripts/ci/gitlab/pipeline/zombienet.yml
@@ -51,3 +51,12 @@ zombienet-0001-basic-warp-sync:
     - /home/nonroot/zombie-net/scripts/ci/run-test-env-manager.sh
         --github-remote-dir="${GH_DIR}/0001-basic-warp-sync"
         --test="test-warp-sync.zndsl"
+
+
+zombienet-0002-validators-warp-sync:
+  extends:
+    - .zombienet-common
+  script:
+    - /home/nonroot/zombie-net/scripts/ci/run-test-env-manager.sh
+        --github-remote-dir="${GH_DIR}/0002-validators-warp-sync"
+        --test="test-validators-warp-sync.zndsl"

--- a/zombienet/0002-validators-warp-sync/README.md
+++ b/zombienet/0002-validators-warp-sync/README.md
@@ -1,0 +1,4 @@
+Refer to ../0001-basic-warp-sync/README.md for more details. This test is nearly a clone. We want to warp-sync validators and make sure they can build blocks.
+0001-basic-warp-sync chainspec and database are reused in this test.
+
+

--- a/zombienet/0002-validators-warp-sync/test-validators-warp-sync.toml
+++ b/zombienet/0002-validators-warp-sync/test-validators-warp-sync.toml
@@ -1,0 +1,35 @@
+[settings]
+enable_tracing = false
+
+[relaychain]
+default_image = "{{ZOMBIENET_INTEGRATION_TEST_IMAGE}}"
+default_command = "substrate"
+
+chain = "gen-db"
+chain_spec_path = "zombienet/0000-basic-warp-sync/chain-spec.json"
+
+  [[relaychain.nodes]]
+  name = "alice"
+  validator = true
+  args = ["--sync warp"]
+
+  [[relaychain.nodes]]
+  name = "bob"
+  validator = true
+  args = ["--sync warp"]
+
+  #we need at least 3 nodes for warp sync
+  [[relaychain.nodes]]
+  name = "charlie"
+  validator = false
+  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-0bb3f0be2ce41b5615b224215bcc8363aa0416a6.tgz"
+
+  [[relaychain.nodes]]
+  name = "dave"
+  validator = false
+  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-0bb3f0be2ce41b5615b224215bcc8363aa0416a6.tgz"
+
+  [[relaychain.nodes]]
+  name = "eve"
+  validator = false
+  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-0bb3f0be2ce41b5615b224215bcc8363aa0416a6.tgz"

--- a/zombienet/0002-validators-warp-sync/test-validators-warp-sync.zndsl
+++ b/zombienet/0002-validators-warp-sync/test-validators-warp-sync.zndsl
@@ -1,0 +1,43 @@
+Description: Warp sync
+Network: ./test-validators-warp-sync.toml
+Creds: config
+
+alice: is up within 30 seconds
+bob: is up within 30 seconds
+charlie: is up within 30 seconds
+dave: is up within 30 seconds
+eve: is up within 30 seconds
+
+alice: reports node_roles is 4
+bob: reports node_roles is 4
+charlie: reports node_roles is 1
+dave: reports node_roles is 1
+eve: reports node_roles is 1
+
+alice: reports peers count is at least 4 within 60 seconds
+bob: reports peers count is at least 4 within 60 seconds
+charlie: reports peers count is at least 4 within 60 seconds
+dave: reports peers count is at least 4 within 60 seconds
+eve: reports peers count is at least 4 within 60 seconds
+
+# db snapshot has 12133 blocks
+charlie: reports block height is at least 12133 within 60 seconds
+dave: reports block height is at least 12133 within 60 seconds
+eve: reports block height is at least 12133 within 60 seconds
+
+alice: log line matches "Warp sync is complete" within 60 seconds
+bob: log line matches "Warp sync is complete" within 60 seconds
+
+# workaround for: https://github.com/paritytech/zombienet/issues/580
+alice: count of log lines containing  "Block history download is complete" is 1 within 60 seconds
+bob: count of log lines containing  "Block history download is complete" is 1 within 60 seconds
+
+alice: reports block height is at least 12133 within 10 seconds
+bob: reports block height is at least 12133 within 10 seconds
+
+alice: count of log lines containing "error" is 0 within 10 seconds
+bob: count of log lines containing "verification failed" is 0 within 10 seconds
+
+# new block were built
+alice: reports block height is at least 12136 within 90 seconds
+bob: reports block height is at least 12136 within 90 seconds


### PR DESCRIPTION
Sketch of warp-sync test for validators. Not tested.

`warp-sync` is now failing with `babe-skip-epochs`, the reason is here: https://github.com/paritytech/substrate/pull/12751#issuecomment-1328032781
Follow-up of: #12769 
