### PR TITLE
Less picky epoch changes lookup, with gap fallback

### DIFF
--- a/client/consensus/epochs/src/lib.rs
+++ b/client/consensus/epochs/src/lib.rs
@@ -512,7 +512,7 @@ where
 	) -> Result<(), fork_tree::Error<D::Error>> {
 		if self.gap.is_some() {
 			// Do not remove any node while a gap is present.
-			// Tree nodes may be still required while we importing gap blocks.
+			// Tree nodes may be required while importing gap blocks.
 			return Ok(())
 		}
 
@@ -677,7 +677,7 @@ where
 			})
 		});
 		if stop_search {
-			// Stop the lookup if the slot is within the bounds of a the found epoch entry.
+			// Stop the lookup if slot is within the bounds of the found epoch entry.
 			// A slot may be out of bounds only in case of skipped epochs.
 			return Ok(gap_entry)
 		}


### PR DESCRIPTION
Fix for the issue described by https://github.com/paritytech/substrate/pull/12751#issuecomment-1328032781

In the (unlucky) event of skipped epochs, full nodes using BABE were receiving an error during the VRF output verification.

```
2022-11-26 10:44:22.488  WARN tokio-runtime-worker sync: 💔 Verification failed for block 0x2babfbf24066fa1b420934090c6472bf57f9b16a91fddf7ba3659ef7ad82449b received from peer: 12D3KooWPKzmmE2uYgF3z13xjpbFTp63g9dZFag8pG6MgnpSLF4S, "Could not fetch epoch at 0x5448eda4b7963ee85d28ea523149317dc39ce41173e198126b7ba67b7e123854"    
```

The problem was triggered because after warp sync the epoch changes data was contained within the gap structure AND (in contrast to the epoch changes tree) the gap is picky about the check. I.e. it requires that `epoch.start_slot <= slot < epoch.end_slot`.

---

Additionally we prevent epoch changes tree prune on finalization if there is something in the `gap`. This is because we may require (again, after warp sync and if some epoch hash been skipped) the first tree entry during import of last gap entries.

@andresilva this requires some brainstorming

---

I'm going to add some tests before merge

