### PR TITLE
Use balance trait in transaction-payment pallets

### DIFF
--- a/frame/transaction-payment/asset-tx-payment/src/payment.rs
+++ b/frame/transaction-payment/asset-tx-payment/src/payment.rs
@@ -21,15 +21,13 @@ use codec::FullCodec;
 use frame_support::{
 	traits::{
 		fungibles::{Balanced, CreditOf, Inspect},
-		tokens::BalanceConversion,
+		tokens::{Balance, BalanceConversion},
 	},
 	unsigned::TransactionValidityError,
 };
 use scale_info::TypeInfo;
 use sp_runtime::{
-	traits::{
-		AtLeast32BitUnsigned, DispatchInfoOf, MaybeSerializeDeserialize, One, PostDispatchInfoOf,
-	},
+	traits::{DispatchInfoOf, MaybeSerializeDeserialize, One, PostDispatchInfoOf},
 	transaction_validity::InvalidTransaction,
 };
 use sp_std::{fmt::Debug, marker::PhantomData};
@@ -37,13 +35,7 @@ use sp_std::{fmt::Debug, marker::PhantomData};
 /// Handle withdrawing, refunding and depositing of transaction fees.
 pub trait OnChargeAssetTransaction<T: Config> {
 	/// The underlying integer type in which fees are calculated.
-	type Balance: AtLeast32BitUnsigned
-		+ FullCodec
-		+ Copy
-		+ MaybeSerializeDeserialize
-		+ Debug
-		+ Default
-		+ TypeInfo;
+	type Balance: Balance;
 	/// The type used to identify the assets used for transaction payment.
 	type AssetId: FullCodec + Copy + MaybeSerializeDeserialize + Debug + Default + Eq + TypeInfo;
 	/// The type used to store the intermediate values between pre- and post-dispatch.

--- a/frame/transaction-payment/src/payment.rs
+++ b/frame/transaction-payment/src/payment.rs
@@ -1,15 +1,11 @@
 /// ! Traits and default implementation for paying transaction fees.
 use crate::Config;
 
-use codec::FullCodec;
 use sp_runtime::{
-	traits::{
-		AtLeast32BitUnsigned, DispatchInfoOf, MaybeSerializeDeserialize, PostDispatchInfoOf,
-		Saturating, Zero,
-	},
+	traits::{DispatchInfoOf, PostDispatchInfoOf, Saturating, Zero},
 	transaction_validity::InvalidTransaction,
 };
-use sp_std::{fmt::Debug, marker::PhantomData};
+use sp_std::marker::PhantomData;
 
 use frame_support::{
 	traits::{Currency, ExistenceRequirement, Imbalance, OnUnbalanced, WithdrawReasons},
@@ -22,13 +18,8 @@ type NegativeImbalanceOf<C, T> =
 /// Handle withdrawing, refunding and depositing of transaction fees.
 pub trait OnChargeTransaction<T: Config> {
 	/// The underlying integer type in which fees are calculated.
-	type Balance: AtLeast32BitUnsigned
-		+ FullCodec
-		+ Copy
-		+ MaybeSerializeDeserialize
-		+ Debug
-		+ Default
-		+ scale_info::TypeInfo;
+	type Balance: frame_support::traits::tokens::Balance;
+
 	type LiquidityInfo: Default;
 
 	/// Before the transaction is executed the payment of the transaction fees


### PR DESCRIPTION
Can we use the balance trait here rather than enumerating all the trait bounds that we'd like Balance to have?