### PR TITLE
Scheduler is already at V4

### DIFF
--- a/frame/referenda/src/migration.rs
+++ b/frame/referenda/src/migration.rs
@@ -88,7 +88,7 @@ pub mod v1 {
 	use super::*;
 
 	/// The log target.
-	const TARGET: &'static str = "runtime::democracy::migration::v1";
+	const TARGET: &'static str = "runtime::referenda::migration::v1";
 
 	/// Transforms a submission deposit of ReferendumInfo(Approved|Rejected|Cancelled|TimedOut) to
 	/// optional value, making it refundable.

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -169,7 +169,7 @@ pub mod pallet {
 	use frame_system::pallet_prelude::*;
 
 	/// The current storage version.
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(4);
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]

--- a/frame/scheduler/src/tests.rs
+++ b/frame/scheduler/src/tests.rs
@@ -973,7 +973,7 @@ fn migration_to_v4_works() {
 		}
 		assert_eq_uvec!(x, expected);
 
-		assert_eq!(Scheduler::current_storage_version(), 3);
+		assert_eq!(Scheduler::on_chain_storage_version(), 4);
 	});
 }
 


### PR DESCRIPTION
Looks like we forgot to bump the scheduler code version from V3 to V4 here https://github.com/paritytech/substrate/pull/11649  

Chains who deployed a scheduler/genesis without this patch should manually set the scheduler version to 4 and not use `v3::MigrateToV4`.