### PR TITLE
Disallow burning externally locked nfts

### DIFF
--- a/frame/nfts/src/features/create_delete_item.rs
+++ b/frame/nfts/src/features/create_delete_item.rs
@@ -91,6 +91,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		item: T::ItemId,
 		with_details: impl FnOnce(&ItemDetailsFor<T, I>) -> DispatchResult,
 	) -> DispatchResult {
+		ensure!(!T::Locker::is_locked(collection, item), Error::<T, I>::ItemLocked);
 		let owner = Collection::<T, I>::try_mutate(
 			&collection,
 			|maybe_collection_details| -> Result<T::AccountId, DispatchError> {

--- a/frame/nfts/src/lib.rs
+++ b/frame/nfts/src/lib.rs
@@ -856,7 +856,9 @@ pub mod pallet {
 
 		/// Destroy a single item.
 		///
-		/// Origin must be Signed and the sender should be the Admin of the `collection`.
+		/// Origin must be Signed and the signing account must be either:
+		/// - the Admin of the `collection`;
+		/// - the Owner of the `item`;
 		///
 		/// - `collection`: The collection of the item to be burned.
 		/// - `item`: The item to be burned.

--- a/frame/uniques/src/functions.rs
+++ b/frame/uniques/src/functions.rs
@@ -189,6 +189,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		item: T::ItemId,
 		with_details: impl FnOnce(&CollectionDetailsFor<T, I>, &ItemDetailsFor<T, I>) -> DispatchResult,
 	) -> DispatchResult {
+		ensure!(!T::Locker::is_locked(collection, item), Error::<T, I>::Locked);
 		let owner = Collection::<T, I>::try_mutate(
 			&collection,
 			|maybe_collection_details| -> Result<T::AccountId, DispatchError> {

--- a/frame/uniques/src/lib.rs
+++ b/frame/uniques/src/lib.rs
@@ -577,7 +577,9 @@ pub mod pallet {
 
 		/// Destroy a single item.
 		///
-		/// Origin must be Signed and the sender should be the Admin of the `collection`.
+		/// Origin must be Signed and the signing account must be either:
+		/// - the Admin of the `collection`;
+		/// - the Owner of the `item`;
 		///
 		/// - `collection`: The collection of the item to be burned.
 		/// - `item`: The item of the item to be burned.


### PR DESCRIPTION
If the NFT was locked externally via the Locker trait, the owner shouldn't be able to burn it.