### PR TITLE
subkey: only decode hex if requested

### DIFF
--- a/client/cli/src/commands/utils.rs
+++ b/client/cli/src/commands/utils.rs
@@ -274,15 +274,17 @@ where
 }
 
 /// checks if message is Some, otherwise reads message from stdin and optionally decodes hex
-pub fn read_message(msg: Option<&String>, should_decode: bool) -> Result<Vec<u8>, Error> {
+pub fn read_message(msg: Option<&String>, decode_hex: bool) -> Result<Vec<u8>, Error> {
 	let mut message = vec![];
 	match msg {
 		Some(m) => {
-			message = array_bytes::hex2bytes(m.as_str())?;
+			if decode_hex {
+				message = array_bytes::hex2bytes(m.as_str())?;
+			}
 		},
 		None => {
 			std::io::stdin().lock().read_to_end(&mut message)?;
-			if should_decode {
+			if decode_hex {
 				message = array_bytes::hex2bytes(array_bytes::hex_bytes2hex_str(&message)?)?;
 			}
 		},

--- a/client/cli/src/commands/verify.rs
+++ b/client/cli/src/commands/verify.rs
@@ -37,12 +37,13 @@ pub struct VerifyCmd {
 	/// If not given, you will be prompted for the URI.
 	uri: Option<String>,
 
-	/// Message to verify, if not provided you will be prompted to
-	/// pass the message via STDIN
+	/// Message to verify, if not provided you will be prompted to pass the message via STDIN.
+	///
+	/// The message is assumed to be raw bytes, unless `--hex` is specified.
 	#[arg(long)]
 	message: Option<String>,
 
-	/// The message on STDIN is hex-encoded data
+	/// The message is hex-encoded data.
 	#[arg(long)]
 	hex: bool,
 


### PR DESCRIPTION
@NukeManDan found out that a message is assumed to be hex when passed as option, but not when through STDIN.  
Changing it here for consistent, LMK if this was intentional, but there is no test anyway.

Change to the `verify` sub-command:  
- Do not assume a message on the CLI to be hex unless `--hex` is specified.

