### PR TITLE
Derive `Debug` on `SyncStatus`

### DIFF
--- a/client/network/common/src/sync.rs
+++ b/client/network/common/src/sync.rs
@@ -70,7 +70,7 @@ pub struct StateDownloadProgress {
 }
 
 /// Syncing status and statistics.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct SyncStatus<Block: BlockT> {
 	/// Current global sync state.
 	pub state: SyncState<NumberFor<Block>>,


### PR DESCRIPTION
I found this helpful during debugging, other data structures already have `Debug` implemented.