### PR TITLE
Adds custom RPC to staking related calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,6 +3479,7 @@ dependencies = [
  "pallet-society",
  "pallet-staking",
  "pallet-staking-reward-curve",
+ "pallet-staking-rpc-runtime-api",
  "pallet-state-trie-migration",
  "pallet-sudo",
  "pallet-timestamp",
@@ -4826,6 +4827,7 @@ dependencies = [
  "jsonrpsee",
  "mmr-rpc",
  "node-primitives",
+ "pallet-staking-rpc",
  "pallet-transaction-payment-rpc",
  "sc-chain-spec",
  "sc-client-api",
@@ -6393,6 +6395,32 @@ version = "4.0.0-dev"
 dependencies = [
  "log",
  "sp-arithmetic",
+]
+
+[[package]]
+name = "pallet-staking-rpc"
+version = "4.0.0-dev"
+dependencies = [
+ "jsonrpsee",
+ "pallet-staking-rpc-runtime-api",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-blockchain",
+ "sp-core",
+ "sp-rpc",
+ "sp-runtime",
+ "sp-weights",
+]
+
+[[package]]
+name = "pallet-staking-rpc-runtime-api"
+version = "4.0.0-dev"
+dependencies = [
+ "pallet-staking",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-runtime",
+ "sp-weights",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,8 @@ members = [
 	"frame/staking",
 	"frame/staking/reward-curve",
 	"frame/staking/reward-fn",
+	"frame/staking/rpc",
+	"frame/staking/rpc/runtime-api",
 	"frame/state-trie-migration",
 	"frame/sudo",
 	"frame/root-offences",

--- a/bin/node/rpc/Cargo.toml
+++ b/bin/node/rpc/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 node-primitives = { version = "2.0.0", path = "../primitives" }
 pallet-transaction-payment-rpc = { version = "4.0.0-dev", path = "../../../frame/transaction-payment/rpc/" }
+pallet-staking-rpc = { version = "4.0.0-dev", path = "../../../frame/staking/rpc/" }
 mmr-rpc = { version = "4.0.0-dev", path = "../../../client/merkle-mountain-range/rpc/" }
 sc-chain-spec = { version = "4.0.0-dev", path = "../../../client/chain-spec" }
 sc-client-api = { version = "4.0.0-dev", path = "../../../client/api" }

--- a/bin/node/rpc/src/lib.rs
+++ b/bin/node/rpc/src/lib.rs
@@ -110,6 +110,7 @@ where
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
 	C::Api: mmr_rpc::MmrRuntimeApi<Block, <Block as sp_runtime::traits::Block>::Hash, BlockNumber>,
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
+	C::Api: pallet_staking_rpc::StakingRuntimeApi<Block, Balance>,
 	C::Api: BabeApi<Block>,
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + 'static,
@@ -118,6 +119,7 @@ where
 	B::State: sc_client_api::backend::StateBackend<sp_runtime::traits::HashFor<Block>>,
 {
 	use mmr_rpc::{Mmr, MmrApiServer};
+	use pallet_staking_rpc::{Staking, StakingApiServer};
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
 	use sc_consensus_babe_rpc::{Babe, BabeApiServer};
 	use sc_finality_grandpa_rpc::{Grandpa, GrandpaApiServer};
@@ -150,6 +152,7 @@ where
 	// These RPCs should use an asynchronous caller instead.
 	io.merge(Mmr::new(client.clone()).into_rpc())?;
 	io.merge(TransactionPayment::new(client.clone()).into_rpc())?;
+	io.merge(Staking::new(client.clone()).into_rpc())?;
 	io.merge(
 		Babe::new(
 			client.clone(),

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -96,6 +96,7 @@ pallet-session = { version = "4.0.0-dev", features = [ "historical" ], path = ".
 pallet-session-benchmarking = { version = "4.0.0-dev", path = "../../../frame/session/benchmarking", default-features = false, optional = true }
 pallet-staking = { version = "4.0.0-dev", default-features = false, path = "../../../frame/staking" }
 pallet-staking-reward-curve = { version = "4.0.0-dev", default-features = false, path = "../../../frame/staking/reward-curve" }
+pallet-staking-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, path = "../../../frame/staking/rpc/runtime-api/" }
 pallet-state-trie-migration = { version = "4.0.0-dev", default-features = false, path = "../../../frame/state-trie-migration" }
 pallet-scheduler = { version = "4.0.0-dev", default-features = false, path = "../../../frame/scheduler" }
 pallet-society = { version = "4.0.0-dev", default-features = false, path = "../../../frame/society" }

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -59,7 +59,6 @@ use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_nfts::PalletFeatures;
 use pallet_nis::WithMaximumOf;
 use pallet_session::historical::{self as pallet_session_historical};
-use pallet_staking::Nominators;
 pub use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use pallet_transaction_payment::{FeeDetails, RuntimeDispatchInfo};
 use sp_api::impl_runtime_apis;
@@ -2138,9 +2137,9 @@ impl_runtime_apis! {
 			Staking::query_nominations_quota()
 		}
 
-        fn query_points_to_balance(pool_id: u32) -> Result<u32, ()> {
-            NominationPools::query_points_to_balance(pool_id)
-        }
+		fn query_points_to_balance(points: Balance, pool_id: u32) -> Result<Balance, ()> {
+			NominationPools::query_points_to_balance(points, pool_id)
+		}
 	}
 
 	impl pallet_mmr::primitives::MmrApi<

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -59,6 +59,7 @@ use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_nfts::PalletFeatures;
 use pallet_nis::WithMaximumOf;
 use pallet_session::historical::{self as pallet_session_historical};
+use pallet_staking::Nominators;
 pub use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use pallet_transaction_payment::{FeeDetails, RuntimeDispatchInfo};
 use sp_api::impl_runtime_apis;
@@ -2130,6 +2131,16 @@ impl_runtime_apis! {
 		fn query_call_fee_details(call: RuntimeCall, len: u32) -> FeeDetails<Balance> {
 			TransactionPayment::query_call_fee_details(call, len)
 		}
+	}
+
+	impl pallet_staking_rpc_runtime_api::StakingApi<Block, Balance> for Runtime {
+		fn query_nominations_quota() -> u32 {
+			Staking::query_nominations_quota()
+		}
+
+        fn query_points_to_balance(pool_id: u32) -> Result<u32, ()> {
+            NominationPools::query_points_to_balance(pool_id)
+        }
 	}
 
 	impl pallet_mmr::primitives::MmrApi<

--- a/frame/nomination-pools/src/lib.rs
+++ b/frame/nomination-pools/src/lib.rs
@@ -2140,6 +2140,12 @@ pub mod pallet {
 }
 
 impl<T: Config> Pallet<T> {
+    // Query points to balance for a given pool. Used for custom RPC call.
+    pub fn query_points_to_balance(pool_id: u32) -> Result<u32, ()> {
+        // TODO(gpestana): finish
+        Ok(0)
+    }
+
 	/// Returns the pending rewards for the specified `member_account`.
 	///
 	/// In the case of error, `None` is returned.

--- a/frame/nomination-pools/src/lib.rs
+++ b/frame/nomination-pools/src/lib.rs
@@ -2140,11 +2140,14 @@ pub mod pallet {
 }
 
 impl<T: Config> Pallet<T> {
-    // Query points to balance for a given pool. Used for custom RPC call.
-    pub fn query_points_to_balance(pool_id: u32) -> Result<u32, ()> {
-        // TODO(gpestana): finish
-        Ok(0)
-    }
+	// Query points to balance for a given pool. Used for custom RPC call.
+	pub fn query_points_to_balance(points: BalanceOf<T>, pool_id: u32) -> Result<BalanceOf<T>, ()> {
+		if let Some(pool) = BondedPool::<T>::get(pool_id).defensive() {
+			Ok(pool.points_to_balance(points))
+		} else {
+			Err(())
+		}
+	}
 
 	/// Returns the pending rewards for the specified `member_account`.
 	///

--- a/frame/staking/rpc/Cargo.toml
+++ b/frame/staking/rpc/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "pallet-staking-rpc"
+version = "4.0.0-dev"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+license = "Apache-2.0"
+homepage = "https://substrate.io"
+repository = "https://github.com/paritytech/substrate/"
+description = "RPC interface for the staking pallet."
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0" }
+jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
+pallet-staking-rpc-runtime-api = { version = "4.0.0-dev", path = "./runtime-api" }
+sp-api = { version = "4.0.0-dev", path = "../../../primitives/api" }
+sp-blockchain = { version = "4.0.0-dev", path = "../../../primitives/blockchain" }
+sp-core = { version = "7.0.0", path = "../../../primitives/core" }
+sp-rpc = { version = "6.0.0", path = "../../../primitives/rpc" }
+sp-runtime = { version = "7.0.0", path = "../../../primitives/runtime" }
+sp-weights = { version = "4.0.0", path = "../../../primitives/weights" }

--- a/frame/staking/rpc/README.md
+++ b/frame/staking/rpc/README.md
@@ -1,0 +1,3 @@
+RPC interface for the staking pallet.
+
+License: Apache-2.0

--- a/frame/staking/rpc/runtime-api/Cargo.toml
+++ b/frame/staking/rpc/runtime-api/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "pallet-staking-rpc-runtime-api"
+version = "4.0.0-dev"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+license = "Apache-2.0"
+homepage = "https://substrate.io"
+repository = "https://github.com/paritytech/substrate/"
+description = "RPC runtime API for transaction payment FRAME pallet"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+pallet-staking = { version = "4.0.0-dev", default-features = false, path = "../../../staking" }
+sp-api = { version = "4.0.0-dev", default-features = false, path = "../../../../primitives/api" }
+sp-runtime = { version = "7.0.0", default-features = false, path = "../../../../primitives/runtime" }
+sp-weights = { version = "4.0.0", default-features = false, path = "../../../../primitives/weights" }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"pallet-staking/std",
+	"sp-api/std",
+	"sp-runtime/std",
+	"sp-weights/std",
+]

--- a/frame/staking/rpc/runtime-api/README.md
+++ b/frame/staking/rpc/runtime-api/README.md
@@ -1,0 +1,3 @@
+Runtime API definition for the staking pallet.
+
+License: Apache-2.0

--- a/frame/staking/rpc/runtime-api/src/lib.rs
+++ b/frame/staking/rpc/runtime-api/src/lib.rs
@@ -28,6 +28,6 @@ sp_api::decl_runtime_apis! {
 		Balance: Codec + MaybeDisplay,
 	{
 		fn query_nominations_quota() -> u32;
-        fn query_points_to_balance(pool_id: u32) -> Result<u32, ()>;
+		fn query_points_to_balance(points: Balance, pool_id: u32) -> Result<Balance, ()>;
 	}
 }

--- a/frame/staking/rpc/runtime-api/src/lib.rs
+++ b/frame/staking/rpc/runtime-api/src/lib.rs
@@ -1,0 +1,33 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2019-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Runtime API definition for the staking pallet.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::Codec;
+use sp_runtime::traits::MaybeDisplay;
+
+sp_api::decl_runtime_apis! {
+	#[api_version(1)]
+	pub trait StakingApi<Balance> where
+		Balance: Codec + MaybeDisplay,
+	{
+		fn query_nominations_quota() -> u32;
+        fn query_points_to_balance(pool_id: u32) -> Result<u32, ()>;
+	}
+}

--- a/frame/staking/rpc/src/lib.rs
+++ b/frame/staking/rpc/src/lib.rs
@@ -1,0 +1,107 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2019-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! RPC interface for the staking pallet.
+
+use std::sync::Arc;
+
+use codec::Codec;
+use jsonrpsee::{
+	core::RpcResult,
+	proc_macros::rpc,
+	types::error::{CallError, ErrorObject},
+};
+use sp_api::ProvideRuntimeApi;
+use sp_blockchain::HeaderBackend;
+use sp_rpc::number::NumberOrHex;
+use sp_runtime::{
+	generic::BlockId,
+	traits::{Block as BlockT, MaybeDisplay},
+};
+
+pub use pallet_staking_rpc_runtime_api::StakingApi as StakingRuntimeApi;
+
+#[rpc(client, server)]
+pub trait StakingApi<Balance> {
+	#[method(name = "staking_nominationsQuota")]
+	fn query_nominations_quota(&self) -> RpcResult<u32>;
+    #[method(name = "nominationPools_pointsToBalance")]
+	fn query_points_to_balance(&self, pool_id: u32) -> RpcResult<u32>;
+}
+
+pub struct Staking<C, P> {
+	client: Arc<C>,
+	_marker: std::marker::PhantomData<P>,
+}
+
+impl<C, P> Staking<C, P> {
+	pub fn new(client: Arc<C>) -> Self {
+		Self { client, _marker: Default::default() }
+	}
+}
+
+/// Error type of this RPC api.
+pub enum Error {
+	/// The call to runtime failed.
+	RuntimeError,
+}
+
+impl From<Error> for i32 {
+	fn from(e: Error) -> i32 {
+		match e {
+			Error::RuntimeError => 1,
+		}
+	}
+}
+
+impl<C, Block, Balance> StakingApiServer<Balance> for Staking<C, Block>
+where
+	Block: BlockT,
+	C: ProvideRuntimeApi<Block> + HeaderBackend<Block> + Send + Sync + 'static,
+	C::Api: StakingRuntimeApi<Block, Balance>,
+	Balance: Codec + MaybeDisplay + Copy + TryInto<NumberOrHex> + Send + Sync + 'static,
+{
+	fn query_nominations_quota(&self) -> RpcResult<u32> {
+		let api = self.client.runtime_api();
+		let at = BlockId::hash(self.client.info().best_hash);
+
+		let runtime_api_result = api.query_nominations_quota(&at);
+
+		Ok(runtime_api_result.map_err(|e| {
+			CallError::Custom(ErrorObject::owned(
+				Error::RuntimeError.into(),
+				"Unable to query the nominations quota.",
+				Some(e.to_string()),
+			))
+		})?)
+	}
+
+    fn query_points_to_balance(&self, pool_id: u32) -> RpcResult<u32> {
+        let api = self.client.runtime_api();
+		let at = BlockId::hash(self.client.info().best_hash);
+
+		let runtime_api_result = api.query_points_to_balance(&at, pool_id);
+
+	    runtime_api_result.map_err(|e| {
+			CallError::Custom(ErrorObject::owned(
+				Error::RuntimeError.into(),
+				"Unable to query the points to balance conversion for pool.",
+				Some(e.to_string()),
+			))
+		})?
+    }
+}

--- a/frame/staking/rpc/src/lib.rs
+++ b/frame/staking/rpc/src/lib.rs
@@ -94,14 +94,20 @@ where
         let api = self.client.runtime_api();
 		let at = BlockId::hash(self.client.info().best_hash);
 
-		let runtime_api_result = api.query_points_to_balance(&at, pool_id);
-
-	    runtime_api_result.map_err(|e| {
+		api.query_points_to_balance(&at, pool_id).map_err(|e| {
 			CallError::Custom(ErrorObject::owned(
 				Error::RuntimeError.into(),
 				"Unable to query the points to balance conversion for pool.",
 				Some(e.to_string()),
 			))
-		})?
+		}).and_then(|r| {
+            r.map_err(|e| {
+                CallError::Custom(ErrorObject::owned(
+                    Error::RuntimeError.into(),
+                    "Unable to query the points to balance conversion for pool.",
+                    Some(e.to_string()),
+                ))
+            })?
+        })
     }
 }

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -59,6 +59,11 @@ use super::{pallet::*, STAKING_ID};
 const NPOS_MAX_ITERATIONS_COEFFICIENT: u32 = 2;
 
 impl<T: Config> Pallet<T> {
+	/// Query nominations quota for a given balance. Used for custom RPC call.
+	pub fn query_nominations_quota() -> u32 {
+        T::MaxNominations::get()
+	}
+
 	/// The total balance that can be slashed from a stash account as of right now.
 	pub fn slashable_balance_of(stash: &T::AccountId) -> BalanceOf<T> {
 		// Weight note: consider making the stake accessible through stash.


### PR DESCRIPTION
major WIP, open for comments and discussion

Open questions:
- should the points to balance be part of the staking RPC or should it have its own RPC trait and machinery?
- should we add the `staking_queryNominationsQuota` before merging https://github.com/paritytech/substrate/pull/12970? (nomination quota is `T::MaxNominations` before having the dynamic nominations quota)

Related to https://github.com/paritytech/substrate/issues/13069