### PR TITLE
contracts: Rework generated API docs

### DIFF
--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -24,8 +24,13 @@ mod runtime;
 
 #[cfg(feature = "runtime-benchmarks")]
 pub use crate::wasm::code_cache::reinstrument;
+
 #[cfg(doc)]
 pub use crate::wasm::runtime::api_doc;
+
+#[cfg(test)]
+pub use tests::MockExt;
+
 pub use crate::wasm::{
 	prepare::TryInstantiate,
 	runtime::{
@@ -45,8 +50,6 @@ use frame_support::dispatch::{DispatchError, DispatchResult};
 use sp_core::Get;
 use sp_runtime::RuntimeDebug;
 use sp_std::prelude::*;
-#[cfg(test)]
-pub use tests::MockExt;
 use wasmi::{
 	Config as WasmiConfig, Engine, Instance, Linker, Memory, MemoryType, Module, StackLimits, Store,
 };


### PR DESCRIPTION
Follow up for https://github.com/paritytech/substrate/pull/13032

Initially, different versions of APIs are emitted into different modules. IMHO that makes discovering all functions harder because you need to look through all modules. Additionally, we also emitted all the functions twice which are exist under different prefixes.

This PR changes this behaviour by only emitting the newest and unprefixed version of each function. Hence we now only have a single trait containing everything relevant.