### PR TITLE
storage-monitor: statvfs arithmetic bug fixed

### DIFF
--- a/client/storage-monitor/src/lib.rs
+++ b/client/storage-monitor/src/lib.rs
@@ -118,7 +118,10 @@ impl StorageMonitorService {
 	/// Returns free space in MB, or error if statvfs failed.
 	fn free_space(path: &Path) -> Result<u64, Error> {
 		statvfs(path)
-			.map(|stats| stats.blocks_available() * stats.block_size() / 1_000_000)
+			.map(|stats| {
+				u64::from(stats.blocks_available()).saturating_mul(u64::from(stats.block_size())) /
+					1_000_000
+			})
 			.map_err(Error::from)
 	}
 


### PR DESCRIPTION
Should fix: https://github.com/paritytech/substrate/pull/13082#discussion_r1085613384

[`blocks_available`](https://docs.rs/nix/latest/x86_64-apple-darwin/nix/sys/statvfs/struct.Statvfs.html#method.blocks_available) returns `u32` for Apple/Darwin (https://docs.rs/libc/0.2.139/x86_64-apple-darwin/libc/type.fsblkcnt_t.html). This fix should solve this problem.