### PR TITLE
Upgrade wasm-opt to 0.111.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10967,9 +10967,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt"
-version = "0.110.2"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68e8037b4daf711393f4be2056246d12d975651b14d581520ad5d1f19219cec"
+checksum = "84a303793cbc01fb96551badfc7367db6007396bba6bac97936b3c8b6f7fdb41"
 dependencies = [
  "anyhow",
  "libc",
@@ -10983,9 +10983,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-cxx-sys"
-version = "0.110.2"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91adbad477e97bba3fbd21dd7bfb594e7ad5ceb9169ab1c93ab9cb0ada636b6f"
+checksum = "d9c9deb56f8a9f2ec177b3bd642a8205621835944ed5da55f2388ef216aca5a4"
 dependencies = [
  "anyhow",
  "cxx",
@@ -10995,9 +10995,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-sys"
-version = "0.110.2"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4fa5a322a4e6ac22fd141f498d56afbdbf9df5debeac32380d2dcaa3e06941"
+checksum = "4432e28b542738a9776cedf92e8a99d8991c7b4667ee2c7ccddfb479dd2856a7"
 dependencies = [
  "anyhow",
  "cc",

--- a/utils/wasm-builder/Cargo.toml
+++ b/utils/wasm-builder/Cargo.toml
@@ -22,4 +22,4 @@ toml = "0.5.4"
 walkdir = "2.3.2"
 sp-maybe-compressed-blob = { version = "4.1.0-dev", path = "../../primitives/maybe-compressed-blob" }
 filetime = "0.2.16"
-wasm-opt = "0.110"
+wasm-opt = "0.111"


### PR DESCRIPTION
This upgrades binaryen to version 111.

Binaryen (and wasm-opt) now enables the `SignExt` and `MutableGlobals` features by default, which are also enabled in the LLVM backend. In the future Binaryen will align its default feature selection with the LLVM backend.

This is _probably_ is ok for wasm-builder - wasmi supports both these.

This also points to potential future optimizations by explicitly turning on more features that wasmi supports but that aren't enabled in wasm-opt by default.

The [changelog](https://github.com/brson/wasm-opt-rs/blob/master/CHANGELOG.md) for 0.111.0.
