### PR TITLE
Update tests for 1.66 and switch CI to stable Rust 1.66

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,7 +48,7 @@ variables:
   CARGO_INCREMENTAL:               0
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  CI_IMAGE:                        "paritytech/ci-linux:production"
+  CI_IMAGE:                        "paritytech/ci-linux@sha256:9140bc3c843a8b12a3bcf6f5886346536092795bbadfd7f1836362cb28dfcc71"
   BUILDAH_IMAGE:                   "quay.io/buildah/stable:v1.27"
   RUSTY_CACHIER_SINGLE_BRANCH:     master
   RUSTY_CACHIER_DONT_OPERATE_ON_MAIN_BRANCH: "true"

--- a/frame/support/test/tests/construct_runtime_ui/invalid_module_details.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/invalid_module_details.stderr
@@ -1,5 +1,5 @@
 error: Unexpected tokens, expected one of `::$ident` `::{`, `exclude_parts`, `use_parts`, `=`, `,`
- --> $DIR/invalid_module_details.rs:9:17
+ --> tests/construct_runtime_ui/invalid_module_details.rs:9:17
   |
 9 |         system: System::(),
-  |                       ^^
+  |                       ^

--- a/frame/support/test/tests/derive_no_bound.rs
+++ b/frame/support/test/tests/derive_no_bound.rs
@@ -211,7 +211,7 @@ fn test_enum() {
 
 	assert_eq!(
 		format!("{:?}", variant_0),
-		String::from("Enum::VariantUnnamed(1, 2, 3, PhantomData)"),
+		String::from("Enum::VariantUnnamed(1, 2, 3, PhantomData<(derive_no_bound::ImplNone, derive_no_bound::ImplNone)>)"),
 	);
 	assert_eq!(
 		format!("{:?}", variant_1),

--- a/frame/support/test/tests/derive_no_bound.rs
+++ b/frame/support/test/tests/derive_no_bound.rs
@@ -103,7 +103,7 @@ fn test_struct_unnamed() {
 	assert_eq!(a_2.1, 2);
 	assert_eq!(a_2.2, 3);
 	assert_eq!(a_2, a_1);
-	assert_eq!(format!("{:?}", a_1), String::from("StructUnnamed(1, 2, 3, PhantomData)"));
+	assert_eq!(format!("{:?}", a_1), String::from("StructUnnamed(1, 2, 3, PhantomData<(derive_no_bound::ImplNone, derive_no_bound::ImplNone)>)"));
 
 	let b = StructUnnamed::<Runtime, ImplNone, ImplNone>(1, 2, 4, Default::default());
 

--- a/frame/support/test/tests/derive_no_bound.rs
+++ b/frame/support/test/tests/derive_no_bound.rs
@@ -72,7 +72,7 @@ fn test_struct_named() {
 	assert_eq!(a_2, a_1);
 	assert_eq!(
 		format!("{:?}", a_1),
-		String::from("StructNamed { a: 1, b: 2, c: 3, phantom: PhantomData }")
+		String::from("StructNamed { a: 1, b: 2, c: 3, phantom: PhantomData<(derive_no_bound::ImplNone, derive_no_bound::ImplNone)> }")
 	);
 
 	let b = StructNamed::<Runtime, ImplNone, ImplNone> {

--- a/frame/support/test/tests/derive_no_bound.rs
+++ b/frame/support/test/tests/derive_no_bound.rs
@@ -215,7 +215,7 @@ fn test_enum() {
 	);
 	assert_eq!(
 		format!("{:?}", variant_1),
-		String::from("Enum::VariantNamed { a: 1, b: 2, c: 3, phantom: PhantomData }"),
+		String::from("Enum::VariantNamed { a: 1, b: 2, c: 3, phantom: PhantomData<(derive_no_bound::ImplNone, derive_no_bound::ImplNone)> }"),
 	);
 	assert_eq!(format!("{:?}", variant_2), String::from("Enum::VariantUnit"));
 	assert_eq!(format!("{:?}", variant_3), String::from("Enum::VariantUnit2"));

--- a/frame/support/test/tests/pallet_ui/call_invalid_return.stderr
+++ b/frame/support/test/tests/pallet_ui/call_invalid_return.stderr
@@ -1,5 +1,5 @@
 error: expected `DispatchResultWithPostInfo` or `DispatchResult`
-  --> $DIR/call_invalid_return.rs:17:39
+  --> tests/pallet_ui/call_invalid_return.rs:17:39
    |
 17 |         pub fn foo(origin: OriginFor<T>) -> ::DispatchResult { todo!() }
-   |                                             ^^
+   |                                             ^


### PR DESCRIPTION
Also pins the CI image to the current staging with Rust 1.66, will revert back to the generic `production` tag after this is merged.