### PR TITLE
Update trybuild to avoid random test failures.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11387,9 +11387,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed01de3de062db82c0920b5cabe804f88d599a3f217932292597c678c903754d"
+checksum = "654bfc024d30963fce210f22f98956407fe8c8365eb85a1fa530f6f8844137ed"
 dependencies = [
  "dissimilar",
  "glob",

--- a/frame/election-provider-support/solution-type/Cargo.toml
+++ b/frame/election-provider-support/solution-type/Cargo.toml
@@ -27,4 +27,4 @@ sp-arithmetic = { version = "6.0.0", path = "../../../primitives/arithmetic" }
 # used by generate_solution_type:
 frame-election-provider-support = { version = "4.0.0-dev", path = ".." }
 frame-support = { version = "4.0.0-dev", path = "../../support" }
-trybuild = "1.0.60"
+trybuild = "1.0.74"

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -23,7 +23,7 @@ sp-runtime = { version = "7.0.0", default-features = false, path = "../../../pri
 sp-core = { version = "7.0.0", default-features = false, path = "../../../primitives/core" }
 sp-std = { version = "5.0.0", default-features = false, path = "../../../primitives/std" }
 sp-version = { version = "5.0.0", default-features = false, path = "../../../primitives/version" }
-trybuild = { version = "1.0.60", features = [ "diff" ] }
+trybuild = { version = "1.0.74", features = [ "diff" ] }
 pretty_assertions = "1.2.1"
 rustversion = "1.0.6"
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system" }

--- a/primitives/api/test/Cargo.toml
+++ b/primitives/api/test/Cargo.toml
@@ -21,7 +21,7 @@ sp-consensus = { version = "0.10.0-dev", path = "../../consensus/common" }
 sc-block-builder = { version = "0.10.0-dev", path = "../../../client/block-builder" }
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 sp-state-machine = { version = "0.13.0", path = "../../state-machine" }
-trybuild = "1.0.60"
+trybuild = "1.0.74"
 rustversion = "1.0.6"
 
 [dev-dependencies]

--- a/primitives/runtime-interface/Cargo.toml
+++ b/primitives/runtime-interface/Cargo.toml
@@ -32,7 +32,7 @@ sp-state-machine = { version = "0.13.0", path = "../state-machine" }
 sp-core = { version = "7.0.0", path = "../core" }
 sp-io = { version = "7.0.0", path = "../io" }
 rustversion = "1.0.6"
-trybuild = "1.0.60"
+trybuild = "1.0.74"
 
 [features]
 default = [ "std" ]

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -18,5 +18,5 @@ tokio = { version = "1.22.0", features = ["macros", "time"] }
 substrate-test-utils-derive = { version = "0.10.0-dev", path = "./derive" }
 
 [dev-dependencies]
-trybuild = { version = "1.0.53", features = [ "diff" ] }
+trybuild = { version = "1.0.74", features = [ "diff" ] }
 sc-service = { version = "0.10.0-dev", path = "../client/service" }


### PR DESCRIPTION
A feature was added to trybuild >1.0.70 avoid failing on different variant counts in the line `and 278 others`

fixes #12955
