### PR TITLE
Put `sp_keystore::testing` behind the `std` feature flag

### DIFF
--- a/primitives/keystore/src/testing.rs
+++ b/primitives/keystore/src/testing.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "std")]
 // This file is part of Substrate.
 
 // Copyright (C) 2019-2022 Parity Technologies (UK) Ltd.


### PR DESCRIPTION
Hi there,
I'm experimenting with VRF capabilities in the runtime and it seems that the `testing` mod is preventing me from compiling my runtime. I want to use some of the sources defined in `mod vrf`.

Is there any reason why the testing module is not behind the "std" feature flag? Is the whole sp-keystore package only meant to be used as the client?

Cheers.