### PR TITLE
Stop keeping track of epoch changes for the sync gap

### DIFF
--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -111,7 +111,7 @@ use sp_api::{ApiExt, ProvideRuntimeApi};
 use sp_application_crypto::AppKey;
 use sp_block_builder::BlockBuilder as BlockBuilderApi;
 use sp_blockchain::{
-	Backend as _, Error as ClientError, ForkBackend, HeaderBackend, HeaderMetadata,
+	Backend as _, BlockStatus, Error as ClientError, ForkBackend, HeaderBackend, HeaderMetadata,
 	Result as ClientResult,
 };
 use sp_consensus::{
@@ -1133,11 +1133,19 @@ where
 		let hash = block.header.hash();
 		let parent_hash = *block.header.parent_hash();
 
-		if block.with_state() {
-			// When importing whole state we don't calculate epoch descriptor, but rather
-			// read it from the state after import. We also skip all verifications
-			// because there's no parent state and we trust the sync module to verify
-			// that the state is correct and finalized.
+		let finalized_number = self.client.info().finalized_number;
+		let number = *block.header.number();
+
+		if (block.origin == BlockOrigin::NetworkInitialSync && number < finalized_number) ||
+			block.with_state()
+		{
+			// Verification for imported blocks is skipped in two cases:
+			// 1. When importing blocks below the last finalized block during network initial
+			//    synchronization.
+			// 2. When importing whole state we don't calculate epoch descriptor, but rather
+			//    read it from the state after import. We also skip all verifications
+			//    because there's no parent state and we trust the sync module to verify
+			//    that the state is correct and finalized.
 			return Ok((block, Default::default()))
 		}
 
@@ -1399,18 +1407,23 @@ where
 	) -> Result<ImportResult, Self::Error> {
 		let hash = block.post_hash();
 		let number = *block.header.number();
+		let info = self.client.info();
 
-		// early exit if block already in chain, otherwise the check for
-		// epoch changes will error when trying to re-import an epoch change
-		match self.client.status(hash) {
-			Ok(sp_blockchain::BlockStatus::InChain) => {
-				// When re-importing existing block strip away intermediates.
-				let _ = block.remove_intermediate::<BabeIntermediate<Block>>(INTERMEDIATE_KEY);
-				block.fork_choice = Some(ForkChoiceStrategy::Custom(false));
-				return self.inner.import_block(block, new_cache).await.map_err(Into::into)
-			},
-			Ok(sp_blockchain::BlockStatus::Unknown) => {},
-			Err(e) => return Err(ConsensusError::ClientImport(e.to_string())),
+		let block_status = self
+			.client
+			.status(hash)
+			.map_err(|e| ConsensusError::ClientImport(e.to_string()))?;
+
+		// Early exit if block already in chain or importing blocks during initial sync,
+		// otherwise the check for epoch changes will error when trying to re-import an epoch change
+		if (block.origin == BlockOrigin::NetworkInitialSync && number < info.finalized_number) ||
+			block_status == BlockStatus::InChain
+		{
+			// When re-importing existing block strip away intermediates.
+			// In case of initial sync intermediates should not be present...
+			let _ = block.remove_intermediate::<BabeIntermediate<Block>>(INTERMEDIATE_KEY);
+			block.fork_choice = Some(ForkChoiceStrategy::Custom(false));
+			return self.inner.import_block(block, new_cache).await.map_err(Into::into)
 		}
 
 		if block.with_state() {
@@ -1505,8 +1518,6 @@ where
 						babe_err(Error::<Block>::UnexpectedEpochChange).into(),
 					)),
 			}
-
-			let info = self.client.info();
 
 			if let Some(next_epoch_descriptor) = next_epoch_digest {
 				old_epoch_changes = Some((*epoch_changes).clone());
@@ -1701,9 +1712,6 @@ where
 	Client: HeaderBackend<Block> + HeaderMetadata<Block, Error = sp_blockchain::Error>,
 {
 	let info = client.info();
-	if info.block_gap.is_none() {
-		epoch_changes.clear_gap();
-	}
 
 	let finalized_slot = {
 		let finalized_header = client

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -1133,10 +1133,10 @@ where
 		let hash = block.header.hash();
 		let parent_hash = *block.header.parent_hash();
 
-		let finalized_number = self.client.info().finalized_number;
+		let info = self.client.info()
 		let number = *block.header.number();
 
-		if (block.origin == BlockOrigin::NetworkInitialSync && number < finalized_number) ||
+		if info.block_gap.map_or(false, |(s, e)| s <= number && number <= e)  ||
 			block.with_state()
 		{
 			// Verification for imported blocks is skipped in two cases:
@@ -1417,7 +1417,7 @@ where
 		// Skip babe logic if block already in chain or importing blocks during initial sync,
 		// otherwise the check for epoch changes will error because trying to re-import an
 		// epoch change or because of missing epoch data in the tree, respectivelly.
-		if (block.origin == BlockOrigin::NetworkInitialSync && number < info.finalized_number) ||
+		if info.block_gap.map_or(false, |(s, e)| s <= number && number <= e) ||
 			block_status == BlockStatus::InChain
 		{
 			// When re-importing existing block strip away intermediates.

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -1414,8 +1414,9 @@ where
 			.status(hash)
 			.map_err(|e| ConsensusError::ClientImport(e.to_string()))?;
 
-		// Early exit if block already in chain or importing blocks during initial sync,
-		// otherwise the check for epoch changes will error when trying to re-import an epoch change
+		// Skip babe logic if block already in chain or importing blocks during initial sync,
+		// otherwise the check for epoch changes will error because trying to re-import an
+		// epoch change or because of missing epoch data in the tree, respectivelly.
 		if (block.origin == BlockOrigin::NetworkInitialSync && number < info.finalized_number) ||
 			block_status == BlockStatus::InChain
 		{

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -1133,12 +1133,10 @@ where
 		let hash = block.header.hash();
 		let parent_hash = *block.header.parent_hash();
 
-		let info = self.client.info()
+		let info = self.client.info();
 		let number = *block.header.number();
 
-		if info.block_gap.map_or(false, |(s, e)| s <= number && number <= e)  ||
-			block.with_state()
-		{
+		if info.block_gap.map_or(false, |(s, e)| s <= number && number <= e) || block.with_state() {
 			// Verification for imported blocks is skipped in two cases:
 			// 1. When importing blocks below the last finalized block during network initial
 			//    synchronization.

--- a/client/consensus/epochs/src/migration.rs
+++ b/client/consensus/epochs/src/migration.rs
@@ -64,7 +64,7 @@ where
 			header
 		});
 
-		EpochChanges { inner, epochs, gap: None }
+		EpochChanges { inner, epochs }
 	}
 }
 
@@ -75,6 +75,6 @@ where
 {
 	/// Migrate the type into current epoch changes definition.
 	pub fn migrate(self) -> EpochChanges<Hash, Number, E> {
-		EpochChanges { inner: self.inner, epochs: self.epochs, gap: None }
+		EpochChanges { inner: self.inner, epochs: self.epochs }
 	}
 }


### PR DESCRIPTION
Epoch changes data for the gap (i.e. the blocks below the warp sync point) was used to verify the blocks imported after a warp sync.

Currently this verification is not really required since all our security depends on the last finalized block.

Once the last finalized block is imported (i.e. the warp sync point) then we start importing all the previous blocks and we can detect a bad history only after we finished importing the block before the warp sync point.

We may think that in this way we may be tricked by a malicious full node into downloading an history of blocks that in the end we find out to not be good WRT the finalized block we warp synced to. However, the same type of attack can be performed by one of the initial authorities by feeding an history that is coherently signed together with a crafted dummy authority set changes.

Thus our only stable grip is the last finalized block anyway. This is the point that in the end will allow us to distinguish between a good history from a bad one.

---

Note. In the future we may think to early detect this type of annoyance by downloading the blocks in reverse order. In this way, for each block we can immediately check if the header hash is equal to the parent of the block that follows.

---

Fixes zombienet test 0003 in https://github.com/paritytech/substrate/pull/13078