### PR TITLE
Add keep-blocks archive params

### DIFF
--- a/bin/node/cli/tests/remember_pruning_works.rs
+++ b/bin/node/cli/tests/remember_pruning_works.rs
@@ -36,3 +36,20 @@ async fn remember_state_pruning_works() {
 	// This should load state pruning settings from the db.
 	common::run_node_for_a_while(base_path.path(), &["--dev", "--no-hardware-benchmarks"]).await;
 }
+
+#[tokio::test]
+#[cfg(unix)]
+async fn remember_blocks_pruning_works() {
+	let base_path = tempdir().expect("could not create a temp dir");
+
+	// First run with `--state-pruning=archive`.
+	common::run_node_for_a_while(
+		base_path.path(),
+		&["--dev", "--blocks-pruning=archive", "--no-hardware-benchmarks"],
+	)
+	.await;
+
+	// Then run again without specifying the state pruning.
+	// This should load state pruning settings from the db.
+	common::run_node_for_a_while(base_path.path(), &["--dev", "--no-hardware-benchmarks"]).await;
+}

--- a/bin/node/cli/tests/remember_pruning_works.rs
+++ b/bin/node/cli/tests/remember_pruning_works.rs
@@ -42,7 +42,7 @@ async fn remember_state_pruning_works() {
 async fn remember_blocks_pruning_works() {
 	let base_path = tempdir().expect("could not create a temp dir");
 
-	// First run with `--state-pruning=archive`.
+	// First run with `--blocks-pruning=archive`.
 	common::run_node_for_a_while(
 		base_path.path(),
 		&["--dev", "--blocks-pruning=archive", "--no-hardware-benchmarks"],

--- a/utils/frame/benchmarking-cli/src/block/README.md
+++ b/utils/frame/benchmarking-cli/src/block/README.md
@@ -87,7 +87,7 @@ You should see after some seconds that it started to produce blocks:
 ```
 You can now kill the node with `Ctrl+C`. Then measure how long it takes to execute these blocks:  
 ```sh
-cargo run --profile=production -- benchmark block --from 1 --to 1 --dev -d /tmp/dev --pruning archive
+cargo run --profile=production -- benchmark block --from 1 --to 1 --dev -d /tmp/dev --pruning archive --keep-blocks archive
 ```
 This will benchmark the first block. If you killed the node at a later point, you can measure multiple blocks.
 ```pre
@@ -105,6 +105,7 @@ Since this block is empty, its not very interesting.
 - `--repeat` How often each block should be measured.
 - [`--db`]
 - [`--pruning`]
+- [`--keep-blocks`]
 
 License: Apache-2.0
 
@@ -116,3 +117,4 @@ License: Apache-2.0
 
 [`--db`]: ../shared/README.md#arguments
 [`--pruning`]: ../shared/README.md#arguments
+[`--keep-blocks`]: ../shared/README.md#arguments

--- a/utils/frame/benchmarking-cli/src/block/cmd.rs
+++ b/utils/frame/benchmarking-cli/src/block/cmd.rs
@@ -44,7 +44,7 @@ use super::bench::{Benchmark, BenchmarkParams};
 /// And wait some time to let it produce 3 blocks. Then benchmark them with:
 ///
 /// $ substrate benchmark-block --from 1 --to 3 --dev -d /tmp/my-dev
-///   --execution wasm --wasm-execution compiled --pruning archive
+///   --execution wasm --wasm-execution compiled --pruning archive --keep-blocks archive
 ///
 /// The output will be similar to this:
 ///

--- a/utils/frame/benchmarking-cli/src/shared/README.md
+++ b/utils/frame/benchmarking-cli/src/shared/README.md
@@ -10,6 +10,7 @@ Contains code that is shared among multiple sub-commands.
 - `--weight-path` Set the file or directory to write the weight files to.
 - `--db` The database backend to use. This depends on your snapshot.
 - `--pruning` Set the pruning mode of the node. Some benchmarks require you to set this to `archive`.
+- `--keep-blocks` Set the pruning mode of the node. Some benchmarks require you to set this to `archive`.
 - `--base-path` The location on the disk that should be used for the benchmarks. You can try this on different disks or even on a mounted RAM-disk. It is important to use the same location that will later-on be used to store the chain data to get the correct results.
 - `--header` Optional file header which will be prepended to the weight output file. Can be used for adding LICENSE headers.
 


### PR DESCRIPTION
https://github.com/paritytech/substrate/commit/a0ec652e341f694f182a3c5fcc80d4c3fb280003?diff=unified#diff-0e523389a21c9bd9fc1da47816eb73a5ad21637337bb938abecedfe7f936d824R1720

The logic of `prune_blocks` has changed, and the `--keep-blocks=archive` needs to be specified.