### PR TITLE
sc-finality-grandpa: Warp proof generation can not expect justifications

### DIFF
--- a/client/cli/src/params/pruning_params.rs
+++ b/client/cli/src/params/pruning_params.rs
@@ -49,6 +49,7 @@ pub struct PruningParams {
 	/// [default: 256]
 	#[arg(alias = "pruning", long, value_name = "PRUNING_MODE")]
 	pub state_pruning: Option<DatabasePruningMode>,
+
 	/// Specify the blocks pruning mode.
 	///
 	/// This mode specifies when the block's body (including justifications)

--- a/client/finality-grandpa/src/warp_proof.rs
+++ b/client/finality-grandpa/src/warp_proof.rs
@@ -135,11 +135,7 @@ impl<Block: BlockT> WarpSyncProof<Block> {
 			let justification = blockchain
 				.justifications(header.hash())?
 				.and_then(|just| just.into_justification(GRANDPA_ENGINE_ID))
-				.expect(
-					"header is last in set and contains standard change signal; \
-					must have justification; \
-					qed.",
-				);
+				.ok_or_else(|| Error::MissingData)?;
 
 			let justification = GrandpaJustification::<Block>::decode(&mut &justification[..])?;
 


### PR DESCRIPTION
When a node is running with `--blocks-pruning` it will also prunes justifications. So, the warp proof generation can not use `expect` for unwrapping the justification.

Closes: https://github.com/paritytech/substrate/issues/13168