### PR TITLE
Fix derive PassByInner with generics

### DIFF
--- a/primitives/runtime-interface/proc-macro/src/pass_by/inner.rs
+++ b/primitives/runtime-interface/proc-macro/src/pass_by/inner.rs
@@ -52,7 +52,7 @@ pub fn derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 			#crate_include
 
 			impl #impl_generics #crate_::pass_by::PassBy for #ident #ty_generics #where_clause {
-				type PassBy = #crate_::pass_by::Inner<#ident, #inner_ty>;
+				type PassBy = #crate_::pass_by::Inner<#ident #ty_generics, #inner_ty>;
 			}
 
 			impl #impl_generics #crate_::pass_by::PassByInner for #ident #ty_generics #where_clause {

--- a/primitives/runtime-interface/proc-macro/src/pass_by/inner.rs
+++ b/primitives/runtime-interface/proc-macro/src/pass_by/inner.rs
@@ -52,7 +52,7 @@ pub fn derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 			#crate_include
 
 			impl #impl_generics #crate_::pass_by::PassBy for #ident #ty_generics #where_clause {
-				type PassBy = #crate_::pass_by::Inner<#ident #ty_generics, #inner_ty>;
+				type PassBy = #crate_::pass_by::Inner<Self, #inner_ty>;
 			}
 
 			impl #impl_generics #crate_::pass_by::PassByInner for #ident #ty_generics #where_clause {


### PR DESCRIPTION
`PassByInner` derive macro is designed to work with generic data types, but it doesn't work due to missing part in associated type `Inner` definition. This PR adds missing part to make macro work correctly.