### PR TITLE
Rename `pallet-random-collective-flip` to Insecure...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3513,6 +3513,7 @@ dependencies = [
  "pallet-identity",
  "pallet-im-online",
  "pallet-indices",
+ "pallet-insecure-randomness-collective-flip",
  "pallet-lottery",
  "pallet-membership",
  "pallet-message-queue",
@@ -3527,7 +3528,6 @@ dependencies = [
  "pallet-offences-benchmarking",
  "pallet-preimage",
  "pallet-proxy",
- "pallet-randomness-collective-flip",
  "pallet-ranked-collective",
  "pallet-recovery",
  "pallet-referenda",
@@ -4977,7 +4977,7 @@ dependencies = [
  "pallet-aura",
  "pallet-balances",
  "pallet-grandpa",
- "pallet-randomness-collective-flip",
+ "pallet-insecure-randomness-collective-flip",
  "pallet-sudo",
  "pallet-template",
  "pallet-timestamp",
@@ -5587,7 +5587,7 @@ dependencies = [
  "pallet-balances",
  "pallet-contracts-primitives",
  "pallet-contracts-proc-macro",
- "pallet-randomness-collective-flip",
+ "pallet-insecure-randomness-collective-flip",
  "pallet-timestamp",
  "pallet-utility",
  "parity-scale-codec",
@@ -5863,6 +5863,21 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-keyring",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-insecure-randomness-collective-flip"
+version = "4.0.0-dev"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "safe-mix",
+ "scale-info",
+ "sp-core",
+ "sp-io",
  "sp-runtime",
  "sp-std",
 ]
@@ -6185,21 +6200,6 @@ dependencies = [
  "pallet-balances",
  "pallet-utility",
  "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-randomness-collective-flip"
-version = "4.0.0-dev"
-dependencies = [
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "safe-mix",
  "scale-info",
  "sp-core",
  "sp-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ members = [
 	"frame/nomination-pools/benchmarking",
 	"frame/nomination-pools/test-staking",
 	"frame/nomination-pools/runtime-api",
-	"frame/randomness-collective-flip",
+	"frame/insecure-randomness-collective-flip",
 	"frame/ranked-collective",
 	"frame/recovery",
 	"frame/referenda",

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -20,7 +20,7 @@ pallet-aura = { version = "4.0.0-dev", default-features = false, path = "../../.
 pallet-balances = { version = "4.0.0-dev", default-features = false, path = "../../../frame/balances" }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../../../frame/support" }
 pallet-grandpa = { version = "4.0.0-dev", default-features = false, path = "../../../frame/grandpa" }
-pallet-randomness-collective-flip = { version = "4.0.0-dev", default-features = false, path = "../../../frame/randomness-collective-flip" }
+pallet-insecure-randomness-collective-flip = { version = "4.0.0-dev", default-features = false, path = "../../../frame/insecure-randomness-collective-flip" }
 pallet-sudo = { version = "4.0.0-dev", default-features = false, path = "../../../frame/sudo" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../../frame/system" }
 frame-try-runtime = { version = "0.10.0-dev", default-features = false, path = "../../../frame/try-runtime", optional = true }
@@ -69,7 +69,7 @@ std = [
 	"pallet-aura/std",
 	"pallet-balances/std",
 	"pallet-grandpa/std",
-	"pallet-randomness-collective-flip/std",
+	"pallet-insecure-randomness-collective-flip/std",
 	"pallet-sudo/std",
 	"pallet-template/std",
 	"pallet-timestamp/std",
@@ -107,7 +107,7 @@ try-runtime = [
 	"pallet-aura/try-runtime",
 	"pallet-balances/try-runtime",
 	"pallet-grandpa/try-runtime",
-	"pallet-randomness-collective-flip/try-runtime",
+	"pallet-insecure-randomness-collective-flip/try-runtime",
 	"pallet-sudo/try-runtime",
 	"pallet-template/try-runtime",
 	"pallet-timestamp/try-runtime",

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -205,7 +205,7 @@ impl frame_system::Config for Runtime {
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
-impl pallet_randomness_collective_flip::Config for Runtime {}
+impl pallet_insecure_randomness_collective_flip::Config for Runtime {}
 
 impl pallet_aura::Config for Runtime {
 	type AuthorityId = AuraId;
@@ -290,7 +290,7 @@ construct_runtime!(
 		UncheckedExtrinsic = UncheckedExtrinsic,
 	{
 		System: frame_system,
-		RandomnessCollectiveFlip: pallet_randomness_collective_flip,
+		RandomnessCollectiveFlip: pallet_insecure_randomness_collective_flip,
 		Timestamp: pallet_timestamp,
 		Aura: pallet_aura,
 		Grandpa: pallet_grandpa,

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -87,7 +87,7 @@ pallet-offences = { version = "4.0.0-dev", default-features = false, path = "../
 pallet-offences-benchmarking = { version = "4.0.0-dev", path = "../../../frame/offences/benchmarking", default-features = false, optional = true }
 pallet-preimage = { version = "4.0.0-dev", default-features = false, path = "../../../frame/preimage" }
 pallet-proxy = { version = "4.0.0-dev", default-features = false, path = "../../../frame/proxy" }
-pallet-randomness-collective-flip = { version = "4.0.0-dev", default-features = false, path = "../../../frame/randomness-collective-flip" }
+pallet-insecure-randomness-collective-flip = { version = "4.0.0-dev", default-features = false, path = "../../../frame/insecure-randomness-collective-flip" }
 pallet-ranked-collective = { version = "4.0.0-dev", default-features = false, path = "../../../frame/ranked-collective" }
 pallet-recovery = { version = "4.0.0-dev", default-features = false, path = "../../../frame/recovery" }
 pallet-referenda = { version = "4.0.0-dev", default-features = false, path = "../../../frame/referenda" }
@@ -167,7 +167,7 @@ std = [
 	"pallet-preimage/std",
 	"pallet-proxy/std",
 	"sp-core/std",
-	"pallet-randomness-collective-flip/std",
+	"pallet-insecure-randomness-collective-flip/std",
 	"sp-std/std",
 	"pallet-session/std",
 	"pallet-session-benchmarking?/std",
@@ -300,7 +300,7 @@ try-runtime = [
 	"pallet-offences/try-runtime",
 	"pallet-preimage/try-runtime",
 	"pallet-proxy/try-runtime",
-	"pallet-randomness-collective-flip/try-runtime",
+	"pallet-insecure-randomness-collective-flip/try-runtime",
 	"pallet-ranked-collective/try-runtime",
 	"pallet-recovery/try-runtime",
 	"pallet-referenda/try-runtime",

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -233,7 +233,7 @@ impl frame_system::Config for Runtime {
 	type MaxConsumers = ConstU32<16>;
 }
 
-impl pallet_randomness_collective_flip::Config for Runtime {}
+impl pallet_insecure_randomness_collective_flip::Config for Runtime {}
 
 impl pallet_utility::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
@@ -1732,7 +1732,7 @@ construct_runtime!(
 		AuthorityDiscovery: pallet_authority_discovery,
 		Offences: pallet_offences,
 		Historical: pallet_session_historical::{Pallet},
-		RandomnessCollectiveFlip: pallet_randomness_collective_flip,
+		RandomnessCollectiveFlip: pallet_insecure_randomness_collective_flip,
 		Identity: pallet_identity,
 		Society: pallet_society,
 		Recovery: pallet_recovery,

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -56,7 +56,7 @@ wat = "1"
 # Substrate Dependencies
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }
 pallet-timestamp = { version = "4.0.0-dev", path = "../timestamp" }
-pallet-randomness-collective-flip = { version = "4.0.0-dev", path = "../randomness-collective-flip" }
+pallet-insecure-randomness-collective-flip = { version = "4.0.0-dev", path = "../insecure-randomness-collective-flip" }
 pallet-utility = { version = "4.0.0-dev", path = "../utility" }
 sp-keystore = { version = "0.13.0", path = "../../primitives/keystore" }
 

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -67,7 +67,7 @@ frame_support::construct_runtime!(
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
-		Randomness: pallet_randomness_collective_flip::{Pallet, Storage},
+		Randomness: pallet_insecure_randomness_collective_flip::{Pallet, Storage},
 		Utility: pallet_utility::{Pallet, Call, Storage, Event},
 		Contracts: pallet_contracts::{Pallet, Call, Storage, Event<T>},
 	}
@@ -311,7 +311,7 @@ impl frame_system::Config for Test {
 	type OnSetCode = ();
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
-impl pallet_randomness_collective_flip::Config for Test {}
+impl pallet_insecure_randomness_collective_flip::Config for Test {}
 impl pallet_balances::Config for Test {
 	type MaxLocks = ();
 	type MaxReserves = ();

--- a/frame/insecure-randomness-collective-flip/Cargo.toml
+++ b/frame/insecure-randomness-collective-flip/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "pallet-randomness-collective-flip"
+name = "pallet-insecure-randomness-collective-flip"
 version = "4.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://substrate.io"
 repository = "https://github.com/paritytech/substrate/"
-description = "FRAME randomness collective flip pallet"
+description = "Insecure do not use in production: FRAME randomness collective flip pallet"
 readme = "README.md"
 
 [package.metadata.docs.rs]

--- a/frame/insecure-randomness-collective-flip/README.md
+++ b/frame/insecure-randomness-collective-flip/README.md
@@ -1,6 +1,10 @@
+# DO NOT USE IN PRODUCTION
+
+The produced values do not fulfill the cryptographic requirements for random numbers. Should not be used for high-stake production use-cases.
+
 # Randomness Module
 
-The Randomness Collective Flip module provides a [`random`](https://docs.rs/pallet-randomness-collective-flip/latest/pallet_randomness_collective_flip/struct.Module.html#method.random)
+The Randomness Collective Flip module provides a [`random`](https://docs.rs/pallet-insecure-randomness-collective-flip/latest/pallet_insecure_randomness_collective_flip/struct.Module.html#method.random)
 function that generates low-influence random values based on the block hashes from the previous
 `81` blocks. Low-influence randomness can be useful when defending against relatively weak
 adversaries. Using this pallet as a randomness source is advisable primarily in low-security
@@ -8,7 +12,7 @@ situations like testing.
 
 ## Public Functions
 
-See the [`Module`](https://docs.rs/pallet-randomness-collective-flip/latest/pallet_randomness_collective_flip/struct.Module.html) struct for details of publicly available functions.
+See the [`Module`](https://docs.rs/pallet-insecure-randomness-collective-flip/latest/pallet_insecure_randomness_collective_flip/struct.Module.html) struct for details of publicly available functions.
 
 ## Usage
 
@@ -32,13 +36,13 @@ pub mod pallet {
     pub struct Pallet<T>(_);
 
     #[pallet::config]
-    pub trait Config: frame_system::Config + pallet_randomness_collective_flip::Config {}
+    pub trait Config: frame_system::Config + pallet_insecure_randomness_collective_flip::Config {}
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
         #[pallet::weight(0)]
         pub fn random_module_example(origin: OriginFor<T>) -> DispatchResult {
-            let _random_value = <pallet_randomness_collective_flip::Pallet<T>>::random(&b"my context"[..]);
+            let _random_value = <pallet_insecure_randomness_collective_flip::Pallet<T>>::random(&b"my context"[..]);
             Ok(())
         }
     }

--- a/frame/insecure-randomness-collective-flip/src/lib.rs
+++ b/frame/insecure-randomness-collective-flip/src/lib.rs
@@ -15,6 +15,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! # DO NOT USE IN PRODUCTION
+//! 
+//! The produced values do not fulfill the cryptographic requirements for random numbers.  
+//! Should not be used for high-stake production use-cases.
+//!
 //! # Randomness Pallet
 //!
 //! The Randomness Collective Flip pallet provides a [`random`](./struct.Module.html#method.random)
@@ -50,13 +55,13 @@
 //!     pub struct Pallet<T>(_);
 //!
 //!     #[pallet::config]
-//!     pub trait Config: frame_system::Config + pallet_randomness_collective_flip::Config {}
+//!     pub trait Config: frame_system::Config + pallet_insecure_randomness_collective_flip::Config {}
 //!
 //!     #[pallet::call]
 //!     impl<T: Config> Pallet<T> {
 //!         #[pallet::weight(0)]
 //!         pub fn random_module_example(origin: OriginFor<T>) -> DispatchResult {
-//!             let _random_value = <pallet_randomness_collective_flip::Pallet<T>>::random(&b"my context"[..]);
+//!             let _random_value = <pallet_insecure_randomness_collective_flip::Pallet<T>>::random(&b"my context"[..]);
 //!             Ok(())
 //!         }
 //!     }
@@ -157,7 +162,7 @@ impl<T: Config> Randomness<T::Hash, T::BlockNumber> for Pallet<T> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate as pallet_randomness_collective_flip;
+	use crate as pallet_insecure_randomness_collective_flip;
 
 	use sp_core::H256;
 	use sp_runtime::{
@@ -181,7 +186,7 @@ mod tests {
 			UncheckedExtrinsic = UncheckedExtrinsic,
 		{
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
-			CollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage},
+			CollectiveFlip: pallet_insecure_randomness_collective_flip::{Pallet, Storage},
 		}
 	);
 
@@ -217,7 +222,7 @@ mod tests {
 		type MaxConsumers = ConstU32<16>;
 	}
 
-	impl pallet_randomness_collective_flip::Config for Test {}
+	impl pallet_insecure_randomness_collective_flip::Config for Test {}
 
 	fn new_test_ext() -> sp_io::TestExternalities {
 		let t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();

--- a/frame/insecure-randomness-collective-flip/src/lib.rs
+++ b/frame/insecure-randomness-collective-flip/src/lib.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 //! # DO NOT USE IN PRODUCTION
-//! 
+//!
 //! The produced values do not fulfill the cryptographic requirements for random numbers.  
 //! Should not be used for high-stake production use-cases.
 //!


### PR DESCRIPTION
Breaking change to explicable state the fact that the `randomness-collective-flip` pallet should not be used for production use-cases. Renames `pallet-randomness-collective-flip` to `pallet-insecure-randomness-collective-flip`.  
Cumulus companion: https://github.com/paritytech/cumulus/pull/2159  

There is currently no alternative other than to bridge to a secure randomness source.

What should happen with the crates.io release? Just leave it as it?