### PR TITLE
Add build date (UTC) to the version

### DIFF
--- a/bin/node-template/node/src/command.rs
+++ b/bin/node-template/node/src/command.rs
@@ -16,7 +16,9 @@ impl SubstrateCli for Cli {
 	}
 
 	fn impl_version() -> String {
-		env!("SUBSTRATE_CLI_IMPL_VERSION").into()
+		let impl_version: String = env!("SUBSTRATE_CLI_IMPL_VERSION").into();
+		let build_date: String = env!("SUBSTRATE_CLI_BUILD_DATE").into();
+		format!("{impl_version} built {build_date}")
 	}
 
 	fn description() -> String {

--- a/bin/node/cli/src/command.rs
+++ b/bin/node/cli/src/command.rs
@@ -38,7 +38,9 @@ impl SubstrateCli for Cli {
 	}
 
 	fn impl_version() -> String {
-		env!("SUBSTRATE_CLI_IMPL_VERSION").into()
+		let impl_version: String = env!("SUBSTRATE_CLI_IMPL_VERSION").into();
+		let build_date: String = env!("SUBSTRATE_CLI_BUILD_DATE").into();
+		format!("{impl_version} built {build_date}")
 	}
 
 	fn description() -> String {

--- a/utils/build-script-utils/src/version.rs
+++ b/utils/build-script-utils/src/version.rs
@@ -17,8 +17,8 @@
 
 use std::{borrow::Cow, process::Command};
 
-/// Generate the `cargo:` key output
-pub fn generate_cargo_keys() {
+/// Add `SUBSTRATE_CLI_IMPL_VERSION` to the cargo env
+pub fn generate_git_commit_key() {
 	let commit = if let Ok(hash) = std::env::var("SUBSTRATE_CLI_GIT_COMMIT_HASH") {
 		Cow::from(hash.trim().to_owned())
 	} else {
@@ -41,10 +41,12 @@ pub fn generate_cargo_keys() {
 		}
 	};
 
-	println!("cargo:rustc-env=SUBSTRATE_CLI_IMPL_VERSION={}", get_version(&commit))
+	println!("cargo:rustc-env=SUBSTRATE_CLI_IMPL_VERSION={}", generate_version_string(&commit));
 }
 
-fn get_version(impl_commit: &str) -> String {
+/// Generate a string made of the version number followed by the git commit hash
+/// if available.
+fn generate_version_string(impl_commit: &str) -> String {
 	let commit_dash = if impl_commit.is_empty() { "" } else { "-" };
 
 	format!(


### PR DESCRIPTION
polkadot companion: https://github.com/paritytech/polkadot/pull/6700
cumulus companion: TBD

## Description: add the build date to the version

tldr:
```
node 4.0.0-dev-6a504b063cf
```
becomes
```
node 4.0.0-dev-6a504b063cf built 2023-02-10T10:45:22Z
```

Knowing the date becomes relevant for deterministic builds where we need some ways to find which version of the tooling is appropriate to redo the exact same build.

The strategy here is to remain open on what this strategy could be. Providing the date allows using the information to fetch the right version of the builders.


 
