### PR TITLE
Unpin `ci-linux` and use the latest `production` tag as before

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,8 +48,7 @@ variables:
   CARGO_INCREMENTAL:               0
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  # staging image with rust 1.65 and nightly-2022-11-16
-  CI_IMAGE:                        "paritytech/ci-linux@sha256:786869e731963b3cc0a4aa9deb83367ed9e87a6ae48b6eb029d62b0cab4d87c1"
+  CI_IMAGE:                        "paritytech/ci-linux:production"
   BUILDAH_IMAGE:                   "quay.io/buildah/stable:v1.27"
   RUSTY_CACHIER_SINGLE_BRANCH:     master
   RUSTY_CACHIER_DONT_OPERATE_ON_MAIN_BRANCH: "true"


### PR DESCRIPTION
Fixes [absent](https://gitlab.parity.io/parity/mirrors/substrate/-/pipelines/235897) `zstd` as it's only available in the latest `production` image.