### PR TITLE
Ignore empty authority changes

### DIFF
--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -153,7 +153,15 @@ impl<T: Config> Pallet<T> {
 	///
 	/// The storage will be applied immediately.
 	/// And aura consensus log will be appended to block's log.
+	///
+	/// This is a no-op if `new` is empty.
 	pub fn change_authorities(new: BoundedVec<T::AuthorityId, T::MaxAuthorities>) {
+		if new.is_empty() {
+			log::warn!(target: LOG_TARGET, "Ignoring empty authority change.");
+
+			return
+		}
+
 		<Authorities<T>>::put(&new);
 
 		let log = DigestItem::Consensus(

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -572,6 +572,8 @@ impl<T: Config> Pallet<T> {
 	///
 	/// Typically, this is not handled directly by the user, but by higher-level validator-set
 	/// manager logic like `pallet-session`.
+	///
+	/// This doesn't do anything if `authorities` is empty.
 	pub fn enact_epoch_change(
 		authorities: WeakBoundedVec<(AuthorityId, BabeAuthorityWeight), T::MaxAuthorities>,
 		next_authorities: WeakBoundedVec<(AuthorityId, BabeAuthorityWeight), T::MaxAuthorities>,
@@ -579,6 +581,12 @@ impl<T: Config> Pallet<T> {
 		// PRECONDITION: caller has done initialization and is guaranteed
 		// by the session module to be called before this.
 		debug_assert!(Self::initialized().is_some());
+
+		if authorities.is_empty() {
+			log::warn!(target: LOG_TARGET, "Ignoring empty epoch change.");
+
+			return
+		}
 
 		// Update epoch index
 		let epoch_index = EpochIndex::<T>::get()


### PR DESCRIPTION
When something tries to enact an authority change with an empty authority set, we will ignore this now.

