### PR TITLE
benchmarks: `EnsureRankedMember` must add ranked members

### DIFF
--- a/frame/ranked-collective/src/lib.rs
+++ b/frame/ranked-collective/src/lib.rs
@@ -256,8 +256,7 @@ impl<T: Config<I>, I: 'static, const MIN_RANK: u16> EnsureOrigin<T::RuntimeOrigi
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn try_successful_origin() -> Result<T::RuntimeOrigin, ()> {
-		let who = IndexToId::<T, I>::get(MIN_RANK, 0).ok_or(())?;
-		Ok(frame_system::RawOrigin::Signed(who).into())
+		EnsureRankedMember::<T, I, MIN_RANK>::try_successful_origin()
 	}
 }
 
@@ -279,8 +278,7 @@ impl<T: Config<I>, I: 'static, const MIN_RANK: u16> EnsureOrigin<T::RuntimeOrigi
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn try_successful_origin() -> Result<T::RuntimeOrigin, ()> {
-		let who = IndexToId::<T, I>::get(MIN_RANK, 0).ok_or(())?;
-		Ok(frame_system::RawOrigin::Signed(who).into())
+		EnsureRankedMember::<T, I, MIN_RANK>::try_successful_origin()
 	}
 }
 
@@ -302,7 +300,9 @@ impl<T: Config<I>, I: 'static, const MIN_RANK: u16> EnsureOrigin<T::RuntimeOrigi
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn try_successful_origin() -> Result<T::RuntimeOrigin, ()> {
-		let who = IndexToId::<T, I>::get(MIN_RANK, 0).ok_or(())?;
+		let who = frame_benchmarking::account::<T::AccountId>("successful_origin", 0, 0);
+		crate::Pallet::<T, I>::do_add_member_to_rank(who.clone(), MIN_RANK)
+			.expect("Could not add members for benchmarks");
 		Ok(frame_system::RawOrigin::Signed(who).into())
 	}
 }


### PR DESCRIPTION
We use `EnsureMember` in Kusama runtime [here](https://github.com/paritytech/polkadot/blob/48de7a20d95a0ba87447e77ede531dc44cc7cd4a/runtime/kusama/src/governance/fellowship.rs#L306). This requires that there be a successful origin.  
Now there is no member at all and the referenda pallet does not know that it needs to add some to the ranked collective pallet.   IMO we have to add it in the `EnsureMember`. Other solutions welcome.

cc @acatangiu @lexnv 
Needed to unblock Polkadot CI https://github.com/paritytech/polkadot/pull/6663 and https://github.com/paritytech/polkadot/pull/6528

Fake companions to make the CI green:  
Polkadot companion: https://github.com/paritytech/polkadot/pull/6528