### PR TITLE
Add ensure_pow method

### DIFF
--- a/primitives/arithmetic/src/traits.rs
+++ b/primitives/arithmetic/src/traits.rs
@@ -19,9 +19,9 @@
 
 use codec::HasCompact;
 pub use ensure::{
-	Ensure, EnsureAdd, EnsureAddAssign, EnsureDiv, EnsureDivAssign, EnsureFixedPointNumber,
-	EnsureFrom, EnsureInto, EnsureMul, EnsureMulAssign, EnsureOp, EnsureOpAssign, EnsureSub,
-	EnsureSubAssign,
+	ensure_pow, Ensure, EnsureAdd, EnsureAddAssign, EnsureDiv, EnsureDivAssign,
+	EnsureFixedPointNumber, EnsureFrom, EnsureInto, EnsureMul, EnsureMulAssign, EnsureOp,
+	EnsureOpAssign, EnsureSub, EnsureSubAssign,
 };
 pub use integer_sqrt::IntegerSquareRoot;
 pub use num_traits::{
@@ -340,7 +340,7 @@ impl<T: Sized> SaturatedConversion for T {}
 /// The *EnsureOps* family functions follows the same behavior as *CheckedOps* but
 /// returning an [`ArithmeticError`](crate::ArithmeticError) instead of `None`.
 mod ensure {
-	use super::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Zero};
+	use super::{checked_pow, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, One, Zero};
 	use crate::{ArithmeticError, FixedPointNumber, FixedPointOperand};
 
 	/// Performs addition that returns [`ArithmeticError`] instead of wrapping around on overflow.
@@ -459,6 +459,24 @@ mod ensure {
 		fn ensure_div(self, v: Self) -> Result<Self, ArithmeticError> {
 			self.checked_div(&v).ok_or_else(|| error::division(self, v))
 		}
+	}
+
+	/// Raises a value to the power of exp, returning `ArithmeticError` if an overflow occurred.
+	///
+	/// Check [`checked_pow`] for more info about border cases.
+	///
+	/// ```
+	/// use sp_arithmetic::{traits::ensure_pow, ArithmeticError};
+	///
+	/// fn overflow() -> Result<(), ArithmeticError> {
+	///     ensure_pow(2u64, 64)?;
+	///     Ok(())
+	/// }
+	///
+	/// assert_eq!(overflow(), Err(ArithmeticError::Overflow));
+	/// ```
+	pub fn ensure_pow<T: One + EnsureMul>(base: T, exp: usize) -> Result<T, ArithmeticError> {
+		checked_pow(base, exp).ok_or(ArithmeticError::Overflow)
 	}
 
 	impl<T: CheckedAdd + PartialOrd + Zero + Copy> EnsureAdd for T {}

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -32,11 +32,11 @@ use impl_trait_for_tuples::impl_for_tuples;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sp_application_crypto::AppKey;
 pub use sp_arithmetic::traits::{
-	AtLeast32Bit, AtLeast32BitUnsigned, Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedShl,
-	CheckedShr, CheckedSub, Ensure, EnsureAdd, EnsureAddAssign, EnsureDiv, EnsureDivAssign,
-	EnsureFixedPointNumber, EnsureFrom, EnsureInto, EnsureMul, EnsureMulAssign, EnsureOp,
-	EnsureOpAssign, EnsureSub, EnsureSubAssign, IntegerSquareRoot, One, SaturatedConversion,
-	Saturating, UniqueSaturatedFrom, UniqueSaturatedInto, Zero,
+	checked_pow, ensure_pow, AtLeast32Bit, AtLeast32BitUnsigned, Bounded, CheckedAdd, CheckedDiv,
+	CheckedMul, CheckedShl, CheckedShr, CheckedSub, Ensure, EnsureAdd, EnsureAddAssign, EnsureDiv,
+	EnsureDivAssign, EnsureFixedPointNumber, EnsureFrom, EnsureInto, EnsureMul, EnsureMulAssign,
+	EnsureOp, EnsureOpAssign, EnsureSub, EnsureSubAssign, IntegerSquareRoot, One,
+	SaturatedConversion, Saturating, UniqueSaturatedFrom, UniqueSaturatedInto, Zero,
 };
 use sp_core::{self, storage::StateVersion, Hasher, RuntimeDebug, TypeId};
 #[doc(hidden)]


### PR DESCRIPTION
This PR extends #12967 with the `ensure_pow` function. I think this is also an interesting function to have along with the `ensure_ops` family methods.

`ensure_pow` acts similarly to `checked_pow` but returns an `ArithmeticError` instead.

Related #12754

