### PR TITLE
[contracts] Add upfront weight of merkle trie proofs for storage reading functions

### DIFF
--- a/frame/contracts/proc-macro/src/lib.rs
+++ b/frame/contracts/proc-macro/src/lib.rs
@@ -124,21 +124,24 @@ fn format_weight(field: &Ident) -> TokenStream2 {
 	quote_spanned! { field.span() =>
 		&if self.#field.ref_time() > 1_000_000_000 {
 			format!(
-				"{:.1?} ms",
-				Fixed::saturating_from_rational(self.#field.ref_time(), 1_000_000_000).to_float()
+				"{:.1?} ms, {} bytes",
+				Fixed::saturating_from_rational(self.#field.ref_time(), 1_000_000_000).to_float(),
+				self.#field.proof_size()
 			)
 		} else if self.#field.ref_time() > 1_000_000 {
 			format!(
-				"{:.1?} µs",
-				Fixed::saturating_from_rational(self.#field.ref_time(), 1_000_000).to_float()
+				"{:.1?} µs, {} bytes",
+				Fixed::saturating_from_rational(self.#field.ref_time(), 1_000_000).to_float(),
+				self.#field.proof_size()
 			)
 		} else if self.#field.ref_time() > 1_000 {
 			format!(
-				"{:.1?} ns",
-				Fixed::saturating_from_rational(self.#field.ref_time(), 1_000).to_float()
+				"{:.1?} ns, {} bytes",
+				Fixed::saturating_from_rational(self.#field.ref_time(), 1_000).to_float(),
+				self.#field.proof_size()
 			)
 		} else {
-			format!("{} ps", self.#field.ref_time())
+			format!("{} ps, {} bytes", self.#field.ref_time(), self.#field.proof_size())
 		}
 	}
 }

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -78,7 +78,7 @@
 //!
 //! * [`ink`](https://github.com/paritytech/ink) is
 //! an [`eDSL`](https://wiki.haskell.org/Embedded_domain_specific_language) that enables writing
-//! WebAssembly based smart contracts in the Rust programming language. This is a work in progress.
+//! WebAssembly based smart contracts in the Rust programming language.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "runtime-benchmarks", recursion_limit = "512")]

--- a/frame/contracts/src/schedule.rs
+++ b/frame/contracts/src/schedule.rs
@@ -644,23 +644,23 @@ impl<T: Config> Default for HostFnWeights<T> {
 				1
 			)),
 			debug_message: to_weight!(cost_batched!(seal_debug_message)),
-			set_storage: to_weight!(cost_batched!(seal_set_storage)),
+			set_storage: to_weight!(cost_batched!(seal_set_storage), 1024u64),
 			set_code_hash: to_weight!(cost_batched!(seal_set_code_hash)),
 			set_storage_per_new_byte: to_weight!(cost_byte_batched!(seal_set_storage_per_new_kb)),
 			set_storage_per_old_byte: to_weight!(
 				cost_byte_batched!(seal_set_storage_per_old_kb),
 				1u64
 			),
-			clear_storage: to_weight!(cost_batched!(seal_clear_storage)),
+			clear_storage: to_weight!(cost_batched!(seal_clear_storage), 1024u64),
 			clear_storage_per_byte: to_weight!(cost_byte_batched!(seal_clear_storage_per_kb), 1u64),
-			contains_storage: to_weight!(cost_batched!(seal_contains_storage)),
+			contains_storage: to_weight!(cost_batched!(seal_contains_storage), 1024u64),
 			contains_storage_per_byte: to_weight!(
 				cost_byte_batched!(seal_contains_storage_per_kb),
 				1u64
 			),
-			get_storage: to_weight!(cost_batched!(seal_get_storage)),
+			get_storage: to_weight!(cost_batched!(seal_get_storage), 1024u64),
 			get_storage_per_byte: to_weight!(cost_byte_batched!(seal_get_storage_per_kb), 1u64),
-			take_storage: to_weight!(cost_batched!(seal_take_storage)),
+			take_storage: to_weight!(cost_batched!(seal_take_storage), 1024u64),
 			take_storage_per_byte: to_weight!(cost_byte_batched!(seal_take_storage_per_kb), 1u64),
 			transfer: to_weight!(cost_batched!(seal_transfer)),
 			call: to_weight!(cost_batched!(seal_call)),


### PR DESCRIPTION
Follow-up to https://github.com/paritytech/substrate/pull/12976

Even for a single-byte reading operation, proofs of all merkle trie hashes would apparently be needed. Hence this static weight is added to all the storage reading functions. 
