### PR TITLE
Remove `Copy` from `Ensure*` traits

### DIFF
--- a/primitives/arithmetic/src/traits.rs
+++ b/primitives/arithmetic/src/traits.rs
@@ -57,6 +57,7 @@ pub trait BaseArithmetic:
 	+ CheckedMul
 	+ CheckedDiv
 	+ CheckedRem
+	+ Ensure
 	+ Saturating
 	+ PartialOrd<Self>
 	+ Ord
@@ -113,6 +114,7 @@ impl<
 			+ CheckedMul
 			+ CheckedDiv
 			+ CheckedRem
+			+ Ensure
 			+ Saturating
 			+ PartialOrd<Self>
 			+ Ord
@@ -340,7 +342,7 @@ impl<T: Sized> SaturatedConversion for T {}
 /// The *EnsureOps* family functions follows the same behavior as *CheckedOps* but
 /// returning an [`ArithmeticError`](crate::ArithmeticError) instead of `None`.
 mod ensure {
-	use super::{BaseArithmetic, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Zero};
+	use super::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Zero};
 	use crate::{ArithmeticError, FixedPointNumber, FixedPointOperand};
 
 	/// Performs addition that returns [`ArithmeticError`] instead of wrapping around on overflow.
@@ -614,7 +616,7 @@ mod ensure {
 	}
 
 	pub trait Ensure: EnsureOp + EnsureOpAssign {}
