### PR TITLE
rpc: Use the blocks pinning API for chainHead methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8833,6 +8833,7 @@ dependencies = [
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
+ "sc-service",
  "sc-transaction-pool-api",
  "serde",
  "serde_json",

--- a/client/api/src/in_mem.rs
+++ b/client/api/src/in_mem.rs
@@ -440,7 +440,7 @@ impl<Block: BlockT> blockchain::Backend<Block> for Blockchain<Block> {
 	}
 
 	fn children(&self, _parent_hash: Block::Hash) -> sp_blockchain::Result<Vec<Block::Hash>> {
-		unimplemented!()
+		Ok(Default::default())
 	}
 
 	fn indexed_transaction(&self, _hash: Block::Hash) -> sp_blockchain::Result<Option<Vec<u8>>> {
@@ -626,6 +626,7 @@ where
 	states: RwLock<HashMap<Block::Hash, InMemoryBackend<HashFor<Block>>>>,
 	blockchain: Blockchain<Block>,
 	import_lock: RwLock<()>,
+	pinned_blocks: RwLock<HashMap<Block::Hash, i64>>,
 }
 
 impl<Block: BlockT> Backend<Block>
@@ -633,12 +634,27 @@ where
 	Block::Hash: Ord,
 {
 	/// Create a new instance of in-mem backend.
+	///
+	/// # Warning
+	///
+	/// For testing purposes only!
 	pub fn new() -> Self {
 		Backend {
 			states: RwLock::new(HashMap::new()),
 			blockchain: Blockchain::new(),
 			import_lock: Default::default(),
+			pinned_blocks: Default::default(),
 		}
+	}
+
+	/// Return the number of references active for a pinned block.
+	///
+	/// # Warning
+	///
+	/// For testing purposes only!
+	pub fn pin_refs(&self, hash: &<Block as BlockT>::Hash) -> Option<i64> {
+		let blocks = self.pinned_blocks.read();
+		blocks.get(hash).map(|value| *value)
 	}
 }
 
@@ -789,11 +805,17 @@ where
 		false
 	}
 
-	fn pin_block(&self, _: <Block as BlockT>::Hash) -> blockchain::Result<()> {
+	fn pin_block(&self, hash: <Block as BlockT>::Hash) -> blockchain::Result<()> {
+		let mut blocks = self.pinned_blocks.write();
+		blocks.entry(hash).and_modify(|counter| *counter += 1).or_insert(1);
+
 		Ok(())
 	}
 
-	fn unpin_block(&self, _: <Block as BlockT>::Hash) {}
+	fn unpin_block(&self, hash: <Block as BlockT>::Hash) {
+		let mut blocks = self.pinned_blocks.write();
+		blocks.entry(hash).and_modify(|counter| *counter -= 1).or_insert(-1);
+	}
 }
 
 impl<Block: BlockT> backend::LocalBackend<Block> for Backend<Block> where Block::Hash: Ord {}

--- a/client/rpc-spec-v2/Cargo.toml
+++ b/client/rpc-spec-v2/Cargo.toml
@@ -43,4 +43,5 @@ substrate-test-runtime = { version = "2.0.0", path = "../../test-utils/runtime" 
 sp-consensus = { version = "0.10.0-dev", path = "../../primitives/consensus/common" }
 sp-maybe-compressed-blob = { version = "4.1.0-dev", path = "../../primitives/maybe-compressed-blob" }
 sc-block-builder = { version = "0.10.0-dev", path = "../block-builder" }
+sc-service = { version = "0.10.0-dev", features = ["test-helpers"], path = "../service" }
 assert_matches = "1.3.0"


### PR DESCRIPTION
This PR uses the new pinning API introduced by https://github.com/paritytech/substrate/pull/13157.

The backend is propagated to the subscription management, which internally calls pinning only once for a given block.
An alternative to this approach would be holding the `UnpinHandle` structures that perform the unpinning on drop.
I decided to implement the first option because`chainHead` must also report all the blocks from memory and those blocks are not generated by notifications, therefore having a single uniform way of pinning across the chainHead methods.

To ensure proper testing the in-memory `Backend` is extended to describe the number of active pinned references for a given block. An in-memory `Backend` instance is used for testing the `chainHead`, therefore the `children` method of the in-memory Backend is extended to return an empty list.
