### PR TITLE
grandpa: bump version to v0.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "finality-grandpa"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22349c6a11563a202d95772a68e0fcf56119e74ea8a2a19cf2301460fcd0df5"
+checksum = "e24e6c429951433ccb7c87fd528c60084834dcd14763182c1f83291bcde24c34"
 dependencies = [
  "either",
  "futures",

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -18,7 +18,7 @@ ahash = "0.7.6"
 array-bytes = "4.1"
 async-trait = "0.1.57"
 dyn-clone = "1.0"
-finality-grandpa = { version = "0.16.0", features = ["derive-codec"] }
+finality-grandpa = { version = "0.16.1", features = ["derive-codec"] }
 futures = "0.3.21"
 futures-timer = "3.0.1"
 log = "0.4.17"
@@ -50,7 +50,7 @@ sp-runtime = { version = "7.0.0", path = "../../primitives/runtime" }
 
 [dev-dependencies]
 assert_matches = "1.3.0"
-finality-grandpa = { version = "0.16.0", features = ["derive-codec", "test-helpers"] }
+finality-grandpa = { version = "0.16.1", features = ["derive-codec", "test-helpers"] }
 serde = "1.0.136"
 tokio = "1.22.0"
 sc-network = { version = "0.10.0-dev", path = "../network" }

--- a/client/finality-grandpa/rpc/Cargo.toml
+++ b/client/finality-grandpa/rpc/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 homepage = "https://substrate.io"
 
 [dependencies]
-finality-grandpa = { version = "0.16.0", features = ["derive-codec"] }
+finality-grandpa = { version = "0.16.1", features = ["derive-codec"] }
 futures = "0.3.16"
 jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
 log = "0.4.8"

--- a/frame/grandpa/Cargo.toml
+++ b/frame/grandpa/Cargo.toml
@@ -31,7 +31,7 @@ sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../pr
 sp-std = { version = "5.0.0", default-features = false, path = "../../primitives/std" }
 
 [dev-dependencies]
-grandpa = { package = "finality-grandpa", version = "0.16.0", features = ["derive-codec"] }
+grandpa = { package = "finality-grandpa", version = "0.16.1", features = ["derive-codec"] }
 frame-benchmarking = { version = "4.0.0-dev", path = "../benchmarking" }
 frame-election-provider-support = { version = "4.0.0-dev", path = "../election-provider-support" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }

--- a/primitives/finality-grandpa/Cargo.toml
+++ b/primitives/finality-grandpa/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-grandpa = { package = "finality-grandpa", version = "0.16.0", default-features = false, features = ["derive-codec"] }
+grandpa = { package = "finality-grandpa", version = "0.16.1", default-features = false, features = ["derive-codec"] }
 log = { version = "0.4.17", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.136", features = ["derive"], optional = true }


### PR DESCRIPTION
New version changes log targets from `afg` to `grandpa`. Related https://github.com/paritytech/substrate/pull/12875.