### PR TITLE
Aura: Fix warp syncing

### DIFF
--- a/client/consensus/aura/src/import_queue.rs
+++ b/client/consensus/aura/src/import_queue.rs
@@ -186,16 +186,14 @@ where
 		&mut self,
 		mut block: BlockImportParams<B, ()>,
 	) -> Result<(BlockImportParams<B, ()>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
-		// When importing whole state we don't verify the seal as the state is not available.
-		if block.with_state() {
-			return Ok((block, Default::default()))
-		}
-
-		// Skip checks that include execution, if being told so.
+		// Skip checks that include execution, if being told so or when importing only state.
 		//
 		// This is done for example when gap syncing and it is expected that the block after the gap
 		// was checked/chosen properly, e.g. by warp syncing to this block using a finality proof.
+		// Or when we are importing state only and can not verify the seal.
 		if block.state_action.skip_execution_checks() {
+			block.fork_choice = Some(ForkChoiceStrategy::Custom(false));
+
 			return Ok((block, Default::default()))
 		}
 

--- a/client/consensus/aura/src/import_queue.rs
+++ b/client/consensus/aura/src/import_queue.rs
@@ -191,8 +191,9 @@ where
 		// This is done for example when gap syncing and it is expected that the block after the gap
 		// was checked/chosen properly, e.g. by warp syncing to this block using a finality proof.
 		// Or when we are importing state only and can not verify the seal.
-		if block.state_action.skip_execution_checks() {
-			block.fork_choice = Some(ForkChoiceStrategy::Custom(false));
+		if block.with_state() || block.state_action.skip_execution_checks() {
+			// When we are importing only the state of a block, it will be the best block.
+			block.fork_choice = Some(ForkChoiceStrategy::Custom(block.with_state()));
 
 			return Ok((block, Default::default()))
 		}


### PR DESCRIPTION
We need to set the fork choice rule! When using Cumulus this is done by the `ParachainsBlockImport`, but for standalone chains we still need this!

Closes: https://github.com/paritytech/substrate/issues/13220

