### PR TITLE
Fix benchmarks failing on scheduler overflow

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -356,7 +356,7 @@ impl pallet_scheduler::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type MaximumWeight = MaximumSchedulerWeight;
 	type ScheduleOrigin = EnsureRoot<AccountId>;
-	type MaxScheduledPerBlock = ConstU32<512>;
+	type MaxScheduledPerBlock = ConstU32<50>;
 	type WeightInfo = pallet_scheduler::weights::SubstrateWeight<Runtime>;
 	type OriginPrivilegeCmp = EqualPrivilegeOnly;
 	type Preimages = Preimage;
@@ -828,10 +828,10 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
 			0u16,
 			pallet_referenda::TrackInfo {
 				name: "root",
-				max_deciding: 1,
+				max_deciding: 50,
 				decision_deposit: 10,
-				prepare_period: 4,
-				decision_period: 4,
+				prepare_period: 10,
+				decision_period: 20,
 				confirm_period: 2,
 				min_enactment_period: 4,
 				min_approval: pallet_referenda::Curve::LinearDecreasing {

--- a/frame/referenda/src/lib.rs
+++ b/frame/referenda/src/lib.rs
@@ -79,7 +79,7 @@ use frame_support::{
 };
 use scale_info::TypeInfo;
 use sp_runtime::{
-	traits::{AtLeast32BitUnsigned, Bounded, Dispatchable, One, Saturating, Zero},
+	traits::{AtLeast32BitUnsigned, Dispatchable, One, Saturating, Zero},
 	DispatchError, Perbill,
 };
 use sp_std::{fmt::Debug, prelude::*};

--- a/frame/referenda/src/lib.rs
+++ b/frame/referenda/src/lib.rs
@@ -691,6 +691,7 @@ impl<T: Config<I>, I: 'static> Polling<T::Tally> for Pallet<T, I> {
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn create_ongoing(class: Self::Class) -> Result<Self::Index, ()> {
+		use sp_runtime::traits::Bounded;
 		let index = ReferendumCount::<T, I>::mutate(|x| {
 			let r = *x;
 			*x += 1;

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -1253,6 +1253,11 @@ impl<T: Config> schedule::v3::Anon<T::BlockNumber, <T as Config>::RuntimeCall, T
 			.ok_or(DispatchError::Unavailable)
 			.map(|_| when)
 	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn max_scheduled_per_block() -> u32 {
+		T::MaxScheduledPerBlock::get()
+	}
 }
 
 use schedule::v3::TaskName;

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -1253,11 +1253,6 @@ impl<T: Config> schedule::v3::Anon<T::BlockNumber, <T as Config>::RuntimeCall, T
 			.ok_or(DispatchError::Unavailable)
 			.map(|_| when)
 	}
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn max_scheduled_per_block() -> u32 {
-		T::MaxScheduledPerBlock::get()
-	}
 }
 
 use schedule::v3::TaskName;
@@ -1302,5 +1297,12 @@ fn map_err_to_v3_err<T: Config>(err: DispatchError) -> DispatchError {
 		DispatchError::Unavailable
 	} else {
 		err
+	}
+}
+
+impl<T: Config> schedule::ConfigInfo for Pallet<T> {
+	#[cfg(feature = "runtime-benchmarks")]
+	fn max_scheduled_per_block() -> u32 {
+		T::MaxScheduledPerBlock::get()
 	}
 }

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -1300,7 +1300,9 @@ fn map_err_to_v3_err<T: Config>(err: DispatchError) -> DispatchError {
 	}
 }
 
+/// Implements [schedule::ConfigInfo] trait.
 impl<T: Config> schedule::ConfigInfo for Pallet<T> {
+	/// Return the maximum number of tasks possible to schedule per block.
 	#[cfg(feature = "runtime-benchmarks")]
 	fn max_scheduled_per_block() -> u32 {
 		T::MaxScheduledPerBlock::get()

--- a/frame/support/src/traits/schedule.rs
+++ b/frame/support/src/traits/schedule.rs
@@ -426,6 +426,10 @@ pub mod v3 {
 		///
 		/// Will return an `Unavailable` error if the `address` is invalid.
 		fn next_dispatch_time(address: Self::Address) -> Result<BlockNumber, DispatchError>;
+
+		/// Return the maximum number of tasks possible to schedule per block.
+		#[cfg(feature = "runtime-benchmarks")]
+		fn max_scheduled_per_block() -> u32;
 	}
 
 	pub type TaskName = [u8; 32];

--- a/frame/support/src/traits/schedule.rs
+++ b/frame/support/src/traits/schedule.rs
@@ -426,10 +426,6 @@ pub mod v3 {
 		///
 		/// Will return an `Unavailable` error if the `address` is invalid.
 		fn next_dispatch_time(address: Self::Address) -> Result<BlockNumber, DispatchError>;
-
-		/// Return the maximum number of tasks possible to schedule per block.
-		#[cfg(feature = "runtime-benchmarks")]
-		fn max_scheduled_per_block() -> u32;
 	}
 
 	pub type TaskName = [u8; 32];
@@ -477,3 +473,10 @@ pub mod v3 {
 }
 
 pub use v1::*;
+
+/// A type that aware about a scheduler configuration.
+pub trait ConfigInfo {
+	/// Return the maximum number of tasks possible to schedule per block.
+	#[cfg(feature = "runtime-benchmarks")]
+	fn max_scheduled_per_block() -> u32;
+}

--- a/frame/support/src/traits/voting.rs
+++ b/frame/support/src/traits/voting.rs
@@ -189,5 +189,7 @@ pub trait Polling<Tally> {
 
 	/// The maximum number of the access poll invocations possible per block.
 	#[cfg(feature = "runtime-benchmarks")]
-	fn max_access_poll_per_block() -> u32;
+	fn max_access_poll_per_block() -> u32 {
+		u32::max_value()
+	}
 }

--- a/frame/support/src/traits/voting.rs
+++ b/frame/support/src/traits/voting.rs
@@ -186,4 +186,8 @@ pub trait Polling<Tally> {
 	fn max_ongoing() -> (Self::Class, u32) {
 		(Self::classes().into_iter().next().expect("Always one class"), u32::max_value())
 	}
+
+	/// The maximum number of the access poll invocations possible per block.
+	#[cfg(feature = "runtime-benchmarks")]
+	fn max_access_poll_per_block() -> u32;
 }


### PR DESCRIPTION
Scheduler has the upper limit for the number of the calls scheduled per block.
The benchmarks of the `pallet_referenda` and `pallet_conviction_voting` do not respect the limit and overflows it if the scheduler `MaxScheduledPerBlock` not high enough.

For `pallet_referenda` benchmarks the limit reached **if**
track.max_deciding > scheduler.max_scheduled_per_block **OR** 
referenda.max_queued > scheduler.max_scheduled_per_block **OR** 
track.max_deciding + referenda.max_queued > scheduler.max_scheduled_per_block 

For `pallet_conviction_voting` benchmarks the limit reached **if**
number_of_registered_votes > scheduler.max_scheduled_per_block 

This PR fixes it with aim to make it seamless for users. 