### PR TITLE
Rename `*-private-ipv4` to `*-private-ip` CLI args

### DIFF
--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -68,18 +68,18 @@ pub struct NetworkParams {
 	#[arg(long, value_name = "PORT", conflicts_with_all = &[ "listen_addr" ])]
 	pub port: Option<u16>,
 
-	/// Always forbid connecting to private IPv4 addresses (as specified in
+	/// Always forbid connecting to private IPv4/IPv6 addresses (as specified in
 	/// [RFC1918](https://tools.ietf.org/html/rfc1918)), unless the address was passed with
 	/// `--reserved-nodes` or `--bootnodes`. Enabled by default for chains marked as "live" in
 	/// their chain specifications.
-	#[arg(long, conflicts_with_all = &["allow_private_ipv4"])]
-	pub no_private_ipv4: bool,
+	#[arg(long, alias = "no-private-ipv4", conflicts_with_all = &["allow_private_ip"])]
+	pub no_private_ip: bool,
 
-	/// Always accept connecting to private IPv4 addresses (as specified in
+	/// Always accept connecting to private IPv4/IPv6 addresses (as specified in
 	/// [RFC1918](https://tools.ietf.org/html/rfc1918)). Enabled by default for chains marked as
 	/// "local" in their chain specifications, or when `--dev` is passed.
-	#[arg(long, conflicts_with_all = &["no_private_ipv4"])]
-	pub allow_private_ipv4: bool,
+	#[arg(long, alias = "allow-private-ipv4", conflicts_with_all = &["no_private_ip"])]
+	pub allow_private_ip: bool,
 
 	/// Specify the number of outgoing connections we're trying to maintain.
 	#[arg(long, value_name = "COUNT", default_value_t = 15)]
@@ -200,8 +200,8 @@ impl NetworkParams {
 			self.discover_local ||
 				is_dev || matches!(chain_type, ChainType::Local | ChainType::Development);
 
-		let allow_private_ipv4 = match (self.allow_private_ipv4, self.no_private_ipv4) {
-			(true, true) => unreachable!("`*_private_ipv4` flags are mutually exclusive; qed"),
+		let allow_private_ip = match (self.allow_private_ip, self.no_private_ip) {
+			(true, true) => unreachable!("`*_private_ip` flags are mutually exclusive; qed"),
 			(true, false) => true,
 			(false, true) => false,
 			(false, false) =>
@@ -231,7 +231,7 @@ impl NetworkParams {
 			client_version: client_id.to_string(),
 			transport: TransportConfig::Normal {
 				enable_mdns: !is_dev && !self.no_mdns,
-				allow_private_ipv4,
+				allow_private_ip,
 			},
 			max_parallel_downloads: self.max_parallel_downloads,
 			enable_dht_random_walk: !self.reserved_only,

--- a/client/network/common/src/config.rs
+++ b/client/network/common/src/config.rs
@@ -301,10 +301,10 @@ pub enum TransportConfig {
 		/// and connect to them if they support the same chain.
 		enable_mdns: bool,
 
-		/// If true, allow connecting to private IPv4 addresses (as defined in
+		/// If true, allow connecting to private IPv4/IPv6 addresses (as defined in
 		/// [RFC1918](https://tools.ietf.org/html/rfc1918)). Irrelevant for addresses that have
 		/// been passed in `::sc_network::config::NetworkConfiguration::boot_nodes`.
-		allow_private_ipv4: bool,
+		allow_private_ip: bool,
 	},
 
 	/// Only allow connections within the same process.

--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -223,7 +223,7 @@ impl NetworkConfiguration {
 			extra_sets: Vec::new(),
 			client_version: client_version.into(),
 			node_name: node_name.into(),
-			transport: TransportConfig::Normal { enable_mdns: false, allow_private_ipv4: true },
+			transport: TransportConfig::Normal { enable_mdns: false, allow_private_ip: true },
 			max_parallel_downloads: 5,
 			sync_mode: SyncMode::Full,
 			enable_dht_random_walk: true,

--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -278,8 +278,8 @@ pub struct DiscoveryBehaviour {
 	local_peer_id: PeerId,
 	/// Number of nodes we're currently connected to.
 	num_connections: u64,
-	/// If false, `addresses_of_peer` won't return any private IPv4/IPv6 address, except for the ones
-	/// stored in `permanent_addresses` or `ephemeral_addresses`.
+	/// If false, `addresses_of_peer` won't return any private IPv4/IPv6 address, except for the
+	/// ones stored in `permanent_addresses` or `ephemeral_addresses`.
 	allow_private_ip: bool,
 	/// Number of active connections over which we interrupt the discovery process.
 	discovery_only_if_under_num: u64,

--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -96,7 +96,7 @@ pub struct DiscoveryConfig {
 	local_peer_id: PeerId,
 	permanent_addresses: Vec<(PeerId, Multiaddr)>,
 	dht_random_walk: bool,
-	allow_private_ipv4: bool,
+	allow_private_ip: bool,
 	allow_non_globals_in_dht: bool,
 	discovery_only_if_under_num: u64,
 	enable_mdns: bool,
@@ -111,7 +111,7 @@ impl DiscoveryConfig {
 			local_peer_id: local_public_key.to_peer_id(),
 			permanent_addresses: Vec::new(),
 			dht_random_walk: true,
-			allow_private_ipv4: true,
+			allow_private_ip: true,
 			allow_non_globals_in_dht: false,
 			discovery_only_if_under_num: std::u64::MAX,
 			enable_mdns: false,
@@ -142,9 +142,9 @@ impl DiscoveryConfig {
 		self
 	}
 
-	/// Should private IPv4 addresses be reported?
-	pub fn allow_private_ipv4(&mut self, value: bool) -> &mut Self {
-		self.allow_private_ipv4 = value;
+	/// Should private IPv4/IPv6 addresses be reported?
+	pub fn allow_private_ip(&mut self, value: bool) -> &mut Self {
+		self.allow_private_ip = value;
 		self
 	}
 
@@ -189,7 +189,7 @@ impl DiscoveryConfig {
 			local_peer_id,
 			permanent_addresses,
 			dht_random_walk,
-			allow_private_ipv4,
+			allow_private_ip,
 			allow_non_globals_in_dht,
 			discovery_only_if_under_num,
 			enable_mdns,
@@ -231,7 +231,7 @@ impl DiscoveryConfig {
 			pending_events: VecDeque::new(),
 			local_peer_id,
 			num_connections: 0,
-			allow_private_ipv4,
+			allow_private_ip,
 			discovery_only_if_under_num,
 			mdns: if enable_mdns {
 				match TokioMdns::new(mdns::Config::default()) {
@@ -278,9 +278,9 @@ pub struct DiscoveryBehaviour {
 	local_peer_id: PeerId,
 	/// Number of nodes we're currently connected to.
 	num_connections: u64,
-	/// If false, `addresses_of_peer` won't return any private IPv4 address, except for the ones
+	/// If false, `addresses_of_peer` won't return any private IPv4/IPv6 address, except for the ones
 	/// stored in `permanent_addresses` or `ephemeral_addresses`.
-	allow_private_ipv4: bool,
+	allow_private_ip: bool,
 	/// Number of active connections over which we interrupt the discovery process.
 	discovery_only_if_under_num: u64,
 	/// Should non-global addresses be added to the DHT?
@@ -506,7 +506,7 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 				list_to_filter.extend(mdns.addresses_of_peer(peer_id));
 			}
 
-			if !self.allow_private_ipv4 {
+			if !self.allow_private_ip {
 				list_to_filter.retain(|addr| match addr.iter().next() {
 					Some(Protocol::Ip4(addr)) if !IpNetwork::from(addr).is_global() => false,
 					Some(Protocol::Ip6(addr)) if !IpNetwork::from(addr).is_global() => false,
@@ -947,7 +947,7 @@ mod tests {
 					let mut config = DiscoveryConfig::new(keypair.public());
 					config
 						.with_permanent_addresses(first_swarm_peer_id_and_addr.clone())
-						.allow_private_ipv4(true)
+						.allow_private_ip(true)
 						.allow_non_globals_in_dht(true)
 						.discovery_limit(50)
 						.with_kademlia(genesis_hash, fork_id, &protocol_id);
@@ -1065,7 +1065,7 @@ mod tests {
 			let keypair = Keypair::generate_ed25519();
 			let mut config = DiscoveryConfig::new(keypair.public());
 			config
-				.allow_private_ipv4(true)
+				.allow_private_ip(true)
 				.allow_non_globals_in_dht(true)
 				.discovery_limit(50)
 				.with_kademlia(supported_genesis_hash, None, &supported_protocol_id);

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -291,11 +291,11 @@ where
 				match params.network_config.transport {
 					TransportConfig::MemoryOnly => {
 						config.with_mdns(false);
-						config.allow_private_ipv4(false);
+						config.allow_private_ip(false);
 					},
-					TransportConfig::Normal { enable_mdns, allow_private_ipv4, .. } => {
+					TransportConfig::Normal { enable_mdns, allow_private_ip: allow_private_ipv4, .. } => {
 						config.with_mdns(enable_mdns);
-						config.allow_private_ipv4(allow_private_ipv4);
+						config.allow_private_ip(allow_private_ipv4);
 					},
 				}
 

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -293,7 +293,11 @@ where
 						config.with_mdns(false);
 						config.allow_private_ip(false);
 					},
-					TransportConfig::Normal { enable_mdns, allow_private_ip: allow_private_ipv4, .. } => {
+					TransportConfig::Normal {
+						enable_mdns,
+						allow_private_ip: allow_private_ipv4,
+						..
+					} => {
 						config.with_mdns(enable_mdns);
 						config.allow_private_ip(allow_private_ipv4);
 					},

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -220,7 +220,7 @@ fn node_config<
 	);
 
 	network_config.transport =
-		TransportConfig::Normal { enable_mdns: false, allow_private_ipv4: true };
+		TransportConfig::Normal { enable_mdns: false, allow_private_ip: true };
 
 	Configuration {
 		impl_name: String::from("network-test-impl"),


### PR DESCRIPTION
Renames the `*-private-ipv4` to `*-private-ip` in the CLI interface. The old names are staying as alias, thus it will not break for anyone. Besides that it also fixes the naming in the rest of the code.

