### PR TITLE
feat: renamed ensure_none to unsure_unsigned

### DIFF
--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -558,8 +558,9 @@ fn aux_storage_cleanup<C: HeaderMetadata<Block> + HeaderBackend<Block>, Block: B
 		Ok(meta) => {
 			hashes.insert(meta.parent);
 		},
-		Err(err) =>
-			warn!(target: LOG_TARGET, "Failed to lookup metadata for block `{:?}`: {}", first, err,),
+		Err(err) => {
+			warn!(target: LOG_TARGET, "Failed to lookup metadata for block `{:?}`: {}", first, err,)
+		},
 	}
 
 	// Cleans data for finalized block's ancestors

--- a/client/db/src/pinned_blocks_cache.rs
+++ b/client/db/src/pinned_blocks_cache.rs
@@ -149,8 +149,9 @@ impl<Block: BlockT> PinnedBlocksCache<Block> {
 					self.cache.len()
 				);
 			},
-			None =>
-				log::warn!(target: LOG_TARGET, "Unable to bump reference count. hash = {}", hash),
+			None => {
+				log::warn!(target: LOG_TARGET, "Unable to bump reference count. hash = {}", hash)
+			},
 		};
 	}
 

--- a/client/finality-grandpa/src/communication/gossip.rs
+++ b/client/finality-grandpa/src/communication/gossip.rs
@@ -794,14 +794,15 @@ impl<Block: BlockT> Inner<Block> {
 		{
 			let local_view = match self.local_view {
 				None => return None,
-				Some(ref mut v) =>
+				Some(ref mut v) => {
 					if v.round == round {
 						// Do not send neighbor packets out if `round` has not changed ---
 						// such behavior is punishable.
 						return None
 					} else {
 						v
-					},
+					}
+				},
 			};
 
 			let set_id = local_view.set_id;
@@ -827,7 +828,7 @@ impl<Block: BlockT> Inner<Block> {
 		{
 			let local_view = match self.local_view {
 				ref mut x @ None => x.get_or_insert(LocalView::new(set_id, Round(1))),
-				Some(ref mut v) =>
+				Some(ref mut v) => {
 					if v.set_id == set_id {
 						let diff_authorities = self.authorities.iter().collect::<HashSet<_>>() !=
 							authorities.iter().collect::<HashSet<_>>();
@@ -845,7 +846,8 @@ impl<Block: BlockT> Inner<Block> {
 						return None
 					} else {
 						v
-					},
+					}
+				},
 			};
 
 			local_view.update_set(set_id);

--- a/client/network/bitswap/src/lib.rs
+++ b/client/network/bitswap/src/lib.rs
@@ -127,8 +127,9 @@ impl<B: BlockT> BitswapRequestHandler<B> {
 					};
 
 					match pending_response.send(response) {
-						Ok(()) =>
-							trace!(target: LOG_TARGET, "Handled bitswap request from {peer}.",),
+						Ok(()) => {
+							trace!(target: LOG_TARGET, "Handled bitswap request from {peer}.",)
+						},
 						Err(_) => debug!(
 							target: LOG_TARGET,
 							"Failed to handle light client request from {peer}: {}",

--- a/client/network/src/request_responses.rs
+++ b/client/network/src/request_responses.rs
@@ -344,7 +344,7 @@ impl NetworkBehaviour for RequestResponsesBehaviour {
 						)
 					}
 				},
-			FromSwarm::DialFailure(DialFailure { peer_id, error, handler }) =>
+			FromSwarm::DialFailure(DialFailure { peer_id, error, handler }) => {
 				for (p_name, p_handler) in handler.into_iter() {
 					if let Some((proto, _)) = self.protocols.get_mut(p_name.as_str()) {
 						proto.on_swarm_event(FromSwarm::DialFailure(DialFailure {
@@ -359,7 +359,8 @@ impl NetworkBehaviour for RequestResponsesBehaviour {
 						  p_name,
 						)
 					}
-				},
+				}
+			},
 			FromSwarm::ListenerClosed(e) =>
 				for (p, _) in self.protocols.values_mut() {
 					NetworkBehaviour::on_swarm_event(p, FromSwarm::ListenerClosed(e));

--- a/client/state-db/src/lib.rs
+++ b/client/state-db/src/lib.rs
@@ -184,12 +184,14 @@ impl fmt::Debug for StateDbError {
 				"Incompatible pruning modes [stored: {:?}; requested: {:?}]",
 				stored, requested
 			),
-			Self::TooManySiblingBlocks { number } =>
-				write!(f, "Too many sibling blocks at #{number} inserted"),
+			Self::TooManySiblingBlocks { number } => {
+				write!(f, "Too many sibling blocks at #{number} inserted")
+			},
 			Self::BlockAlreadyExists => write!(f, "Block already exists"),
 			Self::Metadata(message) => write!(f, "Invalid metadata: {}", message),
-			Self::BlockUnavailable =>
-				write!(f, "Trying to get a block record from db while it is not commit to db yet"),
+			Self::BlockUnavailable => {
+				write!(f, "Trying to get a block record from db while it is not commit to db yet")
+			},
 			Self::BlockMissing => write!(f, "Block record is missing from the pruning window"),
 		}
 	}

--- a/frame/babe/src/equivocation.rs
+++ b/frame/babe/src/equivocation.rs
@@ -162,8 +162,9 @@ where
 
 		match SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into()) {
 			Ok(()) => log::info!(target: LOG_TARGET, "Submitted BABE equivocation report.",),
-			Err(e) =>
-				log::error!(target: LOG_TARGET, "Error submitting equivocation report: {:?}", e,),
+			Err(e) => {
+				log::error!(target: LOG_TARGET, "Error submitting equivocation report: {:?}", e,)
+			},
 		}
 
 		Ok(())

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -436,7 +436,7 @@ pub mod pallet {
 			equivocation_proof: Box<EquivocationProof<T::Header>>,
 			key_owner_proof: T::KeyOwnerProof,
 		) -> DispatchResultWithPostInfo {
-			ensure_none(origin)?;
+			ensure_unsigned(origin)?;
 
 			Self::do_report_equivocation(
 				T::HandleEquivocation::block_author(),

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -62,7 +62,7 @@ mod pallet_test {
 		#[pallet::call_index(1)]
 		#[pallet::weight(0)]
 		pub fn dummy(origin: OriginFor<T>, _n: u32) -> DispatchResult {
-			let _sender = ensure_none(origin)?;
+			let _sender = ensure_unsigned(origin)?;
 			Ok(())
 		}
 

--- a/frame/benchmarking/src/tests_instance.rs
+++ b/frame/benchmarking/src/tests_instance.rs
@@ -72,7 +72,7 @@ mod pallet_test {
 		#[pallet::call_index(1)]
 		#[pallet::weight(0)]
 		pub fn dummy(origin: OriginFor<T>, _n: u32) -> DispatchResult {
-			let _sender = ensure_none(origin)?;
+			let _sender = ensure_unsigned(origin)?;
 			Ok(())
 		}
 	}

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -241,7 +241,7 @@ use frame_support::{
 	weights::Weight,
 	DefaultNoBound, EqNoBound, PartialEqNoBound,
 };
-use frame_system::{ensure_none, offchain::SendTransactionTypes};
+use frame_system::{ensure_unsigned, offchain::SendTransactionTypes};
 use scale_info::TypeInfo;
 use sp_arithmetic::{
 	traits::{CheckedAdd, Zero},
@@ -907,7 +907,7 @@ pub mod pallet {
 			raw_solution: Box<RawSolution<SolutionOf<T::MinerConfig>>>,
 			witness: SolutionOrSnapshotSize,
 		) -> DispatchResult {
-			ensure_none(origin)?;
+			ensure_unsigned(origin)?;
 			let error_message = "Invalid unsigned submission must produce invalid block and \
 				 deprive validator from their authoring reward.";
 

--- a/frame/examples/basic/README.md
+++ b/frame/examples/basic/README.md
@@ -99,7 +99,7 @@ Copy and paste this template from frame/examples/basic/src/lib.rs into file
 
 // What origins are used and supported in this pallet (root, signed, none)
 // i.e. root when <code>\`ensure_root\`</code> used
-// i.e. none when <code>\`ensure_none\`</code> used
+// i.e. none when <code>\`ensure_unsigned\`</code> used
 // i.e. signed when <code>\`ensure_signed\`</code> used
 
 <code>\`inherent\`</code> <INSERT_DESCRIPTION>

--- a/frame/examples/basic/src/lib.rs
+++ b/frame/examples/basic/src/lib.rs
@@ -126,7 +126,7 @@
 //!
 //! // What origins are used and supported in this pallet (root, signed, none)
 //! // i.e. root when <code>\`ensure_root\`</code> used
-//! // i.e. none when <code>\`ensure_none\`</code> used
+//! // i.e. none when <code>\`ensure_unsigned\`</code> used
 //! // i.e. signed when <code>\`ensure_signed\`</code> used
 //!
 //! <code>\`inherent\`</code> <INSERT_DESCRIPTION>
@@ -441,7 +441,7 @@ pub mod pallet {
 	// to the above bullets: `::Signed(AccountId)`, `::Root` and `::None`. You should always match
 	// against them as the first thing you do in your function. There are three convenience calls
 	// in system that do the matching for you and return a convenient result: `ensure_signed`,
-	// `ensure_root` and `ensure_none`.
+	// `ensure_root` and `ensure_unsigned`.
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// This is your public interface. Be extremely careful.

--- a/frame/examples/offchain-worker/src/lib.rs
+++ b/frame/examples/offchain-worker/src/lib.rs
@@ -263,7 +263,7 @@ pub mod pallet {
 			price: u32,
 		) -> DispatchResultWithPostInfo {
 			// This ensures that the function can only be called via unsigned transaction.
-			ensure_none(origin)?;
+			ensure_unsigned(origin)?;
 			// Add the price to the on-chain list, but mark it as coming from an empty address.
 			Self::add_price(None, price);
 			// now increment the block number at which we expect next unsigned transaction.
@@ -280,7 +280,7 @@ pub mod pallet {
 			_signature: T::Signature,
 		) -> DispatchResultWithPostInfo {
 			// This ensures that the function can only be called via unsigned transaction.
-			ensure_none(origin)?;
+			ensure_unsigned(origin)?;
 			// Add the price to the on-chain list, but mark it as coming from an empty address.
 			Self::add_price(None, price_payload.price);
 			// now increment the block number at which we expect next unsigned transaction.

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -760,7 +760,7 @@ mod tests {
 			#[pallet::call_index(2)]
 			#[pallet::weight(0)]
 			pub fn some_unsigned_message(origin: OriginFor<T>) -> DispatchResult {
-				frame_system::ensure_none(origin)?;
+				frame_system::ensure_unsigned(origin)?;
 				Ok(())
 			}
 
@@ -781,7 +781,7 @@ mod tests {
 			#[pallet::call_index(5)]
 			#[pallet::weight((0, DispatchClass::Mandatory))]
 			pub fn inherent_call(origin: OriginFor<T>) -> DispatchResult {
-				frame_system::ensure_none(origin)?;
+				frame_system::ensure_unsigned(origin)?;
 				Ok(())
 			}
 

--- a/frame/grandpa/src/equivocation.rs
+++ b/frame/grandpa/src/equivocation.rs
@@ -171,8 +171,9 @@ where
 
 		match SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into()) {
 			Ok(()) => log::info!(target: LOG_TARGET, "Submitted GRANDPA equivocation report.",),
-			Err(e) =>
-				log::error!(target: LOG_TARGET, "Error submitting equivocation report: {:?}", e,),
+			Err(e) => {
+				log::error!(target: LOG_TARGET, "Error submitting equivocation report: {:?}", e,)
+			},
 		}
 
 		Ok(())

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -230,7 +230,7 @@ pub mod pallet {
 			equivocation_proof: Box<EquivocationProof<T::Hash, T::BlockNumber>>,
 			key_owner_proof: T::KeyOwnerProof,
 		) -> DispatchResultWithPostInfo {
-			ensure_none(origin)?;
+			ensure_unsigned(origin)?;
 
 			Self::do_report_equivocation(
 				T::HandleEquivocation::block_author(),

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -486,7 +486,7 @@ pub mod pallet {
 			// we can skip doing it here again.
 			_signature: <T::AuthorityId as RuntimeAppPublic>::Signature,
 		) -> DispatchResult {
-			ensure_none(origin)?;
+			ensure_unsigned(origin)?;
 
 			let current_session = T::ValidatorSet::session_index();
 			let exists =

--- a/frame/nfts/src/tests.rs
+++ b/frame/nfts/src/tests.rs
@@ -2099,12 +2099,7 @@ fn claim_swap_should_work() {
 
 		assert_ok!(Nfts::force_create(RuntimeOrigin::root(), user_1, default_collection_config()));
 
-		assert_ok!(Nfts::mint(
-			RuntimeOrigin::signed(user_1),
-			collection_id,
-			item_1,user_1,
-			None,
-		));
+		assert_ok!(Nfts::mint(RuntimeOrigin::signed(user_1), collection_id, item_1, user_1, None,));
 		assert_ok!(Nfts::force_mint(
 			RuntimeOrigin::signed(user_1),
 			collection_id,
@@ -2119,13 +2114,7 @@ fn claim_swap_should_work() {
 			user_2,
 			default_item_config(),
 		));
-		assert_ok!(Nfts::mint(
-			RuntimeOrigin::signed(user_1),
-			collection_id,
-			item_4,
-			user_1,
-			None,
-		));
+		assert_ok!(Nfts::mint(RuntimeOrigin::signed(user_1), collection_id, item_4, user_1, None,));
 		assert_ok!(Nfts::force_mint(
 			RuntimeOrigin::signed(user_1),
 			collection_id,

--- a/frame/scheduler/src/migration.rs
+++ b/frame/scheduler/src/migration.rs
@@ -297,8 +297,9 @@ pub mod v4 {
 					target: TARGET,
 					"Did not clean up any agendas. v4::CleanupAgendas can be removed."
 				),
-				Some(n) =>
-					log::info!(target: TARGET, "Cleaned up {} agendas, now {}", n, new_agendas),
+				Some(n) => {
+					log::info!(target: TARGET, "Cleaned up {} agendas, now {}", n, new_agendas)
+				},
 				None => unreachable!(
 					"Number of agendas cannot increase, old {} new {}",
 					old_agendas, new_agendas
@@ -560,8 +561,9 @@ mod test {
 						"Agenda {} should be removed",
 						i
 					),
-					Some(new) =>
-						assert_eq!(Agenda::<Test>::get(i as u64), new, "Agenda wrong {}", i),
+					Some(new) => {
+						assert_eq!(Agenda::<Test>::get(i as u64), new, "Agenda wrong {}", i)
+					},
 				}
 			}
 		});

--- a/frame/support/procedural/src/benchmark.rs
+++ b/frame/support/procedural/src/benchmark.rs
@@ -157,7 +157,7 @@ impl BenchmarkDef {
 		// parse params such as "x: Linear<0, 1>"
 		for arg in &item_fn.sig.inputs {
 			let invalid_param = |span| {
-				return Err(Error::new(span, "Invalid benchmark function param. A valid example would be `x: Linear<5, 10>`.", ))
+				return Err(Error::new(span, "Invalid benchmark function param. A valid example would be `x: Linear<5, 10>`.", ));
 			};
 
 			let FnArg::Typed(arg) = arg else { return invalid_param(arg.span()) };
@@ -169,7 +169,7 @@ impl BenchmarkDef {
 				return Err(Error::new(
 					var_span,
 					"Benchmark parameter names must consist of a single lowercase letter (a-z) and no other characters.",
-				))
+				));
 			};
 			let name = ident.ident.to_token_stream().to_string();
 			if name.len() > 1 {

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -976,7 +976,7 @@ where
 }
 
 /// Ensure that the origin `o` represents an unsigned extrinsic. Returns `Ok` or an `Err` otherwise.
-pub fn ensure_none<OuterOrigin, AccountId>(o: OuterOrigin) -> Result<(), BadOrigin>
+pub fn ensure_unsigned<OuterOrigin, AccountId>(o: OuterOrigin) -> Result<(), BadOrigin>
 where
 	OuterOrigin: Into<Result<RawOrigin<AccountId>, OuterOrigin>>,
 {
@@ -1753,7 +1753,7 @@ impl<T: Config> Lookup for ChainContext<T> {
 
 /// Prelude to be used alongside pallet macro, for ease of use.
 pub mod pallet_prelude {
-	pub use crate::{ensure_none, ensure_root, ensure_signed, ensure_signed_or_root};
+	pub use crate::{ensure_unsigned, ensure_root, ensure_signed, ensure_signed_or_root};
 
 	/// Type alias for the `Origin` associated type of system config.
 	pub type OriginFor<T> = <T as crate::Config>::RuntimeOrigin;

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -975,6 +975,17 @@ where
 	}
 }
 
+/// Earlier Usage:
+/// Ensure that the origin `o` represents the root. Returns `Ok` or an `Err` otherwise.
+/// Now Deprecated, Use `ensure_unsigned` instead
+#[deprecated]
+pub fn ensure_none<OuterOrigin, AccountId>(o: OuterOrigin) -> Result<(), BadOrigin>
+where
+	OuterOrigin: Into<Result<RawOrigin<AccountId>, OuterOrigin>>,
+{
+	ensure_unsigned(o)
+}
+
 /// Ensure that the origin `o` represents an unsigned extrinsic. Returns `Ok` or an `Err` otherwise.
 pub fn ensure_unsigned<OuterOrigin, AccountId>(o: OuterOrigin) -> Result<(), BadOrigin>
 where
@@ -1753,7 +1764,7 @@ impl<T: Config> Lookup for ChainContext<T> {
 
 /// Prelude to be used alongside pallet macro, for ease of use.
 pub mod pallet_prelude {
-	pub use crate::{ensure_unsigned, ensure_root, ensure_signed, ensure_signed_or_root};
+	pub use crate::{ensure_root, ensure_signed, ensure_signed_or_root, ensure_unsigned};
 
 	/// Type alias for the `Origin` associated type of system config.
 	pub type OriginFor<T> = <T as crate::Config>::RuntimeOrigin;

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -204,7 +204,7 @@ pub mod pallet {
 			DispatchClass::Mandatory
 		))]
 		pub fn set(origin: OriginFor<T>, #[pallet::compact] now: T::Moment) -> DispatchResult {
-			ensure_none(origin)?;
+			ensure_unsigned(origin)?;
 			assert!(!DidUpdate::<T>::exists(), "Timestamp must be updated only once in the block");
 			let prev = Self::now();
 			assert!(

--- a/frame/transaction-storage/src/lib.rs
+++ b/frame/transaction-storage/src/lib.rs
@@ -289,7 +289,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			proof: TransactionStorageProof,
 		) -> DispatchResultWithPostInfo {
-			ensure_none(origin)?;
+			ensure_unsigned(origin)?;
 			ensure!(!ProofChecked::<T>::get(), Error::<T>::DoubleCheck);
 			let number = <frame_system::Pallet<T>>::block_number();
 			let period = <StoragePeriod<T>>::get();

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -205,7 +205,7 @@ pub mod pallet {
 			calls: Vec<<T as Config>::RuntimeCall>,
 		) -> DispatchResultWithPostInfo {
 			// Do not allow the `None` origin.
-			if ensure_none(origin.clone()).is_ok() {
+			if ensure_unsigned(origin.clone()).is_ok() {
 				return Err(BadOrigin.into())
 			}
 
@@ -328,7 +328,7 @@ pub mod pallet {
 			calls: Vec<<T as Config>::RuntimeCall>,
 		) -> DispatchResultWithPostInfo {
 			// Do not allow the `None` origin.
-			if ensure_none(origin.clone()).is_ok() {
+			if ensure_unsigned(origin.clone()).is_ok() {
 				return Err(BadOrigin.into())
 			}
 
@@ -442,7 +442,7 @@ pub mod pallet {
 			calls: Vec<<T as Config>::RuntimeCall>,
 		) -> DispatchResultWithPostInfo {
 			// Do not allow the `None` origin.
-			if ensure_none(origin.clone()).is_ok() {
+			if ensure_unsigned(origin.clone()).is_ok() {
 				return Err(BadOrigin.into())
 			}
 


### PR DESCRIPTION
Fix #13279 
## Description
Deprecate `ensure_none` and introduced the alias name `ensure_unsigned`. 
### NOTE
Not a breaking change

