### PR TITLE
sc-network: Ensure private addresses are disabled if requested

### DIFF
--- a/client/network/src/peer_info.rs
+++ b/client/network/src/peer_info.rs
@@ -89,7 +89,9 @@ impl PeerInfoBehaviour {
 	pub fn new(user_agent: String, local_public_key: PublicKey) -> Self {
 		let identify = {
 			let cfg = IdentifyConfig::new("/substrate/1.0".to_string(), local_public_key)
-				.with_agent_version(user_agent);
+				.with_agent_version(user_agent)
+				// We don't need any peer information cached.
+				.with_cache_size(0);
 			Identify::new(cfg)
 		};
 
@@ -182,10 +184,10 @@ impl NetworkBehaviour for PeerInfoBehaviour {
 		IntoConnectionHandler::select(self.ping.new_handler(), self.identify.new_handler())
 	}
 
-	fn addresses_of_peer(&mut self, peer_id: &PeerId) -> Vec<Multiaddr> {
-		let mut list = self.ping.addresses_of_peer(peer_id);
-		list.extend_from_slice(&self.identify.addresses_of_peer(peer_id));
-		list
+	fn addresses_of_peer(&mut self, _: &PeerId) -> Vec<Multiaddr> {
+		// Only `Discovery::addresses_of_peer` must be returning addresses to ensure that we
+		// don't return unwanted addresses.
+		Vec::new()
 	}
 
 	fn on_swarm_event(&mut self, event: FromSwarm<Self::ConnectionHandler>) {

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -965,8 +965,10 @@ where
 		self.behaviour.new_handler()
 	}
 
-	fn addresses_of_peer(&mut self, peer_id: &PeerId) -> Vec<Multiaddr> {
-		self.behaviour.addresses_of_peer(peer_id)
+	fn addresses_of_peer(&mut self, _: &PeerId) -> Vec<Multiaddr> {
+		// Only `Discovery::addresses_of_peer` must be returning addresses to ensure that we
+		// don't return unwanted addresses.
+		Vec::new()
 	}
 
 	fn on_swarm_event(&mut self, event: FromSwarm<Self::ConnectionHandler>) {


### PR DESCRIPTION
When running with `--no-private-ipv4` the node should not trying to connect to any private ip addresses. With the switch to libp2p this behavior was broken. Part of this version upgrade was the following pr: https://github.com/libp2p/rust-libp2p/pull/2995. This pr changed the default cache size of `libp2p-identity` from `0` aka disabled to `100`. Together with our implementation that was calling into `identity` to request addresses for a given peer. Before the switch to libp2p 0.50.0 this was returning zero addresses, but now with the cache enabled it started to return addresses. This pr fixes this by only letting discovery return addresses for a peer. It also ensures that we filter private addresses if requested. The cache is also disabled to restore the previous caching behavior, but it will actually not be called anymore.

Closes: https://github.com/paritytech/polkadot/issues/6581