### PR TITLE
Make CLI state pruning optional again

### DIFF
--- a/bin/node/cli/tests/common.rs
+++ b/bin/node/cli/tests/common.rs
@@ -161,6 +161,7 @@ pub fn find_ws_url_from_output(read: impl Read + Send) -> (String, String) {
 			let line =
 				line.expect("failed to obtain next line from stdout for WS address discovery");
 			data.push_str(&line);
+			data.push_str("\n");
 
 			// does the line contain our port (we expect this specific output from substrate).
 			let sock_addr = match line.split_once("Running JSON-RPC WS server: addr=") {
@@ -170,7 +171,10 @@ pub fn find_ws_url_from_output(read: impl Read + Send) -> (String, String) {
 
 			Some(format!("ws://{}", sock_addr))
 		})
-		.expect("We should get a WebSocket address");
+		.unwrap_or_else(|| {
+			eprintln!("Observed node output:\n{}", data);
+			panic!("We should get a WebSocket address")
+		});
 
 	(ws_url, data)
 }

--- a/bin/node/cli/tests/remember_state_pruning_works.rs
+++ b/bin/node/cli/tests/remember_state_pruning_works.rs
@@ -1,0 +1,42 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use tempfile::tempdir;
+
+pub mod common;
+
+#[tokio::test]
+#[cfg(unix)]
+async fn remember_state_pruning_works() {
+	let base_path = tempdir().expect("could not create a temp dir");
+
+	// First run with `--state-pruning=archive`.
+	common::run_node_for_a_while(
+		base_path.path(),
+		&["--dev", "--state-pruning=archive", "--no-hardware-benchmarks"],
+	)
+	.await;
+
+	// Then run again without specifying the state pruning.
+	// This should load state pruning settings from the db.
+	common::run_node_for_a_while(
+		base_path.path(),
+		&["--dev", "--no-hardware-benchmarks"],
+	)
+	.await;
+}

--- a/bin/node/cli/tests/remember_state_pruning_works.rs
+++ b/bin/node/cli/tests/remember_state_pruning_works.rs
@@ -34,9 +34,5 @@ async fn remember_state_pruning_works() {
 
 	// Then run again without specifying the state pruning.
 	// This should load state pruning settings from the db.
-	common::run_node_for_a_while(
-		base_path.path(),
-		&["--dev", "--no-hardware-benchmarks"],
-	)
-	.await;
+	common::run_node_for_a_while(base_path.path(), &["--dev", "--no-hardware-benchmarks"]).await;
 }

--- a/client/cli/src/params/pruning_params.rs
+++ b/client/cli/src/params/pruning_params.rs
@@ -29,20 +29,39 @@ pub struct PruningParams {
 	/// should be pruned (ie, removed) from the database.
 	///
 	/// Possible values:
-	///  'archive'            Keep the state of all blocks.
-	///  'archive-canonical'  Keep only the state of finalized blocks.
-	///   number              Keep the state of the last number of finalized blocks.
-	#[arg(alias = "pruning", long, value_name = "PRUNING_MODE", default_value = "256")]
-	pub state_pruning: DatabasePruningMode,
+	///
+	///  - archive:
+	///
+	///    Keep the state of all blocks.
+	///
+	///  - 'archive-canonical'
+	///
+	///    Keep only the state of finalized blocks.
+	///
+	///  - number
+	///
+	///    Keep the state of the last number of finalized blocks.
+	///
+	/// [default: 256]
+	#[arg(alias = "pruning", long, value_name = "PRUNING_MODE")]
+	pub state_pruning: Option<DatabasePruningMode>,
 	/// Specify the blocks pruning mode.
 	///
 	/// This mode specifies when the block's body (including justifications)
 	/// should be pruned (ie, removed) from the database.
 	///
 	/// Possible values:
-	///  'archive'            Keep all blocks.
-	///  'archive-canonical'  Keep only finalized blocks.
-	///   number              Keep the last `number` of finalized blocks.
+	///  - 'archive'
+	///
+	///    Keep all blocks.
+	///
+	///  - 'archive-canonical'
+	///
+	///    Keep only finalized blocks.
+	///
+	///  - number
+	///
+	///  Keep the last `number` of finalized blocks.
 	#[arg(
 		alias = "keep-blocks",
 		long,
@@ -55,7 +74,7 @@ pub struct PruningParams {
 impl PruningParams {
 	/// Get the pruning value from the parameters
 	pub fn state_pruning(&self) -> error::Result<Option<PruningMode>> {
-		Ok(Some(self.state_pruning.into()))
+		Ok(self.state_pruning.map(|v| v.into()))
 	}
 
 	/// Get the block pruning value from the parameters

--- a/client/cli/src/params/pruning_params.rs
+++ b/client/cli/src/params/pruning_params.rs
@@ -28,6 +28,10 @@ pub struct PruningParams {
 	/// This mode specifies when the block's state (ie, storage)
 	/// should be pruned (ie, removed) from the database.
 	///
+	/// This setting can only be set on the first creation of the database. Every subsequent run
+	/// will load the pruning mode from the database and will error if the stored mode doesn't
+	/// match this CLI value. It is fine to drop this CLI flag for subsequent runs.
+	///
 	/// Possible values:
 	///
 	///  - archive:


### PR DESCRIPTION
The state pruning setting is stored in the database when it is created. In later runs it is fine to drop the `--state-pruning` CLI argument as the setting is stored in the database. The state db will only return an error if the stored state pruning doesn't match the state pruning given via CLI. Users of Polkadot have reported exactly this behavior. They had their nodes running without `--state-pruning`, but initially they had created a database using `archive`. With the latest Polkadot release their node rejected to start, because the default value is `256` which is different to `archive`.

Recently we improved the state pruning CLI handling and accidentally made the state pruning value always present (as we set some default value for the clap). If we could find out if a user has passed a value or the default value was taken, we could keep the default value in the CLI interface, but clap isn't supporting this right now. So, we need to go back and make `state_pruning` an optional with the default written into the docs.

It also adds a test to ensure that we don't break this behavior again.

