### PR TITLE
bump version of zombienet and update snaps links

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ variables:
   RUSTY_CACHIER_COMPRESSION_METHOD: zstd
   NEXTEST_FAILURE_OUTPUT:          immediate-final
   NEXTEST_SUCCESS_OUTPUT:          final
-  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.3.22"
+  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.3.34"
 
 .shared-default:                   &shared-default
   retry:

--- a/zombienet/0001-basic-warp-sync/test-warp-sync.toml
+++ b/zombienet/0001-basic-warp-sync/test-warp-sync.toml
@@ -11,18 +11,18 @@ chain_spec_path = "zombienet/0001-basic-warp-sync/chain-spec.json"
   [[relaychain.nodes]]
   name = "alice"
   validator = false
-  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-0bb3f0be2ce41b5615b224215bcc8363aa0416a6.tgz"
+  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-a233bbacff650aac6bcb56b4e4ef7db7dc143cfb.tgz"
 
   [[relaychain.nodes]]
   name = "bob"
   validator = false
-  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-0bb3f0be2ce41b5615b224215bcc8363aa0416a6.tgz"
+  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-a233bbacff650aac6bcb56b4e4ef7db7dc143cfb.tgz"
 
   #we need at least 3 nodes for warp sync
   [[relaychain.nodes]]
   name = "charlie"
   validator = false
-  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-0bb3f0be2ce41b5615b224215bcc8363aa0416a6.tgz"
+  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-a233bbacff650aac6bcb56b4e4ef7db7dc143cfb.tgz"
 
   [[relaychain.nodes]]
   name = "dave"

--- a/zombienet/0002-validators-warp-sync/test-validators-warp-sync.toml
+++ b/zombienet/0002-validators-warp-sync/test-validators-warp-sync.toml
@@ -22,14 +22,14 @@ chain_spec_path = "zombienet/0002-validators-warp-sync/chain-spec.json"
   [[relaychain.nodes]]
   name = "charlie"
   validator = false
-  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-0bb3f0be2ce41b5615b224215bcc8363aa0416a6.tgz"
+  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-a233bbacff650aac6bcb56b4e4ef7db7dc143cfb.tgz"
 
   [[relaychain.nodes]]
   name = "dave"
   validator = false
-  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-0bb3f0be2ce41b5615b224215bcc8363aa0416a6.tgz"
+  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-a233bbacff650aac6bcb56b4e4ef7db7dc143cfb.tgz"
 
   [[relaychain.nodes]]
   name = "eve"
   validator = false
-  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-0bb3f0be2ce41b5615b224215bcc8363aa0416a6.tgz"
+  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-a233bbacff650aac6bcb56b4e4ef7db7dc143cfb.tgz"

--- a/zombienet/0003-block-building-warp-sync/test-block-building-warp-sync.toml
+++ b/zombienet/0003-block-building-warp-sync/test-block-building-warp-sync.toml
@@ -12,17 +12,17 @@ chain_spec_path = "zombienet/0003-block-building-warp-sync/chain-spec.json"
   [[relaychain.nodes]]
   name = "alice"
   validator = true
-  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-0bb3f0be2ce41b5615b224215bcc8363aa0416a6.tgz"
+  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-a233bbacff650aac6bcb56b4e4ef7db7dc143cfb.tgz"
 
   [[relaychain.nodes]]
   name = "bob"
   validator = true
-  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-0bb3f0be2ce41b5615b224215bcc8363aa0416a6.tgz"
+  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-a233bbacff650aac6bcb56b4e4ef7db7dc143cfb.tgz"
 
   [[relaychain.nodes]]
   name = "charlie"
   validator = false
-  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-0bb3f0be2ce41b5615b224215bcc8363aa0416a6.tgz"
+  db_snapshot="https://storage.googleapis.com/zombienet-db-snaps/substrate/0001-basic-warp-sync/chains-a233bbacff650aac6bcb56b4e4ef7db7dc143cfb.tgz"
 
   [[relaychain.nodes]]
   name = "dave"


### PR DESCRIPTION
Update zombienet version to the latest (v1.3.34) and update the links of the snapshots since the new version require a different directory structure for the snapshots (after this [pr](https://github.com/paritytech/zombienet/pull/673)).

cc @michalkucharczyk @skunert 
