### PR TITLE
revamp locking & reserving

### DIFF
--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -195,6 +195,13 @@ pub mod pallet {
 	#[pallet::without_storage_info]
 	pub struct Pallet<T>(PhantomData<T>);
 
+	// local lock id.
+	// `#[pallet::composite]`
+	enum LockId {
+		CouncilVoting,
+		OtherReason,
+	}
+
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
@@ -204,15 +211,14 @@ pub mod pallet {
 		type PalletId: Get<LockIdentifier>;
 
 		/// This will come from the outer runtime, and it will be the amalgamated lock ids.
-		type RuntimeLockIds: From<crate::pallet::LockIds>;
+		type RuntimeLockIds: From<crate::pallet::LockId>;
 
 		/// The currency that people are electing with.
 		type Currency: LockableCurrency<
-			Self::AccountId,
-			Moment = Self::BlockNumber,
-			LockId = Self::RuntimeLockId
-		>
-			+ ReservableCurrency<Self::AccountId>;
+				Self::AccountId,
+				Moment = Self::BlockNumber,
+				LockId = Self::RuntimeLockIds,
+			> + ReservableCurrency<Self::AccountId>;
 
 		/// What to do when the members change.
 		type ChangeMembers: ChangeMembers<Self::AccountId>;
@@ -367,13 +373,6 @@ pub mod pallet {
 					debug_assert!(_remainder.is_zero());
 				},
 			};
-
-			// local lock id.
-			#[pallet::composite]
-			enum LockId {
-				CouncilVoting,
-				OtherReason,
-			}
 
 			let id: T::RuntimeLockIds = LockId::CouncilVoting.into();
 

--- a/frame/support/procedural/src/lib.rs
+++ b/frame/support/procedural/src/lib.rs
@@ -1289,3 +1289,8 @@ pub fn validate_unsigned(_: TokenStream, _: TokenStream) -> TokenStream {
 pub fn origin(_: TokenStream, _: TokenStream) -> TokenStream {
 	pallet_macro_stub()
 }
+
+#[proc_macro_attribute]
+pub fn composite(_: TokenStream, _: TokenStream) -> TokenStream {
+	pallet_macro_stub()
+}

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -2738,10 +2738,10 @@ pub use frame_support_procedural::pallet;
 /// Contains macro stubs for all of the pallet:: macros
 pub mod pallet_macros {
 	pub use frame_support_procedural::{
-		call_index, compact, config, constant, disable_frame_system_supertrait_check, error, event,
-		extra_constants, generate_deposit, generate_storage_info, generate_store, genesis_build,
-		genesis_config, getter, hooks, inherent, origin, storage, storage_prefix, storage_version,
-		type_value, unbounded, validate_unsigned, weight, whitelist_storage,
+		call_index, compact, composite, config, constant, disable_frame_system_supertrait_check,
+		error, event, extra_constants, generate_deposit, generate_storage_info, generate_store,
+		genesis_build, genesis_config, getter, hooks, inherent, origin, storage, storage_prefix,
+		storage_version, type_value, unbounded, validate_unsigned, weight, whitelist_storage,
 	};
 }
 

--- a/frame/support/src/traits/tokens/currency/lockable.rs
+++ b/frame/support/src/traits/tokens/currency/lockable.rs
@@ -29,6 +29,10 @@ pub trait LockableCurrency<AccountId>: Currency<AccountId> {
 	/// The quantity used to denote time; usually just a `BlockNumber`.
 	type Moment;
 
+	/// Opaque Identifier for lock.
+	// TODO: can already be ported to master with LockIdentifier used everywhere.
+	type LockId;
+
 	/// The maximum number of locks a user should have on their account.
 	type MaxLocks: Get<u32>;
 
@@ -39,7 +43,7 @@ pub trait LockableCurrency<AccountId>: Currency<AccountId> {
 	///
 	/// If the lock `id` already exists, this will update it.
 	fn set_lock(
-		id: LockIdentifier,
+		id: Self::LockId,
 		who: &AccountId,
 		amount: Self::Balance,
 		reasons: WithdrawReasons,
@@ -54,7 +58,7 @@ pub trait LockableCurrency<AccountId>: Currency<AccountId> {
 	/// - maximum `amount`
 	/// - bitwise mask of all `reasons`
 	fn extend_lock(
-		id: LockIdentifier,
+		id: Self::LockId,
 		who: &AccountId,
 		amount: Self::Balance,
 		reasons: WithdrawReasons,


### PR DESCRIPTION
## Description

This PR is our initial stab at #12918, which involves revisiting the definitions of free, locked, and reserved, especially as these concepts relate to voting, aucitions/crowdloans, and staking. In particular reserving will be replaced with "holding" via a type-safe `HoldReason`, and 

This will entail:
- [ ] generic `#[pallet::composite]` syntax for definining composite enums that can then be used at the runtime level
- [ ] `HoldReason` / type-safe reserve/hold identifier via `#[pallet::composite]`
- [ ] `FreezeReason` / type-safe lock/freeze identifier via `#[pallet::composite]`
- [ ] TBD, see original issue #12918

## Related Issued
- #12918