### PR TITLE
Adds StakingAPI_nominations_quota and NominationPoolsApi_balanceToPoi…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,6 +3479,7 @@ dependencies = [
  "pallet-society",
  "pallet-staking",
  "pallet-staking-reward-curve",
+ "pallet-staking-runtime-api",
  "pallet-state-trie-migration",
  "pallet-sudo",
  "pallet-timestamp",
@@ -6393,6 +6394,14 @@ version = "4.0.0-dev"
 dependencies = [
  "log",
  "sp-arithmetic",
+]
+
+[[package]]
+name = "pallet-staking-runtime-api"
+version = "4.0.0-dev"
+dependencies = [
+ "parity-scale-codec",
+ "sp-api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ members = [
 	"frame/staking",
 	"frame/staking/reward-curve",
 	"frame/staking/reward-fn",
+	"frame/staking/runtime-api",
 	"frame/state-trie-migration",
 	"frame/sudo",
 	"frame/root-offences",

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -96,6 +96,7 @@ pallet-session = { version = "4.0.0-dev", features = [ "historical" ], path = ".
 pallet-session-benchmarking = { version = "4.0.0-dev", path = "../../../frame/session/benchmarking", default-features = false, optional = true }
 pallet-staking = { version = "4.0.0-dev", default-features = false, path = "../../../frame/staking" }
 pallet-staking-reward-curve = { version = "4.0.0-dev", default-features = false, path = "../../../frame/staking/reward-curve" }
+pallet-staking-runtime-api = { version = "4.0.0-dev", default-features = false, path = "../../../frame/staking/runtime-api" }
 pallet-state-trie-migration = { version = "4.0.0-dev", default-features = false, path = "../../../frame/state-trie-migration" }
 pallet-scheduler = { version = "4.0.0-dev", default-features = false, path = "../../../frame/scheduler" }
 pallet-society = { version = "4.0.0-dev", default-features = false, path = "../../../frame/society" }

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1972,7 +1972,21 @@ impl_runtime_apis! {
 
 	impl pallet_nomination_pools_runtime_api::NominationPoolsApi<Block, AccountId, Balance> for Runtime {
 		fn pending_rewards(member_account: AccountId) -> Balance {
-			NominationPools::pending_rewards(member_account).unwrap_or_default()
+			NominationPools::api_pending_rewards(member_account).unwrap_or_default()
+		}
+
+		fn points_to_balance(pool_id: u32) -> Result<Balance, ()> {
+			NominationPools::api_points_to_balance(pool_id)
+		}
+
+		fn balance_to_point(pool_id: u32, new_funds: Balance) -> Result<Balance, ()> {
+			NominationPools::api_balance_to_point(pool_id, new_funds)
+		}
+	}
+
+	impl pallet_staking_runtime_api::StakingApi<Block> for Runtime {
+		fn nominations_quota() -> u32 {
+			Staking::api_nominations_quota()
 		}
 	}
 

--- a/frame/nomination-pools/runtime-api/src/lib.rs
+++ b/frame/nomination-pools/runtime-api/src/lib.rs
@@ -24,10 +24,19 @@ use codec::Codec;
 
 sp_api::decl_runtime_apis! {
 	/// Runtime api for accessing information about nomination pools.
+	#[api_version(1)]
 	pub trait NominationPoolsApi<AccountId, Balance>
-		where AccountId: Codec, Balance: Codec
+		where
+			AccountId: Codec,
+			Balance: Codec,
 	{
 		/// Returns the pending rewards for the member that the AccountId was given for.
 		fn pending_rewards(member: AccountId) -> Balance;
+
+		/// Returns the points to balance conversion for a given pool.
+		fn points_to_balance(pool_id: u32) -> Result<Balance, ()>;
+
+		/// Returns the equivalent points of `new_funds` for a given pool
+		fn balance_to_point(pool_id: u32, new_funds: Balance) -> Result<Balance, ()>;
 	}
 }

--- a/frame/staking/runtime-api/Cargo.toml
+++ b/frame/staking/runtime-api/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "pallet-staking-runtime-api"
+version = "4.0.0-dev"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+license = "Apache-2.0"
+homepage = "https://substrate.io"
+repository = "https://github.com/paritytech/substrate/"
+description = "RPC runtime API for transaction payment FRAME pallet"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+sp-api = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/api" }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"sp-api/std",
+]

--- a/frame/staking/runtime-api/README.md
+++ b/frame/staking/runtime-api/README.md
@@ -1,0 +1,3 @@
+Runtime API definition for the staking pallet.
+
+License: Apache-2.0

--- a/frame/staking/runtime-api/src/lib.rs
+++ b/frame/staking/runtime-api/src/lib.rs
@@ -1,0 +1,28 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2019-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Runtime API definition for the staking pallet.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+sp_api::decl_runtime_apis! {
+	#[api_version(1)]
+	pub trait StakingApi {
+		/// Returns the current nominations quota for nominators.
+		fn nominations_quota() -> u32;
+	}
+}

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -59,6 +59,13 @@ use super::{pallet::*, STAKING_ID};
 const NPOS_MAX_ITERATIONS_COEFFICIENT: u32 = 2;
 
 impl<T: Config> Pallet<T> {
+	/// Returns the current nominations quota for nominators.
+	///
+	/// Used by runtime API.
+	pub fn api_nominations_quota() -> u32 {
+		T::MaxNominations::get()
+	}
+
 	/// The total balance that can be slashed from a stash account as of right now.
 	pub fn slashable_balance_of(stash: &T::AccountId) -> BalanceOf<T> {
 		// Weight note: consider making the stake accessible through stash.


### PR DESCRIPTION
This PR adds new runtime API calls that can be called through `state_call` rpc to fetch:

- Nominations quota (`StakingApi_nominations_quota`)
- Points to balance conversion for pools (`NominationPoolsApi_points_to_balance`)
- Balance to point conversion for pools (`NominationPoolsApi_balance_to_point`) 

Closes https://github.com/paritytech/substrate/issues/13069
