### PR TITLE
EPM and staking events improvement

### DIFF
--- a/frame/election-provider-multi-phase/src/benchmarking.rs
+++ b/frame/election-provider-multi-phase/src/benchmarking.rs
@@ -200,7 +200,7 @@ frame_benchmarking::benchmarks! {
 		assert!(<MultiPhase<T>>::snapshot().is_none());
 		assert!(<MultiPhase<T>>::current_phase().is_off());
 	}: {
-		<MultiPhase<T>>::on_initialize_open_signed();
+		<MultiPhase<T>>::phase_transition(Phase::Signed);
 	} verify {
 		assert!(<MultiPhase<T>>::snapshot().is_none());
 		assert!(<MultiPhase<T>>::current_phase().is_signed());
@@ -210,7 +210,8 @@ frame_benchmarking::benchmarks! {
 		assert!(<MultiPhase<T>>::snapshot().is_none());
 		assert!(<MultiPhase<T>>::current_phase().is_off());
 	}: {
-		<MultiPhase<T>>::on_initialize_open_unsigned(true, 1u32.into())
+		let now = frame_system::Pallet::<T>::block_number();
+		<MultiPhase<T>>::phase_transition(Phase::Unsigned((true, now)));
 	} verify {
 		assert!(<MultiPhase<T>>::snapshot().is_none());
 		assert!(<MultiPhase<T>>::current_phase().is_unsigned());
@@ -318,7 +319,7 @@ frame_benchmarking::benchmarks! {
 	submit {
 		// the queue is full and the solution is only better than the worse.
 		<MultiPhase<T>>::create_snapshot().map_err(<&str>::from)?;
-		MultiPhase::<T>::on_initialize_open_signed();
+		<MultiPhase<T>>::phase_transition(Phase::Signed);
 		<Round<T>>::put(1);
 
 		let mut signed_submissions = SignedSubmissions::<T>::get();

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -968,7 +968,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			supports: Supports<T::AccountId>,
 		) -> DispatchResult {
-			T::ForceOrigin::ensure_origin(origin.clone())?;
+			T::ForceOrigin::ensure_origin(origin)?;
 			ensure!(Self::current_phase().is_emergency(), <Error<T>>::CallNotAllowed);
 
 			// bound supports with T::MaxWinners

--- a/frame/election-provider-multi-phase/src/signed.rs
+++ b/frame/election-provider-multi-phase/src/signed.rs
@@ -539,7 +539,6 @@ mod tests {
 	use super::*;
 	use crate::{mock::*, ElectionCompute, ElectionError, Error, Event, Perbill, Phase};
 	use frame_support::{assert_noop, assert_ok, assert_storage_noop};
-	use frame_system::RawOrigin;
 
 	#[test]
 	fn cannot_submit_too_early() {
@@ -621,10 +620,10 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
+					Event::PhaseTransitioned { from: Phase::Off, to: Phase::Signed, round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						origin: RawOrigin::Signed(99),
+						origin: Some(99),
 						prev_ejected: false
 					}
 				]
@@ -650,10 +649,10 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
+					Event::PhaseTransitioned { from: Phase::Off, to: Phase::Signed, round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						origin: RawOrigin::Signed(99),
+						origin: Some(99),
 						prev_ejected: false
 					},
 					Event::Rewarded { account: 99, value: 7 }
@@ -685,10 +684,10 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
+					Event::PhaseTransitioned { from: Phase::Off, to: Phase::Signed, round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						origin: RawOrigin::Signed(99),
+						origin: Some(99),
 						prev_ejected: false
 					},
 					Event::Slashed { account: 99, value: 5 }
@@ -726,15 +725,15 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
+					Event::PhaseTransitioned { from: Phase::Off, to: Phase::Signed, round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						origin: RawOrigin::Signed(99),
+						origin: Some(99),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						origin: RawOrigin::Signed(999),
+						origin: Some(999),
 						prev_ejected: false
 					},
 					Event::Rewarded { account: 99, value: 7 }
@@ -809,30 +808,30 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
+					Event::PhaseTransitioned { from: Phase::Off, to: Phase::Signed, round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						origin: RawOrigin::Signed(99),
+						origin: Some(99),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						origin: RawOrigin::Signed(100),
+						origin: Some(100),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						origin: RawOrigin::Signed(101),
+						origin: Some(101),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						origin: RawOrigin::Signed(102),
+						origin: Some(102),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						origin: RawOrigin::Signed(103),
+						origin: Some(103),
 						prev_ejected: false
 					},
 					Event::Rewarded { account: 99, value: 7 },
@@ -897,15 +896,15 @@ mod tests {
 				assert_eq!(
 					multi_phase_events(),
 					vec![
-						Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
+						Event::PhaseTransitioned { from: Phase::Off, to: Phase::Signed, round: 1 },
 						Event::SolutionStored {
 							compute: ElectionCompute::Signed,
-							origin: RawOrigin::Signed(99),
+							origin: Some(99),
 							prev_ejected: false
 						},
 						Event::SolutionStored {
 							compute: ElectionCompute::Signed,
-							origin: RawOrigin::Signed(99),
+							origin: Some(99),
 							prev_ejected: true
 						}
 					]
@@ -1155,24 +1154,24 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
+					Event::PhaseTransitioned { from: Phase::Off, to: Phase::Signed, round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						origin: RawOrigin::Signed(100),
+						origin: Some(100),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						origin: RawOrigin::Signed(101),
+						origin: Some(101),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						origin: RawOrigin::Signed(102),
+						origin: Some(102),
 						prev_ejected: false
 					},
 					Event::Rewarded { account: 100, value: 7 },
-					Event::PhaseTransition {
+					Event::PhaseTransitioned {
 						from: Phase::Signed,
 						to: Phase::Unsigned((true, 25)),
 						round: 1
@@ -1229,20 +1228,20 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
+					Event::PhaseTransitioned { from: Phase::Off, to: Phase::Signed, round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						origin: RawOrigin::Signed(99),
+						origin: Some(99),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						origin: RawOrigin::Signed(999),
+						origin: Some(999),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						origin: RawOrigin::Signed(9999),
+						origin: Some(9999),
 						prev_ejected: false
 					},
 					Event::Slashed { account: 999, value: 5 },
@@ -1375,10 +1374,10 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
+					Event::PhaseTransitioned { from: Phase::Off, to: Phase::Signed, round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						origin: RawOrigin::Signed(99),
+						origin: Some(99),
 						prev_ejected: false
 					},
 					Event::Rewarded { account: 99, value: 7 }

--- a/frame/election-provider-multi-phase/src/signed.rs
+++ b/frame/election-provider-multi-phase/src/signed.rs
@@ -621,7 +621,11 @@ mod tests {
 				multi_phase_events(),
 				vec![
 					Event::SignedPhaseStarted { round: 1 },
-					Event::SolutionStored { compute: ElectionCompute::Signed, prev_ejected: false }
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						account_id: Some(99),
+						prev_ejected: false
+					}
 				]
 			);
 		})
@@ -646,7 +650,11 @@ mod tests {
 				multi_phase_events(),
 				vec![
 					Event::SignedPhaseStarted { round: 1 },
-					Event::SolutionStored { compute: ElectionCompute::Signed, prev_ejected: false },
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						account_id: Some(99),
+						prev_ejected: false
+					},
 					Event::Rewarded { account: 99, value: 7 }
 				]
 			);
@@ -677,7 +685,11 @@ mod tests {
 				multi_phase_events(),
 				vec![
 					Event::SignedPhaseStarted { round: 1 },
-					Event::SolutionStored { compute: ElectionCompute::Signed, prev_ejected: false },
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						account_id: Some(99),
+						prev_ejected: false
+					},
 					Event::Slashed { account: 99, value: 5 }
 				]
 			);
@@ -714,8 +726,16 @@ mod tests {
 				multi_phase_events(),
 				vec![
 					Event::SignedPhaseStarted { round: 1 },
-					Event::SolutionStored { compute: ElectionCompute::Signed, prev_ejected: false },
-					Event::SolutionStored { compute: ElectionCompute::Signed, prev_ejected: false },
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						account_id: Some(99),
+						prev_ejected: false
+					},
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						account_id: Some(999),
+						prev_ejected: false
+					},
 					Event::Rewarded { account: 99, value: 7 }
 				]
 			);
@@ -789,11 +809,31 @@ mod tests {
 				multi_phase_events(),
 				vec![
 					Event::SignedPhaseStarted { round: 1 },
-					Event::SolutionStored { compute: ElectionCompute::Signed, prev_ejected: false },
-					Event::SolutionStored { compute: ElectionCompute::Signed, prev_ejected: false },
-					Event::SolutionStored { compute: ElectionCompute::Signed, prev_ejected: false },
-					Event::SolutionStored { compute: ElectionCompute::Signed, prev_ejected: false },
-					Event::SolutionStored { compute: ElectionCompute::Signed, prev_ejected: false },
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						account_id: Some(99),
+						prev_ejected: false
+					},
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						account_id: Some(100),
+						prev_ejected: false
+					},
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						account_id: Some(101),
+						prev_ejected: false
+					},
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						account_id: Some(102),
+						prev_ejected: false
+					},
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						account_id: Some(103),
+						prev_ejected: false
+					},
 					Event::Rewarded { account: 99, value: 7 },
 					Event::ElectionFinalized {
 						compute: ElectionCompute::Signed,
@@ -859,10 +899,12 @@ mod tests {
 						Event::SignedPhaseStarted { round: 1 },
 						Event::SolutionStored {
 							compute: ElectionCompute::Signed,
+							account_id: Some(99),
 							prev_ejected: false
 						},
 						Event::SolutionStored {
 							compute: ElectionCompute::Signed,
+							account_id: Some(99),
 							prev_ejected: true
 						}
 					]
@@ -1113,9 +1155,21 @@ mod tests {
 				multi_phase_events(),
 				vec![
 					Event::SignedPhaseStarted { round: 1 },
-					Event::SolutionStored { compute: ElectionCompute::Signed, prev_ejected: false },
-					Event::SolutionStored { compute: ElectionCompute::Signed, prev_ejected: false },
-					Event::SolutionStored { compute: ElectionCompute::Signed, prev_ejected: false },
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						account_id: Some(100),
+						prev_ejected: false
+					},
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						account_id: Some(101),
+						prev_ejected: false
+					},
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						account_id: Some(102),
+						prev_ejected: false
+					},
 					Event::Rewarded { account: 100, value: 7 },
 					Event::UnsignedPhaseStarted { round: 1 }
 				]
