### PR TITLE
implemented `contains_prefix` for StorageDoubleMap and StorageNMap

### DIFF
--- a/frame/support/src/storage/generator/double_map.rs
+++ b/frame/support/src/storage/generator/double_map.rs
@@ -237,7 +237,7 @@ where
 	where
 		KArg1: EncodeLike<K1>,
 	{
-		unhashed::contains_prefix(Self::storage_double_map_final_key1(k1).as_ref())
+		unhashed::contains_prefixed_key(Self::storage_double_map_final_key1(k1).as_ref())
 	}
 
 	fn iter_prefix_values<KArg1>(k1: KArg1) -> storage::PrefixIterator<V>

--- a/frame/support/src/storage/generator/double_map.rs
+++ b/frame/support/src/storage/generator/double_map.rs
@@ -233,6 +233,13 @@ where
 		.into()
 	}
 
+	fn contains_prefix<KArg1>(k1: KArg1) -> bool
+	where
+		KArg1: EncodeLike<K1>,
+	{
+		unhashed::contains_prefix(Self::storage_double_map_final_key1(k1).as_ref())
+	}
+
 	fn iter_prefix_values<KArg1>(k1: KArg1) -> storage::PrefixIterator<V>
 	where
 		KArg1: ?Sized + EncodeLike<K1>,

--- a/frame/support/src/storage/generator/nmap.rs
+++ b/frame/support/src/storage/generator/nmap.rs
@@ -208,6 +208,13 @@ where
 		)
 	}
 
+	fn contains_prefix<KP>(partial_key: KP) -> bool
+	where
+		K: HasKeyPrefix<KP>,
+	{
+		unhashed::contains_prefix(&Self::storage_n_map_partial_key(partial_key))
+	}
+
 	fn iter_prefix_values<KP>(partial_key: KP) -> PrefixIterator<V>
 	where
 		K: HasKeyPrefix<KP>,

--- a/frame/support/src/storage/generator/nmap.rs
+++ b/frame/support/src/storage/generator/nmap.rs
@@ -212,7 +212,7 @@ where
 	where
 		K: HasKeyPrefix<KP>,
 	{
-		unhashed::contains_prefix(&Self::storage_n_map_partial_key(partial_key))
+		unhashed::contains_prefixed_key(&Self::storage_n_map_partial_key(partial_key))
 	}
 
 	fn iter_prefix_values<KP>(partial_key: KP) -> PrefixIterator<V>

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -1792,6 +1792,7 @@ mod test {
 			assert_eq!(FooDoubleMap::contains_prefix(0), false);
 
 			assert_ok!(FooDoubleMap::try_append(1, 1, 4));
+			assert_ok!(FooDoubleMap::try_append(2, 1, 4));
 			assert!(FooDoubleMap::iter_prefix_values(1).next().is_some());
 			assert!(FooDoubleMap::contains_prefix(1));
 			FooDoubleMap::remove(1, 1);

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -558,6 +558,7 @@ pub trait StorageDoubleMap<K1: FullEncode, K2: FullEncode, V: FullCodec> {
 		KArg1: ?Sized + EncodeLike<K1>;
 
 	/// Does any value under the first key `k1` (explicitly) exist in storage?
+	/// Might have unexpected behaviour with empty keys, e.g. `[]`.
 	fn contains_prefix<KArg1>(k1: KArg1) -> bool
 	where
 		KArg1: EncodeLike<K1>;
@@ -739,6 +740,7 @@ pub trait StorageNMap<K: KeyGenerator, V: FullCodec> {
 		K: HasKeyPrefix<KP>;
 
 	/// Does any value under a `partial_key` prefix (explicitly) exist in storage?
+	/// Might have unexpected behaviour with empty keys, e.g. `[]`.
 	fn contains_prefix<KP>(partial_key: KP) -> bool
 	where
 		K: HasKeyPrefix<KP>;

--- a/frame/support/src/storage/unhashed.rs
+++ b/frame/support/src/storage/unhashed.rs
@@ -154,6 +154,10 @@ pub fn clear_prefix(
 	MultiRemovalResults { maybe_cursor, backend: i, unique: i, loops: i }
 }
 
+pub fn contains_prefix(prefix: &[u8]) -> bool {
+	sp_io::storage::next_key(prefix).is_some()
+}
+
 /// Get a Vec of bytes from storage.
 pub fn get_raw(key: &[u8]) -> Option<Vec<u8>> {
 	sp_io::storage::get(key).map(|value| value.to_vec())

--- a/frame/support/src/storage/unhashed.rs
+++ b/frame/support/src/storage/unhashed.rs
@@ -155,7 +155,10 @@ pub fn clear_prefix(
 }
 
 pub fn contains_prefix(prefix: &[u8]) -> bool {
-	sp_io::storage::next_key(prefix).is_some()
+	match sp_io::storage::next_key(prefix) {
+		Some(key) => key.starts_with(prefix),
+		None => false,
+	}
 }
 
 /// Get a Vec of bytes from storage.

--- a/frame/support/src/storage/unhashed.rs
+++ b/frame/support/src/storage/unhashed.rs
@@ -154,7 +154,10 @@ pub fn clear_prefix(
 	MultiRemovalResults { maybe_cursor, backend: i, unique: i, loops: i }
 }
 
-pub fn contains_prefix(prefix: &[u8]) -> bool {
+/// Returns `true` if the storage contains any key, which starts with a certain prefix,
+/// and is longer than said prefix.
+/// This means that a key which equals the prefix will not be counted.
+pub fn contains_prefixed_key(prefix: &[u8]) -> bool {
 	match sp_io::storage::next_key(prefix) {
 		Some(key) => key.starts_with(prefix),
 		None => false,


### PR DESCRIPTION
In both StorageDoubleMap and StorageNMap is possible to delete or iterate on entries over a certain prefix, but there's no easy and optimized way of checking if at least one of those entries exists.

If you think I should add tests for StorageNMaps and point me where to add them, I'll be happy to do it.

polkadot address: 12poSUQPtcF1HUPQGY3zZu2P8emuW9YnsPduA4XG3oCEfJVp