### PR TITLE
Calling proxy doesn't remove announcement

### DIFF
--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -183,8 +183,6 @@ pub mod pallet {
 		/// Dispatch the given `call` from an account that the sender is authorised for through
 		/// `add_proxy`.
 		///
-		/// Removes any corresponding announcement(s).
-		///
 		/// The dispatch origin for this call must be _Signed_.
 		///
 		/// Parameters:

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -292,12 +292,15 @@ fn announcer_must_be_proxy() {
 fn calling_proxy_doesnt_remove_announcement() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Proxy::add_proxy(RuntimeOrigin::signed(1), 2, ProxyType::Any, 0));
+		
 		let call = Box::new(call_transfer(6, 1));
 		let call_hash = BlakeTwo256::hash_of(&call);
+		
 		assert_ok!(Proxy::announce(RuntimeOrigin::signed(2), 1, call_hash));
 		assert_ok!(Proxy::proxy(RuntimeOrigin::signed(2), 1, None, call));
-		let announcements = Announcements::<Test>::get(2);
+
 		// The announcement is not removed by calling proxy.
+		let announcements = Announcements::<Test>::get(2);
 		assert_eq!(announcements.0, vec![Announcement { real: 1, call_hash, height: 1 }]);
 	});
 }

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -292,10 +292,10 @@ fn announcer_must_be_proxy() {
 fn calling_proxy_doesnt_remove_announcement() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Proxy::add_proxy(RuntimeOrigin::signed(1), 2, ProxyType::Any, 0));
-		
+
 		let call = Box::new(call_transfer(6, 1));
 		let call_hash = BlakeTwo256::hash_of(&call);
-		
+
 		assert_ok!(Proxy::announce(RuntimeOrigin::signed(2), 1, call_hash));
 		assert_ok!(Proxy::proxy(RuntimeOrigin::signed(2), 1, None, call));
 

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -289,6 +289,20 @@ fn announcer_must_be_proxy() {
 }
 
 #[test]
+fn calling_proxy_doesnt_remove_announcement() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Proxy::add_proxy(RuntimeOrigin::signed(1), 2, ProxyType::Any, 0));
+		let call = Box::new(call_transfer(6, 1));
+		let call_hash = BlakeTwo256::hash_of(&call);
+		assert_ok!(Proxy::announce(RuntimeOrigin::signed(2), 1, call_hash));
+		assert_ok!(Proxy::proxy(RuntimeOrigin::signed(2), 1, None, call));
+		let announcements = Announcements::<Test>::get(2);
+		// The announcement is not removed by calling proxy.
+		assert_eq!(announcements.0, vec![Announcement { real: 1, call_hash, height: 1 }]);
+	});
+}
+
+#[test]
 fn delayed_requires_pre_announcement() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Proxy::add_proxy(RuntimeOrigin::signed(1), 2, ProxyType::Any, 1));


### PR DESCRIPTION
The documentation was incorrect. 
I have updated it and written a test to confirm this.