-	impl<T: BaseArithmetic> Ensure for T {}
+	impl<T: EnsureOp + EnsureOpAssign> Ensure for T {}
 
 	/// Extends [`FixedPointNumber`] with the Ensure family functions.
 	pub trait EnsureFixedPointNumber: FixedPointNumber {

--- a/primitives/arithmetic/src/traits.rs
+++ b/primitives/arithmetic/src/traits.rs
@@ -353,6 +353,17 @@ mod ensure {
 		///
 		/// Similar to [`CheckedAdd::checked_add()`] but returning an [`ArithmeticError`] error.
 		///
+		/// # Examples
+		///
+		/// ```
+		/// use sp_arithmetic::traits::EnsureAdd;
+		///
+		/// let a: i32 = 10;
+		/// let b: i32 = 20;
+		///
+		/// assert_eq!(a.ensure_add(b), Ok(30));
+		/// ```
+		///
 		/// ```
 		/// use sp_arithmetic::{traits::EnsureAdd, ArithmeticError};
 		///
@@ -383,6 +394,17 @@ mod ensure {
 		/// If it fails, [`ArithmeticError`] is returned.
 		///
 		/// Similar to [`CheckedSub::checked_sub()`] but returning an [`ArithmeticError`] error.
+		///
+		/// # Examples
+		///
+		/// ```
+		/// use sp_arithmetic::traits::EnsureSub;
+		///
+		/// let a: i32 = 10;
+		/// let b: i32 = 20;
+		///
+		/// assert_eq!(a.ensure_sub(b), Ok(-10));
+		/// ```
 		///
 		/// ```
 		/// use sp_arithmetic::{traits::EnsureSub, ArithmeticError};
@@ -415,6 +437,17 @@ mod ensure {
 		///
 		/// Similar to [`CheckedMul::checked_mul()`] but returning an [`ArithmeticError`] error.
 		///
+		/// # Examples
+		///
+		/// ```
+		/// use sp_arithmetic::traits::EnsureMul;
+		///
+		/// let a: i32 = 10;
+		/// let b: i32 = 20;
+		///
+		/// assert_eq!(a.ensure_mul(b), Ok(200));
+		/// ```
+		///
 		/// ```
 		/// use sp_arithmetic::{traits::EnsureMul, ArithmeticError};
 		///
@@ -444,6 +477,17 @@ mod ensure {
 		/// If it fails, [`ArithmeticError`] is returned.
 		///
 		/// Similar to [`CheckedDiv::checked_div()`] but returning an [`ArithmeticError`] error.
+		///
+		/// # Examples
+		///
+		/// ```
+		/// use sp_arithmetic::traits::EnsureDiv;
+		///
+		/// let a: i32 = 20;
+		/// let b: i32 = 10;
+		///
+		/// assert_eq!(a.ensure_div(b), Ok(2));
+		/// ```
 		///
 		/// ```
 		/// use sp_arithmetic::{traits::EnsureDiv, ArithmeticError};
@@ -483,6 +527,18 @@ mod ensure {
 		///
 		/// If it fails, [`ArithmeticError`] is returned.
 		///
+		/// # Examples
+		///
+		/// ```
+		/// use sp_arithmetic::traits::EnsureAddAssign;
+		///
+		/// let mut a: i32 = 10;
+		/// let b: i32 = 20;
+		///
+		/// a.ensure_add_assign(b).unwrap();
+		/// assert_eq!(a, 30);
+		/// ```
+		///
 		/// ```
 		/// use sp_arithmetic::{traits::EnsureAddAssign, ArithmeticError};
 		///
@@ -513,6 +569,18 @@ mod ensure {
 		/// Subtracts two numbers overwriting the left hand one, checking for overflow.
 		///
 		/// If it fails, [`ArithmeticError`] is returned.
+		///
+		/// # Examples
+		///
+		/// ```
+		/// use sp_arithmetic::traits::EnsureSubAssign;
+		///
+		/// let mut a: i32 = 10;
+		/// let b: i32 = 20;
+		///
+		/// a.ensure_sub_assign(b).unwrap();
+		/// assert_eq!(a, -10);
+		/// ```
 		///
 		/// ```
 		/// use sp_arithmetic::{traits::EnsureSubAssign, ArithmeticError};
@@ -545,6 +613,18 @@ mod ensure {
 		///
 		/// If it fails, [`ArithmeticError`] is returned.
 		///
+		/// # Examples
+		///
+		/// ```
+		/// use sp_arithmetic::traits::EnsureMulAssign;
+		///
+		/// let mut a: i32 = 10;
+		/// let b: i32 = 20;
+		///
+		/// a.ensure_mul_assign(b).unwrap();
+		/// assert_eq!(a, 200);
+		/// ```
+		///
 		/// ```
 		/// use sp_arithmetic::{traits::EnsureMulAssign, ArithmeticError};
 		///
@@ -575,6 +655,18 @@ mod ensure {
 		/// Divides two numbers overwriting the left hand one, checking for overflow.
 		///
 		/// If it fails, [`ArithmeticError`] is returned.
+		///
+		/// # Examples
+		///
+		/// ```
+		/// use sp_arithmetic::traits::EnsureDivAssign;
+		///
+		/// let mut a: i32 = 20;
+		/// let b: i32 = 10;
+		///
+		/// a.ensure_div_assign(b).unwrap();
+		/// assert_eq!(a, 2);
+		/// ```
 		///
 		/// ```
 		/// use sp_arithmetic::{traits::EnsureDivAssign, ArithmeticError, FixedI64};

--- a/primitives/arithmetic/src/traits.rs
+++ b/primitives/arithmetic/src/traits.rs
@@ -533,7 +533,7 @@ mod ensure {
 		/// assert_eq!(overflow(), Err(ArithmeticError::Overflow));
 		/// ```
 		fn ensure_sub_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
-			self.checked_sub(&v).ok_or_else(|| error::inverse(&v))?;
+			*self = self.checked_sub(&v).ok_or_else(|| error::inverse(&v))?;
 			Ok(())
 		}
 	}
@@ -564,7 +564,7 @@ mod ensure {
 		/// assert_eq!(underflow(), Err(ArithmeticError::Underflow));
 		/// ```
 		fn ensure_mul_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
-			self.checked_mul(&v).ok_or_else(|| error::multiplication(self, &v))?;
+			*self = self.checked_mul(&v).ok_or_else(|| error::multiplication(self, &v))?;
 			Ok(())
 		}
 	}
@@ -595,7 +595,7 @@ mod ensure {
 		/// assert_eq!(overflow(), Err(ArithmeticError::Overflow));
 		/// ```
 		fn ensure_div_assign(&mut self, v: Self) -> Result<(), ArithmeticError> {
-			self.checked_div(&v).ok_or_else(|| error::division(self, &v))?;
+			*self = self.checked_div(&v).ok_or_else(|| error::division(self, &v))?;
 			Ok(())
 		}
 	}

--- a/primitives/arithmetic/src/traits.rs
+++ b/primitives/arithmetic/src/traits.rs
@@ -367,14 +367,15 @@ mod ensure {
 		/// assert_eq!(overflow(), Err(ArithmeticError::Overflow));
 		/// assert_eq!(underflow(), Err(ArithmeticError::Underflow));
 		/// ```
-		fn ensure_add(self, v: Self) -> Result<Self, ArithmeticError> {
-			self.checked_add(&v).ok_or_else(|| error::equivalent(&v))
+		fn ensure_add(mut self, v: Self) -> Result<Self, ArithmeticError> {
+			self.ensure_add_assign(v)?;
+			Ok(self)
 		}
 	}
 
 	/// Performs subtraction that returns [`ArithmeticError`] instead of wrapping around on
 	/// underflow.
-	pub trait EnsureSub: CheckedSub + PartialOrd + Zero {
+	pub trait EnsureSub: EnsureSubAssign {
 		/// Subtracts two numbers, checking for overflow.
 		///
 		/// If it fails, [`ArithmeticError`] is returned.
@@ -397,14 +398,15 @@ mod ensure {
 		/// assert_eq!(underflow(), Err(ArithmeticError::Underflow));
 		/// assert_eq!(overflow(), Err(ArithmeticError::Overflow));
 		/// ```
-		fn ensure_sub(self, v: Self) -> Result<Self, ArithmeticError> {
-			self.checked_sub(&v).ok_or_else(|| error::inverse(&v))
+		fn ensure_sub(mut self, v: Self) -> Result<Self, ArithmeticError> {
+			self.ensure_sub_assign(v)?;
+			Ok(self)
 		}
 	}
 
 	/// Performs multiplication that returns [`ArithmeticError`] instead of wrapping around on
 	/// overflow.
-	pub trait EnsureMul: CheckedMul + PartialOrd + Zero {
+	pub trait EnsureMul: EnsureMulAssign {
 		/// Multiplies two numbers, checking for overflow.
 		///
 		/// If it fails, [`ArithmeticError`] is returned.
@@ -427,13 +429,14 @@ mod ensure {
 		/// assert_eq!(overflow(), Err(ArithmeticError::Overflow));
 		/// assert_eq!(underflow(), Err(ArithmeticError::Underflow));
 		/// ```
-		fn ensure_mul(self, v: Self) -> Result<Self, ArithmeticError> {
-			self.checked_mul(&v).ok_or_else(|| error::multiplication(&self, &v))
+		fn ensure_mul(mut self, v: Self) -> Result<Self, ArithmeticError> {
+			self.ensure_mul_assign(v)?;
+			Ok(self)
 		}
 	}
 
 	/// Performs division that returns [`ArithmeticError`] instead of wrapping around on overflow.
-	pub trait EnsureDiv: CheckedDiv + PartialOrd + Zero {
+	pub trait EnsureDiv: EnsureDivAssign {
 		/// Divides two numbers, checking for overflow.
 		///
 		/// If it fails, [`ArithmeticError`] is returned.
@@ -456,15 +459,16 @@ mod ensure {
 		/// assert_eq!(extrinsic_zero(), Err(ArithmeticError::DivisionByZero));
 		/// assert_eq!(overflow(), Err(ArithmeticError::Overflow));
 		/// ```
-		fn ensure_div(self, v: Self) -> Result<Self, ArithmeticError> {
-			self.checked_div(&v).ok_or_else(|| error::division(&self, &v))
+		fn ensure_div(mut self, v: Self) -> Result<Self, ArithmeticError> {
+			self.ensure_div_assign(v)?;
+			Ok(self)
 		}
 	}
 
-	impl<T: CheckedAdd + PartialOrd + Zero> EnsureAdd for T {}
-	impl<T: CheckedSub + PartialOrd + Zero> EnsureSub for T {}
-	impl<T: CheckedMul + PartialOrd + Zero> EnsureMul for T {}
-	impl<T: CheckedDiv + PartialOrd + Zero> EnsureDiv for T {}
+	impl<T: EnsureAddAssign> EnsureAdd for T {}
+	impl<T: EnsureSubAssign> EnsureSub for T {}
+	impl<T: EnsureMulAssign> EnsureMul for T {}
+	impl<T: EnsureDivAssign> EnsureDiv for T {}
 
 	/// Meta trait that supports all immutable arithmetic `Ensure*` operations
 	pub trait EnsureOp: EnsureAdd + EnsureSub + EnsureMul + EnsureDiv {}
@@ -594,10 +598,10 @@ mod ensure {
 		}
 	}
 
-	impl<T: EnsureAdd> EnsureAddAssign for T {}
-	impl<T: EnsureSub> EnsureSubAssign for T {}
-	impl<T: EnsureMul> EnsureMulAssign for T {}
-	impl<T: EnsureDiv> EnsureDivAssign for T {}
+	impl<T: CheckedAdd + PartialOrd + Zero> EnsureAddAssign for T {}
+	impl<T: CheckedSub + PartialOrd + Zero> EnsureSubAssign for T {}
+	impl<T: CheckedMul + PartialOrd + Zero> EnsureMulAssign for T {}
+	impl<T: CheckedDiv + PartialOrd + Zero> EnsureDivAssign for T {}
 
 	/// Meta trait that supports all assigned arithmetic `Ensure*` operations
 	pub trait EnsureOpAssign:

--- a/primitives/arithmetic/src/traits.rs
+++ b/primitives/arithmetic/src/traits.rs
@@ -340,7 +340,7 @@ impl<T: Sized> SaturatedConversion for T {}
 /// The *EnsureOps* family functions follows the same behavior as *CheckedOps* but
 /// returning an [`ArithmeticError`](crate::ArithmeticError) instead of `None`.
 mod ensure {
-	use super::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Zero};
+	use super::{BaseArithmetic, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Zero};
 	use crate::{ArithmeticError, FixedPointNumber, FixedPointOperand};
 
 	/// Performs addition that returns [`ArithmeticError`] instead of wrapping around on overflow.
@@ -609,9 +609,8 @@ mod ensure {
 	{
 	}
 
-	/// Meta trait that supports all arithmetic operations
 	pub trait Ensure: EnsureOp + EnsureOpAssign {}
-	impl<T: EnsureOp + EnsureOpAssign> Ensure for T {}
+	impl<T: BaseArithmetic> Ensure for T {}
 
 	/// Extends [`FixedPointNumber`] with the Ensure family functions.
 	pub trait EnsureFixedPointNumber: FixedPointNumber {

--- a/primitives/arithmetic/src/traits.rs
+++ b/primitives/arithmetic/src/traits.rs
@@ -704,9 +704,7 @@ mod ensure {
 	impl<T: FixedPointNumber> EnsureFixedPointNumber for T {}
 
 	/// Similar to [`TryFrom`] but returning an [`ArithmeticError`] error.
-	pub trait EnsureFrom<T: PartialOrd + Zero + Copy>:
-		TryFrom<T> + PartialOrd + Zero + Copy
-	{
+	pub trait EnsureFrom<T: PartialOrd + Zero>: TryFrom<T> + PartialOrd + Zero {
 		/// Performs the conversion returning an [`ArithmeticError`] if fails.
 		///
 		/// Similar to [`TryFrom::try_from()`] but returning an [`ArithmeticError`] error.
@@ -728,14 +726,13 @@ mod ensure {
 		/// assert_eq!(underflow(), Err(ArithmeticError::Underflow));
 		/// ```
 		fn ensure_from(other: T) -> Result<Self, ArithmeticError> {
-			Self::try_from(other).map_err(|_| error::equivalent(&other))
+			let err = error::equivalent(&other);
+			Self::try_from(other).map_err(|_| err)
 		}
 	}
 
 	/// Similar to [`TryInto`] but returning an [`ArithmeticError`] error.
-	pub trait EnsureInto<T: PartialOrd + Zero + Copy>:
-		TryInto<T> + PartialOrd + Zero + Copy
-	{
+	pub trait EnsureInto<T: PartialOrd + Zero>: TryInto<T> + PartialOrd + Zero {
 		/// Performs the conversion returning an [`ArithmeticError`] if fails.
 		///
 		/// Similar to [`TryInto::try_into()`] but returning an [`ArithmeticError`] error
@@ -757,12 +754,13 @@ mod ensure {
 		/// assert_eq!(underflow(), Err(ArithmeticError::Underflow));
 		/// ```
 		fn ensure_into(self) -> Result<T, ArithmeticError> {
-			self.try_into().map_err(|_| error::equivalent(&self))
+			let err = error::equivalent(&self);
+			self.try_into().map_err(|_| err)
 		}
 	}
 
-	impl<T: TryFrom<S> + PartialOrd + Zero + Copy, S: PartialOrd + Zero + Copy> EnsureFrom<S> for T {}
-	impl<T: TryInto<S> + PartialOrd + Zero + Copy, S: PartialOrd + Zero + Copy> EnsureInto<S> for T {}
+	impl<T: TryFrom<S> + PartialOrd + Zero, S: PartialOrd + Zero> EnsureFrom<S> for T {}
+	impl<T: TryInto<S> + PartialOrd + Zero, S: PartialOrd + Zero> EnsureInto<S> for T {}
 
 	mod error {
 		use super::{ArithmeticError, Zero};


### PR DESCRIPTION
Follow up on https://github.com/paritytech/substrate/pull/12967#discussion_r1059864886 to make `BaseArithmetic` work with `Ensure`.  
It re-uses the code from `EnsureOpAssign` in `EnsureOp`, instead of the other way around, which incurred the `Copy` requirement.  
It does contain an artificial dependence of  `EnsureOp` on `EnsureOpAssign` to re-use code, but that should be fine since the trait bounds would be the same anyway.

Removes the `Copy` requirement from:
- `EnsureOp` and `EnsureOpAssign`
- `EnsureFrom` and `EnsureInto`: Not sure about this one since we now generate the error in every case. Could be *slightly* slower.
- Require `Ensure` for `BaseArithmetic`

cc @lemunozm 