### PR TITLE
docs: Fix broken documentation links for pallets

### DIFF
--- a/frame/multisig/README.md
+++ b/frame/multisig/README.md
@@ -1,8 +1,8 @@
 # Multisig Module
 A module for doing multisig dispatch.
 
-- [`multisig::Config`](https://docs.rs/pallet-multisig/latest/pallet_multisig/trait.Config.html)
-- [`Call`](https://docs.rs/pallet-multisig/latest/pallet_multisig/enum.Call.html)
+- [`Config`](https://docs.rs/pallet-multisig/latest/pallet_multisig/pallet/trait.Config.html)
+- [`Call`](https://docs.rs/pallet-multisig/latest/pallet_multisig/pallet/enum.Call.html)
 
 ## Overview
 

--- a/frame/multisig/src/lib.rs
+++ b/frame/multisig/src/lib.rs
@@ -39,9 +39,6 @@
 //!   number of signed origins.
 //! * `approve_as_multi` - Approve a call from a composite origin.
 //! * `cancel_as_multi` - Cancel a call from a composite origin.
-//!
-//! [`Call`]: ./enum.Call.html
-//! [`Config`]: ./trait.Config.html
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/frame/nicks/README.md
+++ b/frame/nicks/README.md
@@ -1,7 +1,7 @@
 # Nicks Module
 
-- [`nicks::Config`](https://docs.rs/pallet-nicks/latest/pallet_nicks/trait.Config.html)
-- [`Call`](https://docs.rs/pallet-nicks/latest/pallet_nicks/enum.Call.html)
+- [`Config`](https://docs.rs/pallet-nicks/latest/pallet_nicks/pallet/trait.Config.html)
+- [`Call`](https://docs.rs/pallet-nicks/latest/pallet_nicks/pallet/enum.Call.html)
 
 ## Overview
 

--- a/frame/proxy/README.md
+++ b/frame/proxy/README.md
@@ -6,8 +6,8 @@ The accounts to which permission is delegated may be requied to announce the act
 wish to execute some duration prior to execution happens. In this case, the target account may
 reject the announcement and in doing so, veto the execution.
 
-- [`proxy::Config`](https://docs.rs/pallet-proxy/latest/pallet_proxy/trait.Config.html)
-- [`Call`](https://docs.rs/pallet-proxy/latest/pallet_proxy/enum.Call.html)
+- [`Config`](https://docs.rs/pallet-proxy/latest/pallet_proxy/pallet/trait.Config.html)
+- [`Call`](https://docs.rs/pallet-proxy/latest/pallet_proxy/pallet/enum.Call.html)
 
 ## Overview
 

--- a/frame/sudo/README.md
+++ b/frame/sudo/README.md
@@ -1,7 +1,7 @@
 # Sudo Module
 
-- [`sudo::Config`](https://docs.rs/pallet-sudo/latest/pallet_sudo/trait.Config.html)
-- [`Call`](https://docs.rs/pallet-sudo/latest/pallet_sudo/enum.Call.html)
+- [`Config`](https://docs.rs/pallet-sudo/latest/pallet_sudo/pallet/trait.Config.html)
+- [`Call`](https://docs.rs/pallet-sudo/latest/pallet_sudo/pallet/enum.Call.html)
 
 ## Overview
 

--- a/frame/utility/README.md
+++ b/frame/utility/README.md
@@ -1,8 +1,8 @@
 # Utility Module
 A stateless module with helpers for dispatch management which does no re-authentication.
 
-- [`utility::Config`](https://docs.rs/pallet-utility/latest/pallet_utility/trait.Config.html)
-- [`Call`](https://docs.rs/pallet-utility/latest/pallet_utility/enum.Call.html)
+- [`utility::Config`](https://docs.rs/pallet-utility/latest/pallet_utility/pallet/trait.Config.html)
+- [`Call`](https://docs.rs/pallet-utility/latest/pallet_utility/pallet/enum.Call.html)
 
 ## Overview
 

--- a/frame/vesting/README.md
+++ b/frame/vesting/README.md
@@ -1,7 +1,7 @@
 # Vesting Module
 
-- [`vesting::Config`](https://docs.rs/pallet-vesting/latest/pallet_vesting/trait.Config.html)
-- [`Call`](https://docs.rs/pallet-vesting/latest/pallet_vesting/enum.Call.html)
+- [`Config`](https://docs.rs/pallet-vesting/latest/pallet_vesting/pallet/trait.Config.html)
+- [`Call`](https://docs.rs/pallet-vesting/latest/pallet_vesting/pallet/enum.Call.html)
 
 ## Overview
 


### PR DESCRIPTION
While going through the FRAME docs on Substrate I've noticed a few
broken links on a couple different Pallets. The link were related to
`Config` and `Call` types and there were broken links in both READMEs
and or Rust docs. This PR fix all of those broken links I've found.
