### PR TITLE
fix: Fixes #13071 change order of ldd command and update ./docker/README.md

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -12,8 +12,6 @@ You should refer to the .Dockerfile for the actual list. At the time of editing,
 - node-template
 - chain-spec-builder
 
-> Warning: Currently the pre-built image [`parity/substrate:latest`](https://hub.docker.com/layers/paritytech/substrate/latest/images/sha256-d1be27ff2a93d7de49a5ef9449b4e7aa5f479d9d03f808ec34bf2e8cea89cdc4?context=explore) is outdated and uses `substrate 3.0.0-dev-ea387c63471`. The entrypoint it uses is `ENTRYPOINT ["/usr/local/bin/substrate"]` so it only supports running that old Substrate binary and to use the image you need to provide options to it in the Docker run command but without passing the Substrate binary (i.e. `docker run --rm -it parity/substrate --version`).
-
 To generate the latest parity/substrate image. Please first run:
 ```sh
 ./build.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Substrate Builder Docker Image
 
-The Docker image in this folder is a `builder` image. It is self contained and allow users to build the binaries themselves.
+The Docker image in this folder is a `builder` image. It is self contained and allows users to build the binaries themselves.
 There is no requirement on having Rust or any other toolchain installed but a working Docker environment.
 
 Unlike the `parity/polkadot` image which contains a single binary (`polkadot`!) used by default, the image in this folder builds and contains several binaries and you need to provide the name of the binary to be called.
@@ -11,6 +11,13 @@ You should refer to the .Dockerfile for the actual list. At the time of editing,
 - subkey
 - node-template
 - chain-spec-builder
+
+> Warning: Currently the pre-built image [`parity/substrate:latest`](https://hub.docker.com/layers/paritytech/substrate/latest/images/sha256-d1be27ff2a93d7de49a5ef9449b4e7aa5f479d9d03f808ec34bf2e8cea89cdc4?context=explore) is outdated and uses `substrate 3.0.0-dev-ea387c63471`. The entrypoint it uses is `ENTRYPOINT ["/usr/local/bin/substrate"]` so it only supports running that old Substrate binary and to use the image you need to provide options to it in the Docker run command but without passing the Substrate binary (i.e. `docker run --rm -it parity/substrate --version`).
+
+To generate the latest parity/substrate image. Please first run:
+```sh
+./build.sh
+```
 
 The image can be used by passing the selected binary followed by the appropriate tags for this binary.
 

--- a/docker/substrate_builder.Dockerfile
+++ b/docker/substrate_builder.Dockerfile
@@ -24,10 +24,10 @@ RUN useradd -m -u 1000 -U -s /bin/sh -d /substrate substrate && \
 	mkdir -p /data /substrate/.local/share/substrate && \
 	chown -R substrate:substrate /data && \
 	ln -s /data /substrate/.local/share/substrate && \
-# unclutter and minimize the attack surface
-	rm -rf /usr/bin /usr/sbin && \
 # Sanity checks
 	ldd /usr/local/bin/substrate && \
+# unclutter and minimize the attack surface
+	rm -rf /usr/bin /usr/sbin && \
 	/usr/local/bin/substrate --version
 
 USER substrate


### PR DESCRIPTION
- [X] **Description:** You added a brief description of the PR, e.g.:
  Refer to Issue #13071 

  Removes all the binaries after using the `ldd` command, otherwise if it's done the other way around the `ldd` command no longer exists. Also updated the associated README.md

- [X] **Related Issues:** You mentioned a related issue if this PR is related to it, e.g. `Fixes #228` or `Related #1337`.
- [X] **2 Reviewers:** You asked at least two reviewers to review. If you aren't sure, start with GH suggestions.
  @bkchr @ggwpez 
- [X] **Style Guide:** Your PR adheres to [the style guide](https://github.com/paritytech/substrate/blob/master/docs/STYLE_GUIDE.md)
  - In particular, mind the maximal line length of 100 (120 in exceptional circumstances).
  - There is no commented code checked in unless necessary.
  - Any panickers in the runtime have a proof or were removed.