### PR TITLE
Fix potential huge allocation as a result of `validate_block` output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8270,6 +8270,7 @@ name = "sc-executor"
 version = "0.10.0-dev"
 dependencies = [
  "array-bytes",
+ "assert_matches",
  "criterion",
  "env_logger",
  "lru",
@@ -8842,6 +8843,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-runtime-interface",
  "sp-std",
  "substrate-wasm-builder",
 ]

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -35,6 +35,7 @@ sp-wasm-interface = { version = "7.0.0", path = "../../primitives/wasm-interface
 
 [dev-dependencies]
 array-bytes = "4.1"
+assert_matches = "1.3.0"
 wat = "1.0"
 sc-runtime-test = { version = "2.0.0", path = "runtime-test" }
 substrate-test-runtime = { version = "2.0.0", path = "../../test-utils/runtime" }

--- a/client/executor/runtime-test/Cargo.toml
+++ b/client/executor/runtime-test/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 sp-core = { version = "7.0.0", default-features = false, path = "../../../primitives/core" }
 sp-io = { version = "7.0.0", default-features = false, features = ["improved_panic_error_reporting"], path = "../../../primitives/io" }
 sp-runtime = { version = "7.0.0", default-features = false, path = "../../../primitives/runtime" }
+sp-runtime-interface = { version = "7.0.0", default-features = false, path = "../../../primitives/runtime-interface" }
 sp-std = { version = "5.0.0", default-features = false, path = "../../../primitives/std" }
 
 [build-dependencies]

--- a/client/executor/runtime-test/src/lib.rs
+++ b/client/executor/runtime-test/src/lib.rs
@@ -356,9 +356,6 @@ pub extern "C" fn test_return_huge_len(_params: *const u8, _len: usize) -> u64 {
 #[no_mangle]
 #[cfg(not(feature = "std"))]
 pub extern "C" fn test_return_max_memory_offset(_params: *const u8, _len: usize) -> u64 {
-	// This should use `core::arch::wasm` instead of `core::arch::wasm32`,
-	// but `core::arch::wasm` depends on `#![feature(simd_wasm64)]` on current nightly.
-	// See https://github.com/Craig-Macomber/lol_alloc/issues/1
 	pack_ptr_and_len((core::arch::wasm32::memory_size(0) * WASM_PAGE_SIZE) as u32, 0)
 }
 
@@ -366,9 +363,6 @@ pub extern "C" fn test_return_max_memory_offset(_params: *const u8, _len: usize)
 #[no_mangle]
 #[cfg(not(feature = "std"))]
 pub extern "C" fn test_return_max_memory_offset_plus_one(_params: *const u8, _len: usize) -> u64 {
-	// This should use `core::arch::wasm` instead of `core::arch::wasm32`,
-	// but `core::arch::wasm` depends on `#![feature(simd_wasm64)]` on current nightly.
-	// See https://github.com/Craig-Macomber/lol_alloc/issues/1
 	pack_ptr_and_len((core::arch::wasm32::memory_size(0) * WASM_PAGE_SIZE) as u32, 1)
 }
 

--- a/client/executor/runtime-test/src/lib.rs
+++ b/client/executor/runtime-test/src/lib.rs
@@ -30,6 +30,8 @@ use sp_runtime::{
 	traits::{BlakeTwo256, Hash},
 };
 
+use sp_runtime_interface::pack_ptr_and_len;
+
 extern "C" {
 	#[allow(dead_code)]
 	fn missing_external();
@@ -336,4 +338,16 @@ sp_core::wasm_export_functions! {
 		// Mainly a test that the macro is working when we have a return statement here.
 		return 1234;
 	}
+}
+
+// Returns a huge len. It should result in an error, and not an allocation.
+#[no_mangle]
+pub extern "C" fn test_return_huge_len(_params: *const u8, _len: usize) -> u64 {
+	pack_ptr_and_len(0, u32::MAX)
+}
+
+// Returns an output that overflows the u32 range. It should result in an error.
+#[no_mangle]
+pub extern "C" fn test_return_overflow(_params: *const u8, _len: usize) -> u64 {
+	pack_ptr_and_len(u32::MAX, 1)
 }

--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -42,7 +42,7 @@ use std::{
 		Arc,
 	},
 };
-use wasmtime::{Engine, Memory, StoreLimits, Table, AsContext};
+use wasmtime::{AsContext, Engine, Memory, StoreLimits, Table};
 
 pub(crate) struct StoreData {
 	/// The limits we apply to the store. We need to store it here to return a reference to this
@@ -802,7 +802,7 @@ fn extract_output_data(
 	//
 	// Get the size of the WASM memory in bytes.
 	let memory_size = ctx.as_context().data().memory().data_size(ctx);
-	if let None = checked_range(output_ptr as usize, output_len as usize, memory_size) {
+	if checked_range(output_ptr as usize, output_len as usize, memory_size).is_none() {
 		return Err(WasmError::Other("output exceeds bounds of wasm memory".into()))?
 	}
 	let mut output = vec![0; output_len as usize];

--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -30,6 +30,7 @@ use sc_executor_common::{
 	runtime_blob::{
 		self, DataSegmentsSnapshot, ExposedMutableGlobalsSet, GlobalsSnapshot, RuntimeBlob,
 	},
+	util::checked_range,
 	wasm_runtime::{InvokeMethod, WasmInstance, WasmModule},
 };
 use sp_runtime_interface::unpack_ptr_and_len;
@@ -41,7 +42,7 @@ use std::{
 		Arc,
 	},
 };
-use wasmtime::{Engine, Memory, StoreLimits, Table};
+use wasmtime::{Engine, Memory, StoreLimits, Table, AsContext};
 
 pub(crate) struct StoreData {
 	/// The limits we apply to the store. We need to store it here to return a reference to this
@@ -793,7 +794,19 @@ fn extract_output_data(
 	output_ptr: u32,
 	output_len: u32,
 ) -> Result<Vec<u8>> {
+	let ctx = instance.store();
+
+	// Do a length check before allocating. The returned output should not be bigger than the
+	// available WASM memory. Otherwise, a malicious parachain can trigger a large allocation,
+	// potentially causing memory exhaustion.
+	//
+	// Get the size of the WASM memory in bytes.
+	let memory_size = ctx.as_context().data().memory().data_size(ctx);
+	if let None = checked_range(output_ptr as usize, output_len as usize, memory_size) {
+		return Err(WasmError::Other("output exceeds bounds of wasm memory".into()))?
+	}
 	let mut output = vec![0; output_len as usize];
-	util::read_memory_into(instance.store(), Pointer::new(output_ptr), &mut output)?;
+
+	util::read_memory_into(ctx, Pointer::new(output_ptr), &mut output)?;
 	Ok(output)
 }


### PR DESCRIPTION
# PULL REQUEST

## Overview

> Once the `validate_block` function from a PVF has been executed, it will return a `u64` containing the pointer and length of the (encoded) return data in the wasm memory. This is [unpacked](https://github.com/paritytech/substrate/blob/5722ece5efb61cc82307f3e919a60bd4e807f1df/client/executor/wasmtime/src/runtime.rs#L763) and the length field is directly used to [allocate a memory buffer](https://github.com/paritytech/substrate/blob/5722ece5efb61cc82307f3e919a60bd4e807f1df/client/executor/wasmtime/src/runtime.rs#L796) on the host side without any prior lenght check, even if the returned length field is larger than the wasm memory. This allocation is only limited to 4 Gb by the `u32` range.

## Related issue

Addresses part 1 of https://github.com/paritytech/srlabs_findings/issues/257. Part 2 will require a Polkadot PR; coming soon.