### PR TITLE
Enable `zstd` for `rusty-cachier`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,7 @@ variables:
   BUILDAH_IMAGE:                   "quay.io/buildah/stable:v1.27"
   RUSTY_CACHIER_SINGLE_BRANCH:     master
   RUSTY_CACHIER_DONT_OPERATE_ON_MAIN_BRANCH: "true"
+  RUSTY_CACHIER_COMPRESSION_METHOD: zstd
   ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.3.22"
 
 default:


### PR DESCRIPTION
`zstd` is much faster for our needs than LZMA2-based `xz` which is used currently. Closes https://github.com/paritytech/ci_cd/issues/698.