### PR TITLE
Improve Weight Template and API

### DIFF
--- a/.maintain/frame-weight-template.hbs
+++ b/.maintain/frame-weight-template.hbs
@@ -53,11 +53,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		//  Measured:  `{{benchmark.base_recorded_proof_size}}{{#each benchmark.component_recorded_proof_size as |cp|}} + {{cp.name}} * ({{cp.slope}} ±{{underscore cp.error}}){{/each}}`
 		//  Estimated: `{{benchmark.base_calculated_proof_size}}{{#each benchmark.component_calculated_proof_size as |cp|}} + {{cp.name}} * ({{cp.slope}} ±{{underscore cp.error}}){{/each}}`
 		// Minimum execution time: {{underscore benchmark.min_execution_time}} nanoseconds.
-		{{#if (ne benchmark.base_calculated_proof_size "0")}}
-		Weight::from_parts({{underscore benchmark.base_weight}}, {{benchmark.base_calculated_proof_size}})
-		{{else}}
 		Weight::from_ref_time({{underscore benchmark.base_weight}})
-		{{/if}}
+			.add_proof_size({{underscore benchmark.base_calculated_proof_size}})
 			{{#each benchmark.component_weight as |cw|}}
 			// Standard Error: {{underscore cw.error}}
 			.saturating_add(Weight::from_ref_time({{underscore cw.slope}}).saturating_mul({{cw.name}}.into()))
@@ -99,11 +96,8 @@ impl WeightInfo for () {
 		//  Measured:  `{{benchmark.base_recorded_proof_size}}{{#each benchmark.component_recorded_proof_size as |cp|}} + {{cp.name}} * ({{cp.slope}} ±{{underscore cp.error}}){{/each}}`
 		//  Estimated: `{{benchmark.base_calculated_proof_size}}{{#each benchmark.component_calculated_proof_size as |cp|}} + {{cp.name}} * ({{cp.slope}} ±{{underscore cp.error}}){{/each}}`
 		// Minimum execution time: {{underscore benchmark.min_execution_time}} nanoseconds.
-		{{#if (ne benchmark.base_calculated_proof_size "0")}}
-		Weight::from_parts({{underscore benchmark.base_weight}}, {{benchmark.base_calculated_proof_size}})
-		{{else}}
 		Weight::from_ref_time({{underscore benchmark.base_weight}})
-		{{/if}}
+			.add_proof_size({{underscore benchmark.base_calculated_proof_size}})
 			{{#each benchmark.component_weight as |cw|}}
 			// Standard Error: {{underscore cw.error}}
 			.saturating_add(Weight::from_ref_time({{underscore cw.slope}}).saturating_mul({{cw.name}}.into()))

--- a/.maintain/frame-weight-template.hbs
+++ b/.maintain/frame-weight-template.hbs
@@ -54,7 +54,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		//  Estimated: `{{benchmark.base_calculated_proof_size}}{{#each benchmark.component_calculated_proof_size as |cp|}} + {{cp.name}} * ({{cp.slope}} ±{{underscore cp.error}}){{/each}}`
 		// Minimum execution time: {{underscore benchmark.min_execution_time}} nanoseconds.
 		Weight::from_ref_time({{underscore benchmark.base_weight}})
-			.add_proof_size({{underscore benchmark.base_calculated_proof_size}})
+			.saturating_add(Weight::from_proof_size({{benchmark.base_calculated_proof_size}}))
 			{{#each benchmark.component_weight as |cw|}}
 			// Standard Error: {{underscore cw.error}}
 			.saturating_add(Weight::from_ref_time({{underscore cw.slope}}).saturating_mul({{cw.name}}.into()))
@@ -97,7 +97,7 @@ impl WeightInfo for () {
 		//  Estimated: `{{benchmark.base_calculated_proof_size}}{{#each benchmark.component_calculated_proof_size as |cp|}} + {{cp.name}} * ({{cp.slope}} ±{{underscore cp.error}}){{/each}}`
 		// Minimum execution time: {{underscore benchmark.min_execution_time}} nanoseconds.
 		Weight::from_ref_time({{underscore benchmark.base_weight}})
-			.add_proof_size({{underscore benchmark.base_calculated_proof_size}})
+			.saturating_add(Weight::from_proof_size({{benchmark.base_calculated_proof_size}}))
 			{{#each benchmark.component_weight as |cw|}}
 			// Standard Error: {{underscore cw.error}}
 			.saturating_add(Weight::from_ref_time({{underscore cw.slope}}).saturating_mul({{cw.name}}.into()))

--- a/primitives/weights/src/weight_v2.rs
+++ b/primitives/weights/src/weight_v2.rs
@@ -247,18 +247,32 @@ impl Weight {
 		Self { ref_time: 0, proof_size: 0 }
 	}
 
-	/// Constant version of Add with u64.
+	/// Constant version of Add for `ref_time` component with u64.
 	///
 	/// Is only overflow safe when evaluated at compile-time.
-	pub const fn add(self, scalar: u64) -> Self {
-		Self { ref_time: self.ref_time + scalar, proof_size: self.proof_size + scalar }
+	pub const fn add_ref_time(self, scalar: u64) -> Self {
+		Self { ref_time: self.ref_time + scalar, proof_size: self.proof_size }
 	}
 
-	/// Constant version of Sub with u64.
+	/// Constant version of Add for `proof_size` component with u64.
 	///
 	/// Is only overflow safe when evaluated at compile-time.
-	pub const fn sub(self, scalar: u64) -> Self {
-		Self { ref_time: self.ref_time - scalar, proof_size: self.proof_size - scalar }
+	pub const fn add_proof_size(self, scalar: u64) -> Self {
+		Self { ref_time: self.ref_time, proof_size: self.proof_size + scalar }
+	}
+
+	/// Constant version of Sub for `ref_time` component with u64.
+	///
+	/// Is only overflow safe when evaluated at compile-time.
+	pub const fn sub_ref_time(self, scalar: u64) -> Self {
+		Self { ref_time: self.ref_time - scalar, proof_size: self.proof_size }
+	}
+
+	/// Constant version of Sub for `proof_size` component with u64.
+	///
+	/// Is only overflow safe when evaluated at compile-time.
+	pub const fn sub_proof_size(self, scalar: u64) -> Self {
+		Self { ref_time: self.ref_time, proof_size: self.proof_size - scalar }
 	}
 
 	/// Constant version of Div with u64.

--- a/utils/frame/benchmarking-cli/src/pallet/template.hbs
+++ b/utils/frame/benchmarking-cli/src/pallet/template.hbs
@@ -38,11 +38,8 @@ impl<T: frame_system::Config> {{pallet}}::WeightInfo for WeightInfo<T> {
 		//  Measured:  `{{benchmark.base_recorded_proof_size}}{{#each benchmark.component_recorded_proof_size as |cp|}} + {{cp.name}} * ({{cp.slope}} ±{{underscore cp.error}}){{/each}}`
 		//  Estimated: `{{benchmark.base_calculated_proof_size}}{{#each benchmark.component_calculated_proof_size as |cp|}} + {{cp.name}} * ({{cp.slope}} ±{{underscore cp.error}}){{/each}}`
 		// Minimum execution time: {{underscore benchmark.min_execution_time}} nanoseconds.
-		{{#if (ne benchmark.base_calculated_proof_size "0")}}
-		Weight::from_parts({{underscore benchmark.base_weight}}, {{benchmark.base_calculated_proof_size}})
-		{{else}}
 		Weight::from_ref_time({{underscore benchmark.base_weight}})
-		{{/if}}
+			.add_proof_size({{benchmark.base_calculated_proof_size}})
 			{{#each benchmark.component_weight as |cw|}}
 			// Standard Error: {{underscore cw.error}}
 			.saturating_add(Weight::from_ref_time({{underscore cw.slope}}).saturating_mul({{cw.name}}.into()))

--- a/utils/frame/benchmarking-cli/src/pallet/template.hbs
+++ b/utils/frame/benchmarking-cli/src/pallet/template.hbs
@@ -39,7 +39,7 @@ impl<T: frame_system::Config> {{pallet}}::WeightInfo for WeightInfo<T> {
 		//  Estimated: `{{benchmark.base_calculated_proof_size}}{{#each benchmark.component_calculated_proof_size as |cp|}} + {{cp.name}} * ({{cp.slope}} ±{{underscore cp.error}}){{/each}}`
 		// Minimum execution time: {{underscore benchmark.min_execution_time}} nanoseconds.
 		Weight::from_ref_time({{underscore benchmark.base_weight}})
-			.add_proof_size({{benchmark.base_calculated_proof_size}})
+			.saturating_add(Weight::from_proof_size({{benchmark.base_calculated_proof_size}}))
 			{{#each benchmark.component_weight as |cw|}}
 			// Standard Error: {{underscore cw.error}}
 			.saturating_add(Weight::from_ref_time({{underscore cw.slope}}).saturating_mul({{cw.name}}.into()))


### PR DESCRIPTION
Was browsing through PRs using the new weight template, and I think it would be really more clear to break down each component, rather than using `from_parts`. As I understand, this will also make weights more "forwards" compatible, such that if we add more components, the usage of `from_parts` will not break.

Finally, removing weird APIs which assume you would ever want to scalar add the same amount to both `ref_time` and `proof_size`. This seems like nonsense, since these are totally different units of measurement.