### PR TITLE
Fix NFTs pallet's integration issues

### DIFF
--- a/frame/nfts/Cargo.toml
+++ b/frame/nfts/Cargo.toml
@@ -20,6 +20,7 @@ scale-info = { version = "2.1.1", default-features = false, features = ["derive"
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, path = "../benchmarking" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
+sp-core = { version = "7.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "7.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-std = { version = "5.0.0", default-features = false, path = "../../primitives/std" }
 
@@ -38,6 +39,7 @@ std = [
 	"frame-system/std",
 	"log/std",
 	"scale-info/std",
+	"sp-core/std",
 	"sp-runtime/std",
 	"sp-std/std",
 ]

--- a/frame/nfts/src/lib.rs
+++ b/frame/nfts/src/lib.rs
@@ -1767,3 +1767,5 @@ pub mod pallet {
 		}
 	}
 }
+
+sp_core::generate_feature_enabled_macro!(runtime_benchmarks_enabled, feature = "runtime-benchmarks", $);

--- a/frame/nfts/src/types.rs
+++ b/frame/nfts/src/types.rs
@@ -272,15 +272,15 @@ pub enum MintType<CollectionId> {
 #[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub struct MintSettings<Price, BlockNumber, CollectionId> {
 	/// Whether anyone can mint or if minters are restricted to some subset.
-	pub(super) mint_type: MintType<CollectionId>,
+	pub mint_type: MintType<CollectionId>,
 	/// An optional price per mint.
-	pub(super) price: Option<Price>,
+	pub price: Option<Price>,
 	/// When the mint starts.
-	pub(super) start_block: Option<BlockNumber>,
+	pub start_block: Option<BlockNumber>,
 	/// When the mint ends.
-	pub(super) end_block: Option<BlockNumber>,
+	pub end_block: Option<BlockNumber>,
 	/// Default settings each item will get during the mint.
-	pub(super) default_item_settings: ItemSettings,
+	pub default_item_settings: ItemSettings,
 }
 
 impl<Price, BlockNumber, CollectionId> Default for MintSettings<Price, BlockNumber, CollectionId> {
@@ -315,11 +315,11 @@ pub enum PalletAttributes<CollectionId> {
 )]
 pub struct CollectionConfig<Price, BlockNumber, CollectionId> {
 	/// Collection's settings.
-	pub(super) settings: CollectionSettings,
+	pub settings: CollectionSettings,
 	/// Collection's max supply.
-	pub(super) max_supply: Option<u32>,
+	pub max_supply: Option<u32>,
 	/// Default settings each item will get during the mint.
-	pub(super) mint_settings: MintSettings<Price, BlockNumber, CollectionId>,
+	pub mint_settings: MintSettings<Price, BlockNumber, CollectionId>,
 }
 
 impl<Price, BlockNumber, CollectionId> CollectionConfig<Price, BlockNumber, CollectionId> {


### PR DESCRIPTION
During the integration of the nfts pallet with the upcoming nft-fractionalization pallet here: #13008, I've noticed a few missing things:
1) it was not possible to set the CollectionConfig fields as they were private (the same applies to the `MintSettings`)
2) in order to mock the nfts pallet, I needed to use: `pallet_nfts::runtime_benchmarks_enabled! { type Helper = (); }` which required adding that line into the lib.rs: `sp_core::generate_feature_enabled_macro!(runtime_benchmarks_enabled, feature = "runtime-benchmarks", $);`