### PR TITLE
[contracts] stabilize `[seal0] take_storage`

### DIFF
--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -1230,7 +1230,6 @@ pub mod env {
 	/// # Errors
 	///
 	/// `ReturnCode::KeyNotFound`
-	#[unstable]
 	#[prefixed_alias]
 	fn take_storage(
 		ctx: _,


### PR DESCRIPTION
Stabilize `[seal0] take_storage` as it's now [covered](https://github.com/paritytech/ink/pull/1492) with an e2e test.