@@ -1171,9 +1225,21 @@ mod tests {
 				multi_phase_events(),
 				vec![
 					Event::SignedPhaseStarted { round: 1 },
-					Event::SolutionStored { compute: ElectionCompute::Signed, prev_ejected: false },
-					Event::SolutionStored { compute: ElectionCompute::Signed, prev_ejected: false },
-					Event::SolutionStored { compute: ElectionCompute::Signed, prev_ejected: false },
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						account_id: Some(99),
+						prev_ejected: false
+					},
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						account_id: Some(999),
+						prev_ejected: false
+					},
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						account_id: Some(9999),
+						prev_ejected: false
+					},
 					Event::Slashed { account: 999, value: 5 },
 					Event::Rewarded { account: 99, value: 7 }
 				]
@@ -1305,7 +1371,11 @@ mod tests {
 				multi_phase_events(),
 				vec![
 					Event::SignedPhaseStarted { round: 1 },
-					Event::SolutionStored { compute: ElectionCompute::Signed, prev_ejected: false },
+					Event::SolutionStored {
+						compute: ElectionCompute::Signed,
+						account_id: Some(99),
+						prev_ejected: false
+					},
 					Event::Rewarded { account: 99, value: 7 }
 				]
 			);

--- a/frame/election-provider-multi-phase/src/signed.rs
+++ b/frame/election-provider-multi-phase/src/signed.rs
@@ -539,6 +539,7 @@ mod tests {
 	use super::*;
 	use crate::{mock::*, ElectionCompute, ElectionError, Error, Event, Perbill, Phase};
 	use frame_support::{assert_noop, assert_ok, assert_storage_noop};
+	use frame_system::RawOrigin;
 
 	#[test]
 	fn cannot_submit_too_early() {
@@ -620,7 +621,7 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::SignedPhaseStarted { round: 1 },
+					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
 						origin: RawOrigin::Signed(99),
@@ -649,7 +650,7 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::SignedPhaseStarted { round: 1 },
+					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
 						origin: RawOrigin::Signed(99),
@@ -684,7 +685,7 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::SignedPhaseStarted { round: 1 },
+					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
 						origin: RawOrigin::Signed(99),
@@ -725,7 +726,7 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::SignedPhaseStarted { round: 1 },
+					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
 						origin: RawOrigin::Signed(99),
@@ -808,7 +809,7 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::SignedPhaseStarted { round: 1 },
+					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
 						origin: RawOrigin::Signed(99),
@@ -896,7 +897,7 @@ mod tests {
 				assert_eq!(
 					multi_phase_events(),
 					vec![
-						Event::SignedPhaseStarted { round: 1 },
+						Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
 						Event::SolutionStored {
 							compute: ElectionCompute::Signed,
 							origin: RawOrigin::Signed(99),
@@ -1154,7 +1155,7 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::SignedPhaseStarted { round: 1 },
+					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
 						origin: RawOrigin::Signed(100),
@@ -1171,7 +1172,11 @@ mod tests {
 						prev_ejected: false
 					},
 					Event::Rewarded { account: 100, value: 7 },
-					Event::UnsignedPhaseStarted { round: 1 }
+					Event::PhaseTransition {
+						from: Phase::Signed,
+						to: Phase::Unsigned((true, 25)),
+						round: 1
+					},
 				]
 			);
 		})
@@ -1224,7 +1229,7 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::SignedPhaseStarted { round: 1 },
+					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
 						origin: RawOrigin::Signed(99),
@@ -1370,7 +1375,7 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::SignedPhaseStarted { round: 1 },
+					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
 						origin: RawOrigin::Signed(99),

--- a/frame/election-provider-multi-phase/src/signed.rs
+++ b/frame/election-provider-multi-phase/src/signed.rs
@@ -623,7 +623,7 @@ mod tests {
 					Event::SignedPhaseStarted { round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						account_id: Some(99),
+						origin: RawOrigin::Signed(99),
 						prev_ejected: false
 					}
 				]
@@ -652,7 +652,7 @@ mod tests {
 					Event::SignedPhaseStarted { round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						account_id: Some(99),
+						origin: RawOrigin::Signed(99),
 						prev_ejected: false
 					},
 					Event::Rewarded { account: 99, value: 7 }
@@ -687,7 +687,7 @@ mod tests {
 					Event::SignedPhaseStarted { round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						account_id: Some(99),
+						origin: RawOrigin::Signed(99),
 						prev_ejected: false
 					},
 					Event::Slashed { account: 99, value: 5 }
@@ -728,12 +728,12 @@ mod tests {
 					Event::SignedPhaseStarted { round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						account_id: Some(99),
+						origin: RawOrigin::Signed(99),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						account_id: Some(999),
+						origin: RawOrigin::Signed(999),
 						prev_ejected: false
 					},
 					Event::Rewarded { account: 99, value: 7 }
@@ -811,27 +811,27 @@ mod tests {
 					Event::SignedPhaseStarted { round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						account_id: Some(99),
+						origin: RawOrigin::Signed(99),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						account_id: Some(100),
+						origin: RawOrigin::Signed(100),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						account_id: Some(101),
+						origin: RawOrigin::Signed(101),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						account_id: Some(102),
+						origin: RawOrigin::Signed(102),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						account_id: Some(103),
+						origin: RawOrigin::Signed(103),
 						prev_ejected: false
 					},
 					Event::Rewarded { account: 99, value: 7 },
@@ -899,12 +899,12 @@ mod tests {
 						Event::SignedPhaseStarted { round: 1 },
 						Event::SolutionStored {
 							compute: ElectionCompute::Signed,
-							account_id: Some(99),
+							origin: RawOrigin::Signed(99),
 							prev_ejected: false
 						},
 						Event::SolutionStored {
 							compute: ElectionCompute::Signed,
-							account_id: Some(99),
+							origin: RawOrigin::Signed(99),
 							prev_ejected: true
 						}
 					]
@@ -1157,17 +1157,17 @@ mod tests {
 					Event::SignedPhaseStarted { round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						account_id: Some(100),
+						origin: RawOrigin::Signed(100),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						account_id: Some(101),
+						origin: RawOrigin::Signed(101),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						account_id: Some(102),
+						origin: RawOrigin::Signed(102),
 						prev_ejected: false
 					},
 					Event::Rewarded { account: 100, value: 7 },
@@ -1227,17 +1227,17 @@ mod tests {
 					Event::SignedPhaseStarted { round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						account_id: Some(99),
+						origin: RawOrigin::Signed(99),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						account_id: Some(999),
+						origin: RawOrigin::Signed(999),
 						prev_ejected: false
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						account_id: Some(9999),
+						origin: RawOrigin::Signed(9999),
 						prev_ejected: false
 					},
 					Event::Slashed { account: 999, value: 5 },
@@ -1373,7 +1373,7 @@ mod tests {
 					Event::SignedPhaseStarted { round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Signed,
-						account_id: Some(99),
+						origin: RawOrigin::Signed(99),
 						prev_ejected: false
 					},
 					Event::Rewarded { account: 99, value: 7 }

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -1064,7 +1064,6 @@ mod tests {
 	use frame_support::{
 		assert_noop, assert_ok, bounded_vec, dispatch::Dispatchable, traits::OffchainWorker,
 	};
-	use frame_system::RawOrigin;
 	use sp_npos_elections::ElectionScore;
 	use sp_runtime::{
 		offchain::storage_lock::{BlockAndTime, StorageLock},
@@ -1322,15 +1321,15 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
-					Event::PhaseTransition {
+					Event::PhaseTransitioned { from: Phase::Off, to: Phase::Signed, round: 1 },
+					Event::PhaseTransitioned {
 						from: Phase::Signed,
 						to: Phase::Unsigned((true, 25)),
 						round: 1
 					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Unsigned,
-						origin: RawOrigin::None,
+						origin: None,
 						prev_ejected: false
 					}
 				]
@@ -1679,8 +1678,8 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
-					Event::PhaseTransition {
+					Event::PhaseTransitioned { from: Phase::Off, to: Phase::Signed, round: 1 },
+					Event::PhaseTransitioned {
 						from: Phase::Signed,
 						to: Phase::Unsigned((true, 25)),
 						round: 1

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -1064,6 +1064,7 @@ mod tests {
 	use frame_support::{
 		assert_noop, assert_ok, bounded_vec, dispatch::Dispatchable, traits::OffchainWorker,
 	};
+	use frame_system::RawOrigin;
 	use sp_npos_elections::ElectionScore;
 	use sp_runtime::{
 		offchain::storage_lock::{BlockAndTime, StorageLock},
@@ -1321,8 +1322,12 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::SignedPhaseStarted { round: 1 },
-					Event::UnsignedPhaseStarted { round: 1 },
+					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
+					Event::PhaseTransition {
+						from: Phase::Signed,
+						to: Phase::Unsigned((true, 25)),
+						round: 1
+					},
 					Event::SolutionStored {
 						compute: ElectionCompute::Unsigned,
 						origin: RawOrigin::None,
@@ -1674,8 +1679,12 @@ mod tests {
 			assert_eq!(
 				multi_phase_events(),
 				vec![
-					Event::SignedPhaseStarted { round: 1 },
-					Event::UnsignedPhaseStarted { round: 1 },
+					Event::PhaseTransition { from: Phase::Off, to: Phase::Signed, round: 1 },
+					Event::PhaseTransition {
+						from: Phase::Signed,
+						to: Phase::Unsigned((true, 25)),
+						round: 1
+					},
 					Event::ElectionFinalized {
 						compute: ElectionCompute::Fallback,
 						score: ElectionScore {

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -1325,6 +1325,7 @@ mod tests {
 					Event::UnsignedPhaseStarted { round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Unsigned,
+						account_id: None,
 						prev_ejected: false
 					}
 				]

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -1055,7 +1055,7 @@ mod tests {
 			Runtime, RuntimeCall, RuntimeOrigin, System, TestNposSolution, TrimHelpers,
 			UnsignedPhase,
 		},
-		CurrentPhase, Event, InvalidTransaction, Phase, QueuedSolution, TransactionSource,
+		Event, InvalidTransaction, Phase, QueuedSolution, TransactionSource,
 		TransactionValidityError,
 	};
 	use codec::Decode;
@@ -1128,7 +1128,7 @@ mod tests {
 			assert!(<MultiPhase as ValidateUnsigned>::pre_dispatch(&call).is_ok());
 
 			// unsigned -- but not enabled.
-			<CurrentPhase<Runtime>>::put(Phase::Unsigned((false, 25)));
+			MultiPhase::phase_transition(Phase::Unsigned((false, 25)));
 			assert!(MultiPhase::current_phase().is_unsigned());
 			assert!(matches!(
 				<MultiPhase as ValidateUnsigned>::validate_unsigned(
@@ -1666,7 +1666,7 @@ mod tests {
 
 			let current_block = block_plus(offchain_repeat * 2 + 2);
 			// force the unsigned phase to start on the current block.
-			CurrentPhase::<Runtime>::set(Phase::Unsigned((true, current_block)));
+			MultiPhase::phase_transition(Phase::Unsigned((true, current_block)));
 
 			// clear the cache and create a solution since we are on the first block of the unsigned
 			// phase.
@@ -1691,7 +1691,12 @@ mod tests {
 							sum_stake: 0,
 							sum_stake_squared: 0
 						}
-					}
+					},
+					Event::PhaseTransitioned {
+						from: Phase::Unsigned((true, 25)),
+						to: Phase::Unsigned((true, 37)),
+						round: 1
+					},
 				]
 			);
 		})

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -1325,7 +1325,7 @@ mod tests {
 					Event::UnsignedPhaseStarted { round: 1 },
 					Event::SolutionStored {
 						compute: ElectionCompute::Unsigned,
-						account_id: None,
+						origin: RawOrigin::None,
 						prev_ejected: false
 					}
 				]

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -339,8 +339,7 @@ impl<T: Config> Pallet<T> {
 			if maybe_new_era_validators.is_some() &&
 				matches!(ForceEra::<T>::get(), Forcing::ForceNew)
 			{
-				ForceEra::<T>::put(Forcing::NotForcing);
-				Self::deposit_event(Event::<T>::ForceEra { mode: Forcing::NotForcing });
+				Self::set_force_era(Forcing::NotForcing);
 			}
 
 			maybe_new_era_validators
@@ -718,14 +717,18 @@ impl<T: Config> Pallet<T> {
 		}
 	}
 
+	/// Helper to set a new `ForceEra` mode.
+	pub(crate) fn set_force_era(mode: Forcing) {
+		log!(info, "Setting force era mode {:?}.", mode);
+		ForceEra::<T>::put(mode);
+		Self::deposit_event(Event::<T>::ForceEra { mode });
+	}
+
 	/// Ensures that at the end of the current session there will be a new era.
 	pub(crate) fn ensure_new_era() {
 		match ForceEra::<T>::get() {
 			Forcing::ForceAlways | Forcing::ForceNew => (),
-			_ => {
-				ForceEra::<T>::put(Forcing::ForceNew);
-				Self::deposit_event(Event::<T>::ForceEra { mode: Forcing::ForceNew });
-			},
+			_ => Self::set_force_era(Forcing::ForceNew),
 		}
 	}
 

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -340,6 +340,7 @@ impl<T: Config> Pallet<T> {
 				matches!(ForceEra::<T>::get(), Forcing::ForceNew)
 			{
 				ForceEra::<T>::put(Forcing::NotForcing);
+				Self::deposit_event(Event::<T>::ForceEra { mode: Forcing::NotForcing });
 			}
 
 			maybe_new_era_validators
@@ -721,7 +722,10 @@ impl<T: Config> Pallet<T> {
 	pub(crate) fn ensure_new_era() {
 		match ForceEra::<T>::get() {
 			Forcing::ForceAlways | Forcing::ForceNew => (),
-			_ => ForceEra::<T>::put(Forcing::ForceNew),
+			_ => {
+				ForceEra::<T>::put(Forcing::ForceNew);
+				Self::deposit_event(Event::<T>::ForceEra { mode: Forcing::ForceNew });
+			},
 		}
 	}
 

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -1375,8 +1375,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::force_no_eras())]
 		pub fn force_no_eras(origin: OriginFor<T>) -> DispatchResult {
 			ensure_root(origin)?;
-			ForceEra::<T>::put(Forcing::ForceNone);
-			Self::deposit_event(Event::<T>::ForceEra { mode: Forcing::ForceNone });
+			Self::set_force_era(Forcing::ForceNone);
 			Ok(())
 		}
 
@@ -1400,8 +1399,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::force_new_era())]
 		pub fn force_new_era(origin: OriginFor<T>) -> DispatchResult {
 			ensure_root(origin)?;
-			ForceEra::<T>::put(Forcing::ForceNew);
-			Self::deposit_event(Event::<T>::ForceEra { mode: Forcing::ForceNew });
+			Self::set_force_era(Forcing::ForceNew);
 			Ok(())
 		}
 
@@ -1452,8 +1450,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::force_new_era_always())]
 		pub fn force_new_era_always(origin: OriginFor<T>) -> DispatchResult {
 			ensure_root(origin)?;
-			ForceEra::<T>::put(Forcing::ForceAlways);
-			Self::deposit_event(Event::<T>::ForceEra { mode: Forcing::ForceAlways });
+			Self::set_force_era(Forcing::ForceAlways);
 			Ok(())
 		}
 

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -710,6 +710,8 @@ pub mod pallet {
 		PayoutStarted { era_index: EraIndex, validator_stash: T::AccountId },
 		/// A validator has set their preferences.
 		ValidatorPrefsSet { stash: T::AccountId, prefs: ValidatorPrefs },
+		/// A new force era mode was set.
+		ForceEra { mode: Forcing },
 	}
 
 	#[pallet::error]
@@ -1374,6 +1376,7 @@ pub mod pallet {
 		pub fn force_no_eras(origin: OriginFor<T>) -> DispatchResult {
 			ensure_root(origin)?;
 			ForceEra::<T>::put(Forcing::ForceNone);
+			Self::deposit_event(Event::<T>::ForceEra { mode: Forcing::ForceNone });
 			Ok(())
 		}
 
@@ -1398,6 +1401,7 @@ pub mod pallet {
 		pub fn force_new_era(origin: OriginFor<T>) -> DispatchResult {
 			ensure_root(origin)?;
 			ForceEra::<T>::put(Forcing::ForceNew);
+			Self::deposit_event(Event::<T>::ForceEra { mode: Forcing::ForceNew });
 			Ok(())
 		}
 
@@ -1449,6 +1453,7 @@ pub mod pallet {
 		pub fn force_new_era_always(origin: OriginFor<T>) -> DispatchResult {
 			ensure_root(origin)?;
 			ForceEra::<T>::put(Forcing::ForceAlways);
+			Self::deposit_event(Event::<T>::ForceEra { mode: Forcing::ForceAlways });
 			Ok(())
 		}
 

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -899,7 +899,7 @@ fn forcing_new_era_works() {
 		assert_eq!(active_era(), 1);
 
 		// no era change.
-		ForceEra::<Test>::put(Forcing::ForceNone);
+		Staking::set_force_era(Forcing::ForceNone);
 
 		start_session(4);
 		assert_eq!(active_era(), 1);
@@ -915,7 +915,7 @@ fn forcing_new_era_works() {
 
 		// back to normal.
 		// this immediately starts a new session.
-		ForceEra::<Test>::put(Forcing::NotForcing);
+		Staking::set_force_era(Forcing::NotForcing);
 
 		start_session(8);
 		assert_eq!(active_era(), 1);
@@ -923,7 +923,7 @@ fn forcing_new_era_works() {
 		start_session(9);
 		assert_eq!(active_era(), 2);
 		// forceful change
-		ForceEra::<Test>::put(Forcing::ForceAlways);
+		Staking::set_force_era(Forcing::ForceAlways);
 
 		start_session(10);
 		assert_eq!(active_era(), 2);
@@ -935,7 +935,7 @@ fn forcing_new_era_works() {
 		assert_eq!(active_era(), 4);
 
 		// just one forceful change
-		ForceEra::<Test>::put(Forcing::ForceNew);
+		Staking::set_force_era(Forcing::ForceNew);
 		start_session(13);
 		assert_eq!(active_era(), 5);
 		assert_eq!(ForceEra::<Test>::get(), Forcing::NotForcing);
@@ -2303,7 +2303,7 @@ fn era_is_always_same_length() {
 		);
 
 		let session = Session::current_index();
-		ForceEra::<Test>::put(Forcing::ForceNew);
+		Staking::set_force_era(Forcing::ForceNew);
 		advance_session();
 		advance_session();
 		assert_eq!(current_era(), 3);

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -2914,7 +2914,10 @@ fn deferred_slashes_are_deferred() {
 			staking_events_since_last_call().as_slice(),
 			&[
 				Event::Chilled { stash: 11 },
+				Event::ForceEra { mode: Forcing::ForceNew },
 				Event::SlashReported { validator: 11, slash_era: 1, .. },
+				Event::StakersElected,
+				Event::ForceEra { mode: Forcing::NotForcing },
 				..,
 				Event::Slashed { staker: 11, amount: 100 },
 				Event::Slashed { staker: 101, amount: 12 }
@@ -2949,6 +2952,7 @@ fn retroactive_deferred_slashes_two_eras_before() {
 			staking_events_since_last_call().as_slice(),
 			&[
 				Event::Chilled { stash: 11 },
+				Event::ForceEra { mode: Forcing::ForceNew },
 				Event::SlashReported { validator: 11, slash_era: 1, .. },
 				..,
 				Event::Slashed { staker: 11, amount: 100 },
@@ -3251,6 +3255,7 @@ fn slash_kicks_validators_not_nominators_and_disables_nominator_for_kicked_valid
 				Event::StakersElected,
 				Event::EraPaid { era_index: 0, validator_payout: 11075, remainder: 33225 },
 				Event::Chilled { stash: 11 },
+				Event::ForceEra { mode: Forcing::ForceNew },
 				Event::SlashReported {
 					validator: 11,
 					fraction: Perbill::from_percent(10),
@@ -3318,6 +3323,7 @@ fn non_slashable_offence_doesnt_disable_validator() {
 				Event::StakersElected,
 				Event::EraPaid { era_index: 0, validator_payout: 11075, remainder: 33225 },
 				Event::Chilled { stash: 11 },
+				Event::ForceEra { mode: Forcing::ForceNew },
 				Event::SlashReported {
 					validator: 11,
 					fraction: Perbill::from_percent(0),
@@ -3380,6 +3386,7 @@ fn slashing_independent_of_disabling_validator() {
 				Event::StakersElected,
 				Event::EraPaid { era_index: 0, validator_payout: 11075, remainder: 33225 },
 				Event::Chilled { stash: 11 },
+				Event::ForceEra { mode: Forcing::ForceNew },
 				Event::SlashReported {
 					validator: 11,
 					fraction: Perbill::from_percent(0),
@@ -4662,8 +4669,15 @@ mod election_data_provider {
 			MinimumValidatorCount::<Test>::put(2);
 			run_to_block(55);
 			assert_eq!(Staking::next_election_prediction(System::block_number()), 55 + 25);
-			assert_eq!(staking_events().len(), 6);
-			assert_eq!(*staking_events().last().unwrap(), Event::StakersElected);
+			assert_eq!(staking_events().len(), 10);
+			assert_eq!(
+				*staking_events().last().unwrap(),
+				Event::ForceEra { mode: Forcing::NotForcing }
+			);
+			assert_eq!(
+				*staking_events().get(staking_events().len() - 2).unwrap(),
+				Event::StakersElected
+			);
 			// The new era has been planned, forcing is changed from `ForceNew` to `NotForcing`.
 			assert_eq!(ForceEra::<Test>::get(), Forcing::NotForcing);
 		})


### PR DESCRIPTION
This PR refactors some events in the EPM pallet and staking with the goal of making it easier to trace runtime events related to the election provider and staking pallets:

**EPM pallet**
- `SolutionStored { compute, prev_ejected, origin: Option<T::AccountId> }` (modified).
- `PhaseTransitioned { from: Phase, to: Phase, round: u32}`: All the phase transition events (`Event::SignedPhaseStarted`, `Event::UnsighedPhaseStarted`) are replaced by a state transition event that keep the previous and next phase. This will also allow us to easily start emitting when the emergency and phase off start and all new future phases that we may need.

**Staking pallet**:
- `ForceEra { mode: Forcing }`: signals that a new `Forcing` mode was set.

In addition to refactoring and adding new events, this PR also adds helper functions to transition EPM phases and set a new force era mode.

---

Further discussion in https://github.com/paritytech/substrate/issues/13026
Closes https://github.com/paritytech/substrate/issues/13026