### PR TITLE
Disable default features for `strum` (fix `polkadot` CI)

### DIFF
--- a/primitives/beefy/Cargo.toml
+++ b/primitives/beefy/Cargo.toml
@@ -22,7 +22,7 @@ sp-io = { version = "7.0.0", default-features = false, path = "../io" }
 sp-mmr-primitives = { version = "4.0.0-dev", default-features = false, path = "../merkle-mountain-range" }
 sp-runtime = { version = "7.0.0", default-features = false, path = "../runtime" }
 sp-std = { version = "5.0.0", default-features = false, path = "../std" }
-strum = { version = "0.24.1", features = ["derive"] }
+strum = { version = "0.24.1", features = ["derive"], default-features = false }
 lazy_static = "1.4.0"
 
 [dev-dependencies]

--- a/primitives/keyring/Cargo.toml
+++ b/primitives/keyring/Cargo.toml
@@ -15,6 +15,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 lazy_static = "1.4.0"
-strum = { version = "0.24.1", features = ["derive"] }
+strum = { version = "0.24.1", features = ["derive"], default-features = false }
 sp-core = { version = "7.0.0", path = "../core" }
 sp-runtime = { version = "7.0.0", path = "../runtime" }


### PR DESCRIPTION
My PR [here](https://github.com/paritytech/polkadot/pull/6661) fails with a weird error on CI:

```
error[E0152]: duplicate lang item in crate `std` (which `strum` depends on): `panic_impl`.
    |
    = note: the lang item is first defined in crate `sp_io` (which `pallet_election_provider_multi_phase` depends on)
    = note: first definition in `sp_io` loaded from /builds/parity/mirrors/polkadot/target/testnet/wbuild/polkadot-runtime/target/wasm32-unknown-unknown/release/deps/libsp_io-f050ec3b6933463a.rmeta
    = note: second definition in `std` loaded from /usr/local/rustup/toolchains/nightly-2022-11-16-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-unknown/lib/libstd-65032bf6a898adaa.rlib
```

I reproduced it locally, and disabling default features for the `strum` crate seems to fix it (it has an `std` feature which is enabled by default). So hopefully it will also fix the CI.

polkadot companion: https://github.com/paritytech/polkadot/pull/6661