### PR TITLE
Run `frame_system` integrity tests in Externalities

### DIFF
--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -361,7 +361,9 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn integrity_test() {
-			T::BlockWeights::get().validate().expect("The weights are invalid.");
+			sp_io::TestExternalities::default().execute_with(|| {
+				T::BlockWeights::get().validate().expect("The weights are invalid.");
+			});
 		}
 	}
 

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -360,6 +360,7 @@ pub mod pallet {
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		#[cfg(feature = "std")]
 		fn integrity_test() {
 			sp_io::TestExternalities::default().execute_with(|| {
 				T::BlockWeights::get().validate().expect("The weights are invalid.");


### PR DESCRIPTION
`storage` parameter types are currently not usable as `BlockWeight`, since the `integrity_test` of `frame_system` runs outside of externalities and therefore fails. This MR just wraps it in externalities to allow that.

Having quickly adjustable block PoV weights would be useful for testing the limits on Rococo and Westmint.