### PR TITLE
Move update-node-template to Polkadot's pipeline

### DIFF
--- a/scripts/ci/gitlab/pipeline/publish.yml
+++ b/scripts/ci/gitlab/pipeline/publish.yml
@@ -182,20 +182,6 @@ publish-draft-release:
     - ./scripts/ci/gitlab/publish_draft_release.sh
   allow_failure:                   true
 
-# Ref: https://github.com/paritytech/opstooling/issues/111
-update-node-template:
-  stage:                           publish
-  extends:                         .kubernetes-env
-  rules:
-    - if: $CI_COMMIT_REF_NAME =~ /^polkadot-v[0-9]+\.[0-9]+.*$/ # i.e. polkadot-v1.0.99, polkadot-v2.1rc1
-  script:
-    - git clone --depth=1 --branch="$PIPELINE_SCRIPTS_TAG" https://github.com/paritytech/pipeline-scripts
-    - ./pipeline-scripts/update_substrate_template.sh
-      --repo-name "substrate-node-template"
-      --template-path "bin/node-template"
-      --github-api-token "$GITHUB_TOKEN"
-      --polkadot-branch "$CI_COMMIT_REF_NAME"
-
 .publish-crates-template:
   stage:                           publish
   extends:                         .crates-publishing-template


### PR DESCRIPTION
According to https://github.com/paritytech/release-engineering/issues/142

> The desired behaviour is that this job should be triggered only once when the final release tag is created.

The simplest solution I found for that requirement entails moving the job to Polkadot's pipeline and triggering it on the tags of that repository (https://github.com/paritytech/polkadot/pull/6522).

Alternatively we could keep the job here and trigger a remote pipeline from Polkadot to this repository ([example](https://github.com/paritytech/scripts/blob/d17032f1c2b12cfd18b4aa13f9e1e4d67d55b23e/.gitlab-ci.yml#L679)), but the extra complexity of that solution seems unwarranted for this script.