### PR TITLE
pallet-assets: Rename `total_supply` to `amount`

### DIFF
--- a/frame/assets/src/benchmarking.rs
+++ b/frame/assets/src/benchmarking.rs
@@ -220,7 +220,7 @@ benchmarks_instance_pallet! {
 		let amount = T::Balance::from(100u32);
 	}: _(SystemOrigin::Signed(caller.clone()), asset_id, caller_lookup, amount)
 	verify {
-		assert_last_event::<T, I>(Event::Issued { asset_id: asset_id.into(), owner: caller, total_supply: amount }.into());
+		assert_last_event::<T, I>(Event::Issued { asset_id: asset_id.into(), owner: caller, amount }.into());
 	}
 
 	burn {

--- a/frame/assets/src/functions.rs
+++ b/frame/assets/src/functions.rs
@@ -355,17 +355,21 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				ensure!(check_issuer == details.issuer, Error::<T, I>::NoPermission);
 			}
 			debug_assert!(
-				T::Balance::max_value() - details.supply >= amount,
+				details.supply.checked_add(&amount).is_some(),
 				"checked in prep; qed"
 			);
+
 			details.supply = details.supply.saturating_add(amount);
+
 			Ok(())
 		})?;
+
 		Self::deposit_event(Event::Issued {
 			asset_id: id,
 			owner: beneficiary.clone(),
-			total_supply: amount,
+			amount,
 		});
+
 		Ok(())
 	}
 

--- a/frame/assets/src/functions.rs
+++ b/frame/assets/src/functions.rs
@@ -354,21 +354,14 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			if let Some(check_issuer) = maybe_check_issuer {
 				ensure!(check_issuer == details.issuer, Error::<T, I>::NoPermission);
 			}
-			debug_assert!(
-				details.supply.checked_add(&amount).is_some(),
-				"checked in prep; qed"
-			);
+			debug_assert!(details.supply.checked_add(&amount).is_some(), "checked in prep; qed");
 
 			details.supply = details.supply.saturating_add(amount);
 
 			Ok(())
 		})?;
 
-		Self::deposit_event(Event::Issued {
-			asset_id: id,
-			owner: beneficiary.clone(),
-			amount,
-		});
+		Self::deposit_event(Event::Issued { asset_id: id, owner: beneficiary.clone(), amount });
 
 		Ok(())
 	}

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -151,9 +151,7 @@ pub use types::*;
 
 use scale_info::TypeInfo;
 use sp_runtime::{
-	traits::{
-		AtLeast32BitUnsigned, CheckedAdd, CheckedSub, Saturating, StaticLookup, Zero,
-	},
+	traits::{AtLeast32BitUnsigned, CheckedAdd, CheckedSub, Saturating, StaticLookup, Zero},
 	ArithmeticError, TokenError,
 };
 use sp_std::{borrow::Borrow, prelude::*};

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -152,7 +152,7 @@ pub use types::*;
 use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{
-		AtLeast32BitUnsigned, Bounded, CheckedAdd, CheckedSub, Saturating, StaticLookup, Zero,
+		AtLeast32BitUnsigned, CheckedAdd, CheckedSub, Saturating, StaticLookup, Zero,
 	},
 	ArithmeticError, TokenError,
 };
@@ -427,7 +427,7 @@ pub mod pallet {
 					*amount,
 					|details| -> DispatchResult {
 						debug_assert!(
-							T::Balance::max_value() - details.supply >= *amount,
+							details.supply.checked_add(&amount).is_some(),
 							"checked in prep; qed"
 						);
 						details.supply = details.supply.saturating_add(*amount);

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -445,7 +445,7 @@ pub mod pallet {
 		/// Some asset class was created.
 		Created { asset_id: T::AssetId, creator: T::AccountId, owner: T::AccountId },
 		/// Some assets were issued.
-		Issued { asset_id: T::AssetId, owner: T::AccountId, total_supply: T::Balance },
+		Issued { asset_id: T::AssetId, owner: T::AccountId, amount: T::Balance },
 		/// Some assets were transferred.
 		Transferred {
 			asset_id: T::AssetId,


### PR DESCRIPTION
We are actually passing the `amount` on assets being minted and not the total supply.

Closes: https://github.com/paritytech/substrate/issues/13210

