### PR TITLE
Fix try-runtime with create-snapshot

### DIFF
--- a/utils/frame/try-runtime/cli/src/commands/create_snapshot.rs
+++ b/utils/frame/try-runtime/cli/src/commands/create_snapshot.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{build_executor, LiveState, SharedParams, State, LOG_TARGET};
+use crate::{build_executor, Command, LiveState, SharedParams, State, LOG_TARGET};
 use sc_executor::sp_wasm_interface::HostFunctions;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
 use std::{fmt::Debug, str::FromStr};
@@ -34,10 +34,11 @@ pub struct CreateSnapshotCmd {
 	pub snapshot_path: Option<String>,
 }
 
-/// inner command for `Command::CreateSnapshot`.
+/// inner cmd for `Command::CreateSnapshot`.
 pub(crate) async fn create_snapshot<Block, HostFns>(
 	shared: SharedParams,
-	command: CreateSnapshotCmd,
+	command: Command,
+	cmd: CreateSnapshotCmd,
 ) -> sc_cli::Result<()>
 where
 	Block: BlockT + serde::de::DeserializeOwned,
@@ -48,7 +49,7 @@ where
 	<NumberFor<Block> as FromStr>::Err: Debug,
 	HostFns: HostFunctions,
 {
-	let snapshot_path = command.snapshot_path;
+	let snapshot_path = cmd.snapshot_path;
 	if !matches!(shared.runtime, crate::Runtime::Existing) {
 		return Err("creating a snapshot is only possible with --runtime existing.".into())
 	}
@@ -56,13 +57,13 @@ where
 	let path = match snapshot_path {
 		Some(path) => path,
 		None => {
-			let rpc = ws_client(&command.from.uri).await.unwrap();
+			let rpc = ws_client(&cmd.from.uri).await.unwrap();
 			let remote_spec = StateApi::<Block::Hash>::runtime_version(&rpc, None).await.unwrap();
 			let path_str = format!(
 				"{}-{}@{}.snap",
 				remote_spec.spec_name.to_lowercase(),
 				remote_spec.spec_version,
-				command.from.at.clone().unwrap_or("latest".to_owned())
+				cmd.from.at.clone().unwrap_or("latest".to_owned())
 			);
 			log::info!(target: LOG_TARGET, "snapshot path not provided (-s), using '{}'", path_str);
 			path_str.into()
@@ -70,8 +71,8 @@ where
 	};
 
 	let executor = build_executor::<HostFns>(&shared);
-	let _ = State::Live(command.from)
-		.into_ext::<Block, HostFns>(&shared, &executor, Some(path.into()))
+	let _ = State::Live(cmd.from)
+		.into_ext::<Block, HostFns>(&shared, &command, &executor, Some(path.into()))
 		.await?;
 
 	Ok(())

--- a/utils/frame/try-runtime/cli/src/commands/execute_block.rs
+++ b/utils/frame/try-runtime/cli/src/commands/execute_block.rs
@@ -16,8 +16,8 @@
 // limitations under the License.
 
 use crate::{
-	build_executor, full_extensions, rpc_err_handler, state_machine_call_with_proof, Command,
-	LiveState, SharedParams, State, LOG_TARGET,
+	build_executor, full_extensions, rpc_err_handler, state_machine_call_with_proof, LiveState,
+	SharedParams, State, LOG_TARGET,
 };
 use parity_scale_codec::Encode;
 use sc_executor::sp_wasm_interface::HostFunctions;
@@ -87,8 +87,7 @@ impl ExecuteBlockCmd {
 
 pub(crate) async fn execute_block<Block, HostFns>(
 	shared: SharedParams,
-	command: Command,
-	cmd: ExecuteBlockCmd,
+	command: ExecuteBlockCmd,
 ) -> sc_cli::Result<()>
 where
 	Block: BlockT + serde::de::DeserializeOwned,
@@ -100,10 +99,10 @@ where
 	HostFns: HostFunctions,
 {
 	let executor = build_executor::<HostFns>(&shared);
-	let ext = cmd.state.into_ext::<Block, HostFns>(&shared, &command, &executor, None).await?;
+	let ext = command.state.into_ext::<Block, HostFns>(&shared, &executor, None, true).await?;
 
 	// get the block number associated with this block.
-	let block_ws_uri = cmd.block_ws_uri::<Block>();
+	let block_ws_uri = command.block_ws_uri::<Block>();
 	let rpc = ws_client(&block_ws_uri).await?;
 	let next_hash = next_hash_of::<Block>(&rpc, ext.block_hash).await?;
 
@@ -127,7 +126,7 @@ where
 	// for now, hardcoded for the sake of simplicity. We might customize them one day.
 	let state_root_check = false;
 	let signature_check = false;
-	let payload = (block.clone(), state_root_check, signature_check, cmd.try_state).encode();
+	let payload = (block.clone(), state_root_check, signature_check, command.try_state).encode();
 
 	let _ = state_machine_call_with_proof::<Block, HostFns>(
 		&ext,

--- a/utils/frame/try-runtime/cli/src/commands/follow_chain.rs
+++ b/utils/frame/try-runtime/cli/src/commands/follow_chain.rs
@@ -17,7 +17,7 @@
 
 use crate::{
 	build_executor, full_extensions, parse, rpc_err_handler, state_machine_call_with_proof,
-	LiveState, SharedParams, State, LOG_TARGET,
+	Command, LiveState, SharedParams, State, LOG_TARGET,
 };
 use parity_scale_codec::{Decode, Encode};
 use sc_executor::sp_wasm_interface::HostFunctions;
@@ -80,7 +80,8 @@ async fn start_subscribing<Header: DeserializeOwned + Serialize + Send + Sync + 
 
 pub(crate) async fn follow_chain<Block, HostFns>(
 	shared: SharedParams,
-	command: FollowChainCmd,
+	command: Command,
+	cmd: FollowChainCmd,
 ) -> sc_cli::Result<()>
 where
 	Block: BlockT<Hash = H256> + DeserializeOwned,
@@ -91,7 +92,7 @@ where
 	<NumberFor<Block> as FromStr>::Err: Debug,
 	HostFns: HostFunctions,
 {
-	let (rpc, subscription) = start_subscribing::<Block::Header>(&command.uri).await?;
+	let (rpc, subscription) = start_subscribing::<Block::Header>(&cmd.uri).await?;
 	let mut finalized_headers: FinalizedHeaders<Block, _, _> =
 		FinalizedHeaders::new(&rpc, subscription);
 
@@ -130,14 +131,14 @@ where
 		// create an ext at the state of this block, whatever is the first subscription event.
 		if maybe_state_ext.is_none() {
 			let state = State::Live(LiveState {
-				uri: command.uri.clone(),
+				uri: cmd.uri.clone(),
 				// a bit dodgy, we have to un-parse the has to a string again and re-parse it
 				// inside.
 				at: Some(hex::encode(header.parent_hash().encode())),
 				pallet: vec![],
 				child_tree: true,
 			});
-			let ext = state.into_ext::<Block, HostFns>(&shared, &executor, None).await?;
+			let ext = state.into_ext::<Block, HostFns>(&shared, &command, &executor, None).await?;
 			maybe_state_ext = Some(ext);
 		}
 
@@ -148,7 +149,7 @@ where
 			state_ext,
 			&executor,
 			"TryRuntime_execute_block",
-			(block, command.state_root_check, command.try_state.clone()).encode().as_ref(),
+			(block, cmd.state_root_check, cmd.try_state.clone()).encode().as_ref(),
 			full_extensions(),
 			shared
 				.export_proof

--- a/utils/frame/try-runtime/cli/src/commands/offchain_worker.rs
+++ b/utils/frame/try-runtime/cli/src/commands/offchain_worker.rs
@@ -17,7 +17,7 @@
 
 use crate::{
 	build_executor, commands::execute_block::next_hash_of, full_extensions, parse, rpc_err_handler,
-	state_machine_call, Command, LiveState, SharedParams, State, LOG_TARGET,
+	state_machine_call, LiveState, SharedParams, State, LOG_TARGET,
 };
 use parity_scale_codec::Encode;
 use sc_executor::sp_wasm_interface::HostFunctions;
@@ -65,8 +65,7 @@ impl OffchainWorkerCmd {
 
 pub(crate) async fn offchain_worker<Block, HostFns>(
 	shared: SharedParams,
-	command: Command,
-	cmd: OffchainWorkerCmd,
+	command: OffchainWorkerCmd,
 ) -> sc_cli::Result<()>
 where
 	Block: BlockT + serde::de::DeserializeOwned,
@@ -79,9 +78,9 @@ where
 {
 	let executor = build_executor(&shared);
 	// we first build the externalities with the remote code.
-	let ext = cmd.state.into_ext::<Block, HostFns>(&shared, &command, &executor, None).await?;
+	let ext = command.state.into_ext::<Block, HostFns>(&shared, &executor, None, true).await?;
 
-	let header_ws_uri = cmd.header_ws_uri::<Block>();
+	let header_ws_uri = command.header_ws_uri::<Block>();
 
 	let rpc = ws_client(&header_ws_uri).await?;
 	let next_hash = next_hash_of::<Block>(&rpc, ext.block_hash).await?;

--- a/utils/frame/try-runtime/cli/src/commands/offchain_worker.rs
+++ b/utils/frame/try-runtime/cli/src/commands/offchain_worker.rs
@@ -17,7 +17,7 @@
 
 use crate::{
 	build_executor, commands::execute_block::next_hash_of, full_extensions, parse, rpc_err_handler,
-	state_machine_call, LiveState, SharedParams, State, LOG_TARGET,
+	state_machine_call, Command, LiveState, SharedParams, State, LOG_TARGET,
 };
 use parity_scale_codec::Encode;
 use sc_executor::sp_wasm_interface::HostFunctions;
@@ -65,7 +65,8 @@ impl OffchainWorkerCmd {
 
 pub(crate) async fn offchain_worker<Block, HostFns>(
 	shared: SharedParams,
-	command: OffchainWorkerCmd,
+	command: Command,
+	cmd: OffchainWorkerCmd,
 ) -> sc_cli::Result<()>
 where
 	Block: BlockT + serde::de::DeserializeOwned,
@@ -78,9 +79,9 @@ where
 {
 	let executor = build_executor(&shared);
 	// we first build the externalities with the remote code.
-	let ext = command.state.into_ext::<Block, HostFns>(&shared, &executor, None).await?;
+	let ext = cmd.state.into_ext::<Block, HostFns>(&shared, &command, &executor, None).await?;
 
-	let header_ws_uri = command.header_ws_uri::<Block>();
+	let header_ws_uri = cmd.header_ws_uri::<Block>();
 
 	let rpc = ws_client(&header_ws_uri).await?;
 	let next_hash = next_hash_of::<Block>(&rpc, ext.block_hash).await?;

--- a/utils/frame/try-runtime/cli/src/commands/on_runtime_upgrade.rs
+++ b/utils/frame/try-runtime/cli/src/commands/on_runtime_upgrade.rs
@@ -15,7 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{build_executor, state_machine_call_with_proof, SharedParams, State, LOG_TARGET};
+use crate::{
+	build_executor, state_machine_call_with_proof, Command, SharedParams, State, LOG_TARGET,
+};
 use frame_try_runtime::UpgradeCheckSelect;
 use parity_scale_codec::{Decode, Encode};
 use sc_executor::sp_wasm_interface::HostFunctions;
@@ -50,7 +52,8 @@ pub struct OnRuntimeUpgradeCmd {
 
 pub(crate) async fn on_runtime_upgrade<Block, HostFns>(
 	shared: SharedParams,
-	command: OnRuntimeUpgradeCmd,
+	command: Command,
+	cmd: OnRuntimeUpgradeCmd,
 ) -> sc_cli::Result<()>
 where
 	Block: BlockT + serde::de::DeserializeOwned,
@@ -62,13 +65,13 @@ where
 	HostFns: HostFunctions,
 {
 	let executor = build_executor(&shared);
-	let ext = command.state.into_ext::<Block, HostFns>(&shared, &executor, None).await?;
+	let ext = cmd.state.into_ext::<Block, HostFns>(&shared, &command, &executor, None).await?;
 
 	let (_, encoded_result) = state_machine_call_with_proof::<Block, HostFns>(
 		&ext,
 		&executor,
 		"TryRuntime_on_runtime_upgrade",
-		command.checks.encode().as_ref(),
+		cmd.checks.encode().as_ref(),
 		Default::default(), // we don't really need any extensions here.
 		shared.export_proof,
 	)?;

--- a/utils/frame/try-runtime/cli/src/commands/on_runtime_upgrade.rs
+++ b/utils/frame/try-runtime/cli/src/commands/on_runtime_upgrade.rs
@@ -15,9 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{
-	build_executor, state_machine_call_with_proof, Command, SharedParams, State, LOG_TARGET,
-};
+use crate::{build_executor, state_machine_call_with_proof, SharedParams, State, LOG_TARGET};
 use frame_try_runtime::UpgradeCheckSelect;
 use parity_scale_codec::{Decode, Encode};
 use sc_executor::sp_wasm_interface::HostFunctions;
@@ -52,8 +50,7 @@ pub struct OnRuntimeUpgradeCmd {
 
 pub(crate) async fn on_runtime_upgrade<Block, HostFns>(
 	shared: SharedParams,
-	command: Command,
-	cmd: OnRuntimeUpgradeCmd,
+	command: OnRuntimeUpgradeCmd,
 ) -> sc_cli::Result<()>
 where
 	Block: BlockT + serde::de::DeserializeOwned,
@@ -65,13 +62,13 @@ where
 	HostFns: HostFunctions,
 {
 	let executor = build_executor(&shared);
-	let ext = cmd.state.into_ext::<Block, HostFns>(&shared, &command, &executor, None).await?;
+	let ext = command.state.into_ext::<Block, HostFns>(&shared, &executor, None, true).await?;
 
 	let (_, encoded_result) = state_machine_call_with_proof::<Block, HostFns>(
 		&ext,
 		&executor,
 		"TryRuntime_on_runtime_upgrade",
-		cmd.checks.encode().as_ref(),
+		command.checks.encode().as_ref(),
 		Default::default(), // we don't really need any extensions here.
 		shared.export_proof,
 	)?;

--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -607,9 +607,9 @@ impl State {
 	pub(crate) async fn into_ext<Block: BlockT + DeserializeOwned, HostFns: HostFunctions>(
 		&self,
 		shared: &SharedParams,
-		command: &Command,
 		executor: &WasmExecutor<HostFns>,
 		state_snapshot: Option<SnapshotConfig>,
+		try_runtime_check: bool,
 	) -> sc_cli::Result<RemoteExternalities<Block>>
 	where
 		Block::Hash: FromStr,
@@ -707,10 +707,8 @@ impl State {
 			}
 		}
 
-		// ignore the `create-snapshot` command
-		if !matches!(command, Command::CreateSnapshot(_)) {
-			// whatever runtime we have in store now must have been compiled with try-runtime
-			// feature.
+		// whatever runtime we have in store now must have been compiled with try-runtime feature.
+		if try_runtime_check {
 			if !ensure_try_runtime::<Block, HostFns>(&executor, &mut ext) {
 				return Err("given runtime is NOT compiled with try-runtime feature!".into())
 			}
@@ -736,35 +734,30 @@ impl TryRuntimeCmd {
 			Command::OnRuntimeUpgrade(ref cmd) =>
 				commands::on_runtime_upgrade::on_runtime_upgrade::<Block, HostFns>(
 					self.shared.clone(),
-					self.command.clone(),
 					cmd.clone(),
 				)
 				.await,
 			Command::OffchainWorker(cmd) =>
 				commands::offchain_worker::offchain_worker::<Block, HostFns>(
 					self.shared.clone(),
-					self.command.clone(),
 					cmd.clone(),
 				)
 				.await,
 			Command::ExecuteBlock(cmd) =>
 				commands::execute_block::execute_block::<Block, HostFns>(
 					self.shared.clone(),
-					self.command.clone(),
 					cmd.clone(),
 				)
 				.await,
 			Command::FollowChain(cmd) =>
 				commands::follow_chain::follow_chain::<Block, HostFns>(
 					self.shared.clone(),
-					self.command.clone(),
 					cmd.clone(),
 				)
 				.await,
 			Command::CreateSnapshot(cmd) =>
 				commands::create_snapshot::create_snapshot::<Block, HostFns>(
 					self.shared.clone(),
-					self.command.clone(),
 					cmd.clone(),
 				)
 				.await,


### PR DESCRIPTION
run the `create-snapshot`  command in Polkadot will get an error:
```
cargo run --features try-runtime -- try-runtime --runtime existing create-snapshot --uri wss://rpc.polkadot.io:443 --pallet indices
```

```
Invalid input: given runtime is NOT compiled with try-runtime feature!
```



<img width="992" alt="image" src="https://user-images.githubusercontent.com/16496415/214149937-ff181c04-4558-478e-942a-841197bc7d06.png">
