### PR TITLE
Add Capped tally to limit votes when approval might change drastically

### DIFF
--- a/frame/conviction-voting/src/lib.rs
+++ b/frame/conviction-voting/src/lib.rs
@@ -49,7 +49,7 @@ pub mod weights;
 pub use self::{
 	conviction::Conviction,
 	pallet::*,
-	types::{Delegations, Tally, UnvoteScope},
+	types::{Capped, Delegations, Tally, UnvoteScope},
 	vote::{AccountVote, Casting, Delegating, Vote, Voting},
 	weights::WeightInfo,
 };
@@ -78,7 +78,8 @@ type DelegatingOf<T, I = ()> = Delegating<
 	<T as frame_system::Config>::AccountId,
 	<T as frame_system::Config>::BlockNumber,
 >;
-pub type TallyOf<T, I = ()> = Tally<BalanceOf<T, I>, <T as Config<I>>::MaxTurnout>;
+pub type TallyOf<T, I = ()> =
+	Capped<Tally<BalanceOf<T, I>, <T as Config<I>>::MaxTurnout>, <T as Config<I>>::MaxVoteSlippage>;
 pub type VotesOf<T, I = ()> = BalanceOf<T, I>;
 type PollIndexOf<T, I = ()> = <<T as Config<I>>::Polls as Polling<TallyOf<T, I>>>::Index;
 #[cfg(feature = "runtime-benchmarks")]
@@ -132,6 +133,12 @@ pub mod pallet {
 		/// those successful voters are locked into the consequences that their votes entail.
 		#[pallet::constant]
 		type VoteLockingPeriod: Get<Self::BlockNumber>;
+
+		/// The maximum variation a vote can introduce on the current support.
+		///
+		///  have over the current support before is capped to
+		#[pallet::constant]
+		type MaxVoteSlippage: Get<sp_runtime::PerU16>;
 	}
 
 	/// All voting for a particular voter in a particular voting class. We store the balance for the


### PR DESCRIPTION
## Whale mitigation in OpenGov

This PR introduces an idea to mitigate the big influence users with big capital can have when voting on referenda with relatively low support with a follow up topic to avoid gaming the solution.

### Capped votes

Users voting with large amount of funds(conviction and delegations included) can change the approval ratio considerably with a single vote, this has proven be problematic as single individuals not only can decide the fate of entire proposals but also introduce a big voting bias as future voters might follow the new trend blindly without realizing it was set by a single voter instead of the entire community.

Here I propose a `Capped` struct that implements `VoteTally` and wraps `Tally` to check the methods that mutate the internal ayes, nays data of the struct, limiting the mutation so that the approval after the vote doesn't exceed the defined `MaxVoteSlippage` percentage(not sure if slippage would be the right name).

The concept of a whale therefore becomes relative, having the nice side effect(IMO) that early whales might want to keep coming back to review the proposal later on to cast their vote again with an updated conviction(also giving teams the change to improve their proposal and persuade early retractors), or whales would simply have the incentive to vote later on reducing the bias they introduce with their heavy conviction. 

### Whale alert track

The previous method could be gamed with automation spreading funds across multiple accounts. My second proposal would be to have a track in governance that allows citizens to report malicious/anti democratic behavior of a set of accounts(i.e. the accounts controlled by the whale), the reporter provides enough evidence to the general community or to a specific origin that looks after the community's code of ethics(Alliance?) and if approved the reported accounts would lose all of the funds used for the vote that would get transferred to the reporter. The reporter also places a deposit that could be lost in case the accounts are reported unfairly without sufficient proof.