### PR TITLE
CI: configure `cargo-nextest`'s reporter options explicitly

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,8 @@ variables:
   RUSTY_CACHIER_SINGLE_BRANCH:     master
   RUSTY_CACHIER_DONT_OPERATE_ON_MAIN_BRANCH: "true"
   RUSTY_CACHIER_COMPRESSION_METHOD: zstd
+  NEXTEST_FAILURE_OUTPUT:          immediate-final
+  NEXTEST_SUCCESS_OUTPUT:          final
   ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.3.22"
 
 default:


### PR DESCRIPTION
These changes will allow `cargo-nextest` to output logs in any case. Passed tests don't output anything currently. 