### PR TITLE
Improving try state running time for staking pallet

### DIFF
--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -1691,11 +1691,11 @@ impl<T: Config> Pallet<T> {
 		ensure!(
 			<T as Config>::VoterList::count() ==
 				Nominators::<T>::count() + Validators::<T>::count(),
-			"wrong external count"
+			"wrong external voterlist count"
 		);
 		ensure!(
 			<T as Config>::TargetList::count() == Validators::<T>::count(),
-			"wrong external count"
+			"wrong external targetlist count"
 		);
 		ensure!(
 			ValidatorCount::<T>::get() <=

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -1681,11 +1681,6 @@ impl<T: Config> StakingInterface for Pallet<T> {
 #[cfg(any(test, feature = "try-runtime"))]
 impl<T: Config> Pallet<T> {
 	pub(crate) fn do_try_state(_: BlockNumberFor<T>) -> Result<(), &'static str> {
-		ensure!(
-			T::VoterList::count() == <Nominators<T>>::count() + <Validators<T>>::count(),
-			"VoterList not equal to Validators + Nominators"
-		);
-
 		Self::check_nominators()?;
 		Self::check_exposures()?;
 		Self::check_ledgers()?;

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -1684,7 +1684,25 @@ impl<T: Config> Pallet<T> {
 		Self::check_nominators()?;
 		Self::check_exposures()?;
 		Self::check_ledgers()?;
+		Self::check_voters()?;
 		Self::check_count()
+	}
+
+	fn check_voters() -> Result<(), &'static str> {
+		// build sorted list
+		let mut voter_list = T::VoterList::iter().collect::<Vec<_>>();
+		voter_list.sort();
+		let mut nominators = Nominators::<T>::iter_keys().collect::<Vec<_>>();
+		nominators.sort();
+		let mut validators = Validators::<T>::iter_keys().collect::<Vec<_>>();
+		validators.sort();
+
+		ensure!(
+			voter_list.iter()
+				.all(|x| nominators.binary_search(&x).or_else(|_| validators.binary_search(&x)).is_ok()),
+				"VoterList contains non-staker"
+		);
+		Ok(())
 	}
 
 	fn check_count() -> Result<(), &'static str> {

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -1682,9 +1682,8 @@ impl<T: Config> StakingInterface for Pallet<T> {
 impl<T: Config> Pallet<T> {
 	pub(crate) fn do_try_state(_: BlockNumberFor<T>) -> Result<(), &'static str> {
 		ensure!(
-			T::VoterList::iter()
-				.all(|x| <Nominators<T>>::contains_key(&x) || <Validators<T>>::contains_key(&x)),
-			"VoterList contains non-staker"
+			T::VoterList::count() == <Nominators<T>>::count() + <Validators<T>>::count(),
+			"VoterList not equal to Validators + Nominators"
 		);
 
 		Self::check_nominators()?;


### PR DESCRIPTION
This should improve try state running time. We already check that `VoterList::count == Nominators::count + Validators::count`  in `fn check_count()` which should give us sufficient safety as well as speed.

Should resolve https://github.com/paritytech/substrate/issues/13114. It took around 6 second for try staking test to run locally on my computer with polkadot runtime and state.

Note: The try state checks will fail on kusama runtime because of a corrupted ledger. I am following up with the team whose account is affected to get it fixed via governance.