### PR TITLE
contracts: Remove fixtures from crate

### DIFF
--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.io"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet for WASM contracts"
 readme = "README.md"
+include = ["src/**/*", "README.md", "CHANGELOG.md"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
Now that the crate is published to crates.io we should remove unnecessary files to bring down the crate size. This just removes all test fixtures and benchmark files.