### PR TITLE
grandpa: cleanup stale entries in set id session mapping

### DIFF
--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -230,6 +230,7 @@ impl pallet_grandpa::Config for Runtime {
 
 	type WeightInfo = ();
 	type MaxAuthorities = ConstU32<32>;
+	type MaxSetIdSessionEntries = ConstU32<0>;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -230,7 +230,7 @@ impl pallet_grandpa::Config for Runtime {
 
 	type WeightInfo = ();
 	type MaxAuthorities = ConstU32<32>;
-	type MaxSetIdSessionEntries = ConstU32<0>;
+	type MaxSetIdSessionEntries = ConstU64<0>;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1313,6 +1313,10 @@ impl pallet_authority_discovery::Config for Runtime {
 	type MaxAuthorities = MaxAuthorities;
 }
 
+parameter_types! {
+	pub const MaxSetIdSessionEntries: u32 = BondingDuration::get() * SessionsPerEra::get();
+}
+
 impl pallet_grandpa::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 
@@ -1334,6 +1338,7 @@ impl pallet_grandpa::Config for Runtime {
 
 	type WeightInfo = ();
 	type MaxAuthorities = MaxAuthorities;
+	type MaxSetIdSessionEntries = MaxSetIdSessionEntries;
 }
 
 parameter_types! {

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -122,7 +122,7 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxAuthorities: Get<u32>;
 
-		/// The maximum number of entries to keep in the set id to sesion index mapping.
+		/// The maximum number of entries to keep in the set id to session index mapping.
 		///
 		/// Since the `SetIdSession` map is only used for validating equivocations this
 		/// value should relate to the bonding duration of whatever staking system is

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -129,7 +129,7 @@ pub mod pallet {
 		/// being used (if any). If equivocation handling is not enabled then this value
 		/// can be zero.
 		#[pallet::constant]
-		type MaxSetIdSessionEntries: Get<u32>;
+		type MaxSetIdSessionEntries: Get<u64>;
 	}
 
 	#[pallet::hooks]
@@ -663,7 +663,7 @@ where
 					*s
 				});
 
-				let max_set_id_session_entries = (T::MaxSetIdSessionEntries::get() as u64).max(1);
+				let max_set_id_session_entries = T::MaxSetIdSessionEntries::get().max(1);
 				if current_set_id >= max_set_id_session_entries {
 					SetIdSession::<T>::remove(current_set_id - max_set_id_session_entries);
 				}

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -333,7 +333,7 @@ pub mod pallet {
 	/// members were responsible.
 	///
 	/// This is only used for validating equivocation proofs. An equivocation proof must
-	/// contain a key-ownership proof for a given session, therefore we need a way to tie
+	/// contains a key-ownership proof for a given session, therefore we need a way to tie
 	/// together sessions and GRANDPA set ids, i.e. we need to validate that a validator
 	/// was the owner of a given key on a given session, and what the active set ID was
 	/// during that session.

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -121,6 +121,15 @@ pub mod pallet {
 		/// Max Authorities in use
 		#[pallet::constant]
 		type MaxAuthorities: Get<u32>;
+
+		/// The maximum number of entries to keep in the set id to sesion index mapping.
+		///
+		/// Since the `SetIdSession` map is only used for validating equivocations this
+		/// value should relate to the bonding duration of whatever staking system is
+		/// being used (if any). If equivocation handling is not enabled then this value
+		/// can be zero.
+		#[pallet::constant]
+		type MaxSetIdSessionEntries: Get<u32>;
 	}
 
 	#[pallet::hooks]
@@ -322,6 +331,12 @@ pub mod pallet {
 
 	/// A mapping from grandpa set ID to the index of the *most recent* session for which its
 	/// members were responsible.
+	///
+	/// This is only used for validating equivocation proofs. An equivocation proof must
+	/// contain a key-ownership proof for a given session, therefore we need a way to tie
+	/// together sessions and GRANDPA set ids, i.e. we need to validate that a validator
+	/// was the owner of a given key on a given session, and what the active set ID was
+	/// during that session.
 	///
 	/// TWOX-NOTE: `SetId` is not under user control.
 	#[pallet::storage]
@@ -643,10 +658,17 @@ where
 			};
 
 			if res.is_ok() {
-				CurrentSetId::<T>::mutate(|s| {
+				let current_set_id = CurrentSetId::<T>::mutate(|s| {
 					*s += 1;
 					*s
-				})
+				});
+
+				let max_set_id_session_entries = (T::MaxSetIdSessionEntries::get() as u64).max(1);
+				if current_set_id >= max_set_id_session_entries {
+					SetIdSession::<T>::remove(current_set_id - max_set_id_session_entries);
+				}
+
+				current_set_id
 			} else {
 				// either the session module signalled that the validators have changed
 				// or the set was stalled. but since we didn't successfully schedule
@@ -659,8 +681,8 @@ where
 			Self::current_set_id()
 		};
 
-		// if we didn't issue a change, we update the mapping to note that the current
-		// set corresponds to the latest equivalent session (i.e. now).
+		// update the mapping to note that the current set corresponds to the
+		// latest equivalent session (i.e. now).
 		let session_index = <pallet_session::Pallet<T>>::current_index();
 		SetIdSession::<T>::insert(current_set_id, &session_index);
 	}

--- a/frame/grandpa/src/migrations.rs
+++ b/frame/grandpa/src/migrations.rs
@@ -56,11 +56,11 @@ fn cleanup_set_id_sesion_map<T: Config>() -> Weight {
 	let until_set_id =
 		CurrentSetId::<T>::get().saturating_sub(T::MaxSetIdSessionEntries::get() as u64);
 
-	for set_id in 0..until_set_id {
+	for set_id in 0..=until_set_id {
 		SetIdSession::<T>::remove(set_id);
 	}
 
 	T::DbWeight::get()
 		.reads(1)
-		.saturating_add(T::DbWeight::get().writes(until_set_id))
+		.saturating_add(T::DbWeight::get().writes(until_set_id + 1))
 }

--- a/frame/grandpa/src/migrations.rs
+++ b/frame/grandpa/src/migrations.rs
@@ -53,8 +53,7 @@ impl<T: Config> OnRuntimeUpgrade for CleanupSetIdSessionMap<T> {
 }
 
 fn cleanup_set_id_sesion_map<T: Config>() -> Weight {
-	let until_set_id =
-		CurrentSetId::<T>::get().saturating_sub(T::MaxSetIdSessionEntries::get() as u64);
+	let until_set_id = CurrentSetId::<T>::get().saturating_sub(T::MaxSetIdSessionEntries::get());
 
 	for set_id in 0..=until_set_id {
 		SetIdSession::<T>::remove(set_id);

--- a/frame/grandpa/src/migrations.rs
+++ b/frame/grandpa/src/migrations.rs
@@ -19,7 +19,6 @@ use frame_support::{
 	traits::{Get, OnRuntimeUpgrade},
 	weights::Weight,
 };
-use sp_runtime::SaturatedConversion;
 
 use crate::{Config, CurrentSetId, SetIdSession, LOG_TARGET};
 

--- a/frame/grandpa/src/migrations.rs
+++ b/frame/grandpa/src/migrations.rs
@@ -63,5 +63,5 @@ fn cleanup_set_id_sesion_map<T: Config>() -> Weight {
 
 	T::DbWeight::get()
 		.reads(1)
-		.saturating_add(T::DbWeight::get().writes((0..until_set_id).count().saturated_into()))
+		.saturating_add(T::DbWeight::get().writes(until_set_id))
 }

--- a/frame/grandpa/src/migrations.rs
+++ b/frame/grandpa/src/migrations.rs
@@ -15,5 +15,53 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use frame_support::{
+	traits::{Get, OnRuntimeUpgrade},
+	weights::Weight,
+};
+use sp_runtime::SaturatedConversion;
+
+use crate::{Config, CurrentSetId, SetIdSession, LOG_TARGET};
+
 /// Version 4.
 pub mod v4;
+
+/// This migration will clean up all stale set id -> session entries from the
+/// `SetIdSession` storage map, only the latest `max_set_id_session_entries`
+/// will be kept.
+///
+/// This migration should be added with a runtime upgrade that introduces the
+/// `MaxSetIdSessionEntries` constant to the pallet (although it could also be
+/// done later on).
+pub struct CleanupSetIdSessionMap<T>(sp_std::marker::PhantomData<T>);
+impl<T: Config> OnRuntimeUpgrade for CleanupSetIdSessionMap<T> {
+	fn on_runtime_upgrade() -> Weight {
+		// NOTE: since this migration will loop over all stale entries in the
+		// map we need to set some cutoff value, otherwise the migration might
+		// take too long to run. for scenarios where there are that many entries
+		// to cleanup a multiblock migration will be needed instead.
+		if CurrentSetId::<T>::get() > 25_000 {
+			log::warn!(
+				target: LOG_TARGET,
+				"CleanupSetIdSessionMap migration was aborted since there are too many entries to cleanup."
+			);
+
+			return T::DbWeight::get().reads(1)
+		}
+
+		cleanup_set_id_sesion_map::<T>()
+	}
+}
+
+fn cleanup_set_id_sesion_map<T: Config>() -> Weight {
+	let until_set_id =
+		CurrentSetId::<T>::get().saturating_sub(T::MaxSetIdSessionEntries::get() as u64);
+
+	for set_id in 0..until_set_id {
+		SetIdSession::<T>::remove(set_id);
+	}
+
+	T::DbWeight::get()
+		.reads(1)
+		.saturating_add(T::DbWeight::get().writes((0..until_set_id).count().saturated_into()))
+}

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -221,6 +221,7 @@ impl pallet_offences::Config for Test {
 parameter_types! {
 	pub const ReportLongevity: u64 =
 		BondingDuration::get() as u64 * SessionsPerEra::get() as u64 * Period::get();
+	pub const MaxSetIdSessionEntries: u32 = BondingDuration::get() * SessionsPerEra::get();
 }
 
 impl Config for Test {
@@ -241,6 +242,7 @@ impl Config for Test {
 
 	type WeightInfo = ();
 	type MaxAuthorities = ConstU32<100>;
+	type MaxSetIdSessionEntries = MaxSetIdSessionEntries;
 }
 
 pub fn grandpa_log(log: ConsensusLog<u64>) -> DigestItem {


### PR DESCRIPTION
 In the GRANDPA pallet we keep a mapping of `set id -> session index`, this is necessary to validate equivocation proofs. The entries in this map were never being pruned. This PR bounds the maximum number of entries in this mapping which will usually be set to the bonding duration (in sessions).

polkadot companion: https://github.com/paritytech/polkadot/pull/6626