### PR TITLE
Rename UncheckedExtrinsic to RuntimeExtrinsic

### DIFF
--- a/bin/node-template/node/src/benchmarking.rs
+++ b/bin/node-template/node/src/benchmarking.rs
@@ -103,7 +103,7 @@ pub fn create_benchmark_extrinsic(
 	sender: sp_core::sr25519::Pair,
 	call: runtime::RuntimeCall,
 	nonce: u32,
-) -> runtime::UncheckedExtrinsic {
+) -> runtime::RuntimeExtrinsic {
 	let genesis_hash = client.block_hash(0).ok().flatten().expect("Genesis block exists; qed");
 	let best_hash = client.chain_info().best_hash;
 	let best_block = client.chain_info().best_number;
@@ -142,7 +142,7 @@ pub fn create_benchmark_extrinsic(
 	);
 	let signature = raw_payload.using_encoded(|e| sender.sign(e));
 
-	runtime::UncheckedExtrinsic::new_signed(
+	runtime::RuntimeExtrinsic::new_signed(
 		call.clone(),
 		sp_runtime::AccountId32::from(sender.public()).into(),
 		runtime::Signature::Sr25519(signature.clone()),

--- a/bin/node-template/pallets/template/src/mock.rs
+++ b/bin/node-template/pallets/template/src/mock.rs
@@ -6,7 +6,7 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 // Configure a mock runtime to test the pallet.
@@ -14,7 +14,7 @@ frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system,
 		TemplateModule: pallet_template,

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -76,12 +76,12 @@ pub type Hash = sp_core::H256;
 pub mod opaque {
 	use super::*;
 
-	pub use sp_runtime::OpaqueExtrinsic as UncheckedExtrinsic;
+	pub use sp_runtime::OpaqueExtrinsic as RuntimeExtrinsic;
 
 	/// Opaque block header type.
 	pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 	/// Opaque block type.
-	pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+	pub type Block = generic::Block<Header, RuntimeExtrinsic>;
 	/// Opaque block identifier type.
 	pub type BlockId = generic::BlockId<Block>;
 
@@ -287,7 +287,7 @@ construct_runtime!(
 	where
 		Block = Block,
 		NodeBlock = opaque::Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system,
 		RandomnessCollectiveFlip: pallet_insecure_randomness_collective_flip,
@@ -307,7 +307,7 @@ pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
 /// Block header type as expected by this runtime.
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 /// Block type as expected by this runtime.
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
 	frame_system::CheckNonZeroSender<Runtime>,
@@ -321,8 +321,7 @@ pub type SignedExtra = (
 );
 
 /// Unchecked extrinsic type as expected by this runtime.
-pub type UncheckedExtrinsic =
-	generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
 /// The payload being signed in transactions.
 pub type SignedPayload = generic::SignedPayload<RuntimeCall, SignedExtra>;
 /// Executive: handles dispatch to the various modules.

--- a/bin/node/cli/benches/block_production.rs
+++ b/bin/node/cli/benches/block_production.rs
@@ -120,7 +120,7 @@ fn new_node(tokio_handle: Handle) -> node_cli::service::NewFullBase {
 }
 
 fn extrinsic_set_time(now: u64) -> OpaqueExtrinsic {
-	kitchensink_runtime::UncheckedExtrinsic {
+	kitchensink_runtime::RuntimeExtrinsic {
 		signature: None,
 		function: kitchensink_runtime::RuntimeCall::Timestamp(pallet_timestamp::Call::set { now }),
 	}

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -73,7 +73,7 @@ pub fn create_extrinsic(
 	sender: sp_core::sr25519::Pair,
 	function: impl Into<kitchensink_runtime::RuntimeCall>,
 	nonce: Option<u32>,
-) -> kitchensink_runtime::UncheckedExtrinsic {
+) -> kitchensink_runtime::RuntimeExtrinsic {
 	let function = function.into();
 	let genesis_hash = client.block_hash(0).ok().flatten().expect("Genesis block exists; qed");
 	let best_hash = client.chain_info().best_hash;
@@ -117,7 +117,7 @@ pub fn create_extrinsic(
 	);
 	let signature = raw_payload.using_encoded(|e| sender.sign(e));
 
-	kitchensink_runtime::UncheckedExtrinsic::new_signed(
+	kitchensink_runtime::RuntimeExtrinsic::new_signed(
 		function,
 		sp_runtime::AccountId32::from(sender.public()).into(),
 		kitchensink_runtime::Signature::Sr25519(signature),
@@ -569,7 +569,7 @@ mod tests {
 	use codec::Encode;
 	use kitchensink_runtime::{
 		constants::{currency::CENTS, time::SLOT_DURATION},
-		Address, BalancesCall, RuntimeCall, UncheckedExtrinsic,
+		Address, BalancesCall, RuntimeCall, RuntimeExtrinsic,
 	};
 	use node_primitives::{Block, DigestItem, Signature};
 	use sc_client_api::BlockBackend;
@@ -790,8 +790,7 @@ mod tests {
 				let signature = raw_payload.using_encoded(|payload| signer.sign(payload));
 				let (function, extra, _) = raw_payload.deconstruct();
 				index += 1;
-				UncheckedExtrinsic::new_signed(function, from.into(), signature.into(), extra)
-					.into()
+				RuntimeExtrinsic::new_signed(function, from.into(), signature.into(), extra).into()
 			},
 		);
 	}

--- a/bin/node/executor/benches/bench.rs
+++ b/bin/node/executor/benches/bench.rs
@@ -20,7 +20,7 @@ use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use frame_support::Hashable;
 use kitchensink_runtime::{
 	constants::currency::*, Block, BuildStorage, CheckedExtrinsic, GenesisConfig, Header,
-	RuntimeCall, UncheckedExtrinsic,
+	RuntimeCall, RuntimeExtrinsic,
 };
 use node_executor::ExecutorDispatch;
 use node_primitives::{BlockNumber, Hash};
@@ -63,7 +63,7 @@ enum ExecutionMethod {
 	Wasm(WasmExecutionMethod),
 }
 
-fn sign(xt: CheckedExtrinsic) -> UncheckedExtrinsic {
+fn sign(xt: CheckedExtrinsic) -> RuntimeExtrinsic {
 	node_testing::keyring::sign(xt, SPEC_VERSION, TRANSACTION_VERSION, GENESIS_HASH)
 }
 

--- a/bin/node/executor/tests/basic.rs
+++ b/bin/node/executor/tests/basic.rs
@@ -29,8 +29,8 @@ use sp_runtime::{
 
 use kitchensink_runtime::{
 	constants::{currency::*, time::SLOT_DURATION},
-	Balances, CheckedExtrinsic, Header, Runtime, RuntimeCall, RuntimeEvent, System,
-	TransactionPayment, Treasury, UncheckedExtrinsic,
+	Balances, CheckedExtrinsic, Header, Runtime, RuntimeCall, RuntimeEvent, RuntimeExtrinsic,
+	System, TransactionPayment, Treasury,
 };
 use node_primitives::{Balance, Hash};
 use node_testing::keyring::*;
@@ -65,7 +65,7 @@ fn transfer_fee<E: Encode>(extrinsic: &E) -> Balance {
 	)
 }
 
-fn xt() -> UncheckedExtrinsic {
+fn xt() -> RuntimeExtrinsic {
 	sign(CheckedExtrinsic {
 		signed: Some((alice(), signed_extra(0, 0))),
 		function: RuntimeCall::Balances(default_transfer_call()),

--- a/bin/node/executor/tests/common.rs
+++ b/bin/node/executor/tests/common.rs
@@ -36,7 +36,7 @@ use sp_state_machine::TestExternalities as CoreTestExternalities;
 
 use kitchensink_runtime::{
 	constants::currency::*, Block, BuildStorage, CheckedExtrinsic, Header, Runtime,
-	UncheckedExtrinsic,
+	RuntimeExtrinsic,
 };
 use node_executor::ExecutorDispatch;
 use node_primitives::{BlockNumber, Hash};
@@ -82,7 +82,7 @@ pub const TRANSACTION_VERSION: u32 = kitchensink_runtime::VERSION.transaction_ve
 
 pub type TestExternalities<H> = CoreTestExternalities<H>;
 
-pub fn sign(xt: CheckedExtrinsic) -> UncheckedExtrinsic {
+pub fn sign(xt: CheckedExtrinsic) -> RuntimeExtrinsic {
 	node_testing::keyring::sign(xt, SPEC_VERSION, TRANSACTION_VERSION, GENESIS_HASH)
 }
 

--- a/bin/node/executor/tests/submit_transaction.rs
+++ b/bin/node/executor/tests/submit_transaction.rs
@@ -17,7 +17,7 @@
 
 use codec::Decode;
 use frame_system::offchain::{SendSignedTransaction, Signer, SubmitTransaction};
-use kitchensink_runtime::{Executive, Indices, Runtime, UncheckedExtrinsic};
+use kitchensink_runtime::{Executive, Indices, Runtime, RuntimeExtrinsic};
 use sp_application_crypto::AppKey;
 use sp_core::offchain::{testing::TestTransactionPoolExt, TransactionPoolExt};
 use sp_keyring::sr25519::Keyring::Alice;
@@ -146,12 +146,12 @@ fn should_submit_signed_twice_from_the_same_account() {
 
 		// now check that the transaction nonces are not equal
 		let s = state.read();
-		fn nonce(tx: UncheckedExtrinsic) -> frame_system::CheckNonce<Runtime> {
+		fn nonce(tx: RuntimeExtrinsic) -> frame_system::CheckNonce<Runtime> {
 			let extra = tx.signature.unwrap().2;
 			extra.5
 		}
-		let nonce1 = nonce(UncheckedExtrinsic::decode(&mut &*s.transactions[0]).unwrap());
-		let nonce2 = nonce(UncheckedExtrinsic::decode(&mut &*s.transactions[1]).unwrap());
+		let nonce1 = nonce(RuntimeExtrinsic::decode(&mut &*s.transactions[0]).unwrap());
+		let nonce2 = nonce(RuntimeExtrinsic::decode(&mut &*s.transactions[1]).unwrap());
 		assert!(nonce1 != nonce2, "Transactions should have different nonces. Got: {:?}", nonce1);
 	});
 }
@@ -195,14 +195,14 @@ fn should_submit_signed_twice_from_all_accounts() {
 
 		// now check that the transaction nonces are not equal
 		let s = state.read();
-		fn nonce(tx: UncheckedExtrinsic) -> frame_system::CheckNonce<Runtime> {
+		fn nonce(tx: RuntimeExtrinsic) -> frame_system::CheckNonce<Runtime> {
 			let extra = tx.signature.unwrap().2;
 			extra.5
 		}
-		let nonce1 = nonce(UncheckedExtrinsic::decode(&mut &*s.transactions[0]).unwrap());
-		let nonce2 = nonce(UncheckedExtrinsic::decode(&mut &*s.transactions[1]).unwrap());
-		let nonce3 = nonce(UncheckedExtrinsic::decode(&mut &*s.transactions[2]).unwrap());
-		let nonce4 = nonce(UncheckedExtrinsic::decode(&mut &*s.transactions[3]).unwrap());
+		let nonce1 = nonce(RuntimeExtrinsic::decode(&mut &*s.transactions[0]).unwrap());
+		let nonce2 = nonce(RuntimeExtrinsic::decode(&mut &*s.transactions[1]).unwrap());
+		let nonce3 = nonce(RuntimeExtrinsic::decode(&mut &*s.transactions[2]).unwrap());
+		let nonce4 = nonce(RuntimeExtrinsic::decode(&mut &*s.transactions[3]).unwrap());
 		assert!(
 			nonce1 != nonce3,
 			"Transactions should have different nonces. Got: 1st tx nonce: {:?}, 2nd nonce: {:?}", nonce1, nonce3
@@ -254,7 +254,7 @@ fn submitted_transaction_should_be_valid() {
 	let mut t = new_test_ext(compact_code_unwrap());
 	t.execute_with(|| {
 		let source = TransactionSource::External;
-		let extrinsic = UncheckedExtrinsic::decode(&mut &*tx0).unwrap();
+		let extrinsic = RuntimeExtrinsic::decode(&mut &*tx0).unwrap();
 		// add balance to the account
 		let author = extrinsic.signature.clone().unwrap().0;
 		let address = Indices::lookup(author).unwrap();

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1243,7 +1243,7 @@ where
 		public: <Signature as traits::Verify>::Signer,
 		account: AccountId,
 		nonce: Index,
-	) -> Option<(RuntimeCall, <UncheckedExtrinsic as traits::Extrinsic>::SignaturePayload)> {
+	) -> Option<(RuntimeCall, <RuntimeExtrinsic as traits::Extrinsic>::SignaturePayload)> {
 		let tip = 0;
 		// take the biggest period possible.
 		let period =
@@ -1285,7 +1285,7 @@ impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime
 where
 	RuntimeCall: From<C>,
 {
-	type Extrinsic = UncheckedExtrinsic;
+	type Extrinsic = RuntimeExtrinsic;
 	type OverarchingCall = RuntimeCall;
 }
 
@@ -1705,7 +1705,7 @@ construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = node_primitives::Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system,
 		Utility: pallet_utility,
@@ -1776,7 +1776,7 @@ pub type Address = sp_runtime::MultiAddress<AccountId, AccountIndex>;
 /// Block header type as expected by this runtime.
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 /// Block type as expected by this runtime.
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
 /// A Block signed with a Justification
 pub type SignedBlock = generic::SignedBlock<Block>;
 /// BlockId type as expected by this runtime.
@@ -1798,8 +1798,7 @@ pub type SignedExtra = (
 );
 
 /// Unchecked extrinsic type as expected by this runtime.
-pub type UncheckedExtrinsic =
-	generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
 /// The payload being signed in transactions.
 pub type SignedPayload = generic::SignedPayload<RuntimeCall, SignedExtra>;
 /// Extrinsic type that has already been checked.

--- a/bin/node/testing/src/bench.rs
+++ b/bin/node/testing/src/bench.rs
@@ -36,7 +36,7 @@ use codec::{Decode, Encode};
 use futures::executor;
 use kitchensink_runtime::{
 	constants::currency::DOLLARS, AccountId, BalancesCall, CheckedExtrinsic, MinimumPeriod,
-	RuntimeCall, Signature, SystemCall, UncheckedExtrinsic,
+	RuntimeCall, RuntimeExtrinsic, Signature, SystemCall,
 };
 use node_primitives::Block;
 use sc_block_builder::BlockBuilderProvider;
@@ -574,7 +574,7 @@ impl BenchKeyring {
 		spec_version: u32,
 		tx_version: u32,
 		genesis_hash: [u8; 32],
-	) -> UncheckedExtrinsic {
+	) -> RuntimeExtrinsic {
 		match xt.signed {
 			Some((signed, extra)) => {
 				let payload = (
@@ -593,12 +593,12 @@ impl BenchKeyring {
 						key.sign(b)
 					}
 				});
-				UncheckedExtrinsic {
+				RuntimeExtrinsic {
 					signature: Some((sp_runtime::MultiAddress::Id(signed), signature, extra)),
 					function: payload.0,
 				}
 			},
-			None => UncheckedExtrinsic { signature: None, function: xt.function },
+			None => RuntimeExtrinsic { signature: None, function: xt.function },
 		}
 	}
 

--- a/bin/node/testing/src/keyring.rs
+++ b/bin/node/testing/src/keyring.rs
@@ -19,7 +19,7 @@
 //! Test accounts.
 
 use codec::Encode;
-use kitchensink_runtime::{CheckedExtrinsic, SessionKeys, SignedExtra, UncheckedExtrinsic};
+use kitchensink_runtime::{CheckedExtrinsic, RuntimeExtrinsic, SessionKeys, SignedExtra};
 use node_primitives::{AccountId, Balance, Index};
 use sp_keyring::{AccountKeyring, Ed25519Keyring, Sr25519Keyring};
 use sp_runtime::generic::Era;
@@ -87,7 +87,7 @@ pub fn sign(
 	spec_version: u32,
 	tx_version: u32,
 	genesis_hash: [u8; 32],
-) -> UncheckedExtrinsic {
+) -> RuntimeExtrinsic {
 	match xt.signed {
 		Some((signed, extra)) => {
 			let payload =
@@ -102,11 +102,11 @@ pub fn sign(
 					}
 				})
 				.into();
-			UncheckedExtrinsic {
+			RuntimeExtrinsic {
 				signature: Some((sp_runtime::MultiAddress::Id(signed), signature, extra)),
 				function: payload.0,
 			}
 		},
-		None => UncheckedExtrinsic { signature: None, function: xt.function },
+		None => RuntimeExtrinsic { signature: None, function: xt.function },
 	}
 }

--- a/frame/alliance/src/mock.rs
+++ b/frame/alliance/src/mock.rs
@@ -229,14 +229,14 @@ impl Config for Test {
 	type RetirementPeriod = RetirementPeriod;
 }
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system,
 		Balances: pallet_balances,

--- a/frame/assets/src/mock.rs
+++ b/frame/assets/src/mock.rs
@@ -32,14 +32,14 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/atomic-swap/src/tests.rs
+++ b/frame/atomic-swap/src/tests.rs
@@ -10,14 +10,14 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/aura/src/mock.rs
+++ b/frame/aura/src/mock.rs
@@ -31,14 +31,14 @@ use sp_runtime::{
 	traits::IdentityLookup,
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},

--- a/frame/authority-discovery/src/lib.rs
+++ b/frame/authority-discovery/src/lib.rs
@@ -181,14 +181,14 @@ mod tests {
 		KeyTypeId, Perbill,
 	};
 
-	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 	type Block = frame_system::mocking::MockBlock<Test>;
 
 	frame_support::construct_runtime!(
 		pub enum Test where
 			Block = Block,
 			NodeBlock = Block,
-			UncheckedExtrinsic = UncheckedExtrinsic,
+			RuntimeExtrinsic = RuntimeExtrinsic,
 		{
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 			Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},

--- a/frame/authorship/src/lib.rs
+++ b/frame/authorship/src/lib.rs
@@ -109,14 +109,14 @@ mod tests {
 		traits::{BlakeTwo256, Header as HeaderT, IdentityLookup},
 	};
 
-	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 	type Block = frame_system::mocking::MockBlock<Test>;
 
 	frame_support::construct_runtime!(
 		pub enum Test where
 			Block = Block,
 			NodeBlock = Block,
-			UncheckedExtrinsic = UncheckedExtrinsic,
+			RuntimeExtrinsic = RuntimeExtrinsic,
 		{
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 			Authorship: pallet_authorship::{Pallet, Storage},

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -43,14 +43,14 @@ use sp_staking::{EraIndex, SessionIndex};
 
 type DummyValidatorId = u64;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system,
 		Authorship: pallet_authorship,

--- a/frame/bags-list/src/mock.rs
+++ b/frame/bags-list/src/mock.rs
@@ -85,13 +85,13 @@ impl bags_list::Config for Runtime {
 	type Score = VoteWeight;
 }
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;
 frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Storage, Event<T>, Config},
 		BagsList: bags_list::{Pallet, Call, Storage, Event<T>},

--- a/frame/balances/src/tests_composite.rs
+++ b/frame/balances/src/tests_composite.rs
@@ -30,14 +30,14 @@ use pallet_transaction_payment::CurrencyAdapter;
 use sp_core::H256;
 use sp_io;
 use sp_runtime::{testing::Header, traits::IdentityLookup};
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/balances/src/tests_local.rs
+++ b/frame/balances/src/tests_local.rs
@@ -31,14 +31,14 @@ use sp_core::H256;
 use sp_io;
 use sp_runtime::{testing::Header, traits::IdentityLookup};
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub struct Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/balances/src/tests_reentrancy.rs
+++ b/frame/balances/src/tests_reentrancy.rs
@@ -35,14 +35,14 @@ use frame_support::{
 };
 use frame_system::RawOrigin;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/beefy-mmr/src/mock.rs
+++ b/frame/beefy-mmr/src/mock.rs
@@ -45,14 +45,14 @@ impl_opaque_keys! {
 	}
 }
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},

--- a/frame/beefy/src/mock.rs
+++ b/frame/beefy/src/mock.rs
@@ -42,14 +42,14 @@ impl_opaque_keys! {
 	}
 }
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Beefy: pallet_beefy::{Pallet, Config<T>, Storage},

--- a/frame/benchmarking/pov/src/benchmarking.rs
+++ b/frame/benchmarking/pov/src/benchmarking.rs
@@ -320,14 +320,14 @@ mod mock {
 	type AccountIndex = u32;
 	type BlockNumber = u64;
 
-	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 	type Block = frame_system::mocking::MockBlock<Test>;
 
 	frame_support::construct_runtime!(
 		pub enum Test where
 			Block = Block,
 			NodeBlock = Block,
-			UncheckedExtrinsic = UncheckedExtrinsic,
+			RuntimeExtrinsic = RuntimeExtrinsic,
 		{
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 			Baseline: crate::{Pallet, Call, Storage, Event<T>},

--- a/frame/benchmarking/pov/src/tests.rs
+++ b/frame/benchmarking/pov/src/tests.rs
@@ -164,14 +164,14 @@ fn noop_is_free() {
 mod mock {
 	use sp_runtime::testing::H256;
 
-	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 	type Block = frame_system::mocking::MockBlock<Test>;
 
 	frame_support::construct_runtime!(
 		pub enum Test where
 			Block = Block,
 			NodeBlock = Block,
-			UncheckedExtrinsic = UncheckedExtrinsic,
+			RuntimeExtrinsic = RuntimeExtrinsic,
 		{
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 			Baseline: crate::{Pallet, Call, Storage, Event<T>},

--- a/frame/benchmarking/src/baseline.rs
+++ b/frame/benchmarking/src/baseline.rs
@@ -117,14 +117,14 @@ pub mod mock {
 	type AccountIndex = u32;
 	type BlockNumber = u64;
 
-	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 	type Block = frame_system::mocking::MockBlock<Test>;
 
 	frame_support::construct_runtime!(
 		pub enum Test where
 			Block = Block,
 			NodeBlock = Block,
-			UncheckedExtrinsic = UncheckedExtrinsic,
+			RuntimeExtrinsic = RuntimeExtrinsic,
 		{
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		}

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -74,14 +74,14 @@ mod pallet_test {
 	}
 }
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		TestPallet: pallet_test::{Pallet, Call, Storage},

--- a/frame/benchmarking/src/tests_instance.rs
+++ b/frame/benchmarking/src/tests_instance.rs
@@ -78,14 +78,14 @@ mod pallet_test {
 	}
 }
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		TestPallet: pallet_test::{Pallet, Call, Storage, Event<T>},

--- a/frame/bounties/src/tests.rs
+++ b/frame/bounties/src/tests.rs
@@ -39,14 +39,14 @@ use sp_runtime::{
 
 use super::Event as BountiesEvent;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/child-bounties/src/tests.rs
+++ b/frame/child-bounties/src/tests.rs
@@ -40,7 +40,7 @@ use sp_runtime::{
 
 use super::Event as ChildBountiesEvent;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 type BountiesError = pallet_bounties::Error<Test>;
 
@@ -48,7 +48,7 @@ frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/collective/src/tests.rs
+++ b/frame/collective/src/tests.rs
@@ -32,14 +32,14 @@ use sp_runtime::{
 	BuildStorage,
 };
 
-pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, u64, RuntimeCall, ()>;
+pub type Block = sp_runtime::generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = sp_runtime::generic::RuntimeExtrinsic<u32, u64, RuntimeCall, ()>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system::{Pallet, Call, Event<T>},
 		Collective: pallet_collective::<Instance1>::{Pallet, Call, Event<T>, Origin<T>, Config<T>},

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -55,14 +55,14 @@ use std::sync::Arc;
 
 use crate as pallet_contracts;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/conviction-voting/src/tests.rs
+++ b/frame/conviction-voting/src/tests.rs
@@ -32,14 +32,14 @@ use sp_runtime::{
 use super::*;
 use crate as pallet_conviction_voting;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/democracy/src/tests.rs
+++ b/frame/democracy/src/tests.rs
@@ -51,14 +51,14 @@ const NAY: Vote = Vote { aye: false, conviction: Conviction::None };
 const BIG_AYE: Vote = Vote { aye: true, conviction: Conviction::Locked1x };
 const BIG_NAY: Vote = Vote { aye: false, conviction: Conviction::Locked1x };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/election-provider-multi-phase/src/mock.rs
+++ b/frame/election-provider-multi-phase/src/mock.rs
@@ -49,15 +49,14 @@ use sp_runtime::{
 };
 use std::sync::Arc;
 
-pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic =
-	sp_runtime::generic::UncheckedExtrinsic<AccountId, RuntimeCall, (), ()>;
+pub type Block = sp_runtime::generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = sp_runtime::generic::RuntimeExtrinsic<AccountId, RuntimeCall, (), ()>;
 
 frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system::{Pallet, Call, Event<T>, Config},
 		Balances: pallet_balances::{Pallet, Call, Event<T>, Config<T>},

--- a/frame/election-provider-support/src/onchain.rs
+++ b/frame/election-provider-support/src/onchain.rs
@@ -193,14 +193,14 @@ mod tests {
 	type BlockNumber = u64;
 
 	pub type Header = sp_runtime::generic::Header<BlockNumber, sp_runtime::traits::BlakeTwo256>;
-	pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<AccountId, (), (), ()>;
-	pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
+	pub type RuntimeExtrinsic = sp_runtime::generic::RuntimeExtrinsic<AccountId, (), (), ()>;
+	pub type Block = sp_runtime::generic::Block<Header, RuntimeExtrinsic>;
 
 	frame_support::construct_runtime!(
 		pub enum Runtime where
 			Block = Block,
 			NodeBlock = Block,
-			UncheckedExtrinsic = UncheckedExtrinsic
+			RuntimeExtrinsic = RuntimeExtrinsic
 		{
 			System: frame_system::{Pallet, Call, Event<T>},
 		}

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -1334,15 +1334,14 @@ mod tests {
 		type MaxCandidates = PhragmenMaxCandidates;
 	}
 
-	pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
-	pub type UncheckedExtrinsic =
-		sp_runtime::generic::UncheckedExtrinsic<u32, u64, RuntimeCall, ()>;
+	pub type Block = sp_runtime::generic::Block<Header, RuntimeExtrinsic>;
+	pub type RuntimeExtrinsic = sp_runtime::generic::RuntimeExtrinsic<u32, u64, RuntimeCall, ()>;
 
 	frame_support::construct_runtime!(
 		pub enum Test where
 			Block = Block,
 			NodeBlock = Block,
-			UncheckedExtrinsic = UncheckedExtrinsic
+			RuntimeExtrinsic = RuntimeExtrinsic
 		{
 			System: frame_system::{Pallet, Call, Event<T>},
 			Balances: pallet_balances::{Pallet, Call, Event<T>, Config<T>},

--- a/frame/examples/basic/src/lib.rs
+++ b/frame/examples/basic/src/lib.rs
@@ -700,7 +700,7 @@ impl<T: Config> Pallet<T> {
 // [here](https://crates.parity.io/sp_runtime/traits/trait.SignedExtension.html).
 //
 // The signed extensions are aggregated in the runtime file of a substrate chain. All extensions
-// should be aggregated in a tuple and passed to the `CheckedExtrinsic` and `UncheckedExtrinsic`
+// should be aggregated in a tuple and passed to the `CheckedExtrinsic` and `RuntimeExtrinsic`
 // types defined in the runtime. Lookup `pub type SignedExtra = (...)` in `node/runtime` and
 // `node-template` for an example of this.
 

--- a/frame/examples/basic/src/tests.rs
+++ b/frame/examples/basic/src/tests.rs
@@ -34,7 +34,7 @@ use sp_runtime::{
 // Reexport crate as its pallet name for construct_runtime.
 use crate as pallet_example_basic;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 // For testing the pallet, we construct a mock runtime.
@@ -42,7 +42,7 @@ frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/examples/offchain-worker/src/tests.rs
+++ b/frame/examples/offchain-worker/src/tests.rs
@@ -36,7 +36,7 @@ use sp_runtime::{
 	RuntimeAppPublic,
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 // For testing the module, we construct a mock runtime.
@@ -44,7 +44,7 @@ frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Example: example_offchain_worker::{Pallet, Call, Storage, Event<T>, ValidateUnsigned},

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -54,10 +54,10 @@
 //! ```
 //! # use sp_runtime::generic;
 //! # use frame_executive as executive;
-//! # pub struct UncheckedExtrinsic {};
+//! # pub struct RuntimeExtrinsic {};
 //! # pub struct Header {};
 //! # type Context = frame_system::ChainContext<Runtime>;
-//! # pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+//! # pub type Block = generic::Block<Header, RuntimeExtrinsic>;
 //! # pub type Balances = u64;
 //! # pub type AllPalletsWithSystem = u64;
 //! # pub enum Runtime {};
@@ -85,10 +85,10 @@
 //! ```
 //! # use sp_runtime::generic;
 //! # use frame_executive as executive;
-//! # pub struct UncheckedExtrinsic {};
+//! # pub struct RuntimeExtrinsic {};
 //! # pub struct Header {};
 //! # type Context = frame_system::ChainContext<Runtime>;
-//! # pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+//! # pub type Block = generic::Block<Header, RuntimeExtrinsic>;
 //! # pub type Balances = u64;
 //! # pub type AllPalletsWithSystem = u64;
 //! # pub enum Runtime {};
@@ -841,7 +841,7 @@ mod tests {
 		pub enum Runtime where
 			Block = TestBlock,
 			NodeBlock = TestBlock,
-			UncheckedExtrinsic = TestUncheckedExtrinsic
+			RuntimeExtrinsic = TestUncheckedExtrinsic
 		{
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 			Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/fast-unstake/src/mock.rs
+++ b/frame/fast-unstake/src/mock.rs
@@ -191,12 +191,12 @@ impl fast_unstake::Config for Runtime {
 }
 
 type Block = frame_system::mocking::MockBlock<Runtime>;
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system,
 		Timestamp: pallet_timestamp,

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -42,14 +42,14 @@ use sp_runtime::{
 };
 use sp_staking::{EraIndex, SessionIndex};
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system,
 		Authorship: pallet_authorship,

--- a/frame/identity/src/tests.rs
+++ b/frame/identity/src/tests.rs
@@ -33,14 +33,14 @@ use sp_runtime::{
 	traits::{BadOrigin, BlakeTwo256, IdentityLookup},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/im-online/src/mock.rs
+++ b/frame/im-online/src/mock.rs
@@ -39,14 +39,14 @@ use sp_staking::{
 use crate as imonline;
 use crate::Config;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;
 
 frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},

--- a/frame/indices/src/mock.rs
+++ b/frame/indices/src/mock.rs
@@ -24,14 +24,14 @@ use frame_support::traits::{ConstU32, ConstU64};
 use sp_core::H256;
 use sp_runtime::testing::Header;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/insecure-randomness-collective-flip/src/lib.rs
+++ b/frame/insecure-randomness-collective-flip/src/lib.rs
@@ -176,14 +176,14 @@ mod tests {
 	};
 	use frame_system::limits;
 
-	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 	type Block = frame_system::mocking::MockBlock<Test>;
 
 	frame_support::construct_runtime!(
 		pub enum Test where
 			Block = Block,
 			NodeBlock = Block,
-			UncheckedExtrinsic = UncheckedExtrinsic,
+			RuntimeExtrinsic = RuntimeExtrinsic,
 		{
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 			CollectiveFlip: pallet_insecure_randomness_collective_flip::{Pallet, Storage},

--- a/frame/lottery/src/mock.rs
+++ b/frame/lottery/src/mock.rs
@@ -33,14 +33,14 @@ use sp_runtime::{
 	Perbill,
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -541,14 +541,14 @@ mod tests {
 	};
 	use frame_system::EnsureSignedBy;
 
-	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 	type Block = frame_system::mocking::MockBlock<Test>;
 
 	frame_support::construct_runtime!(
 		pub enum Test where
 			Block = Block,
 			NodeBlock = Block,
-			UncheckedExtrinsic = UncheckedExtrinsic,
+			RuntimeExtrinsic = RuntimeExtrinsic,
 		{
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 			Membership: pallet_membership::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/merkle-mountain-range/src/mock.rs
+++ b/frame/merkle-mountain-range/src/mock.rs
@@ -30,14 +30,14 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup, Keccak256},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		MMR: pallet_mmr::{Pallet, Storage},

--- a/frame/message-queue/src/integration_test.rs
+++ b/frame/message-queue/src/integration_test.rs
@@ -40,14 +40,14 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>},
@@ -105,15 +105,15 @@ impl Config for Test {
 /// # Example output
 ///
 /// ```pre
-/// Enqueued 1189 messages across 176 queues. Payload 46.97 KiB    
-/// Processing 772 of 1189 messages    
-/// Enqueued 9270 messages across 1559 queues. Payload 131.85 KiB    
-/// Processing 6262 of 9687 messages    
-/// Enqueued 5025 messages across 1225 queues. Payload 100.23 KiB    
-/// Processing 1739 of 8450 messages    
-/// Enqueued 42061 messages across 6357 queues. Payload 536.29 KiB    
-/// Processing 11675 of 48772 messages    
-/// Enqueued 20253 messages across 2420 queues. Payload 288.34 KiB    
+/// Enqueued 1189 messages across 176 queues. Payload 46.97 KiB
+/// Processing 772 of 1189 messages
+/// Enqueued 9270 messages across 1559 queues. Payload 131.85 KiB
+/// Processing 6262 of 9687 messages
+/// Enqueued 5025 messages across 1225 queues. Payload 100.23 KiB
+/// Processing 1739 of 8450 messages
+/// Enqueued 42061 messages across 6357 queues. Payload 536.29 KiB
+/// Processing 11675 of 48772 messages
+/// Enqueued 20253 messages across 2420 queues. Payload 288.34 KiB
 /// Processing 28711 of 57350 messages
 /// Processing all remaining 28639 messages
 /// ```

--- a/frame/message-queue/src/mock.rs
+++ b/frame/message-queue/src/mock.rs
@@ -34,14 +34,14 @@ use sp_runtime::{
 };
 use sp_std::collections::btree_map::BTreeMap;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>},

--- a/frame/multisig/src/tests.rs
+++ b/frame/multisig/src/tests.rs
@@ -32,14 +32,14 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/nfts/src/mock.rs
+++ b/frame/nfts/src/mock.rs
@@ -30,14 +30,14 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/nicks/src/lib.rs
+++ b/frame/nicks/src/lib.rs
@@ -260,14 +260,14 @@ mod tests {
 		traits::{BadOrigin, BlakeTwo256, IdentityLookup},
 	};
 
-	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 	type Block = frame_system::mocking::MockBlock<Test>;
 
 	frame_support::construct_runtime!(
 		pub enum Test where
 			Block = Block,
 			NodeBlock = Block,
-			UncheckedExtrinsic = UncheckedExtrinsic,
+			RuntimeExtrinsic = RuntimeExtrinsic,
 		{
 			System: frame_system,
 			Balances: pallet_balances,

--- a/frame/nis/src/mock.rs
+++ b/frame/nis/src/mock.rs
@@ -32,7 +32,7 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 // Configure a mock runtime to test the pallet.
@@ -40,7 +40,7 @@ frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system,
 		Balances: pallet_balances::<Instance1>,

--- a/frame/node-authorization/src/mock.rs
+++ b/frame/node-authorization/src/mock.rs
@@ -31,14 +31,14 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		NodeAuthorization: pallet_node_authorization::{

--- a/frame/nomination-pools/benchmarking/src/mock.rs
+++ b/frame/nomination-pools/benchmarking/src/mock.rs
@@ -171,12 +171,12 @@ impl pallet_nomination_pools::Config for Runtime {
 impl crate::Config for Runtime {}
 
 type Block = frame_system::mocking::MockBlock<Runtime>;
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system::{Pallet, Call, Event<T>},
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},

--- a/frame/nomination-pools/src/mock.rs
+++ b/frame/nomination-pools/src/mock.rs
@@ -233,13 +233,13 @@ impl pools::Config for Runtime {
 	type MaxPointsToBalance = frame_support::traits::ConstU8<10>;
 }
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;
 frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Storage, Event<T>, Config},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/nomination-pools/test-staking/src/mock.rs
+++ b/frame/nomination-pools/test-staking/src/mock.rs
@@ -183,13 +183,13 @@ impl pallet_nomination_pools::Config for Runtime {
 }
 
 type Block = frame_system::mocking::MockBlock<Runtime>;
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 
 frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system::{Pallet, Call, Event<T>},
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -212,14 +212,14 @@ where
 
 impl crate::Config for Test {}
 
-pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, RuntimeCall, u64, ()>;
+pub type Block = sp_runtime::generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = sp_runtime::generic::RuntimeExtrinsic<u32, RuntimeCall, u64, ()>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: system::{Pallet, Call, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/offences/src/mock.rs
+++ b/frame/offences/src/mock.rs
@@ -66,14 +66,14 @@ pub fn with_on_offence_fractions<R, F: FnOnce(&mut Vec<Perbill>) -> R>(f: F) -> 
 	OnOffencePerbill::mutate(|fractions| f(fractions))
 }
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;
 
 frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Offences: offences::{Pallet, Storage, Event},

--- a/frame/preimage/src/mock.rs
+++ b/frame/preimage/src/mock.rs
@@ -32,14 +32,14 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system,
 		Balances: pallet_balances,

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -35,14 +35,14 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/ranked-collective/src/tests.rs
+++ b/frame/ranked-collective/src/tests.rs
@@ -34,14 +34,14 @@ use sp_runtime::{
 use super::*;
 use crate as pallet_ranked_collective;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Club: pallet_ranked_collective::{Pallet, Call, Storage, Event<T>},

--- a/frame/recovery/src/mock.rs
+++ b/frame/recovery/src/mock.rs
@@ -30,14 +30,14 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/referenda/src/mock.rs
+++ b/frame/referenda/src/mock.rs
@@ -36,14 +36,14 @@ use sp_runtime::{
 	DispatchResult, Perbill,
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system,
 		Balances: pallet_balances,

--- a/frame/remark/src/mock.rs
+++ b/frame/remark/src/mock.rs
@@ -26,7 +26,7 @@ use sp_runtime::{
 	BuildStorage,
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 pub type Block = frame_system::mocking::MockBlock<Test>;
 
 // Configure a mock runtime to test the pallet.
@@ -34,7 +34,7 @@ frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Remark: pallet_remark::{ Pallet, Call, Event<T> },

--- a/frame/root-offences/src/mock.rs
+++ b/frame/root-offences/src/mock.rs
@@ -33,7 +33,7 @@ use sp_runtime::{
 use sp_staking::{EraIndex, SessionIndex};
 use sp_std::collections::btree_map::BTreeMap;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 type AccountId = u64;
 type Balance = u64;
@@ -46,7 +46,7 @@ frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},

--- a/frame/scheduler/src/mock.rs
+++ b/frame/scheduler/src/mock.rs
@@ -94,14 +94,14 @@ pub mod logger {
 	}
 }
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Logger: logger::{Pallet, Call, Event<T>},

--- a/frame/scored-pool/src/mock.rs
+++ b/frame/scored-pool/src/mock.rs
@@ -31,14 +31,14 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -31,14 +31,14 @@ type AccountIndex = u32;
 type BlockNumber = u64;
 type Balance = u64;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/session/src/mock.rs
+++ b/frame/session/src/mock.rs
@@ -75,7 +75,7 @@ impl OpaqueKeys for PreUpgradeMockSessionKeys {
 	}
 }
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 #[cfg(feature = "historical")]
@@ -83,7 +83,7 @@ frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
@@ -96,7 +96,7 @@ frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},

--- a/frame/society/src/mock.rs
+++ b/frame/society/src/mock.rs
@@ -32,14 +32,14 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -82,14 +82,14 @@ pub fn is_disabled(controller: AccountId) -> bool {
 	Session::disabled_validators().contains(&validator_index)
 }
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system,
 		Authorship: pallet_authorship,

--- a/frame/state-trie-migration/src/lib.rs
+++ b/frame/state-trie-migration/src/lib.rs
@@ -1066,7 +1066,7 @@ mod mock {
 		StorageChild,
 	};
 
-	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 	type Block = frame_system::mocking::MockBlock<Test>;
 
 	// Configure a mock runtime to test the pallet.
@@ -1074,7 +1074,7 @@ mod mock {
 		pub enum Test where
 			Block = Block,
 			NodeBlock = Block,
-			UncheckedExtrinsic = UncheckedExtrinsic,
+			RuntimeExtrinsic = RuntimeExtrinsic,
 		{
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 			Balances: pallet_balances::{Pallet, Call, Config<T>, Storage, Event<T>},

--- a/frame/sudo/src/mock.rs
+++ b/frame/sudo/src/mock.rs
@@ -91,14 +91,14 @@ pub mod logger {
 	pub(super) type I32Log<T> = StorageValue<_, BoundedVec<i32, ConstU32<1_000>>, ValueQuery>;
 }
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Sudo: sudo::{Pallet, Call, Config<T>, Storage, Event<T>},

--- a/frame/support/procedural/src/construct_runtime/expand/inherent.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/inherent.rs
@@ -76,7 +76,7 @@ pub fn expand_outer_inherent(
 						let inherent = <#unchecked_extrinsic as #scrate::inherent::Extrinsic>::new(
 							inherent.into(),
 							None,
-						).expect("Runtime UncheckedExtrinsic is not Opaque, so it has to return \
+						).expect("Runtime RuntimeExtrinsic is not Opaque, so it has to return \
 							`Some`; qed");
 
 						inherents.push(inherent);

--- a/frame/support/procedural/src/construct_runtime/mod.rs
+++ b/frame/support/procedural/src/construct_runtime/mod.rs
@@ -271,7 +271,7 @@ fn construct_runtime_final_expansion(
 	let res = quote!(
 		#scrate_decl
 
-		// Prevent UncheckedExtrinsic to print unused warning.
+		// Prevent RuntimeExtrinsic to print unused warning.
 		const _: () = {
 			#[allow(unused)]
 			type __hidden_use_of_unchecked_extrinsic = #unchecked_extrinsic;

--- a/frame/support/procedural/src/construct_runtime/parse.rs
+++ b/frame/support/procedural/src/construct_runtime/parse.rs
@@ -29,7 +29,7 @@ use syn::{
 mod keyword {
 	syn::custom_keyword!(Block);
 	syn::custom_keyword!(NodeBlock);
-	syn::custom_keyword!(UncheckedExtrinsic);
+	syn::custom_keyword!(RuntimeExtrinsic);
 	syn::custom_keyword!(Pallet);
 	syn::custom_keyword!(Call);
 	syn::custom_keyword!(Storage);
@@ -130,7 +130,7 @@ impl Parse for WhereSection {
 		let block = remove_kind(input, WhereKind::Block, &mut definitions)?.value;
 		let node_block = remove_kind(input, WhereKind::NodeBlock, &mut definitions)?.value;
 		let unchecked_extrinsic =
-			remove_kind(input, WhereKind::UncheckedExtrinsic, &mut definitions)?.value;
+			remove_kind(input, WhereKind::RuntimeExtrinsic, &mut definitions)?.value;
 		if let Some(WhereDefinition { ref kind_span, ref kind, .. }) = definitions.first() {
 			let msg = format!(
 				"`{:?}` was declared above. Please use exactly one declaration for `{:?}`.",
@@ -146,7 +146,7 @@ impl Parse for WhereSection {
 pub enum WhereKind {
 	Block,
 	NodeBlock,
-	UncheckedExtrinsic,
+	RuntimeExtrinsic,
 }
 
 #[derive(Debug)]
@@ -163,8 +163,8 @@ impl Parse for WhereDefinition {
 			(input.parse::<keyword::Block>()?.span(), WhereKind::Block)
 		} else if lookahead.peek(keyword::NodeBlock) {
 			(input.parse::<keyword::NodeBlock>()?.span(), WhereKind::NodeBlock)
-		} else if lookahead.peek(keyword::UncheckedExtrinsic) {
-			(input.parse::<keyword::UncheckedExtrinsic>()?.span(), WhereKind::UncheckedExtrinsic)
+		} else if lookahead.peek(keyword::RuntimeExtrinsic) {
+			(input.parse::<keyword::RuntimeExtrinsic>()?.span(), WhereKind::RuntimeExtrinsic)
 		} else {
 			return Err(lookahead.error())
 		};

--- a/frame/support/procedural/src/lib.rs
+++ b/frame/support/procedural/src/lib.rs
@@ -296,7 +296,7 @@ pub fn decl_storage(input: TokenStream) -> TokenStream {
 
 /// Construct a runtime, with the given name and the given pallets.
 ///
-/// The parameters here are specific types for `Block`, `NodeBlock`, and `UncheckedExtrinsic`
+/// The parameters here are specific types for `Block`, `NodeBlock`, and `RuntimeExtrinsic`
 /// and the pallets that are used by the runtime.
 /// `Block` is the block type that is used in the runtime and `NodeBlock` is the block type
 /// that is used in the node. For instance they can differ in the extrinsics type.
@@ -308,7 +308,7 @@ pub fn decl_storage(input: TokenStream) -> TokenStream {
 ///     pub enum Runtime where
 ///         Block = Block,
 ///         NodeBlock = node::Block,
-///         UncheckedExtrinsic = UncheckedExtrinsic
+///         RuntimeExtrinsic = RuntimeExtrinsic
 ///     {
 ///         System: frame_system::{Pallet, Call, Event<T>, Config<T>} = 0,
 ///         Test: path::to::test::{Pallet, Call} = 1,

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -35,7 +35,7 @@ pub use crate::{
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_runtime::{
-	generic::{CheckedExtrinsic, UncheckedExtrinsic},
+	generic::{CheckedExtrinsic, RuntimeExtrinsic},
 	traits::SignedExtension,
 };
 pub use sp_runtime::{
@@ -337,7 +337,7 @@ where
 
 /// Implementation for unchecked extrinsic.
 impl<Address, Call, Signature, Extra> GetDispatchInfo
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+	for RuntimeExtrinsic<Address, Call, Signature, Extra>
 where
 	Call: GetDispatchInfo,
 	Extra: SignedExtension,

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -882,7 +882,7 @@ where
 }
 
 impl<Address, Call, Signature, Extra> ExtrinsicCall
-	for sp_runtime::generic::UncheckedExtrinsic<Address, Call, Signature, Extra>
+	for sp_runtime::generic::RuntimeExtrinsic<Address, Call, Signature, Extra>
 where
 	Extra: sp_runtime::traits::SignedExtension,
 {

--- a/frame/support/test/compile_pass/src/lib.rs
+++ b/frame/support/test/compile_pass/src/lib.rs
@@ -81,14 +81,14 @@ impl frame_system::Config for Runtime {
 }
 
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<u32, RuntimeCall, Signature, ()>;
 
 construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system,
 	}

--- a/frame/support/test/tests/construct_runtime.rs
+++ b/frame/support/test/tests/construct_runtime.rs
@@ -257,7 +257,7 @@ frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: system::{Pallet, Call, Event<T>, Origin<T>} = 30,
 		Module1_1: module1::<Instance1>::{Pallet, Call, Storage, Event<T>, Origin<T>},
@@ -276,8 +276,8 @@ frame_support::construct_runtime!(
 );
 
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<u32, RuntimeCall, Signature, ()>;
 
 #[test]
 fn check_modules_error_type() {
@@ -710,7 +710,7 @@ fn test_metadata() {
 	];
 
 	let extrinsic = ExtrinsicMetadata {
-		ty: meta_type::<UncheckedExtrinsic>(),
+		ty: meta_type::<RuntimeExtrinsic>(),
 		version: 4,
 		signed_extensions: vec![SignedExtensionMetadata {
 			identifier: "UnitSignedExtension",

--- a/frame/support/test/tests/construct_runtime_ui/abundant_where_param.rs
+++ b/frame/support/test/tests/construct_runtime_ui/abundant_where_param.rs
@@ -5,7 +5,7 @@ construct_runtime! {
 		Block = Block,
 		NodeBlock = Block,
 		Block = Block1,
-		UncheckedExtrinsic = Uxt,
+		RuntimeExtrinsic = Uxt,
 	{}
 }
 

--- a/frame/support/test/tests/construct_runtime_ui/both_use_and_excluded_parts.rs
+++ b/frame/support/test/tests/construct_runtime_ui/both_use_and_excluded_parts.rs
@@ -1,6 +1,6 @@
 use frame_support::construct_runtime;
-use sp_runtime::{generic, traits::BlakeTwo256};
 use sp_core::sr25519;
+use sp_runtime::{generic, traits::BlakeTwo256};
 
 #[frame_support::pallet]
 mod pallet {
@@ -14,8 +14,8 @@ mod pallet {
 pub type Signature = sr25519::Signature;
 pub type BlockNumber = u64;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<u32, RuntimeCall, Signature, ()>;
 
 impl pallet::Config for Runtime {}
 
@@ -23,7 +23,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: pallet exclude_parts { Pallet } use_parts { Pallet },

--- a/frame/support/test/tests/construct_runtime_ui/both_use_and_excluded_parts.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/both_use_and_excluded_parts.stderr
@@ -7,7 +7,7 @@ error: Unexpected tokens, expected one of `=`, `,`
 error[E0412]: cannot find type `RuntimeCall` in this scope
   --> tests/construct_runtime_ui/both_use_and_excluded_parts.rs:18:64
    |
-18 | pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
+18 | pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<u32, RuntimeCall, Signature, ()>;
    |                            -                                   ^^^^^^^^^^^ not found in this scope
    |                            |
    |                            help: you might be missing a type parameter: `<RuntimeCall>`

--- a/frame/support/test/tests/construct_runtime_ui/conflicting_index.rs
+++ b/frame/support/test/tests/construct_runtime_ui/conflicting_index.rs
@@ -2,7 +2,7 @@ use frame_support::construct_runtime;
 
 construct_runtime! {
 	pub enum Runtime where
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 		Block = Block,
 		NodeBlock = Block,
 	{

--- a/frame/support/test/tests/construct_runtime_ui/conflicting_index_2.rs
+++ b/frame/support/test/tests/construct_runtime_ui/conflicting_index_2.rs
@@ -2,7 +2,7 @@ use frame_support::construct_runtime;
 
 construct_runtime! {
 	pub enum Runtime where
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 		Block = Block,
 		NodeBlock = Block,
 	{

--- a/frame/support/test/tests/construct_runtime_ui/conflicting_module_name.rs
+++ b/frame/support/test/tests/construct_runtime_ui/conflicting_module_name.rs
@@ -4,7 +4,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: system::{Pallet},
 		Balance: balances::{Pallet},

--- a/frame/support/test/tests/construct_runtime_ui/double_module_parts.rs
+++ b/frame/support/test/tests/construct_runtime_ui/double_module_parts.rs
@@ -4,7 +4,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: system::{Pallet},
 		Balance: balances::{Config, Call, Config<T>, Origin<T>},

--- a/frame/support/test/tests/construct_runtime_ui/duplicate_exclude.rs
+++ b/frame/support/test/tests/construct_runtime_ui/duplicate_exclude.rs
@@ -2,7 +2,7 @@ use frame_support::construct_runtime;
 
 construct_runtime! {
 	pub enum Runtime where
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 		Block = Block,
 		NodeBlock = Block,
 	{

--- a/frame/support/test/tests/construct_runtime_ui/empty_pallet_path.rs
+++ b/frame/support/test/tests/construct_runtime_ui/empty_pallet_path.rs
@@ -4,7 +4,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		system: ,
 	}

--- a/frame/support/test/tests/construct_runtime_ui/exclude_missspell.rs
+++ b/frame/support/test/tests/construct_runtime_ui/exclude_missspell.rs
@@ -2,7 +2,7 @@ use frame_support::construct_runtime;
 
 construct_runtime! {
 	pub enum Runtime where
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 		Block = Block,
 		NodeBlock = Block,
 	{

--- a/frame/support/test/tests/construct_runtime_ui/exclude_undefined_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/exclude_undefined_part.rs
@@ -1,6 +1,6 @@
 use frame_support::construct_runtime;
-use sp_runtime::{generic, traits::BlakeTwo256};
 use sp_core::sr25519;
+use sp_runtime::{generic, traits::BlakeTwo256};
 
 #[frame_support::pallet]
 mod pallet {
@@ -13,14 +13,14 @@ mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::storage]
-	type Foo<T> = StorageValue<Value=u8>;
+	type Foo<T> = StorageValue<Value = u8>;
 }
 
 pub type Signature = sr25519::Signature;
 pub type BlockNumber = u64;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<u32, RuntimeCall, Signature, ()>;
 
 impl pallet::Config for Runtime {}
 
@@ -28,7 +28,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: pallet exclude_parts { Call },

--- a/frame/support/test/tests/construct_runtime_ui/feature_gated_system_pallet.rs
+++ b/frame/support/test/tests/construct_runtime_ui/feature_gated_system_pallet.rs
@@ -4,7 +4,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		#[cfg(test)]
 		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},

--- a/frame/support/test/tests/construct_runtime_ui/generics_in_invalid_module.rs
+++ b/frame/support/test/tests/construct_runtime_ui/generics_in_invalid_module.rs
@@ -4,7 +4,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: system::{Pallet},
 		Balance: balances::<Instance1>::{Call<T>, Origin<T>},

--- a/frame/support/test/tests/construct_runtime_ui/invalid_meta_literal.rs
+++ b/frame/support/test/tests/construct_runtime_ui/invalid_meta_literal.rs
@@ -4,7 +4,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: system::{Pallet},
 		#[cfg(feature = 1)]

--- a/frame/support/test/tests/construct_runtime_ui/invalid_module_details.rs
+++ b/frame/support/test/tests/construct_runtime_ui/invalid_module_details.rs
@@ -4,7 +4,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		system: System::(),
 	}

--- a/frame/support/test/tests/construct_runtime_ui/invalid_module_details_keyword.rs
+++ b/frame/support/test/tests/construct_runtime_ui/invalid_module_details_keyword.rs
@@ -4,7 +4,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		system: System::{enum},
 	}

--- a/frame/support/test/tests/construct_runtime_ui/invalid_module_entry.rs
+++ b/frame/support/test/tests/construct_runtime_ui/invalid_module_entry.rs
@@ -4,7 +4,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: system::{Pallet},
 		Balance: balances::{Error},

--- a/frame/support/test/tests/construct_runtime_ui/invalid_token_after_module.rs
+++ b/frame/support/test/tests/construct_runtime_ui/invalid_token_after_module.rs
@@ -4,7 +4,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		system: System ?
 	}

--- a/frame/support/test/tests/construct_runtime_ui/invalid_token_after_name.rs
+++ b/frame/support/test/tests/construct_runtime_ui/invalid_token_after_name.rs
@@ -4,7 +4,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		system ?
 	}

--- a/frame/support/test/tests/construct_runtime_ui/invalid_where_param.rs
+++ b/frame/support/test/tests/construct_runtime_ui/invalid_where_param.rs
@@ -5,7 +5,7 @@ construct_runtime! {
 		Block = Block,
 		NodeBlock = Block,
 		TypeX = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{}
 }
 

--- a/frame/support/test/tests/construct_runtime_ui/missing_event_generic_on_module_with_instance.rs
+++ b/frame/support/test/tests/construct_runtime_ui/missing_event_generic_on_module_with_instance.rs
@@ -4,7 +4,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: system::{Pallet},
 		Balance: balances::<Instance1>::{Event},

--- a/frame/support/test/tests/construct_runtime_ui/missing_module_instance.rs
+++ b/frame/support/test/tests/construct_runtime_ui/missing_module_instance.rs
@@ -4,7 +4,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		system: System::<>,
 	}

--- a/frame/support/test/tests/construct_runtime_ui/missing_origin_generic_on_module_with_instance.rs
+++ b/frame/support/test/tests/construct_runtime_ui/missing_origin_generic_on_module_with_instance.rs
@@ -4,7 +4,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: system::{Pallet},
 		Balance: balances::<Instance1>::{Origin},

--- a/frame/support/test/tests/construct_runtime_ui/missing_system_module.rs
+++ b/frame/support/test/tests/construct_runtime_ui/missing_system_module.rs
@@ -4,7 +4,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 	}
 }

--- a/frame/support/test/tests/construct_runtime_ui/more_than_256_modules.rs
+++ b/frame/support/test/tests/construct_runtime_ui/more_than_256_modules.rs
@@ -2,7 +2,7 @@ use frame_support::construct_runtime;
 
 construct_runtime! {
 	pub enum Runtime where
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 		Block = Block,
 		NodeBlock = Block,
 	{

--- a/frame/support/test/tests/construct_runtime_ui/no_comma_after_where.rs
+++ b/frame/support/test/tests/construct_runtime_ui/no_comma_after_where.rs
@@ -2,7 +2,7 @@ use frame_support::construct_runtime;
 
 construct_runtime! {
 	pub enum Runtime where
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 		Block = Block,
 		NodeBlock = Block,
 	{

--- a/frame/support/test/tests/construct_runtime_ui/no_std_genesis_config.rs
+++ b/frame/support/test/tests/construct_runtime_ui/no_std_genesis_config.rs
@@ -1,12 +1,12 @@
 use frame_support::construct_runtime;
-use sp_runtime::{generic, traits::BlakeTwo256};
 use sp_core::sr25519;
+use sp_runtime::{generic, traits::BlakeTwo256};
 
 pub type Signature = sr25519::Signature;
 pub type BlockNumber = u32;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<u32, RuntimeCall, Signature, ()>;
 
 impl test_pallet::Config for Runtime {}
 
@@ -41,7 +41,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: test_pallet::{Pallet, Config},

--- a/frame/support/test/tests/construct_runtime_ui/old_unsupported_pallet_decl.rs
+++ b/frame/support/test/tests/construct_runtime_ui/old_unsupported_pallet_decl.rs
@@ -10,11 +10,10 @@ mod pallet_old {
 	decl_module! {
 		pub struct Module<T: Config> for enum Call where origin: T::RuntimeOrigin {}
 	}
-
 }
 construct_runtime! {
 	pub enum Runtime where
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 		Block = Block,
 		NodeBlock = Block,
 	{

--- a/frame/support/test/tests/construct_runtime_ui/pallet_error_too_large.rs
+++ b/frame/support/test/tests/construct_runtime_ui/pallet_error_too_large.rs
@@ -1,6 +1,6 @@
 use frame_support::construct_runtime;
-use sp_runtime::{generic, traits::BlakeTwo256};
 use sp_core::sr25519;
+use sp_runtime::{generic, traits::BlakeTwo256};
 
 #[frame_support::pallet]
 mod pallet {
@@ -18,29 +18,29 @@ mod pallet {
 
 #[derive(scale_info::TypeInfo, frame_support::PalletError, codec::Encode, codec::Decode)]
 pub enum Nested1 {
-	Nested2(Nested2)
+	Nested2(Nested2),
 }
 
 #[derive(scale_info::TypeInfo, frame_support::PalletError, codec::Encode, codec::Decode)]
 pub enum Nested2 {
-	Nested3(Nested3)
+	Nested3(Nested3),
 }
 
 #[derive(scale_info::TypeInfo, frame_support::PalletError, codec::Encode, codec::Decode)]
 pub enum Nested3 {
-	Nested4(Nested4)
+	Nested4(Nested4),
 }
 
 #[derive(scale_info::TypeInfo, frame_support::PalletError, codec::Encode, codec::Decode)]
 pub enum Nested4 {
-	Num(u8)
+	Num(u8),
 }
 
 pub type Signature = sr25519::Signature;
 pub type BlockNumber = u32;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<u32, RuntimeCall, Signature, ()>;
 
 impl pallet::Config for Runtime {}
 
@@ -75,7 +75,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: pallet::{Pallet},

--- a/frame/support/test/tests/construct_runtime_ui/undefined_call_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_call_part.rs
@@ -1,6 +1,6 @@
 use frame_support::construct_runtime;
-use sp_runtime::{generic, traits::BlakeTwo256};
 use sp_core::sr25519;
+use sp_runtime::{generic, traits::BlakeTwo256};
 
 #[frame_support::pallet]
 mod pallet {
@@ -14,8 +14,8 @@ mod pallet {
 pub type Signature = sr25519::Signature;
 pub type BlockNumber = u32;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<u32, RuntimeCall, Signature, ()>;
 
 impl pallet::Config for Runtime {}
 
@@ -50,7 +50,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: pallet::{Pallet, Call},

--- a/frame/support/test/tests/construct_runtime_ui/undefined_event_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_event_part.rs
@@ -1,6 +1,6 @@
 use frame_support::construct_runtime;
-use sp_runtime::{generic, traits::BlakeTwo256};
 use sp_core::sr25519;
+use sp_runtime::{generic, traits::BlakeTwo256};
 
 #[frame_support::pallet]
 mod pallet {
@@ -14,8 +14,8 @@ mod pallet {
 pub type Signature = sr25519::Signature;
 pub type BlockNumber = u32;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<u32, RuntimeCall, Signature, ()>;
 
 impl pallet::Config for Runtime {}
 
@@ -50,7 +50,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: pallet::{Pallet, Event},

--- a/frame/support/test/tests/construct_runtime_ui/undefined_genesis_config_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_genesis_config_part.rs
@@ -1,6 +1,6 @@
 use frame_support::construct_runtime;
-use sp_runtime::{generic, traits::BlakeTwo256};
 use sp_core::sr25519;
+use sp_runtime::{generic, traits::BlakeTwo256};
 
 #[frame_support::pallet]
 mod pallet {
@@ -14,8 +14,8 @@ mod pallet {
 pub type Signature = sr25519::Signature;
 pub type BlockNumber = u32;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<u32, RuntimeCall, Signature, ()>;
 
 impl pallet::Config for Runtime {}
 
@@ -50,7 +50,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: pallet::{Pallet, Config},

--- a/frame/support/test/tests/construct_runtime_ui/undefined_inherent_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_inherent_part.rs
@@ -1,6 +1,6 @@
 use frame_support::construct_runtime;
-use sp_runtime::{generic, traits::BlakeTwo256};
 use sp_core::sr25519;
+use sp_runtime::{generic, traits::BlakeTwo256};
 
 #[frame_support::pallet]
 mod pallet {
@@ -14,8 +14,8 @@ mod pallet {
 pub type Signature = sr25519::Signature;
 pub type BlockNumber = u32;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<u32, RuntimeCall, Signature, ()>;
 
 impl pallet::Config for Runtime {}
 
@@ -50,7 +50,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: pallet::{Pallet, Inherent},

--- a/frame/support/test/tests/construct_runtime_ui/undefined_origin_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_origin_part.rs
@@ -1,6 +1,6 @@
 use frame_support::construct_runtime;
-use sp_runtime::{generic, traits::BlakeTwo256};
 use sp_core::sr25519;
+use sp_runtime::{generic, traits::BlakeTwo256};
 
 #[frame_support::pallet]
 mod pallet {
@@ -14,8 +14,8 @@ mod pallet {
 pub type Signature = sr25519::Signature;
 pub type BlockNumber = u32;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<u32, RuntimeCall, Signature, ()>;
 
 impl pallet::Config for Runtime {}
 
@@ -50,7 +50,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: pallet::{Pallet, Origin},

--- a/frame/support/test/tests/construct_runtime_ui/undefined_validate_unsigned_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/undefined_validate_unsigned_part.rs
@@ -1,6 +1,6 @@
 use frame_support::construct_runtime;
-use sp_runtime::{generic, traits::BlakeTwo256};
 use sp_core::sr25519;
+use sp_runtime::{generic, traits::BlakeTwo256};
 
 #[frame_support::pallet]
 mod pallet {
@@ -14,8 +14,8 @@ mod pallet {
 pub type Signature = sr25519::Signature;
 pub type BlockNumber = u32;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<u32, RuntimeCall, Signature, ()>;
 
 impl pallet::Config for Runtime {}
 
@@ -50,7 +50,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: pallet::{Pallet, ValidateUnsigned},

--- a/frame/support/test/tests/construct_runtime_ui/unsupported_meta_structure.rs
+++ b/frame/support/test/tests/construct_runtime_ui/unsupported_meta_structure.rs
@@ -4,7 +4,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: system::{Pallet},
 		#[cfg(feature(test))]

--- a/frame/support/test/tests/construct_runtime_ui/unsupported_pallet_attr.rs
+++ b/frame/support/test/tests/construct_runtime_ui/unsupported_pallet_attr.rs
@@ -4,7 +4,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: system::{Pallet},
 		#[attr]

--- a/frame/support/test/tests/construct_runtime_ui/use_undefined_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/use_undefined_part.rs
@@ -1,6 +1,6 @@
 use frame_support::construct_runtime;
-use sp_runtime::{generic, traits::BlakeTwo256};
 use sp_core::sr25519;
+use sp_runtime::{generic, traits::BlakeTwo256};
 
 #[frame_support::pallet]
 mod pallet {
@@ -13,14 +13,14 @@ mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::storage]
-	type Foo<T> = StorageValue<Value=u8>;
+	type Foo<T> = StorageValue<Value = u8>;
 }
 
 pub type Signature = sr25519::Signature;
 pub type BlockNumber = u64;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<u32, RuntimeCall, Signature, ()>;
 
 impl pallet::Config for Runtime {}
 
@@ -28,7 +28,7 @@ construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: system::{Pallet, Call, Storage, Config, Event<T>},
 		Pallet: pallet use_parts { Call },

--- a/frame/support/test/tests/instance.rs
+++ b/frame/support/test/tests/instance.rs
@@ -290,7 +290,7 @@ frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: system::{Pallet, Call, Event<T>},
 		Module1_1: module1::<Instance1>::{
@@ -314,8 +314,8 @@ frame_support::construct_runtime!(
 );
 
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<u32, RuntimeCall, Signature, ()>;
 
 fn new_test_ext() -> sp_io::TestExternalities {
 	GenesisConfig {

--- a/frame/support/test/tests/issue2219.rs
+++ b/frame/support/test/tests/issue2219.rs
@@ -154,8 +154,8 @@ pub type AccountId = <Signature as Verify>::Signer;
 pub type BlockNumber = u64;
 pub type Index = u64;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<u32, RuntimeCall, Signature, ()>;
 
 impl system::Config for Runtime {
 	type BaseCallFilter = frame_support::traits::Everything;
@@ -175,7 +175,7 @@ frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: system::{Pallet, Call, Event<T>},
 		Module: module::{Pallet, Call, Storage, Config},

--- a/frame/support/test/tests/origin.rs
+++ b/frame/support/test/tests/origin.rs
@@ -159,7 +159,7 @@ frame_support::construct_runtime!(
 	pub enum RuntimeOriginTest where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: system::{Pallet, Event<T>, Origin<T>},
 		NestedModule: nested::module::{Pallet, Origin, Call},
@@ -170,8 +170,8 @@ frame_support::construct_runtime!(
 pub type Signature = sr25519::Signature;
 pub type BlockNumber = u64;
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+pub type RuntimeExtrinsic = generic::RuntimeExtrinsic<u32, RuntimeCall, Signature, ()>;
+pub type Block = generic::Block<Header, RuntimeExtrinsic>;
 
 #[test]
 fn origin_default_filter() {

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -646,14 +646,14 @@ impl pallet5::Config for Runtime {
 }
 
 pub type Header = sp_runtime::generic::Header<u32, sp_runtime::traits::BlakeTwo256>;
-pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, RuntimeCall, (), ()>;
+pub type Block = sp_runtime::generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = sp_runtime::generic::RuntimeExtrinsic<u32, RuntimeCall, (), ()>;
 
 frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		// Exclude part `Storage` in order not to check its metadata in tests.
 		System: frame_system exclude_parts { Pallet, Storage },
@@ -758,7 +758,7 @@ fn inherent_expand() {
 
 	let inherents = InherentData::new().create_extrinsics();
 
-	let expected = vec![UncheckedExtrinsic {
+	let expected = vec![RuntimeExtrinsic {
 		function: RuntimeCall::Example(pallet::Call::foo_no_post_info {}),
 		signature: None,
 	}];
@@ -773,11 +773,11 @@ fn inherent_expand() {
 			Digest::default(),
 		),
 		vec![
-			UncheckedExtrinsic {
+			RuntimeExtrinsic {
 				function: RuntimeCall::Example(pallet::Call::foo_no_post_info {}),
 				signature: None,
 			},
-			UncheckedExtrinsic {
+			RuntimeExtrinsic {
 				function: RuntimeCall::Example(pallet::Call::foo { foo: 1, bar: 0 }),
 				signature: None,
 			},
@@ -795,11 +795,11 @@ fn inherent_expand() {
 			Digest::default(),
 		),
 		vec![
-			UncheckedExtrinsic {
+			RuntimeExtrinsic {
 				function: RuntimeCall::Example(pallet::Call::foo_no_post_info {}),
 				signature: None,
 			},
-			UncheckedExtrinsic {
+			RuntimeExtrinsic {
 				function: RuntimeCall::Example(pallet::Call::foo { foo: 0, bar: 0 }),
 				signature: None,
 			},
@@ -816,7 +816,7 @@ fn inherent_expand() {
 			BlakeTwo256::hash(b"test"),
 			Digest::default(),
 		),
-		vec![UncheckedExtrinsic {
+		vec![RuntimeExtrinsic {
 			function: RuntimeCall::Example(pallet::Call::foo_storage_layer { foo: 0 }),
 			signature: None,
 		}],
@@ -834,7 +834,7 @@ fn inherent_expand() {
 			BlakeTwo256::hash(b"test"),
 			Digest::default(),
 		),
-		vec![UncheckedExtrinsic {
+		vec![RuntimeExtrinsic {
 			function: RuntimeCall::Example(pallet::Call::foo_no_post_info {}),
 			signature: Some((1, (), ())),
 		}],
@@ -853,11 +853,11 @@ fn inherent_expand() {
 			Digest::default(),
 		),
 		vec![
-			UncheckedExtrinsic {
+			RuntimeExtrinsic {
 				function: RuntimeCall::Example(pallet::Call::foo { foo: 1, bar: 1 }),
 				signature: None,
 			},
-			UncheckedExtrinsic {
+			RuntimeExtrinsic {
 				function: RuntimeCall::Example(pallet::Call::foo_storage_layer { foo: 0 }),
 				signature: None,
 			},
@@ -875,15 +875,15 @@ fn inherent_expand() {
 			Digest::default(),
 		),
 		vec![
-			UncheckedExtrinsic {
+			RuntimeExtrinsic {
 				function: RuntimeCall::Example(pallet::Call::foo { foo: 1, bar: 1 }),
 				signature: None,
 			},
-			UncheckedExtrinsic {
+			RuntimeExtrinsic {
 				function: RuntimeCall::Example(pallet::Call::foo_storage_layer { foo: 0 }),
 				signature: None,
 			},
-			UncheckedExtrinsic {
+			RuntimeExtrinsic {
 				function: RuntimeCall::Example(pallet::Call::foo_no_post_info {}),
 				signature: None,
 			},
@@ -901,15 +901,15 @@ fn inherent_expand() {
 			Digest::default(),
 		),
 		vec![
-			UncheckedExtrinsic {
+			RuntimeExtrinsic {
 				function: RuntimeCall::Example(pallet::Call::foo { foo: 1, bar: 1 }),
 				signature: None,
 			},
-			UncheckedExtrinsic {
+			RuntimeExtrinsic {
 				function: RuntimeCall::Example(pallet::Call::foo { foo: 1, bar: 0 }),
 				signature: Some((1, (), ())),
 			},
-			UncheckedExtrinsic {
+			RuntimeExtrinsic {
 				function: RuntimeCall::Example(pallet::Call::foo_no_post_info {}),
 				signature: None,
 			},
@@ -1566,7 +1566,7 @@ fn metadata() {
 	}
 
 	let extrinsic = ExtrinsicMetadata {
-		ty: meta_type::<UncheckedExtrinsic>(),
+		ty: meta_type::<RuntimeExtrinsic>(),
 		version: 4,
 		signed_extensions: vec![SignedExtensionMetadata {
 			identifier: "UnitSignedExtension",

--- a/frame/support/test/tests/pallet_compatibility.rs
+++ b/frame/support/test/tests/pallet_compatibility.rs
@@ -263,14 +263,14 @@ impl pallet_old::Config for Runtime {
 }
 
 pub type Header = sp_runtime::generic::Header<u32, sp_runtime::traits::BlakeTwo256>;
-pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, RuntimeCall, (), ()>;
+pub type Block = sp_runtime::generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = sp_runtime::generic::RuntimeExtrinsic<u32, RuntimeCall, (), ()>;
 
 frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system::{Pallet, Call, Event<T>},
 		// NOTE: name Example here is needed in order to have same module prefix

--- a/frame/support/test/tests/pallet_compatibility_instance.rs
+++ b/frame/support/test/tests/pallet_compatibility_instance.rs
@@ -264,14 +264,14 @@ impl pallet_old::Config<pallet_old::Instance3> for Runtime {
 }
 
 pub type Header = sp_runtime::generic::Header<u32, sp_runtime::traits::BlakeTwo256>;
-pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, RuntimeCall, (), ()>;
+pub type Block = sp_runtime::generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = sp_runtime::generic::RuntimeExtrinsic<u32, RuntimeCall, (), ()>;
 
 frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system::{Pallet, Call, Event<T>},
 		Example: pallet::{Pallet, Call, Event<T>, Config<T>, Storage},

--- a/frame/support/test/tests/pallet_instance.rs
+++ b/frame/support/test/tests/pallet_instance.rs
@@ -330,14 +330,14 @@ impl pallet2::Config<pallet::Instance1> for Runtime {
 }
 
 pub type Header = sp_runtime::generic::Header<u32, sp_runtime::traits::BlakeTwo256>;
-pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, RuntimeCall, (), ()>;
+pub type Block = sp_runtime::generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = sp_runtime::generic::RuntimeExtrinsic<u32, RuntimeCall, (), ()>;
 
 frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		// Exclude part `Storage` in order not to check its metadata in tests.
 		System: frame_system exclude_parts { Storage },
@@ -902,7 +902,7 @@ fn metadata() {
 		vec![system_pallet_metadata, example_pallet_metadata, example_pallet_instance1_metadata];
 
 	let extrinsic = ExtrinsicMetadata {
-		ty: scale_info::meta_type::<UncheckedExtrinsic>(),
+		ty: scale_info::meta_type::<RuntimeExtrinsic>(),
 		version: 4,
 		signed_extensions: vec![SignedExtensionMetadata {
 			identifier: "UnitSignedExtension",

--- a/frame/support/test/tests/pallet_with_name_trait_is_valid.rs
+++ b/frame/support/test/tests/pallet_with_name_trait_is_valid.rs
@@ -106,7 +106,7 @@ mod tests {
 	);
 	type TestBlock = sp_runtime::generic::Block<TestHeader, TestUncheckedExtrinsic>;
 	type TestHeader = sp_runtime::generic::Header<u64, sp_runtime::traits::BlakeTwo256>;
-	type TestUncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<
+	type TestUncheckedExtrinsic = sp_runtime::generic::RuntimeExtrinsic<
 		<Runtime as frame_system::Config>::AccountId,
 		<Runtime as frame_system::Config>::RuntimeCall,
 		(),
@@ -117,7 +117,7 @@ mod tests {
 		pub enum Runtime where
 			Block = TestBlock,
 			NodeBlock = TestBlock,
-			UncheckedExtrinsic = TestUncheckedExtrinsic
+			RuntimeExtrinsic = TestUncheckedExtrinsic
 		{
 			System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 			PalletTest: pallet_test::{Pallet, Call, Storage, Event<T>, Config, ValidateUnsigned, Inherent},

--- a/frame/support/test/tests/storage_layers.rs
+++ b/frame/support/test/tests/storage_layers.rs
@@ -79,8 +79,8 @@ pub mod decl_pallet {
 pub type BlockNumber = u64;
 pub type Index = u64;
 pub type Header = sp_runtime::generic::Header<u32, sp_runtime::traits::BlakeTwo256>;
-pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, RuntimeCall, (), ()>;
+pub type Block = sp_runtime::generic::Block<Header, RuntimeExtrinsic>;
+pub type RuntimeExtrinsic = sp_runtime::generic::RuntimeExtrinsic<u32, RuntimeCall, (), ()>;
 
 impl frame_system::Config for Runtime {
 	type BlockWeights = ();
@@ -117,7 +117,7 @@ frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
+		RuntimeExtrinsic = RuntimeExtrinsic
 	{
 		System: frame_system,
 		MyPallet: pallet,

--- a/frame/system/benches/bench.rs
+++ b/frame/system/benches/bench.rs
@@ -44,14 +44,14 @@ mod module {
 	}
 }
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;
 
 frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Module: module::{Pallet, Event},

--- a/frame/system/benchmarking/src/mock.rs
+++ b/frame/system/benchmarking/src/mock.rs
@@ -25,14 +25,14 @@ type AccountId = u64;
 type AccountIndex = u32;
 type BlockNumber = u64;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 	}

--- a/frame/system/src/mock.rs
+++ b/frame/system/src/mock.rs
@@ -27,14 +27,14 @@ use sp_runtime::{
 	BuildStorage, Perbill,
 };
 
-type UncheckedExtrinsic = mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = mocking::MockUncheckedExtrinsic<Test>;
 type Block = mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 	}

--- a/frame/system/src/mocking.rs
+++ b/frame/system/src/mocking.rs
@@ -20,7 +20,7 @@
 use sp_runtime::generic;
 
 /// An unchecked extrinsic type to be used in tests.
-pub type MockUncheckedExtrinsic<T, Signature = (), Extra = ()> = generic::UncheckedExtrinsic<
+pub type MockUncheckedExtrinsic<T, Signature = (), Extra = ()> = generic::RuntimeExtrinsic<
 	<T as crate::Config>::AccountId,
 	<T as crate::Config>::RuntimeCall,
 	Signature,

--- a/frame/timestamp/src/mock.rs
+++ b/frame/timestamp/src/mock.rs
@@ -31,7 +31,7 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 type Moment = u64;
 
@@ -39,7 +39,7 @@ frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},

--- a/frame/tips/src/tests.rs
+++ b/frame/tips/src/tests.rs
@@ -39,14 +39,14 @@ use frame_support::{
 use super::*;
 use crate::{self as pallet_tips, Event as TipEvent};
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/transaction-payment/asset-tx-payment/src/mock.rs
+++ b/frame/transaction-payment/asset-tx-payment/src/mock.rs
@@ -34,7 +34,7 @@ use sp_runtime::{
 	traits::{BlakeTwo256, ConvertInto, IdentityLookup, SaturatedConversion},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;
 type Balance = u64;
 type AccountId = u64;
@@ -43,7 +43,7 @@ frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: system,
 		Balances: pallet_balances,

--- a/frame/transaction-payment/src/mock.rs
+++ b/frame/transaction-payment/src/mock.rs
@@ -33,14 +33,14 @@ use frame_support::{
 use frame_system as system;
 use pallet_balances::Call as BalancesCall;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;
 
 frame_support::construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/transaction-storage/src/mock.rs
+++ b/frame/transaction-storage/src/mock.rs
@@ -29,7 +29,7 @@ use sp_runtime::{
 	BuildStorage,
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 pub type Block = frame_system::mocking::MockBlock<Test>;
 
 // Configure a mock runtime to test the pallet.
@@ -37,7 +37,7 @@ frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Config<T>, Storage, Event<T>},

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -36,14 +36,14 @@ use frame_support::{
 use super::*;
 use crate as treasury;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/uniques/src/mock.rs
+++ b/frame/uniques/src/mock.rs
@@ -30,14 +30,14 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -125,14 +125,14 @@ mod mock_democracy {
 	}
 }
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Timestamp: pallet_timestamp::{Call, Inherent},

--- a/frame/vesting/src/mock.rs
+++ b/frame/vesting/src/mock.rs
@@ -28,14 +28,14 @@ use sp_runtime::{
 use super::*;
 use crate as pallet_vesting;
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},

--- a/frame/whitelist/src/mock.rs
+++ b/frame/whitelist/src/mock.rs
@@ -33,14 +33,14 @@ use sp_runtime::{
 	BuildStorage,
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+		RuntimeExtrinsic = RuntimeExtrinsic,
 	{
 		System: frame_system,
 		Balances: pallet_balances,

--- a/primitives/runtime/src/generic/mod.rs
+++ b/primitives/runtime/src/generic/mod.rs
@@ -34,5 +34,5 @@ pub use self::{
 	digest::{Digest, DigestItem, DigestItemRef, OpaqueDigestItemId},
 	era::{Era, Phase},
 	header::Header,
-	unchecked_extrinsic::{SignedPayload, UncheckedExtrinsic},
+	unchecked_extrinsic::{RuntimeExtrinsic, SignedPayload},
 };

--- a/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -31,7 +31,7 @@ use scale_info::{build::Fields, meta_type, Path, StaticTypeInfo, Type, TypeInfo,
 use sp_io::hashing::blake2_256;
 use sp_std::{fmt, prelude::*};
 
-/// Current version of the [`UncheckedExtrinsic`] encoded format.
+/// Current version of the [`RuntimeExtrinsic`] encoded format.
 ///
 /// This version needs to be bumped if the encoded representation changes.
 /// It ensures that if the representation is changed and the format is not known,
@@ -41,7 +41,7 @@ const EXTRINSIC_FORMAT_VERSION: u8 = 4;
 /// A extrinsic right from the external world. This is unchecked and so
 /// can contain a signature.
 #[derive(PartialEq, Eq, Clone)]
-pub struct UncheckedExtrinsic<Address, Call, Signature, Extra>
+pub struct RuntimeExtrinsic<Address, Call, Signature, Extra>
 where
 	Extra: SignedExtension,
 {
@@ -56,20 +56,19 @@ where
 /// Manual [`TypeInfo`] implementation because of custom encoding. The data is a valid encoded
 /// `Vec<u8>`, but requires some logic to extract the signature and payload.
 ///
-/// See [`UncheckedExtrinsic::encode`] and [`UncheckedExtrinsic::decode`].
-impl<Address, Call, Signature, Extra> TypeInfo
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+/// See [`RuntimeExtrinsic::encode`] and [`RuntimeExtrinsic::decode`].
+impl<Address, Call, Signature, Extra> TypeInfo for RuntimeExtrinsic<Address, Call, Signature, Extra>
 where
 	Address: StaticTypeInfo,
 	Call: StaticTypeInfo,
 	Signature: StaticTypeInfo,
 	Extra: SignedExtension + StaticTypeInfo,
 {
-	type Identity = UncheckedExtrinsic<Address, Call, Signature, Extra>;
+	type Identity = RuntimeExtrinsic<Address, Call, Signature, Extra>;
 
 	fn type_info() -> Type {
 		Type::builder()
-			.path(Path::new("UncheckedExtrinsic", module_path!()))
+			.path(Path::new("RuntimeExtrinsic", module_path!()))
 			// Include the type parameter types, even though they are not used directly in any of
 			// the described fields. These type definitions can be used by downstream consumers
 			// to help construct the custom decoding from the opaque bytes (see below).
@@ -79,7 +78,7 @@ where
 				TypeParameter::new("Signature", Some(meta_type::<Signature>())),
 				TypeParameter::new("Extra", Some(meta_type::<Extra>())),
 			])
-			.docs(&["UncheckedExtrinsic raw bytes, requires custom decoding routine"])
+			.docs(&["RuntimeExtrinsic raw bytes, requires custom decoding routine"])
 			// Because of the custom encoding, we can only accurately describe the encoding as an
 			// opaque `Vec<u8>`. Downstream consumers will need to manually implement the codec to
 			// encode/decode the `signature` and `function` fields.
@@ -88,7 +87,7 @@ where
 }
 
 impl<Address, Call, Signature, Extra: SignedExtension>
-	UncheckedExtrinsic<Address, Call, Signature, Extra>
+	RuntimeExtrinsic<Address, Call, Signature, Extra>
 {
 	/// New instance of a signed extrinsic aka "transaction".
 	pub fn new_signed(function: Call, signed: Address, signature: Signature, extra: Extra) -> Self {
@@ -102,7 +101,7 @@ impl<Address, Call, Signature, Extra: SignedExtension>
 }
 
 impl<Address, Call, Signature, Extra: SignedExtension> Extrinsic
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+	for RuntimeExtrinsic<Address, Call, Signature, Extra>
 {
 	type Call = Call;
 
@@ -122,7 +121,7 @@ impl<Address, Call, Signature, Extra: SignedExtension> Extrinsic
 }
 
 impl<Address, AccountId, Call, Signature, Extra, Lookup> Checkable<Lookup>
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+	for RuntimeExtrinsic<Address, Call, Signature, Extra>
 where
 	Address: Member + MaybeDisplay,
 	Call: Encode + Member,
@@ -168,7 +167,7 @@ where
 }
 
 impl<Address, Call, Signature, Extra> ExtrinsicMetadata
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+	for RuntimeExtrinsic<Address, Call, Signature, Extra>
 where
 	Extra: SignedExtension,
 {
@@ -234,7 +233,7 @@ where
 {
 }
 
-impl<Address, Call, Signature, Extra> Decode for UncheckedExtrinsic<Address, Call, Signature, Extra>
+impl<Address, Call, Signature, Extra> Decode for RuntimeExtrinsic<Address, Call, Signature, Extra>
 where
 	Address: Decode,
 	Signature: Decode,
@@ -273,7 +272,7 @@ where
 	}
 }
 
-impl<Address, Call, Signature, Extra> Encode for UncheckedExtrinsic<Address, Call, Signature, Extra>
+impl<Address, Call, Signature, Extra> Encode for RuntimeExtrinsic<Address, Call, Signature, Extra>
 where
 	Address: Encode,
 	Signature: Encode,
@@ -308,7 +307,7 @@ where
 }
 
 impl<Address, Call, Signature, Extra> EncodeLike
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+	for RuntimeExtrinsic<Address, Call, Signature, Extra>
 where
 	Address: Encode,
 	Signature: Encode,
@@ -319,7 +318,7 @@ where
 
 #[cfg(feature = "std")]
 impl<Address: Encode, Signature: Encode, Call: Encode, Extra: SignedExtension> serde::Serialize
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+	for RuntimeExtrinsic<Address, Call, Signature, Extra>
 {
 	fn serialize<S>(&self, seq: S) -> Result<S::Ok, S::Error>
 	where
@@ -331,7 +330,7 @@ impl<Address: Encode, Signature: Encode, Call: Encode, Extra: SignedExtension> s
 
 #[cfg(feature = "std")]
 impl<'a, Address: Decode, Signature: Decode, Call: Decode, Extra: SignedExtension>
-	serde::Deserialize<'a> for UncheckedExtrinsic<Address, Call, Signature, Extra>
+	serde::Deserialize<'a> for RuntimeExtrinsic<Address, Call, Signature, Extra>
 {
 	fn deserialize<D>(de: D) -> Result<Self, D::Error>
 	where
@@ -344,7 +343,7 @@ impl<'a, Address: Decode, Signature: Decode, Call: Decode, Extra: SignedExtensio
 }
 
 impl<Address, Call, Signature, Extra> fmt::Debug
-	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+	for RuntimeExtrinsic<Address, Call, Signature, Extra>
 where
 	Address: fmt::Debug,
 	Call: fmt::Debug,
@@ -353,14 +352,14 @@ where
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(
 			f,
-			"UncheckedExtrinsic({:?}, {:?})",
+			"RuntimeExtrinsic({:?}, {:?})",
 			self.signature.as_ref().map(|x| (&x.0, &x.2)),
 			self.function,
 		)
 	}
 }
 
-impl<Address, Call, Signature, Extra> From<UncheckedExtrinsic<Address, Call, Signature, Extra>>
+impl<Address, Call, Signature, Extra> From<RuntimeExtrinsic<Address, Call, Signature, Extra>>
 	for OpaqueExtrinsic
 where
 	Address: Encode,
@@ -368,9 +367,9 @@ where
 	Call: Encode,
 	Extra: SignedExtension,
 {
-	fn from(extrinsic: UncheckedExtrinsic<Address, Call, Signature, Extra>) -> Self {
+	fn from(extrinsic: RuntimeExtrinsic<Address, Call, Signature, Extra>) -> Self {
 		Self::from_bytes(extrinsic.encode().as_slice()).expect(
-			"both OpaqueExtrinsic and UncheckedExtrinsic have encoding that is compatible with \
+			"both OpaqueExtrinsic and RuntimeExtrinsic have encoding that is compatible with \
 				raw Vec<u8> encoding; qed",
 		)
 	}
@@ -417,7 +416,7 @@ mod tests {
 		}
 	}
 
-	type Ex = UncheckedExtrinsic<TestAccountId, TestCall, TestSig, TestExtra>;
+	type Ex = RuntimeExtrinsic<TestAccountId, TestCall, TestSig, TestExtra>;
 	type CEx = CheckedExtrinsic<TestAccountId, TestCall, TestExtra>;
 
 	#[test]

--- a/utils/frame/rpc/support/src/lib.rs
+++ b/utils/frame/rpc/support/src/lib.rs
@@ -43,7 +43,7 @@ use sp_storage::{StorageData, StorageKey};
 /// # 	pub enum TestRuntime where
 /// # 		Block = frame_system::mocking::MockBlock<TestRuntime>,
 /// # 		NodeBlock = frame_system::mocking::MockBlock<TestRuntime>,
-/// # 		UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<TestRuntime>,
+/// # 		RuntimeExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<TestRuntime>,
 /// # 	{
 /// # 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 /// # 		Test: pallet_test::{Pallet, Storage},


### PR DESCRIPTION
Renaming UncheckedExtrinsic into RuntimeExtrinsic following #13329 suggestion.

I am concerned if there should be a specific mention concerning PolkadotJS and other UIs, concerning [this change](https://github.com/paritytech/substrate/pull/13351/files#diff-3d4efbe0175a2de5346a5cf0a97ee33ab12468704ba54c611f74322c00b43532L41-L44). As far as I understand, this is a Metadata change and a change should be mentioned in the next changelog;

Fixes #13329;
