### PR TITLE
dex child PR: no longer a need to upgrade rpc version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4300,7 +4300,6 @@ dependencies = [
  "node-testing",
  "pallet-balances",
  "pallet-contracts",
- "pallet-dex",
  "pallet-im-online",
  "pallet-root-testing",
  "pallet-sudo",
@@ -9325,7 +9324,7 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "7.0.0"
+version = "6.0.0"
 dependencies = [
  "rustc-hash",
  "serde",

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -39,7 +39,6 @@ pallet-sudo = { version = "4.0.0-dev", path = "../../../frame/sudo" }
 pallet-timestamp = { version = "4.0.0-dev", path = "../../../frame/timestamp" }
 pallet-treasury = { version = "4.0.0-dev", path = "../../../frame/treasury" }
 pallet-transaction-payment = { version = "4.0.0-dev", path = "../../../frame/transaction-payment" }
-pallet-dex = { version = "4.0.0-dev", path = "../../../frame/dex" }
 sp-application-crypto = { version = "7.0.0", path = "../../../primitives/application-crypto" }
 pallet-root-testing = { version = "1.0.0-dev", path = "../../../frame/root-testing" }
 sp-consensus-babe = { version = "0.10.0-dev", path = "../../../primitives/consensus/babe" }

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -21,7 +21,7 @@ thiserror = "1.0"
 sc-chain-spec = { version = "4.0.0-dev", path = "../chain-spec" }
 sc-transaction-pool-api = { version = "4.0.0-dev", path = "../transaction-pool/api" }
 sp-core = { version = "7.0.0", path = "../../primitives/core" }
-sp-rpc = { version = "7.0.0", path = "../../primitives/rpc" }
+sp-rpc = { version = "6.0.0", path = "../../primitives/rpc" }
 sp-runtime = { version = "7.0.0", path = "../../primitives/runtime" }
 sp-version = { version = "5.0.0", path = "../../primitives/version" }
 jsonrpsee = { version = "0.16.2", features = ["server", "client-core", "macros"] }

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -31,7 +31,7 @@ sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sp-core = { version = "7.0.0", path = "../../primitives/core" }
 sp-keystore = { version = "0.13.0", path = "../../primitives/keystore" }
 sp-offchain = { version = "4.0.0-dev", path = "../../primitives/offchain" }
-sp-rpc = { version = "7.0.0", path = "../../primitives/rpc" }
+sp-rpc = { version = "6.0.0", path = "../../primitives/rpc" }
 sp-runtime = { version = "7.0.0", path = "../../primitives/runtime" }
 sp-session = { version = "4.0.0-dev", path = "../../primitives/session" }
 sp-version = { version = "5.0.0", path = "../../primitives/version" }

--- a/client/tracing/Cargo.toml
+++ b/client/tracing/Cargo.toml
@@ -34,7 +34,7 @@ sc-tracing-proc-macro = { version = "4.0.0-dev", path = "./proc-macro" }
 sp-api = { version = "4.0.0-dev", path = "../../primitives/api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../primitives/blockchain" }
 sp-core = { version = "7.0.0", path = "../../primitives/core" }
-sp-rpc = { version = "7.0.0", path = "../../primitives/rpc" }
+sp-rpc = { version = "6.0.0", path = "../../primitives/rpc" }
 sp-runtime = { version = "7.0.0", path = "../../primitives/runtime" }
 sp-tracing = { version = "6.0.0", path = "../../primitives/tracing" }
 

--- a/frame/transaction-payment/rpc/Cargo.toml
+++ b/frame/transaction-payment/rpc/Cargo.toml
@@ -19,6 +19,6 @@ pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", path = "./
 sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
 sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
 sp-core = { version = "7.0.0", path = "../../../primitives/core" }
-sp-rpc = { version = "7.0.0", path = "../../../primitives/rpc" }
+sp-rpc = { version = "6.0.0", path = "../../../primitives/rpc" }
 sp-runtime = { version = "7.0.0", path = "../../../primitives/runtime" }
 sp-weights = { version = "4.0.0", path = "../../../primitives/weights" }

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-rpc"
-version = "7.0.0"
+version = "6.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/utils/frame/try-runtime/cli/Cargo.toml
+++ b/utils/frame/try-runtime/cli/Cargo.toml
@@ -21,7 +21,7 @@ sp-externalities = { version = "0.13.0", path = "../../../../primitives/external
 sp-io = { version = "7.0.0", path = "../../../../primitives/io" }
 sp-keystore = { version = "0.13.0", path = "../../../../primitives/keystore" }
 sp-runtime = { version = "7.0.0", path = "../../../../primitives/runtime" }
-sp-rpc = { version = "7.0.0", path = "../../../../primitives/rpc" }
+sp-rpc = { version = "6.0.0", path = "../../../../primitives/rpc" }
 sp-state-machine = { version = "0.13.0", path = "../../../../primitives/state-machine" }
 sp-version = { version = "5.0.0", path = "../../../../primitives/version" }
 sp-debug-derive = { path = "../../../../primitives/debug-derive" }


### PR DESCRIPTION
Now that we're not depending on something that needed a higher rpc version we don't have to bump the rpc version. This leads to less noise in the main PR.