### PR TITLE
remove storage getters in FRAME

### DIFF
--- a/bin/node-template/pallets/template/src/lib.rs
+++ b/bin/node-template/pallets/template/src/lib.rs
@@ -37,7 +37,6 @@ pub mod pallet {
 	// The pallet's runtime storage items.
 	// https://docs.substrate.io/main-docs/build/runtime-storage/
 	#[pallet::storage]
-	#[pallet::getter(fn something)]
 	// Learn more about declaring storage items:
 	// https://docs.substrate.io/main-docs/build/runtime-storage/#declaring-storage-items
 	pub type Something<T> = StorageValue<_, u32>;

--- a/bin/node-template/pallets/template/src/tests.rs
+++ b/bin/node-template/pallets/template/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{mock::*, Error, Event};
+use crate::{mock::*, Error, Event, Something};
 use frame_support::{assert_noop, assert_ok};
 
 #[test]
@@ -9,7 +9,7 @@ fn it_works_for_default_value() {
 		// Dispatch a signed extrinsic.
 		assert_ok!(TemplateModule::do_something(RuntimeOrigin::signed(1), 42));
 		// Read pallet storage and assert an expected result.
-		assert_eq!(TemplateModule::something(), Some(42));
+		assert_eq!(Something::<Test>::get(), Some(42));
 		// Assert that the correct event was deposited
 		System::assert_last_event(Event::SomethingStored { something: 42, who: 1 }.into());
 	});

--- a/bin/node/executor/tests/fees.rs
+++ b/bin/node/executor/tests/fees.rs
@@ -24,7 +24,6 @@ use frame_support::{
 use kitchensink_runtime::{
 	constants::{currency::*, time::SLOT_DURATION},
 	Balances, CheckedExtrinsic, Multiplier, Runtime, RuntimeCall, TransactionByteFee,
-	TransactionPayment,
 };
 use node_primitives::Balance;
 use node_testing::keyring::*;
@@ -41,7 +40,10 @@ fn fee_multiplier_increases_and_decreases_on_big_weight() {
 	let mut prev_multiplier = Multiplier::one();
 
 	t.execute_with(|| {
-		assert_eq!(TransactionPayment::next_fee_multiplier(), prev_multiplier);
+		assert_eq!(
+			pallet_transaction_payment::NextFeeMultiplier::<Runtime>::get(),
+			prev_multiplier
+		);
 	});
 
 	let mut tt = new_test_ext(compact_code_unwrap());
@@ -99,7 +101,7 @@ fn fee_multiplier_increases_and_decreases_on_big_weight() {
 
 	// weight multiplier is increased for next block.
 	t.execute_with(|| {
-		let fm = TransactionPayment::next_fee_multiplier();
+		let fm = pallet_transaction_payment::NextFeeMultiplier::<Runtime>::get();
 		println!("After a big block: {:?} -> {:?}", prev_multiplier, fm);
 		assert!(fm > prev_multiplier);
 		prev_multiplier = fm;
@@ -110,7 +112,7 @@ fn fee_multiplier_increases_and_decreases_on_big_weight() {
 
 	// weight multiplier is increased for next block.
 	t.execute_with(|| {
-		let fm = TransactionPayment::next_fee_multiplier();
+		let fm = pallet_transaction_payment::NextFeeMultiplier::<Runtime>::get();
 		println!("After a small block: {:?} -> {:?}", prev_multiplier, fm);
 		assert!(fm < prev_multiplier);
 	});

--- a/bin/node/runtime/src/impls.rs
+++ b/bin/node/runtime/src/impls.rs
@@ -121,7 +121,7 @@ mod multiplier_tests {
 	use crate::{
 		constants::{currency::*, time::*},
 		AdjustmentVariable, MaximumMultiplier, MinimumMultiplier, Runtime,
-		RuntimeBlockWeights as BlockWeights, System, TargetBlockFullness, TransactionPayment,
+		RuntimeBlockWeights as BlockWeights, System, TargetBlockFullness,
 	};
 	use frame_support::{
 		dispatch::DispatchClass,
@@ -291,7 +291,7 @@ mod multiplier_tests {
 		run_with_system_weight(block_weight, || {
 			// initial value configured on module
 			let mut fm = Multiplier::one();
-			assert_eq!(fm, TransactionPayment::next_fee_multiplier());
+			assert_eq!(fm, pallet_transaction_payment::NextFeeMultiplier::<Runtime>::get());
 
 			let mut iterations: u64 = 0;
 			loop {

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -2069,8 +2069,8 @@ impl_runtime_apis! {
 				slot_duration: Babe::slot_duration(),
 				epoch_length: EpochDuration::get(),
 				c: epoch_config.c,
-				authorities: Babe::authorities().to_vec(),
-				randomness: Babe::randomness(),
+				authorities: pallet_babe::Authorities::<Runtime>::get().to_vec(),
+				randomness: pallet_babe::Randomness::<Runtime>::get(),
 				allowed_slots: epoch_config.allowed_slots,
 			}
 		}
@@ -2292,11 +2292,11 @@ impl_runtime_apis! {
 		BlockNumber,
 	> for Runtime {
 		fn mmr_root() -> Result<mmr::Hash, mmr::Error> {
-			Ok(Mmr::mmr_root())
+			Ok(pallet_mmr::RootHash::<Runtime>::get())
 		}
 
 		fn mmr_leaf_count() -> Result<mmr::LeafIndex, mmr::Error> {
-			Ok(Mmr::mmr_leaves())
+			Ok(pallet_mmr::NumberOfLeaves::<Runtime>::get())
 		}
 
 		fn generate_proof(

--- a/frame/alliance/src/benchmarking.rs
+++ b/frame/alliance/src/benchmarking.rs
@@ -528,8 +528,8 @@ benchmarks_instance_pallet! {
 			fellows: fellows.clone(),
 			allies: allies.clone(),
 		}.into());
-		assert_eq!(Alliance::<T, I>::members(MemberRole::Fellow), fellows);
-		assert_eq!(Alliance::<T, I>::members(MemberRole::Ally), allies);
+		assert_eq!(Members::<T, I>::get(MemberRole::Fellow), fellows);
+		assert_eq!(Members::<T, I>::get(MemberRole::Ally), allies);
 	}
 
 	disband {
@@ -582,7 +582,7 @@ benchmarks_instance_pallet! {
 			T::AdminOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
 	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
-		assert_eq!(Alliance::<T, I>::rule(), Some(rule.clone()));
+		assert_eq!(Rule::<T, I>::get(), Some(rule.clone()));
 		assert_last_event::<T, I>(Event::NewRuleSet { rule }.into());
 	}
 
@@ -596,7 +596,7 @@ benchmarks_instance_pallet! {
 			T::AnnouncementOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
 	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
-		assert!(Alliance::<T, I>::announcements().contains(&announcement));
+		assert!(Announcements::<T, I>::get().contains(&announcement));
 		assert_last_event::<T, I>(Event::Announced { announcement }.into());
 	}
 
@@ -612,7 +612,7 @@ benchmarks_instance_pallet! {
 			T::AnnouncementOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
 	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
-		assert!(Alliance::<T, I>::announcements().is_empty());
+		assert!(Announcements::<T, I>::get().is_empty());
 		assert_last_event::<T, I>(Event::AnnouncementRemoved { announcement }.into());
 	}
 

--- a/frame/alliance/src/migration.rs
+++ b/frame/alliance/src/migration.rs
@@ -162,18 +162,18 @@ pub(crate) mod v1_to_v2 {
 #[cfg(test)]
 mod test {
 	use super::*;
-	use crate::{mock::*, MemberRole};
+	use crate::{mock::*, MemberRole, Members};
 
 	#[test]
 	fn migration_v1_to_v2_works() {
 		new_test_ext().execute_with(|| {
 			assert_ok!(Alliance::join_alliance(RuntimeOrigin::signed(4)));
-			assert_eq!(Alliance::members(MemberRole::Ally), vec![4]);
-			assert_eq!(Alliance::members(MemberRole::Fellow), vec![1, 2, 3]);
+			assert_eq!(Members::<Test>::get(MemberRole::Ally), vec![4]);
+			assert_eq!(Members::<Test>::get(MemberRole::Fellow), vec![1, 2, 3]);
 			v1_to_v2::migrate::<Test, ()>();
-			assert_eq!(Alliance::members(MemberRole::Fellow), vec![1, 2, 3, 4]);
-			assert_eq!(Alliance::members(MemberRole::Ally), vec![]);
-			assert_eq!(Alliance::members(MemberRole::Retiring), vec![]);
+			assert_eq!(Members::<Test>::get(MemberRole::Fellow), vec![1, 2, 3, 4]);
+			assert_eq!(Members::<Test>::get(MemberRole::Ally), vec![]);
+			assert_eq!(Members::<Test>::get(MemberRole::Retiring), vec![]);
 		});
 	}
 }

--- a/frame/alliance/src/mock.rs
+++ b/frame/alliance/src/mock.rs
@@ -197,7 +197,7 @@ impl ProposalProvider<AccountId, H256, RuntimeCall> for AllianceProposalProvider
 	}
 
 	fn proposal_of(proposal_hash: H256) -> Option<RuntimeCall> {
-		AllianceMotion::proposal_of(proposal_hash)
+		pallet_collective::ProposalOf::<Test, Instance1>::get(proposal_hash)
 	}
 }
 

--- a/frame/alliance/src/tests.rs
+++ b/frame/alliance/src/tests.rs
@@ -115,7 +115,7 @@ fn disband_works() {
 		// join alliance and reserve funds
 		assert_eq!(Balances::free_balance(9), 40);
 		assert_ok!(Alliance::join_alliance(RuntimeOrigin::signed(9)));
-		assert_eq!(Alliance::deposit_of(9), Some(25));
+		assert_eq!(DepositOf::<Test>::get(9), Some(25));
 		assert_eq!(Balances::free_balance(9), 15);
 		assert!(Alliance::is_member_of(&9, MemberRole::Ally));
 
@@ -184,8 +184,8 @@ fn propose_works() {
 			Box::new(proposal.clone()),
 			proposal_len
 		));
-		assert_eq!(*AllianceMotion::proposals(), vec![hash]);
-		assert_eq!(AllianceMotion::proposal_of(&hash), Some(proposal));
+		assert_eq!(*pallet_collective::Proposals::<Test, Instance1>::get(), vec![hash]);
+		assert_eq!(pallet_collective::ProposalOf::<Test, Instance1>::get(&hash), Some(proposal));
 		assert_eq!(
 			System::events(),
 			vec![EventRecord {
@@ -311,7 +311,7 @@ fn set_rule_works() {
 	new_test_ext().execute_with(|| {
 		let cid = test_cid();
 		assert_ok!(Alliance::set_rule(RuntimeOrigin::signed(1), cid.clone()));
-		assert_eq!(Alliance::rule(), Some(cid.clone()));
+		assert_eq!(Rule::<Test>::get(), Some(cid.clone()));
 
 		System::assert_last_event(mock::RuntimeEvent::Alliance(crate::Event::NewRuleSet {
 			rule: cid,
@@ -327,7 +327,7 @@ fn announce_works() {
 		assert_noop!(Alliance::announce(RuntimeOrigin::signed(2), cid.clone()), BadOrigin);
 
 		assert_ok!(Alliance::announce(RuntimeOrigin::signed(3), cid.clone()));
-		assert_eq!(Alliance::announcements(), vec![cid.clone()]);
+		assert_eq!(Announcements::<Test>::get(), vec![cid.clone()]);
 
 		System::assert_last_event(mock::RuntimeEvent::Alliance(crate::Event::Announced {
 			announcement: cid,
@@ -340,7 +340,7 @@ fn remove_announcement_works() {
 	new_test_ext().execute_with(|| {
 		let cid = test_cid();
 		assert_ok!(Alliance::announce(RuntimeOrigin::signed(3), cid.clone()));
-		assert_eq!(Alliance::announcements(), vec![cid.clone()]);
+		assert_eq!(Announcements::<Test>::get(), vec![cid.clone()]);
 		System::assert_last_event(mock::RuntimeEvent::Alliance(crate::Event::Announced {
 			announcement: cid.clone(),
 		}));
@@ -348,7 +348,7 @@ fn remove_announcement_works() {
 		System::set_block_number(2);
 
 		assert_ok!(Alliance::remove_announcement(RuntimeOrigin::signed(3), cid.clone()));
-		assert_eq!(Alliance::announcements(), vec![]);
+		assert_eq!(Announcements::<Test>::get(), vec![]);
 		System::assert_last_event(mock::RuntimeEvent::Alliance(
 			crate::Event::AnnouncementRemoved { announcement: cid },
 		));
@@ -386,8 +386,8 @@ fn join_alliance_works() {
 
 		// success to submit
 		assert_ok!(Alliance::join_alliance(RuntimeOrigin::signed(4)));
-		assert_eq!(Alliance::deposit_of(4), Some(25));
-		assert_eq!(Alliance::members(MemberRole::Ally), vec![4]);
+		assert_eq!(DepositOf::<Test>::get(4), Some(25));
+		assert_eq!(Members::<Test>::get(MemberRole::Ally), vec![4]);
 
 		// check already member
 		assert_noop!(
@@ -441,8 +441,8 @@ fn nominate_ally_works() {
 
 		// success to nominate
 		assert_ok!(Alliance::nominate_ally(RuntimeOrigin::signed(1), 4));
-		assert_eq!(Alliance::deposit_of(4), None);
-		assert_eq!(Alliance::members(MemberRole::Ally), vec![4]);
+		assert_eq!(DepositOf::<Test>::get(4), None);
+		assert_eq!(Members::<Test>::get(MemberRole::Ally), vec![4]);
 
 		// check already member
 		assert_noop!(
@@ -474,12 +474,12 @@ fn elevate_ally_works() {
 		);
 
 		assert_ok!(Alliance::join_alliance(RuntimeOrigin::signed(4)));
-		assert_eq!(Alliance::members(MemberRole::Ally), vec![4]);
-		assert_eq!(Alliance::members(MemberRole::Fellow), vec![1, 2, 3]);
+		assert_eq!(Members::<Test>::get(MemberRole::Ally), vec![4]);
+		assert_eq!(Members::<Test>::get(MemberRole::Fellow), vec![1, 2, 3]);
 
 		assert_ok!(Alliance::elevate_ally(RuntimeOrigin::signed(2), 4));
-		assert_eq!(Alliance::members(MemberRole::Ally), Vec::<u64>::new());
-		assert_eq!(Alliance::members(MemberRole::Fellow), vec![1, 2, 3, 4]);
+		assert_eq!(Members::<Test>::get(MemberRole::Ally), Vec::<u64>::new());
+		assert_eq!(Members::<Test>::get(MemberRole::Fellow), vec![1, 2, 3, 4]);
 	});
 }
 
@@ -491,10 +491,10 @@ fn give_retirement_notice_work() {
 			Error::<Test, ()>::NotMember
 		);
 
-		assert_eq!(Alliance::members(MemberRole::Fellow), vec![1, 2, 3]);
+		assert_eq!(Members::<Test>::get(MemberRole::Fellow), vec![1, 2, 3]);
 		assert_ok!(Alliance::give_retirement_notice(RuntimeOrigin::signed(3)));
-		assert_eq!(Alliance::members(MemberRole::Fellow), vec![1, 2]);
-		assert_eq!(Alliance::members(MemberRole::Retiring), vec![3]);
+		assert_eq!(Members::<Test>::get(MemberRole::Fellow), vec![1, 2]);
+		assert_eq!(Members::<Test>::get(MemberRole::Retiring), vec![3]);
 		System::assert_last_event(mock::RuntimeEvent::Alliance(
 			crate::Event::MemberRetirementPeriodStarted { member: (3) },
 		));
@@ -519,7 +519,7 @@ fn retire_works() {
 			Error::<Test, ()>::RetirementNoticeNotGiven
 		);
 
-		assert_eq!(Alliance::members(MemberRole::Fellow), vec![1, 2, 3]);
+		assert_eq!(Members::<Test>::get(MemberRole::Fellow), vec![1, 2, 3]);
 		assert_ok!(Alliance::give_retirement_notice(RuntimeOrigin::signed(3)));
 		assert_noop!(
 			Alliance::retire(RuntimeOrigin::signed(3)),
@@ -527,7 +527,7 @@ fn retire_works() {
 		);
 		System::set_block_number(System::block_number() + RetirementPeriod::get());
 		assert_ok!(Alliance::retire(RuntimeOrigin::signed(3)));
-		assert_eq!(Alliance::members(MemberRole::Fellow), vec![1, 2]);
+		assert_eq!(Members::<Test>::get(MemberRole::Fellow), vec![1, 2]);
 		System::assert_last_event(mock::RuntimeEvent::Alliance(crate::Event::MemberRetired {
 			member: (3),
 			unreserved: None,
@@ -543,7 +543,7 @@ fn retire_works() {
 #[test]
 fn abdicate_works() {
 	new_test_ext().execute_with(|| {
-		assert_eq!(Alliance::members(MemberRole::Fellow), vec![1, 2, 3]);
+		assert_eq!(Members::<Test>::get(MemberRole::Fellow), vec![1, 2, 3]);
 		assert_ok!(Alliance::abdicate_fellow_status(RuntimeOrigin::signed(3)));
 
 		System::assert_last_event(mock::RuntimeEvent::Alliance(crate::Event::FellowAbdicated {
@@ -565,9 +565,9 @@ fn kick_member_works() {
 		);
 
 		<DepositOf<Test, ()>>::insert(2, 25);
-		assert_eq!(Alliance::members(MemberRole::Fellow), vec![1, 2, 3]);
+		assert_eq!(Members::<Test>::get(MemberRole::Fellow), vec![1, 2, 3]);
 		assert_ok!(Alliance::kick_member(RuntimeOrigin::signed(2), 2));
-		assert_eq!(Alliance::members(MemberRole::Fellow), vec![1, 3]);
+		assert_eq!(Members::<Test>::get(MemberRole::Fellow), vec![1, 3]);
 		assert_eq!(<DepositOf<Test, ()>>::get(2), None);
 		System::assert_last_event(mock::RuntimeEvent::Alliance(crate::Event::MemberKicked {
 			member: (2),
@@ -588,8 +588,11 @@ fn add_unscrupulous_items_works() {
 				UnscrupulousItem::Website("abc".as_bytes().to_vec().try_into().unwrap())
 			]
 		));
-		assert_eq!(Alliance::unscrupulous_accounts().into_inner(), vec![3]);
-		assert_eq!(Alliance::unscrupulous_websites().into_inner(), vec!["abc".as_bytes().to_vec()]);
+		assert_eq!(UnscrupulousAccounts::<Test>::get().into_inner(), vec![3]);
+		assert_eq!(
+			UnscrupulousWebsites::<Test>::get().into_inner(),
+			vec!["abc".as_bytes().to_vec()]
+		);
 
 		assert_noop!(
 			Alliance::add_unscrupulous_items(
@@ -621,11 +624,11 @@ fn remove_unscrupulous_items_works() {
 			RuntimeOrigin::signed(3),
 			vec![UnscrupulousItem::AccountId(3)]
 		));
-		assert_eq!(Alliance::unscrupulous_accounts(), vec![3]);
+		assert_eq!(UnscrupulousAccounts::<Test>::get(), vec![3]);
 		assert_ok!(Alliance::remove_unscrupulous_items(
 			RuntimeOrigin::signed(3),
 			vec![UnscrupulousItem::AccountId(3)]
 		));
-		assert_eq!(Alliance::unscrupulous_accounts(), Vec::<u64>::new());
+		assert_eq!(UnscrupulousAccounts::<Test>::get(), Vec::<u64>::new());
 	});
 }

--- a/frame/aura/src/tests.rs
+++ b/frame/aura/src/tests.rs
@@ -19,7 +19,10 @@
 
 #![cfg(test)]
 
-use crate::mock::{new_test_ext, Aura, MockDisabledValidators, System};
+use crate::{
+	mock::{new_test_ext, Aura, MockDisabledValidators, System, Test},
+	Authorities, CurrentSlot,
+};
 use codec::Encode;
 use frame_support::traits::OnInitialize;
 use sp_consensus_aura::{Slot, AURA_ENGINE_ID};
@@ -28,8 +31,8 @@ use sp_runtime::{Digest, DigestItem};
 #[test]
 fn initial_values() {
 	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
-		assert_eq!(Aura::current_slot(), 0u64);
-		assert_eq!(Aura::authorities().len(), 4);
+		assert_eq!(CurrentSlot::<Test>::get(), 0u64);
+		assert_eq!(Authorities::<Test>::get().len(), 4);
 	});
 }
 

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -259,7 +259,7 @@ pub fn go_to_block(n: u64, s: u64) {
 
 /// Slots will grow accordingly to blocks
 pub fn progress_to_block(n: u64) {
-	let mut slot = u64::from(Babe::current_slot()) + 1;
+	let mut slot = u64::from(CurrentSlot::<Test>::get()) + 1;
 	for i in System::block_number() + 1..=n {
 		go_to_block(i, slot);
 		slot += 1;
@@ -268,15 +268,15 @@ pub fn progress_to_block(n: u64) {
 
 /// Progress to the first block at the given session
 pub fn start_session(session_index: SessionIndex) {
-	let missing = (session_index - Session::current_index()) * 3;
+	let missing = (session_index - pallet_session::CurrentIndex::<Test>::get()) * 3;
 	progress_to_block(System::block_number() + missing as u64 + 1);
-	assert_eq!(Session::current_index(), session_index);
+	assert_eq!(pallet_session::CurrentIndex::<Test>::get(), session_index);
 }
 
 /// Progress to the first block at the given era
 pub fn start_era(era_index: EraIndex) {
 	start_session((era_index * 3).into());
-	assert_eq!(Staking::current_era(), Some(era_index));
+	assert_eq!(pallet_staking::CurrentEra::<Test>::get(), Some(era_index));
 }
 
 pub fn make_primary_pre_digest(
@@ -318,7 +318,8 @@ pub fn make_vrf_output(
 	slot: Slot,
 	pair: &sp_consensus_babe::AuthorityPair,
 ) -> (VrfSignature, Randomness) {
-	let transcript = sp_consensus_babe::make_transcript(&Babe::randomness(), slot, 0);
+	let transcript =
+		sp_consensus_babe::make_transcript(&pallet_babe::Randomness::<Test>::get(), slot, 0);
 
 	let signature = pair.as_ref().vrf_sign(&transcript);
 

--- a/frame/babe/src/tests.rs
+++ b/frame/babe/src/tests.rs
@@ -43,7 +43,7 @@ fn empty_randomness_is_correct() {
 
 #[test]
 fn initial_values() {
-	new_test_ext(4).execute_with(|| assert_eq!(Babe::authorities().len(), 4))
+	new_test_ext(4).execute_with(|| assert_eq!(Authorities::<Test>::get().len(), 4))
 }
 
 #[test]
@@ -67,25 +67,25 @@ fn first_block_epoch_zero_start() {
 
 		let pre_digest = make_primary_pre_digest(0, genesis_slot, vrf_signature);
 
-		assert_eq!(Babe::genesis_slot(), Slot::from(0));
+		assert_eq!(GenesisSlot::<Test>::get(), Slot::from(0));
 		System::reset_events();
 		System::initialize(&1, &Default::default(), &pre_digest);
 
 		// see implementation of the function for details why: we issue an
 		// epoch-change digest but don't do it via the normal session mechanism.
 		assert!(!Babe::should_end_session(1));
-		assert_eq!(Babe::genesis_slot(), genesis_slot);
-		assert_eq!(Babe::current_slot(), genesis_slot);
-		assert_eq!(Babe::epoch_index(), 0);
+		assert_eq!(GenesisSlot::<Test>::get(), genesis_slot);
+		assert_eq!(CurrentSlot::<Test>::get(), genesis_slot);
+		assert_eq!(EpochIndex::<Test>::get(), 0);
 
 		Babe::on_finalize(1);
 		let header = System::finalize();
 
-		assert_eq!(Babe::author_vrf_randomness(), Some(vrf_randomness));
+		assert_eq!(AuthorVrfRandomness::<Test>::get(), Some(vrf_randomness));
 		assert_eq!(SegmentIndex::<Test>::get(), 0);
 		assert_eq!(UnderConstruction::<Test>::get(0), vec![vrf_randomness]);
-		assert_eq!(Babe::randomness(), [0; 32]);
-		assert_eq!(Babe::author_vrf_randomness(), Some(vrf_randomness));
+		assert_eq!(Randomness::<Test>::get(), [0; 32]);
+		assert_eq!(AuthorVrfRandomness::<Test>::get(), Some(vrf_randomness));
 		assert_eq!(NextRandomness::<Test>::get(), [0; 32]);
 
 		assert_eq!(header.digest.logs.len(), 2);
@@ -94,8 +94,8 @@ fn first_block_epoch_zero_start() {
 
 		let consensus_log = sp_consensus_babe::ConsensusLog::NextEpochData(
 			sp_consensus_babe::digests::NextEpochDescriptor {
-				authorities: Babe::authorities().to_vec(),
-				randomness: Babe::randomness(),
+				authorities: Authorities::<Test>::get().to_vec(),
+				randomness: Randomness::<Test>::get(),
 			},
 		);
 		let consensus_digest = DigestItem::Consensus(BABE_ENGINE_ID, consensus_log.encode());
@@ -116,19 +116,19 @@ fn current_slot_is_processed_on_initialization() {
 
 		System::reset_events();
 		System::initialize(&1, &Default::default(), &pre_digest);
-		assert_eq!(Babe::current_slot(), Slot::from(0));
-		assert!(Babe::initialized().is_none());
+		assert_eq!(CurrentSlot::<Test>::get(), Slot::from(0));
+		assert!(Initialized::<Test>::get().is_none());
 
 		// current slot is updated on initialization
 		Babe::initialize(1);
-		assert_eq!(Babe::current_slot(), genesis_slot);
-		assert!(Babe::initialized().is_some());
+		assert_eq!(CurrentSlot::<Test>::get(), genesis_slot);
+		assert!(Initialized::<Test>::get().is_some());
 		// but author vrf randomness isn't
-		assert_eq!(Babe::author_vrf_randomness(), None);
+		assert_eq!(AuthorVrfRandomness::<Test>::get(), None);
 
 		// instead it is updated on block finalization
 		Babe::on_finalize(1);
-		assert_eq!(Babe::author_vrf_randomness(), Some(vrf_randomness));
+		assert_eq!(AuthorVrfRandomness::<Test>::get(), Some(vrf_randomness));
 	})
 }
 
@@ -148,16 +148,16 @@ where
 
 		// author vrf randomness is not updated on initialization
 		Babe::initialize(1);
-		assert_eq!(Babe::author_vrf_randomness(), None);
+		assert_eq!(AuthorVrfRandomness::<Test>::get(), None);
 
 		// instead it is updated on block finalization to account for any
 		// epoch changes that might happen during the block
 		Babe::on_finalize(1);
-		assert_eq!(Babe::author_vrf_randomness(), Some(vrf_randomness));
+		assert_eq!(AuthorVrfRandomness::<Test>::get(), Some(vrf_randomness));
 
 		// and it is kept after finalizing the block
 		System::finalize();
-		assert_eq!(Babe::author_vrf_randomness(), Some(vrf_randomness));
+		assert_eq!(AuthorVrfRandomness::<Test>::get(), Some(vrf_randomness));
 	})
 }
 
@@ -179,14 +179,14 @@ fn no_author_vrf_output_for_secondary_plain() {
 
 		System::reset_events();
 		System::initialize(&1, &Default::default(), &secondary_plain_pre_digest);
-		assert_eq!(Babe::author_vrf_randomness(), None);
+		assert_eq!(AuthorVrfRandomness::<Test>::get(), None);
 
 		Babe::initialize(1);
-		assert_eq!(Babe::author_vrf_randomness(), None);
+		assert_eq!(AuthorVrfRandomness::<Test>::get(), None);
 
 		Babe::on_finalize(1);
 		System::finalize();
-		assert_eq!(Babe::author_vrf_randomness(), None);
+		assert_eq!(AuthorVrfRandomness::<Test>::get(), None);
 	})
 }
 
@@ -207,14 +207,14 @@ fn can_predict_next_epoch_change() {
 		assert_eq!(<Test as Config>::EpochDuration::get(), 3);
 		// this sets the genesis slot to 6;
 		go_to_block(1, 6);
-		assert_eq!(*Babe::genesis_slot(), 6);
-		assert_eq!(*Babe::current_slot(), 6);
-		assert_eq!(Babe::epoch_index(), 0);
+		assert_eq!(*GenesisSlot::<Test>::get(), 6);
+		assert_eq!(*CurrentSlot::<Test>::get(), 6);
+		assert_eq!(EpochIndex::<Test>::get(), 0);
 
 		progress_to_block(5);
 
-		assert_eq!(Babe::epoch_index(), 5 / 3);
-		assert_eq!(*Babe::current_slot(), 10);
+		assert_eq!(EpochIndex::<Test>::get(), 5 / 3);
+		assert_eq!(*CurrentSlot::<Test>::get(), 10);
 
 		// next epoch change will be at
 		assert_eq!(*Babe::current_epoch_start(), 9); // next change will be 12, 2 slots from now
@@ -263,9 +263,9 @@ fn can_enact_next_config() {
 		assert_eq!(<Test as Config>::EpochDuration::get(), 3);
 		// this sets the genesis slot to 6;
 		go_to_block(1, 6);
-		assert_eq!(*Babe::genesis_slot(), 6);
-		assert_eq!(*Babe::current_slot(), 6);
-		assert_eq!(Babe::epoch_index(), 0);
+		assert_eq!(*GenesisSlot::<Test>::get(), 6);
+		assert_eq!(*CurrentSlot::<Test>::get(), 6);
+		assert_eq!(EpochIndex::<Test>::get(), 0);
 		go_to_block(2, 7);
 
 		let current_config = BabeEpochConfiguration {
@@ -411,7 +411,7 @@ fn disabled_validators_cannot_author_blocks() {
 		// so we should still be able to author blocks
 		start_era(2);
 
-		assert_eq!(Staking::current_era().unwrap(), 2);
+		assert_eq!(pallet_staking::CurrentEra::<Test>::get().unwrap(), 2);
 
 		// let's disable the validator at index 0
 		Session::disable_index(0);
@@ -428,8 +428,8 @@ fn report_equivocation_current_session_works() {
 	ext.execute_with(|| {
 		start_era(1);
 
-		let authorities = Babe::authorities();
-		let validators = Session::validators();
+		let authorities = Authorities::<Test>::get();
+		let validators = pallet_session::Validators::<Test>::get();
 
 		// make sure that all authorities have the same balance
 		for validator in &validators {
@@ -437,14 +437,15 @@ fn report_equivocation_current_session_works() {
 			assert_eq!(Staking::slashable_balance_of(validator), 10_000);
 
 			assert_eq!(
-				Staking::eras_stakers(1, validator),
+				pallet_staking::ErasStakers::<Test>::get(1, validator),
 				pallet_staking::Exposure { total: 10_000, own: 10_000, others: vec![] },
 			);
 		}
 
 		// we will use the validator at index 1 as the offending authority
 		let offending_validator_index = 1;
-		let offending_validator_id = Session::validators()[offending_validator_index];
+		let offending_validator_id =
+			pallet_session::Validators::<Test>::get()[offending_validator_index];
 		let offending_authority_pair = pairs
 			.into_iter()
 			.find(|p| p.public() == authorities[offending_validator_index].0)
@@ -478,7 +479,7 @@ fn report_equivocation_current_session_works() {
 		assert_eq!(Balances::total_balance(&offending_validator_id), 10_000_000 - 10_000);
 		assert_eq!(Staking::slashable_balance_of(&offending_validator_id), 0);
 		assert_eq!(
-			Staking::eras_stakers(2, offending_validator_id),
+			pallet_staking::ErasStakers::<Test>::get(2, offending_validator_id),
 			pallet_staking::Exposure { total: 0, own: 0, others: vec![] },
 		);
 
@@ -491,7 +492,7 @@ fn report_equivocation_current_session_works() {
 			assert_eq!(Balances::total_balance(validator), 10_000_000);
 			assert_eq!(Staking::slashable_balance_of(validator), 10_000);
 			assert_eq!(
-				Staking::eras_stakers(2, validator),
+				pallet_staking::ErasStakers::<Test>::get(2, validator),
 				pallet_staking::Exposure { total: 10_000, own: 10_000, others: vec![] },
 			);
 		}
@@ -505,11 +506,12 @@ fn report_equivocation_old_session_works() {
 	ext.execute_with(|| {
 		start_era(1);
 
-		let authorities = Babe::authorities();
+		let authorities = Authorities::<Test>::get();
 
 		// we will use the validator at index 0 as the offending authority
 		let offending_validator_index = 1;
-		let offending_validator_id = Session::validators()[offending_validator_index];
+		let offending_validator_id =
+			pallet_session::Validators::<Test>::get()[offending_validator_index];
 		let offending_authority_pair = pairs
 			.into_iter()
 			.find(|p| p.public() == authorities[offending_validator_index].0)
@@ -550,7 +552,7 @@ fn report_equivocation_old_session_works() {
 		assert_eq!(Balances::total_balance(&offending_validator_id), 10_000_000 - 10_000);
 		assert_eq!(Staking::slashable_balance_of(&offending_validator_id), 0);
 		assert_eq!(
-			Staking::eras_stakers(3, offending_validator_id),
+			pallet_staking::ErasStakers::<Test>::get(3, offending_validator_id),
 			pallet_staking::Exposure { total: 0, own: 0, others: vec![] },
 		);
 	})
@@ -563,7 +565,7 @@ fn report_equivocation_invalid_key_owner_proof() {
 	ext.execute_with(|| {
 		start_era(1);
 
-		let authorities = Babe::authorities();
+		let authorities = Authorities::<Test>::get();
 
 		// we will use the validator at index 0 as the offending authority
 		let offending_validator_index = 0;
@@ -626,7 +628,7 @@ fn report_equivocation_invalid_equivocation_proof() {
 	ext.execute_with(|| {
 		start_era(1);
 
-		let authorities = Babe::authorities();
+		let authorities = Authorities::<Test>::get();
 
 		// we will use the validator at index 0 as the offending authority
 		let offending_validator_index = 0;
@@ -731,7 +733,7 @@ fn report_equivocation_validate_unsigned_prevents_duplicates() {
 	ext.execute_with(|| {
 		start_era(1);
 
-		let authorities = Babe::authorities();
+		let authorities = Authorities::<Test>::get();
 
 		// generate and report an equivocation for the validator at index 0
 		let offending_validator_index = 0;
@@ -845,7 +847,7 @@ fn report_equivocation_after_skipped_epochs_works() {
 		assert_eq!(SkippedEpochs::<Test>::get(), vec![(10, 1)]);
 
 		// generate an equivocation proof for validator at index 1
-		let authorities = Babe::authorities();
+		let authorities = Authorities::<Test>::get();
 		let offending_validator_index = 1;
 		let offending_authority_pair = pairs
 			.into_iter()

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -365,7 +365,6 @@ pub mod pallet {
 
 	/// The total units issued in the system.
 	#[pallet::storage]
-	#[pallet::getter(fn total_issuance)]
 	#[pallet::whitelist_storage]
 	pub type TotalIssuance<T: Config<I>, I: 'static = ()> = StorageValue<_, T::Balance, ValueQuery>;
 

--- a/frame/beefy-mmr/src/lib.rs
+++ b/frame/beefy-mmr/src/lib.rs
@@ -150,7 +150,7 @@ impl<T: Config> LeafDataProvider for Pallet<T> {
 			version: T::LeafVersion::get(),
 			parent_number_and_hash: ParentNumberAndHash::<T>::leaf_data(),
 			leaf_extra: T::BeefyDataProvider::extra_data(),
-			beefy_next_authority_set: Pallet::<T>::beefy_next_authorities(),
+			beefy_next_authority_set: BeefyNextAuthorities::<T>::get(),
 		}
 	}
 }
@@ -175,12 +175,12 @@ where
 impl<T: Config> Pallet<T> {
 	/// Return the currently active BEEFY authority set proof.
 	pub fn authority_set_proof() -> BeefyAuthoritySet<MerkleRootOf<T>> {
-		Pallet::<T>::beefy_authorities()
+		BeefyAuthorities::<T>::get()
 	}
 
 	/// Return the next/queued BEEFY authority set proof.
 	pub fn next_authority_set_proof() -> BeefyNextAuthoritySet<MerkleRootOf<T>> {
-		Pallet::<T>::beefy_next_authorities()
+		BeefyNextAuthorities::<T>::get()
 	}
 
 	/// Returns details of a BEEFY authority set.

--- a/frame/beefy/src/lib.rs
+++ b/frame/beefy/src/lib.rs
@@ -275,8 +275,8 @@ pub mod pallet {
 impl<T: Config> Pallet<T> {
 	/// Return the current active BEEFY validator set.
 	pub fn validator_set() -> Option<ValidatorSet<T::BeefyId>> {
-		let validators: BoundedVec<T::BeefyId, T::MaxAuthorities> = Self::authorities();
-		let id: sp_consensus_beefy::ValidatorSetId = Self::validator_set_id();
+		let validators: BoundedVec<T::BeefyId, T::MaxAuthorities> = Authorities::<T>::get();
+		let id: sp_consensus_beefy::ValidatorSetId = ValidatorSetId::<T>::get();
 		ValidatorSet::<T::BeefyId>::new(validators, id)
 	}
 
@@ -300,7 +300,7 @@ impl<T: Config> Pallet<T> {
 	) {
 		<Authorities<T>>::put(&new);
 
-		let new_id = Self::validator_set_id() + 1u64;
+		let new_id = ValidatorSetId::<T>::get() + 1u64;
 		<ValidatorSetId<T>>::put(new_id);
 
 		<NextAuthorities<T>>::put(&queued);
@@ -414,9 +414,9 @@ where
 		// We want to have at least one BEEFY mandatory block per session.
 		Self::change_authorities(bounded_next_authorities, bounded_next_queued_authorities);
 
-		let validator_set_id = Self::validator_set_id();
+		let validator_set_id = ValidatorSetId::<T>::get();
 		// Update the mapping for the new set id that corresponds to the latest session (i.e. now).
-		let session_index = <pallet_session::Pallet<T>>::current_index();
+		let session_index = <pallet_session::CurrentIndex<T>>::get();
 		SetIdSession::<T>::insert(validator_set_id, &session_index);
 		// Prune old entry if limit reached.
 		let max_set_id_session_entries = T::MaxSetIdSessionEntries::get().max(1);
@@ -437,7 +437,7 @@ where
 
 impl<T: Config> IsMember<T::BeefyId> for Pallet<T> {
 	fn is_member(authority_id: &T::BeefyId) -> bool {
-		Self::authorities().iter().any(|id| id == authority_id)
+		Authorities::<T>::get().iter().any(|id| id == authority_id)
 	}
 }
 

--- a/frame/beefy/src/mock.rs
+++ b/frame/beefy/src/mock.rs
@@ -306,7 +306,7 @@ pub fn new_test_ext_raw_authorities(authorities: Vec<BeefyId>) -> TestExternalit
 }
 
 pub fn start_session(session_index: SessionIndex) {
-	for i in Session::current_index()..session_index {
+	for i in pallet_session::CurrentIndex::<Test>::get()..session_index {
 		System::on_finalize(System::block_number());
 		Session::on_finalize(System::block_number());
 		Staking::on_finalize(System::block_number());
@@ -330,10 +330,10 @@ pub fn start_session(session_index: SessionIndex) {
 		Beefy::on_initialize(System::block_number());
 	}
 
-	assert_eq!(Session::current_index(), session_index);
+	assert_eq!(pallet_session::CurrentIndex::<Test>::get(), session_index);
 }
 
 pub fn start_era(era_index: EraIndex) {
 	start_session((era_index * 3).into());
-	assert_eq!(Staking::current_era(), Some(era_index));
+	assert_eq!(pallet_staking::CurrentEra::<Test>::get(), Some(era_index));
 }

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -45,7 +45,6 @@ mod pallet_test {
 	}
 
 	#[pallet::storage]
-	#[pallet::getter(fn value)]
 	pub(crate) type Value<T: Config> = StorageValue<_, u32, OptionQuery>;
 
 	#[pallet::call]

--- a/frame/benchmarking/src/tests_instance.rs
+++ b/frame/benchmarking/src/tests_instance.rs
@@ -49,7 +49,6 @@ mod pallet_test {
 	}
 
 	#[pallet::storage]
-	#[pallet::getter(fn value)]
 	pub(crate) type Value<T: Config<I>, I: 'static = ()> = StorageValue<_, u32, OptionQuery>;
 
 	#[pallet::event]

--- a/frame/bounties/src/lib.rs
+++ b/frame/bounties/src/lib.rs
@@ -828,7 +828,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			description.try_into().map_err(|_| Error::<T, I>::ReasonTooBig)?;
 		ensure!(value >= T::BountyValueMinimum::get(), Error::<T, I>::InvalidValue);
 
-		let index = Self::bounty_count();
+		let index = BountyCount::<T, I>::get();
 
 		// reserve deposit for new bounty
 		let bond = T::BountyDepositBase::get() +

--- a/frame/bounties/src/tests.rs
+++ b/frame/bounties/src/tests.rs
@@ -20,7 +20,7 @@
 #![cfg(test)]
 
 use super::*;
-use crate as pallet_bounties;
+use crate::{self as pallet_bounties, Bounties as BountiesStorage};
 
 use frame_support::{
 	assert_noop, assert_ok,
@@ -459,7 +459,7 @@ fn propose_bounty_works() {
 		assert_eq!(Balances::free_balance(0), 100 - deposit);
 
 		assert_eq!(
-			Bounties::bounties(0).unwrap(),
+			BountiesStorage::<Test>::get(0).unwrap(),
 			Bounty {
 				proposer: 0,
 				fee: 0,
@@ -470,9 +470,9 @@ fn propose_bounty_works() {
 			}
 		);
 
-		assert_eq!(Bounties::bounty_descriptions(0).unwrap(), b"1234567890".to_vec());
+		assert_eq!(BountyDescriptions::<Test>::get(0).unwrap(), b"1234567890".to_vec());
 
-		assert_eq!(Bounties::bounty_count(), 1);
+		assert_eq!(BountyCount::<Test>::get(), 1);
 	});
 }
 
@@ -523,10 +523,10 @@ fn close_bounty_works() {
 		assert_eq!(Balances::reserved_balance(0), 0);
 		assert_eq!(Balances::free_balance(0), 100 - deposit);
 
-		assert_eq!(Bounties::bounties(0), None);
+		assert_eq!(BountiesStorage::<Test>::get(0), None);
 		assert!(!pallet_treasury::Proposals::<Test>::contains_key(0));
 
-		assert_eq!(Bounties::bounty_descriptions(0), None);
+		assert_eq!(BountyDescriptions::<Test>::get(0), None);
 	});
 }
 
@@ -547,7 +547,7 @@ fn approve_bounty_works() {
 		let deposit: u64 = 80 + 5;
 
 		assert_eq!(
-			Bounties::bounties(0).unwrap(),
+			BountiesStorage::<Test>::get(0).unwrap(),
 			Bounty {
 				proposer: 0,
 				fee: 0,
@@ -557,7 +557,7 @@ fn approve_bounty_works() {
 				status: BountyStatus::Approved,
 			}
 		);
-		assert_eq!(Bounties::bounty_approvals(), vec![0]);
+		assert_eq!(BountyApprovals::<Test>::get(), vec![0]);
 
 		assert_noop!(
 			Bounties::close_bounty(RuntimeOrigin::root(), 0),
@@ -575,7 +575,7 @@ fn approve_bounty_works() {
 		assert_eq!(Balances::free_balance(0), 100);
 
 		assert_eq!(
-			Bounties::bounties(0).unwrap(),
+			BountiesStorage::<Test>::get(0).unwrap(),
 			Bounty {
 				proposer: 0,
 				fee: 0,
@@ -618,7 +618,7 @@ fn assign_curator_works() {
 		assert_ok!(Bounties::propose_curator(RuntimeOrigin::root(), 0, 4, fee));
 
 		assert_eq!(
-			Bounties::bounties(0).unwrap(),
+			BountiesStorage::<Test>::get(0).unwrap(),
 			Bounty {
 				proposer: 0,
 				fee,
@@ -645,7 +645,7 @@ fn assign_curator_works() {
 		let expected_deposit = Bounties::calculate_curator_deposit(&fee);
 
 		assert_eq!(
-			Bounties::bounties(0).unwrap(),
+			BountiesStorage::<Test>::get(0).unwrap(),
 			Bounty {
 				proposer: 0,
 				fee,
@@ -680,7 +680,7 @@ fn unassign_curator_works() {
 		assert_ok!(Bounties::unassign_curator(RuntimeOrigin::signed(4), 0));
 
 		assert_eq!(
-			Bounties::bounties(0).unwrap(),
+			BountiesStorage::<Test>::get(0).unwrap(),
 			Bounty {
 				proposer: 0,
 				fee,
@@ -698,7 +698,7 @@ fn unassign_curator_works() {
 		assert_ok!(Bounties::unassign_curator(RuntimeOrigin::root(), 0));
 
 		assert_eq!(
-			Bounties::bounties(0).unwrap(),
+			BountiesStorage::<Test>::get(0).unwrap(),
 			Bounty {
 				proposer: 0,
 				fee,
@@ -742,7 +742,7 @@ fn award_and_claim_bounty_works() {
 		assert_ok!(Bounties::award_bounty(RuntimeOrigin::signed(4), 0, 3));
 
 		assert_eq!(
-			Bounties::bounties(0).unwrap(),
+			BountiesStorage::<Test>::get(0).unwrap(),
 			Bounty {
 				proposer: 0,
 				fee,
@@ -776,8 +776,8 @@ fn award_and_claim_bounty_works() {
 		assert_eq!(Balances::free_balance(3), 56);
 		assert_eq!(Balances::free_balance(Bounties::bounty_account_id(0)), 0);
 
-		assert_eq!(Bounties::bounties(0), None);
-		assert_eq!(Bounties::bounty_descriptions(0), None);
+		assert_eq!(BountiesStorage::<Test>::get(0), None);
+		assert_eq!(BountyDescriptions::<Test>::get(0), None);
 	});
 }
 
@@ -817,8 +817,8 @@ fn claim_handles_high_fee() {
 		assert_eq!(Balances::free_balance(3), 0);
 		assert_eq!(Balances::free_balance(Bounties::bounty_account_id(0)), 0);
 
-		assert_eq!(Bounties::bounties(0), None);
-		assert_eq!(Bounties::bounty_descriptions(0), None);
+		assert_eq!(BountiesStorage::<Test>::get(0), None);
+		assert_eq!(BountyDescriptions::<Test>::get(0), None);
 	});
 }
 
@@ -843,7 +843,7 @@ fn cancel_and_refund() {
 		));
 
 		assert_eq!(
-			Bounties::bounties(0).unwrap(),
+			BountiesStorage::<Test>::get(0).unwrap(),
 			Bounty {
 				proposer: 0,
 				fee: 0,
@@ -903,8 +903,8 @@ fn award_and_cancel() {
 		assert_eq!(Balances::free_balance(0), 95);
 		assert_eq!(Balances::reserved_balance(0), 0);
 
-		assert_eq!(Bounties::bounties(0), None);
-		assert_eq!(Bounties::bounty_descriptions(0), None);
+		assert_eq!(BountiesStorage::<Test>::get(0), None);
+		assert_eq!(BountyDescriptions::<Test>::get(0), None);
 	});
 }
 
@@ -940,7 +940,7 @@ fn expire_and_unassign() {
 		assert_ok!(Bounties::unassign_curator(RuntimeOrigin::signed(0), 0));
 
 		assert_eq!(
-			Bounties::bounties(0).unwrap(),
+			BountiesStorage::<Test>::get(0).unwrap(),
 			Bounty {
 				proposer: 0,
 				fee: 10,
@@ -990,7 +990,7 @@ fn extend_expiry() {
 		assert_ok!(Bounties::extend_bounty_expiry(RuntimeOrigin::signed(4), 0, Vec::new()));
 
 		assert_eq!(
-			Bounties::bounties(0).unwrap(),
+			BountiesStorage::<Test>::get(0).unwrap(),
 			Bounty {
 				proposer: 0,
 				fee: 10,
@@ -1004,7 +1004,7 @@ fn extend_expiry() {
 		assert_ok!(Bounties::extend_bounty_expiry(RuntimeOrigin::signed(4), 0, Vec::new()));
 
 		assert_eq!(
-			Bounties::bounties(0).unwrap(),
+			BountiesStorage::<Test>::get(0).unwrap(),
 			Bounty {
 				proposer: 0,
 				fee: 10,
@@ -1113,7 +1113,7 @@ fn unassign_curator_self() {
 		assert_ok!(Bounties::unassign_curator(RuntimeOrigin::signed(1), 0));
 
 		assert_eq!(
-			Bounties::bounties(0).unwrap(),
+			BountiesStorage::<Test>::get(0).unwrap(),
 			Bounty {
 				proposer: 0,
 				fee: 10,

--- a/frame/child-bounties/src/benchmarking.rs
+++ b/frame/child-bounties/src/benchmarking.rs
@@ -109,7 +109,7 @@ fn activate_bounty<T: Config>(
 		child_bounty_setup.reason.clone(),
 	)?;
 
-	child_bounty_setup.bounty_id = Bounties::<T>::bounty_count() - 1;
+	child_bounty_setup.bounty_id = <pallet_bounties::BountyCount<T>>::get() - 1;
 
 	let approve_origin =
 		T::SpendOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;

--- a/frame/child-bounties/src/tests.rs
+++ b/frame/child-bounties/src/tests.rs
@@ -21,6 +21,7 @@
 
 use super::*;
 use crate as pallet_child_bounties;
+use crate::ChildBounties as ChildBountiesStorage;
 
 use frame_support::{
 	assert_noop, assert_ok,
@@ -277,7 +278,7 @@ fn add_child_bounty() {
 		// DB check.
 		// Check the child-bounty status.
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -288,10 +289,10 @@ fn add_child_bounty() {
 		);
 
 		// Check the child-bounty count.
-		assert_eq!(ChildBounties::parent_child_bounties(0), 1);
+		assert_eq!(ParentChildBounties::<Test>::get(0), 1);
 
 		// Check the child-bounty description status.
-		assert_eq!(ChildBounties::child_bounty_descriptions(0).unwrap(), b"12345-p1".to_vec(),);
+		assert_eq!(ChildBountyDescriptions::<Test>::get(0).unwrap(), b"12345-p1".to_vec(),);
 	});
 }
 
@@ -353,7 +354,7 @@ fn child_bounty_assign_curator() {
 		assert_ok!(ChildBounties::propose_curator(RuntimeOrigin::signed(4), 0, 0, 8, fee));
 
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -377,7 +378,7 @@ fn child_bounty_assign_curator() {
 		let expected_child_deposit = CuratorDepositMultiplier::get() * fee;
 
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -454,7 +455,7 @@ fn award_claim_child_bounty() {
 
 		let expected_deposit = CuratorDepositMultiplier::get() * fee;
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -492,7 +493,7 @@ fn award_claim_child_bounty() {
 		assert_eq!(Balances::reserved_balance(ChildBounties::child_bounty_account_id(0)), 0);
 
 		// Check the child-bounty count.
-		assert_eq!(ChildBounties::parent_child_bounties(0), 0);
+		assert_eq!(ParentChildBounties::<Test>::get(0), 0);
 	});
 }
 
@@ -541,7 +542,7 @@ fn close_child_bounty_added() {
 		assert_ok!(ChildBounties::close_child_bounty(RuntimeOrigin::signed(4), 0, 0));
 
 		// Check the child-bounty count.
-		assert_eq!(ChildBounties::parent_child_bounties(0), 0);
+		assert_eq!(ParentChildBounties::<Test>::get(0), 0);
 
 		// Parent-bounty account status.
 		assert_eq!(Balances::free_balance(Bounties::bounty_account_id(0)), 50);
@@ -595,7 +596,7 @@ fn close_child_bounty_active() {
 		assert_ok!(ChildBounties::close_child_bounty(RuntimeOrigin::signed(4), 0, 0));
 
 		// Check the child-bounty count.
-		assert_eq!(ChildBounties::parent_child_bounties(0), 0);
+		assert_eq!(ParentChildBounties::<Test>::get(0), 0);
 
 		// Ensure child-bounty curator balance is unreserved.
 		assert_eq!(Balances::free_balance(8), 101);
@@ -660,7 +661,7 @@ fn close_child_bounty_pending() {
 		);
 
 		// Check the child-bounty count.
-		assert_eq!(ChildBounties::parent_child_bounties(0), 1);
+		assert_eq!(ParentChildBounties::<Test>::get(0), 1);
 
 		// Ensure no changes in child-bounty curator balance.
 		assert_eq!(Balances::reserved_balance(8), expected_child_deposit);
@@ -752,7 +753,7 @@ fn child_bounty_curator_proposed_unassign_curator() {
 		assert_ok!(ChildBounties::propose_curator(RuntimeOrigin::signed(4), 0, 0, 8, 2));
 
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -770,7 +771,7 @@ fn child_bounty_curator_proposed_unassign_curator() {
 
 		// Verify updated child-bounty status.
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -833,7 +834,7 @@ fn child_bounty_active_unassign_curator() {
 		let expected_child_deposit = CuratorDepositMultiplier::get() * fee;
 
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -851,7 +852,7 @@ fn child_bounty_active_unassign_curator() {
 
 		// Verify updated child-bounty status.
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -872,7 +873,7 @@ fn child_bounty_active_unassign_curator() {
 		let expected_child_deposit = CuratorDepositMin::get();
 
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -890,7 +891,7 @@ fn child_bounty_active_unassign_curator() {
 
 		// Verify updated child-bounty status.
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -909,7 +910,7 @@ fn child_bounty_active_unassign_curator() {
 		assert_ok!(ChildBounties::accept_curator(RuntimeOrigin::signed(6), 0, 0));
 
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -927,7 +928,7 @@ fn child_bounty_active_unassign_curator() {
 
 		// Verify updated child-bounty status.
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -948,7 +949,7 @@ fn child_bounty_active_unassign_curator() {
 		let expected_child_deposit = CuratorDepositMin::get();
 
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -976,7 +977,7 @@ fn child_bounty_active_unassign_curator() {
 
 		// Verify updated child-bounty status.
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -1038,7 +1039,7 @@ fn parent_bounty_inactive_unassign_curator_child_bounty() {
 		let expected_child_deposit = CuratorDepositMultiplier::get() * fee;
 
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -1069,7 +1070,7 @@ fn parent_bounty_inactive_unassign_curator_child_bounty() {
 
 		// Verify updated child-bounty status.
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -1100,7 +1101,7 @@ fn parent_bounty_inactive_unassign_curator_child_bounty() {
 		let expected_deposit = CuratorDepositMin::get();
 
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -1129,7 +1130,7 @@ fn parent_bounty_inactive_unassign_curator_child_bounty() {
 
 		// Verify updated child-bounty status.
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -1199,7 +1200,7 @@ fn close_parent_with_child_bounty() {
 		assert_ok!(ChildBounties::close_child_bounty(RuntimeOrigin::root(), 0, 0));
 
 		// Check the child-bounty count.
-		assert_eq!(ChildBounties::parent_child_bounties(0), 0);
+		assert_eq!(ParentChildBounties::<Test>::get(0), 0);
 
 		// Try close parent-bounty again.
 		// Should pass this time.
@@ -1248,7 +1249,7 @@ fn children_curator_fee_calculation_test() {
 		// Propose curator for child-bounty.
 		assert_ok!(ChildBounties::propose_curator(RuntimeOrigin::signed(4), 0, 0, 8, fee));
 		// Check curator fee added to the sum.
-		assert_eq!(ChildBounties::children_curator_fees(0), fee);
+		assert_eq!(ChildrenCuratorFees::<Test>::get(0), fee);
 		// Accept curator for child-bounty.
 		assert_ok!(ChildBounties::accept_curator(RuntimeOrigin::signed(8), 0, 0));
 		// Award child-bounty.
@@ -1257,7 +1258,7 @@ fn children_curator_fee_calculation_test() {
 		let expected_child_deposit = CuratorDepositMultiplier::get() * fee;
 
 		assert_eq!(
-			ChildBounties::child_bounties(0, 0).unwrap(),
+			ChildBountiesStorage::<Test>::get(0, 0).unwrap(),
 			ChildBounty {
 				parent_bounty: 0,
 				value: 10,
@@ -1277,7 +1278,7 @@ fn children_curator_fee_calculation_test() {
 		assert_ok!(ChildBounties::claim_child_bounty(RuntimeOrigin::signed(7), 0, 0));
 
 		// Check the child-bounty count.
-		assert_eq!(ChildBounties::parent_child_bounties(0), 0);
+		assert_eq!(ParentChildBounties::<Test>::get(0), 0);
 
 		// Award the parent bounty.
 		assert_ok!(Bounties::award_bounty(RuntimeOrigin::signed(4), 0, 9));

--- a/frame/collective/src/tests.rs
+++ b/frame/collective/src/tests.rs
@@ -204,8 +204,8 @@ fn record(event: RuntimeEvent) -> EventRecord<RuntimeEvent, H256> {
 #[test]
 fn motions_basic_environment_works() {
 	ExtBuilder::default().build_and_execute(|| {
-		assert_eq!(Collective::members(), vec![1, 2, 3]);
-		assert_eq!(*Collective::proposals(), Vec::<H256>::new());
+		assert_eq!(Members::<Test, Instance1>::get(), vec![1, 2, 3]);
+		assert_eq!(*Proposals::<Test>::get(), Vec::<H256>::new());
 	});
 }
 
@@ -583,12 +583,12 @@ fn removal_of_old_voters_votes_works() {
 		assert_ok!(Collective::vote(RuntimeOrigin::signed(1), hash, 0, true));
 		assert_ok!(Collective::vote(RuntimeOrigin::signed(2), hash, 0, true));
 		assert_eq!(
-			Collective::voting(&hash),
+			Voting::<Test, Instance1>::get(&hash),
 			Some(Votes { index: 0, threshold: 3, ayes: vec![1, 2], nays: vec![], end })
 		);
 		Collective::change_members_sorted(&[4], &[1], &[2, 3, 4]);
 		assert_eq!(
-			Collective::voting(&hash),
+			Voting::<Test, Instance1>::get(&hash),
 			Some(Votes { index: 0, threshold: 3, ayes: vec![2], nays: vec![], end })
 		);
 
@@ -604,12 +604,12 @@ fn removal_of_old_voters_votes_works() {
 		assert_ok!(Collective::vote(RuntimeOrigin::signed(2), hash, 1, true));
 		assert_ok!(Collective::vote(RuntimeOrigin::signed(3), hash, 1, false));
 		assert_eq!(
-			Collective::voting(&hash),
+			Voting::<Test, Instance1>::get(&hash),
 			Some(Votes { index: 1, threshold: 2, ayes: vec![2], nays: vec![3], end })
 		);
 		Collective::change_members_sorted(&[], &[3], &[2, 4]);
 		assert_eq!(
-			Collective::voting(&hash),
+			Voting::<Test, Instance1>::get(&hash),
 			Some(Votes { index: 1, threshold: 2, ayes: vec![2], nays: vec![], end })
 		);
 	});
@@ -631,7 +631,7 @@ fn removal_of_old_voters_votes_works_with_set_members() {
 		assert_ok!(Collective::vote(RuntimeOrigin::signed(1), hash, 0, true));
 		assert_ok!(Collective::vote(RuntimeOrigin::signed(2), hash, 0, true));
 		assert_eq!(
-			Collective::voting(&hash),
+			Voting::<Test, Instance1>::get(&hash),
 			Some(Votes { index: 0, threshold: 3, ayes: vec![1, 2], nays: vec![], end })
 		);
 		assert_ok!(Collective::set_members(
@@ -641,7 +641,7 @@ fn removal_of_old_voters_votes_works_with_set_members() {
 			MaxMembers::get()
 		));
 		assert_eq!(
-			Collective::voting(&hash),
+			Voting::<Test, Instance1>::get(&hash),
 			Some(Votes { index: 0, threshold: 3, ayes: vec![2], nays: vec![], end })
 		);
 
@@ -657,7 +657,7 @@ fn removal_of_old_voters_votes_works_with_set_members() {
 		assert_ok!(Collective::vote(RuntimeOrigin::signed(2), hash, 1, true));
 		assert_ok!(Collective::vote(RuntimeOrigin::signed(3), hash, 1, false));
 		assert_eq!(
-			Collective::voting(&hash),
+			Voting::<Test, Instance1>::get(&hash),
 			Some(Votes { index: 1, threshold: 2, ayes: vec![2], nays: vec![3], end })
 		);
 		assert_ok!(Collective::set_members(
@@ -667,7 +667,7 @@ fn removal_of_old_voters_votes_works_with_set_members() {
 			MaxMembers::get()
 		));
 		assert_eq!(
-			Collective::voting(&hash),
+			Voting::<Test, Instance1>::get(&hash),
 			Some(Votes { index: 1, threshold: 2, ayes: vec![2], nays: vec![], end })
 		);
 	});
@@ -686,10 +686,10 @@ fn propose_works() {
 			Box::new(proposal.clone()),
 			proposal_len
 		));
-		assert_eq!(*Collective::proposals(), vec![hash]);
-		assert_eq!(Collective::proposal_of(&hash), Some(proposal));
+		assert_eq!(*Proposals::<Test, Instance1>::get(), vec![hash]);
+		assert_eq!(ProposalOf::<Test, Instance1>::get(&hash), Some(proposal));
 		assert_eq!(
-			Collective::voting(&hash),
+			Voting::<Test, Instance1>::get(&hash),
 			Some(Votes { index: 0, threshold: 3, ayes: vec![], nays: vec![], end })
 		);
 
@@ -849,13 +849,13 @@ fn motions_vote_after_works() {
 		));
 		// Initially there a no votes when the motion is proposed.
 		assert_eq!(
-			Collective::voting(&hash),
+			Voting::<Test, Instance1>::get(&hash),
 			Some(Votes { index: 0, threshold: 2, ayes: vec![], nays: vec![], end })
 		);
 		// Cast first aye vote.
 		assert_ok!(Collective::vote(RuntimeOrigin::signed(1), hash, 0, true));
 		assert_eq!(
-			Collective::voting(&hash),
+			Voting::<Test, Instance1>::get(&hash),
 			Some(Votes { index: 0, threshold: 2, ayes: vec![1], nays: vec![], end })
 		);
 		// Try to cast a duplicate aye vote.
@@ -866,7 +866,7 @@ fn motions_vote_after_works() {
 		// Cast a nay vote.
 		assert_ok!(Collective::vote(RuntimeOrigin::signed(1), hash, 0, false));
 		assert_eq!(
-			Collective::voting(&hash),
+			Voting::<Test, Instance1>::get(&hash),
 			Some(Votes { index: 0, threshold: 2, ayes: vec![], nays: vec![1], end })
 		);
 		// Try to cast a duplicate nay vote.
@@ -917,7 +917,7 @@ fn motions_all_first_vote_free_works() {
 			proposal_len,
 		));
 		assert_eq!(
-			Collective::voting(&hash),
+			Voting::<Test, Instance1>::get(&hash),
 			Some(Votes { index: 0, threshold: 2, ayes: vec![], nays: vec![], end })
 		);
 
@@ -982,14 +982,14 @@ fn motions_reproposing_disapproved_works() {
 			proposal_weight,
 			proposal_len
 		));
-		assert_eq!(*Collective::proposals(), vec![]);
+		assert_eq!(*Proposals::<Test, Instance1>::get(), vec![]);
 		assert_ok!(Collective::propose(
 			RuntimeOrigin::signed(1),
 			2,
 			Box::new(proposal.clone()),
 			proposal_len
 		));
-		assert_eq!(*Collective::proposals(), vec![hash]);
+		assert_eq!(*Proposals::<Test, Instance1>::get(), vec![hash]);
 	});
 }
 

--- a/frame/democracy/src/tests.rs
+++ b/frame/democracy/src/tests.rs
@@ -220,7 +220,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 #[test]
 fn params_should_work() {
 	new_test_ext().execute_with(|| {
-		assert_eq!(Democracy::referendum_count(), 0);
+		assert_eq!(ReferendumCount::<Test>::get(), 0);
 		assert_eq!(Balances::free_balance(42), 0);
 		assert_eq!(Balances::total_issuance(), 210);
 	});

--- a/frame/democracy/src/tests/cancellation.rs
+++ b/frame/democracy/src/tests/cancellation.rs
@@ -30,14 +30,14 @@ fn cancel_referendum_should_work() {
 		);
 		assert_ok!(Democracy::vote(RuntimeOrigin::signed(1), r, aye(1)));
 		assert_ok!(Democracy::cancel_referendum(RuntimeOrigin::root(), r.into()));
-		assert_eq!(Democracy::lowest_unbaked(), 0);
+		assert_eq!(LowestUnbaked::<Test>::get(), 0);
 
 		next_block();
 
 		next_block();
 
-		assert_eq!(Democracy::lowest_unbaked(), 1);
-		assert_eq!(Democracy::lowest_unbaked(), Democracy::referendum_count());
+		assert_eq!(LowestUnbaked::<Test>::get(), 1);
+		assert_eq!(LowestUnbaked::<Test>::get(), ReferendumCount::<Test>::get());
 		assert_eq!(Balances::free_balance(42), 0);
 	});
 }
@@ -56,7 +56,7 @@ fn emergency_cancel_should_work() {
 
 		assert_noop!(Democracy::emergency_cancel(RuntimeOrigin::signed(3), r), BadOrigin);
 		assert_ok!(Democracy::emergency_cancel(RuntimeOrigin::signed(4), r));
-		assert!(Democracy::referendum_info(r).is_none());
+		assert!(ReferendumInfoOf::<Test>::get(r).is_none());
 
 		// some time later...
 

--- a/frame/democracy/src/tests/lock_voting.rs
+++ b/frame/democracy/src/tests/lock_voting.rs
@@ -56,7 +56,7 @@ fn lock_voting_should_work() {
 
 		// All balances are currently locked.
 		for i in 1..=5 {
-			assert_eq!(Balances::locks(i), vec![the_lock(i * 10)]);
+			assert_eq!(pallet_balances::Locks::<Test>::get(i), vec![the_lock(i * 10)]);
 		}
 
 		fast_forward_to(3);
@@ -77,11 +77,11 @@ fn lock_voting_should_work() {
 		assert_ok!(Democracy::remove_vote(RuntimeOrigin::signed(2), r));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(2), 2));
 
-		assert_eq!(Balances::locks(1), vec![]);
-		assert_eq!(Balances::locks(2), vec![the_lock(20)]);
-		assert_eq!(Balances::locks(3), vec![the_lock(30)]);
-		assert_eq!(Balances::locks(4), vec![the_lock(40)]);
-		assert_eq!(Balances::locks(5), vec![]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(1), vec![]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(2), vec![the_lock(20)]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(3), vec![the_lock(30)]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(4), vec![the_lock(40)]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(5), vec![]);
 		assert_eq!(Balances::free_balance(42), 2);
 
 		fast_forward_to(7);
@@ -91,12 +91,12 @@ fn lock_voting_should_work() {
 			Error::<Test>::NoPermission
 		);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(1), 4));
-		assert_eq!(Balances::locks(4), vec![the_lock(40)]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(4), vec![the_lock(40)]);
 		fast_forward_to(8);
 		// 4 should now be able to reap and unlock
 		assert_ok!(Democracy::remove_other_vote(RuntimeOrigin::signed(1), 4, r));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(1), 4));
-		assert_eq!(Balances::locks(4), vec![]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(4), vec![]);
 
 		fast_forward_to(13);
 		assert_noop!(
@@ -104,19 +104,19 @@ fn lock_voting_should_work() {
 			Error::<Test>::NoPermission
 		);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(1), 3));
-		assert_eq!(Balances::locks(3), vec![the_lock(30)]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(3), vec![the_lock(30)]);
 		fast_forward_to(14);
 		assert_ok!(Democracy::remove_other_vote(RuntimeOrigin::signed(1), 3, r));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(1), 3));
-		assert_eq!(Balances::locks(3), vec![]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(3), vec![]);
 
 		// 2 doesn't need to reap_vote here because it was already done before.
 		fast_forward_to(25);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(1), 2));
-		assert_eq!(Balances::locks(2), vec![the_lock(20)]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(2), vec![the_lock(20)]);
 		fast_forward_to(26);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(1), 2));
-		assert_eq!(Balances::locks(2), vec![]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(2), vec![]);
 	});
 }
 
@@ -137,7 +137,7 @@ fn no_locks_without_conviction_should_work() {
 		assert_eq!(Balances::free_balance(42), 2);
 		assert_ok!(Democracy::remove_other_vote(RuntimeOrigin::signed(2), 1, r));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(2), 1));
-		assert_eq!(Balances::locks(1), vec![]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(1), vec![]);
 	});
 }
 
@@ -198,33 +198,33 @@ fn prior_lockvotes_should_be_enforced() {
 			Error::<Test>::NoPermission
 		);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(Balances::locks(5), vec![the_lock(50)]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(5), vec![the_lock(50)]);
 		fast_forward_to(8);
 		assert_ok!(Democracy::remove_other_vote(RuntimeOrigin::signed(1), 5, r.2));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(Balances::locks(5), vec![the_lock(20)]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(5), vec![the_lock(20)]);
 		fast_forward_to(13);
 		assert_noop!(
 			Democracy::remove_other_vote(RuntimeOrigin::signed(1), 5, r.1),
 			Error::<Test>::NoPermission
 		);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(Balances::locks(5), vec![the_lock(20)]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(5), vec![the_lock(20)]);
 		fast_forward_to(14);
 		assert_ok!(Democracy::remove_other_vote(RuntimeOrigin::signed(1), 5, r.1));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(Balances::locks(5), vec![the_lock(10)]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(5), vec![the_lock(10)]);
 		fast_forward_to(25);
 		assert_noop!(
 			Democracy::remove_other_vote(RuntimeOrigin::signed(1), 5, r.0),
 			Error::<Test>::NoPermission
 		);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(Balances::locks(5), vec![the_lock(10)]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(5), vec![the_lock(10)]);
 		fast_forward_to(26);
 		assert_ok!(Democracy::remove_other_vote(RuntimeOrigin::signed(1), 5, r.0));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(Balances::locks(5), vec![]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(5), vec![]);
 	});
 }
 
@@ -239,26 +239,26 @@ fn single_consolidation_of_lockvotes_should_work_as_before() {
 		fast_forward_to(7);
 		assert_ok!(Democracy::remove_vote(RuntimeOrigin::signed(5), r.2));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(Balances::locks(5), vec![the_lock(50)]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(5), vec![the_lock(50)]);
 		fast_forward_to(8);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(Balances::locks(5), vec![the_lock(20)]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(5), vec![the_lock(20)]);
 
 		fast_forward_to(13);
 		assert_ok!(Democracy::remove_vote(RuntimeOrigin::signed(5), r.1));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(Balances::locks(5), vec![the_lock(20)]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(5), vec![the_lock(20)]);
 		fast_forward_to(14);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(Balances::locks(5), vec![the_lock(10)]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(5), vec![the_lock(10)]);
 
 		fast_forward_to(25);
 		assert_ok!(Democracy::remove_vote(RuntimeOrigin::signed(5), r.0));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(Balances::locks(5), vec![the_lock(10)]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(5), vec![the_lock(10)]);
 		fast_forward_to(26);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(Balances::locks(5), vec![]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(5), vec![]);
 	});
 }
 
@@ -276,15 +276,15 @@ fn multi_consolidation_of_lockvotes_should_be_conservative() {
 
 		fast_forward_to(8);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert!(Balances::locks(5)[0].amount >= 20);
+		assert!(pallet_balances::Locks::<Test>::get(5)[0].amount >= 20);
 
 		fast_forward_to(14);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert!(Balances::locks(5)[0].amount >= 10);
+		assert!(pallet_balances::Locks::<Test>::get(5)[0].amount >= 10);
 
 		fast_forward_to(26);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(Balances::locks(5), vec![]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(5), vec![]);
 	});
 }
 
@@ -305,26 +305,26 @@ fn locks_should_persist_from_voting_to_delegation() {
 
 		assert_ok!(Democracy::delegate(RuntimeOrigin::signed(5), 1, Conviction::Locked3x, 20));
 		// locked 20.
-		assert!(Balances::locks(5)[0].amount == 20);
+		assert!(pallet_balances::Locks::<Test>::get(5)[0].amount == 20);
 
 		assert_ok!(Democracy::undelegate(RuntimeOrigin::signed(5)));
 		// locked 20 until #14
 
 		fast_forward_to(13);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert!(Balances::locks(5)[0].amount == 20);
+		assert!(pallet_balances::Locks::<Test>::get(5)[0].amount == 20);
 
 		fast_forward_to(14);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert!(Balances::locks(5)[0].amount >= 10);
+		assert!(pallet_balances::Locks::<Test>::get(5)[0].amount >= 10);
 
 		fast_forward_to(25);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert!(Balances::locks(5)[0].amount >= 10);
+		assert!(pallet_balances::Locks::<Test>::get(5)[0].amount >= 10);
 
 		fast_forward_to(26);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(Balances::locks(5), vec![]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(5), vec![]);
 	});
 }
 
@@ -347,18 +347,18 @@ fn locks_should_persist_from_delegation_to_voting() {
 
 		fast_forward_to(8);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert!(Balances::locks(5)[0].amount >= 20);
+		assert!(pallet_balances::Locks::<Test>::get(5)[0].amount >= 20);
 
 		fast_forward_to(14);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert!(Balances::locks(5)[0].amount >= 10);
+		assert!(pallet_balances::Locks::<Test>::get(5)[0].amount >= 10);
 
 		fast_forward_to(26);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert!(Balances::locks(5)[0].amount >= 5);
+		assert!(pallet_balances::Locks::<Test>::get(5)[0].amount >= 5);
 
 		fast_forward_to(48);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(Balances::locks(5), vec![]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(5), vec![]);
 	});
 }

--- a/frame/democracy/src/tests/metadata.rs
+++ b/frame/democracy/src/tests/metadata.rs
@@ -89,7 +89,7 @@ fn set_proposal_metadata_works() {
 		// create an external proposal.
 		assert_ok!(propose_set_balance(1, 2, 5));
 		// metadata owner is a public proposal.
-		let owner = MetadataOwner::Proposal(Democracy::public_prop_count() - 1);
+		let owner = MetadataOwner::Proposal(PublicPropCount::<Test>::get() - 1);
 		// fails to set non-existing preimage.
 		assert_noop!(
 			Democracy::set_metadata(RuntimeOrigin::signed(1), owner.clone(), Some(invalid_hash),),
@@ -117,7 +117,7 @@ fn clear_proposal_metadata_works() {
 		// create an external proposal.
 		assert_ok!(propose_set_balance(1, 2, 5));
 		// metadata owner is a public proposal.
-		let owner = MetadataOwner::Proposal(Democracy::public_prop_count() - 1);
+		let owner = MetadataOwner::Proposal(PublicPropCount::<Test>::get() - 1);
 		// set metadata.
 		let hash = note_preimage(1);
 		assert_ok!(Democracy::set_metadata(RuntimeOrigin::signed(1), owner.clone(), Some(hash),));

--- a/frame/democracy/src/tests/scheduling.rs
+++ b/frame/democracy/src/tests/scheduling.rs
@@ -30,10 +30,10 @@ fn simple_passing_should_work() {
 		);
 		assert_ok!(Democracy::vote(RuntimeOrigin::signed(1), r, aye(1)));
 		assert_eq!(tally(r), Tally { ayes: 1, nays: 0, turnout: 10 });
-		assert_eq!(Democracy::lowest_unbaked(), 0);
+		assert_eq!(LowestUnbaked::<Test>::get(), 0);
 		next_block();
 		next_block();
-		assert_eq!(Democracy::lowest_unbaked(), 1);
+		assert_eq!(LowestUnbaked::<Test>::get(), 1);
 		assert_eq!(Balances::free_balance(42), 2);
 	});
 }
@@ -140,16 +140,16 @@ fn lowest_unbaked_should_be_sensible() {
 		assert_ok!(Democracy::vote(RuntimeOrigin::signed(1), r2, aye(1)));
 		// r3 is canceled
 		assert_ok!(Democracy::cancel_referendum(RuntimeOrigin::root(), r3.into()));
-		assert_eq!(Democracy::lowest_unbaked(), 0);
+		assert_eq!(LowestUnbaked::<Test>::get(), 0);
 
 		next_block();
 		// r2 ends with approval
-		assert_eq!(Democracy::lowest_unbaked(), 0);
+		assert_eq!(LowestUnbaked::<Test>::get(), 0);
 
 		next_block();
 		// r1 ends with approval
-		assert_eq!(Democracy::lowest_unbaked(), 3);
-		assert_eq!(Democracy::lowest_unbaked(), Democracy::referendum_count());
+		assert_eq!(LowestUnbaked::<Test>::get(), 3);
+		assert_eq!(LowestUnbaked::<Test>::get(), ReferendumCount::<Test>::get());
 
 		// r2 is executed
 		assert_eq!(Balances::free_balance(42), 2);

--- a/frame/democracy/src/tests/voting.rs
+++ b/frame/democracy/src/tests/voting.rs
@@ -55,7 +55,7 @@ fn split_vote_cancellation_should_work() {
 		assert_ok!(Democracy::remove_vote(RuntimeOrigin::signed(5), r));
 		assert_eq!(tally(r), Tally { ayes: 0, nays: 0, turnout: 0 });
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(Balances::locks(5), vec![]);
+		assert_eq!(pallet_balances::Locks::<Test>::get(5), vec![]);
 	});
 }
 
@@ -65,13 +65,13 @@ fn single_proposal_should_work() {
 		System::set_block_number(0);
 		assert_ok!(propose_set_balance(1, 2, 1));
 		let r = 0;
-		assert!(Democracy::referendum_info(r).is_none());
+		assert!(ReferendumInfoOf::<Test>::get(r).is_none());
 
 		// start of 2 => next referendum scheduled.
 		fast_forward_to(2);
 		assert_ok!(Democracy::vote(RuntimeOrigin::signed(1), r, aye(1)));
 
-		assert_eq!(Democracy::referendum_count(), 1);
+		assert_eq!(ReferendumCount::<Test>::get(), 1);
 		assert_eq!(
 			Democracy::referendum_status(0),
 			Ok(ReferendumStatus {

--- a/frame/elections-phragmen/src/benchmarking.rs
+++ b/frame/elections-phragmen/src/benchmarking.rs
@@ -121,18 +121,18 @@ fn distribute_voters<T: Config>(
 /// members, or members and runners-up.
 fn fill_seats_up_to<T: Config>(m: u32) -> Result<Vec<T::AccountId>, &'static str> {
 	let _ = submit_candidates_with_self_vote::<T>(m, "fill_seats_up_to")?;
-	assert_eq!(<Elections<T>>::candidates().len() as u32, m, "wrong number of candidates.");
+	assert_eq!(<Candidates<T>>::get().len() as u32, m, "wrong number of candidates.");
 	<Elections<T>>::do_phragmen();
-	assert_eq!(<Elections<T>>::candidates().len(), 0, "some candidates remaining.");
+	assert_eq!(<Candidates<T>>::get().len(), 0, "some candidates remaining.");
 	assert_eq!(
-		<Elections<T>>::members().len() + <Elections<T>>::runners_up().len(),
+		<Members<T>>::get().len() + RunnersUp::<T>::get().len(),
 		m as usize,
 		"wrong number of members and runners-up",
 	);
-	Ok(<Elections<T>>::members()
+	Ok(<Members<T>>::get()
 		.into_iter()
 		.map(|m| m.who)
-		.chain(<Elections<T>>::runners_up().into_iter().map(|r| r.who))
+		.chain(RunnersUp::<T>::get().into_iter().map(|r| r.who))
 		.collect())
 }
 
@@ -349,7 +349,7 @@ benchmarks! {
 	}: remove_member(RawOrigin::Root, removing, true, false)
 	verify {
 		// must still have enough members.
-		assert_eq!(<Elections<T>>::members().len() as u32, T::DesiredMembers::get());
+		assert_eq!(<Members<T>>::get().len() as u32, T::DesiredMembers::get());
 		#[cfg(test)]
 		{
 			// reset members in between benchmark tests.
@@ -407,9 +407,9 @@ benchmarks! {
 		<Elections<T>>::on_initialize(T::TermDuration::get());
 	}
 	verify {
-		assert_eq!(<Elections<T>>::members().len() as u32, T::DesiredMembers::get().min(c));
+		assert_eq!(<Members<T>>::get().len() as u32, T::DesiredMembers::get().min(c));
 		assert_eq!(
-			<Elections<T>>::runners_up().len() as u32,
+			RunnersUp::<T>::get().len() as u32,
 			T::DesiredRunnersUp::get().min(c.saturating_sub(T::DesiredMembers::get())),
 		);
 

--- a/frame/examples/basic/src/benchmarking.rs
+++ b/frame/examples/basic/src/benchmarking.rs
@@ -48,7 +48,7 @@ mod benchmarks {
 		set_dummy(RawOrigin::Root, value); // The execution phase is just running `set_dummy` extrinsic call
 
 		// This is the optional benchmark verification phase, asserting certain states.
-		assert_eq!(Pallet::<T>::dummy(), Some(value))
+		assert_eq!(Dummy::<T>::get(), Some(value))
 	}
 
 	// An example method that returns a Result that can be called within a benchmark

--- a/frame/examples/basic/src/lib.rs
+++ b/frame/examples/basic/src/lib.rs
@@ -505,8 +505,6 @@ pub mod pallet {
 			let _sender = ensure_signed(origin)?;
 
 			// Read the value of dummy from storage.
-			// let dummy = Self::dummy();
-			// Will also work using the `::get` on the storage item type itself:
 			// let dummy = <Dummy<T>>::get();
 
 			// Calculate the new value.
@@ -600,20 +598,14 @@ pub mod pallet {
 	//   - `Foo::put(1); Foo::get()` returns `1`;
 	//   - `Foo::kill(); Foo::get()` returns `0` (u32::default()).
 	#[pallet::storage]
-	// The getter attribute generate a function on `Pallet` placeholder:
-	// `fn getter_name() -> Type` for basic value items or
-	// `fn getter_name(key: KeyType) -> ValueType` for map items.
-	#[pallet::getter(fn dummy)]
 	pub(super) type Dummy<T: Config> = StorageValue<_, T::Balance>;
 
 	// A map that has enumerable entries.
 	#[pallet::storage]
-	#[pallet::getter(fn bar)]
 	pub(super) type Bar<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, T::Balance>;
 
 	// this one uses the query kind: `ValueQuery`, we'll demonstrate the usage of 'mutate' API.
 	#[pallet::storage]
-	#[pallet::getter(fn foo)]
 	pub(super) type Foo<T: Config> = StorageValue<_, T::Balance, ValueQuery>;
 
 	#[pallet::storage]

--- a/frame/examples/basic/src/tests.rs
+++ b/frame/examples/basic/src/tests.rs
@@ -124,25 +124,25 @@ fn it_works_for_optional_value() {
 		// Check that GenesisBuilder works properly.
 		let val1 = 42;
 		let val2 = 27;
-		assert_eq!(Example::dummy(), Some(val1));
+		assert_eq!(Dummy::<Test>::get(), Some(val1));
 
 		// Check that accumulate works when we have Some value in Dummy already.
 		assert_ok!(Example::accumulate_dummy(RuntimeOrigin::signed(1), val2));
-		assert_eq!(Example::dummy(), Some(val1 + val2));
+		assert_eq!(Dummy::<Test>::get(), Some(val1 + val2));
 
 		// Check that accumulate works when we Dummy has None in it.
 		<Example as OnInitialize<u64>>::on_initialize(2);
 		assert_ok!(Example::accumulate_dummy(RuntimeOrigin::signed(1), val1));
-		assert_eq!(Example::dummy(), Some(val1 + val2 + val1));
+		assert_eq!(Dummy::<Test>::get(), Some(val1 + val2 + val1));
 	});
 }
 
 #[test]
 fn it_works_for_default_value() {
 	new_test_ext().execute_with(|| {
-		assert_eq!(Example::foo(), 24);
+		assert_eq!(Foo::<Test>::get(), 24);
 		assert_ok!(Example::accumulate_foo(RuntimeOrigin::signed(1), 1));
-		assert_eq!(Example::foo(), 25);
+		assert_eq!(Foo::<Test>::get(), 25);
 	});
 }
 
@@ -151,7 +151,7 @@ fn set_dummy_works() {
 	new_test_ext().execute_with(|| {
 		let test_val = 133;
 		assert_ok!(Example::set_dummy(RuntimeOrigin::root(), test_val.into()));
-		assert_eq!(Example::dummy(), Some(test_val));
+		assert_eq!(Dummy::<Test>::get(), Some(test_val));
 	});
 }
 

--- a/frame/grandpa/src/benchmarking.rs
+++ b/frame/grandpa/src/benchmarking.rs
@@ -17,7 +17,7 @@
 
 //! Benchmarks for the GRANDPA pallet.
 
-use super::{Pallet as Grandpa, *};
+use super::*;
 use frame_benchmarking::v1::benchmarks;
 use frame_system::RawOrigin;
 use sp_core::H256;
@@ -66,7 +66,7 @@ benchmarks! {
 
 	}: _(RawOrigin::Root, delay, best_finalized_block_number)
 	verify {
-		assert!(Grandpa::<T>::stalled().is_some());
+		assert!(Stalled::<T>::get().is_some());
 	}
 
 	impl_benchmark_test_suite!(

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -306,7 +306,7 @@ pub fn new_test_ext_raw_authorities(authorities: AuthorityList) -> sp_io::TestEx
 }
 
 pub fn start_session(session_index: SessionIndex) {
-	for i in Session::current_index()..session_index {
+	for i in pallet_session::CurrentIndex::<Test>::get()..session_index {
 		System::on_finalize(System::block_number());
 		Session::on_finalize(System::block_number());
 		Staking::on_finalize(System::block_number());
@@ -330,12 +330,12 @@ pub fn start_session(session_index: SessionIndex) {
 		Grandpa::on_initialize(System::block_number());
 	}
 
-	assert_eq!(Session::current_index(), session_index);
+	assert_eq!(pallet_session::CurrentIndex::<Test>::get(), session_index);
 }
 
 pub fn start_era(era_index: EraIndex) {
 	start_session((era_index * 3).into());
-	assert_eq!(Staking::current_era(), Some(era_index));
+	assert_eq!(pallet_staking::CurrentEra::<Test>::get(), Some(era_index));
 }
 
 pub fn initialize_block(number: u64, parent_hash: H256) {

--- a/frame/grandpa/src/tests.rs
+++ b/frame/grandpa/src/tests.rs
@@ -156,7 +156,7 @@ fn dispatch_forced_change() {
 		for i in 2..7 {
 			initialize_block(i, header.hash());
 			assert!(<PendingChange<Test>>::get().unwrap().forced.is_some());
-			assert_eq!(Grandpa::next_forced(), Some(11));
+			assert_eq!(NextForced::<Test>::get(), Some(11));
 			assert_noop!(
 				Grandpa::schedule_change(to_authorities(vec![(5, 1)]), 1, None),
 				Error::<Test>::ChangePending
@@ -206,7 +206,7 @@ fn dispatch_forced_change() {
 			initialize_block(i, header.hash());
 			assert!(!<PendingChange<Test>>::exists());
 			assert_eq!(Grandpa::grandpa_authorities(), to_authorities(vec![(5, 1)]));
-			assert_eq!(Grandpa::next_forced(), Some(11));
+			assert_eq!(NextForced::<Test>::get(), Some(11));
 			assert_noop!(
 				Grandpa::schedule_change(to_authorities(vec![(5, 1), (6, 1)]), 5, Some(0)),
 				Error::<Test>::TooSoon
@@ -223,7 +223,7 @@ fn dispatch_forced_change() {
 				5,
 				Some(0)
 			));
-			assert_eq!(Grandpa::next_forced(), Some(21));
+			assert_eq!(NextForced::<Test>::get(), Some(21));
 			Grandpa::on_finalize(11);
 			header = System::finalize();
 		}
@@ -239,7 +239,10 @@ fn schedule_pause_only_when_live() {
 		Grandpa::schedule_pause(1).unwrap();
 
 		// we've switched to the pending pause state
-		assert_eq!(Grandpa::state(), StoredState::PendingPause { scheduled_at: 1u64, delay: 1 });
+		assert_eq!(
+			State::<Test>::get(),
+			StoredState::PendingPause { scheduled_at: 1u64, delay: 1 }
+		);
 
 		Grandpa::on_finalize(1);
 		let _ = System::finalize();
@@ -253,7 +256,7 @@ fn schedule_pause_only_when_live() {
 		let _ = System::finalize();
 
 		// after finalizing block 2 the set should have switched to paused state
-		assert_eq!(Grandpa::state(), StoredState::Paused);
+		assert_eq!(State::<Test>::get(), StoredState::Paused);
 	});
 }
 
@@ -265,14 +268,14 @@ fn schedule_resume_only_when_paused() {
 		// the set is currently live, resuming it is an error
 		assert_noop!(Grandpa::schedule_resume(1), Error::<Test>::ResumeFailed);
 
-		assert_eq!(Grandpa::state(), StoredState::Live);
+		assert_eq!(State::<Test>::get(), StoredState::Live);
 
 		// we schedule a pause to be applied instantly
 		Grandpa::schedule_pause(0).unwrap();
 		Grandpa::on_finalize(1);
 		let _ = System::finalize();
 
-		assert_eq!(Grandpa::state(), StoredState::Paused);
+		assert_eq!(State::<Test>::get(), StoredState::Paused);
 
 		// we schedule the set to go back live in 2 blocks
 		initialize_block(2, Default::default());
@@ -289,7 +292,7 @@ fn schedule_resume_only_when_paused() {
 		let _ = System::finalize();
 
 		// it should be live at block 4
-		assert_eq!(Grandpa::state(), StoredState::Live);
+		assert_eq!(State::<Test>::get(), StoredState::Live);
 	});
 }
 
@@ -319,13 +322,13 @@ fn report_equivocation_current_set_works() {
 	let authorities = test_authorities();
 
 	new_test_ext_raw_authorities(authorities).execute_with(|| {
-		assert_eq!(Staking::current_era(), Some(0));
-		assert_eq!(Session::current_index(), 0);
+		assert_eq!(pallet_staking::CurrentEra::<Test>::get(), Some(0));
+		assert_eq!(pallet_session::CurrentIndex::<Test>::get(), 0);
 
 		start_era(1);
 
 		let authorities = Grandpa::grandpa_authorities();
-		let validators = Session::validators();
+		let validators = pallet_session::Validators::<Test>::get();
 
 		// make sure that all validators have the same balance
 		for validator in &validators {
@@ -333,7 +336,7 @@ fn report_equivocation_current_set_works() {
 			assert_eq!(Staking::slashable_balance_of(validator), 10_000);
 
 			assert_eq!(
-				Staking::eras_stakers(1, validator),
+				pallet_staking::ErasStakers::<Test>::get(1, validator),
 				pallet_staking::Exposure { total: 10_000, own: 10_000, others: vec![] },
 			);
 		}
@@ -342,7 +345,7 @@ fn report_equivocation_current_set_works() {
 		let equivocation_key = &authorities[equivocation_authority_index].0;
 		let equivocation_keyring = extract_keyring(equivocation_key);
 
-		let set_id = Grandpa::current_set_id();
+		let set_id = CurrentSetId::<Test>::get();
 
 		// generate an equivocation proof, with two votes in the same round for
 		// different block hashes signed by the same key
@@ -371,7 +374,7 @@ fn report_equivocation_current_set_works() {
 		assert_eq!(Balances::total_balance(&equivocation_validator_id), 10_000_000 - 10_000);
 		assert_eq!(Staking::slashable_balance_of(&equivocation_validator_id), 0);
 		assert_eq!(
-			Staking::eras_stakers(2, equivocation_validator_id),
+			pallet_staking::ErasStakers::<Test>::get(2, equivocation_validator_id),
 			pallet_staking::Exposure { total: 0, own: 0, others: vec![] },
 		);
 
@@ -385,7 +388,7 @@ fn report_equivocation_current_set_works() {
 			assert_eq!(Staking::slashable_balance_of(validator), 10_000);
 
 			assert_eq!(
-				Staking::eras_stakers(2, validator),
+				pallet_staking::ErasStakers::<Test>::get(2, validator),
 				pallet_staking::Exposure { total: 10_000, own: 10_000, others: vec![] },
 			);
 		}
@@ -400,7 +403,7 @@ fn report_equivocation_old_set_works() {
 		start_era(1);
 
 		let authorities = Grandpa::grandpa_authorities();
-		let validators = Session::validators();
+		let validators = pallet_session::Validators::<Test>::get();
 
 		let equivocation_authority_index = 0;
 		let equivocation_key = &authorities[equivocation_authority_index].0;
@@ -417,14 +420,14 @@ fn report_equivocation_old_set_works() {
 			assert_eq!(Staking::slashable_balance_of(validator), 10_000);
 
 			assert_eq!(
-				Staking::eras_stakers(2, validator),
+				pallet_staking::ErasStakers::<Test>::get(2, validator),
 				pallet_staking::Exposure { total: 10_000, own: 10_000, others: vec![] },
 			);
 		}
 
 		let equivocation_keyring = extract_keyring(equivocation_key);
 
-		let set_id = Grandpa::current_set_id();
+		let set_id = CurrentSetId::<Test>::get();
 
 		// generate an equivocation proof for the old set,
 		let equivocation_proof = generate_equivocation_proof(
@@ -450,7 +453,7 @@ fn report_equivocation_old_set_works() {
 		assert_eq!(Staking::slashable_balance_of(&equivocation_validator_id), 0);
 
 		assert_eq!(
-			Staking::eras_stakers(3, equivocation_validator_id),
+			pallet_staking::ErasStakers::<Test>::get(3, equivocation_validator_id),
 			pallet_staking::Exposure { total: 0, own: 0, others: vec![] },
 		);
 
@@ -464,7 +467,7 @@ fn report_equivocation_old_set_works() {
 			assert_eq!(Staking::slashable_balance_of(validator), 10_000);
 
 			assert_eq!(
-				Staking::eras_stakers(3, validator),
+				pallet_staking::ErasStakers::<Test>::get(3, validator),
 				pallet_staking::Exposure { total: 10_000, own: 10_000, others: vec![] },
 			);
 		}
@@ -487,7 +490,7 @@ fn report_equivocation_invalid_set_id() {
 		let key_owner_proof =
 			Historical::prove((sp_consensus_grandpa::KEY_TYPE, &equivocation_key)).unwrap();
 
-		let set_id = Grandpa::current_set_id();
+		let set_id = CurrentSetId::<Test>::get();
 
 		// generate an equivocation for a future set
 		let equivocation_proof = generate_equivocation_proof(
@@ -527,7 +530,7 @@ fn report_equivocation_invalid_session() {
 
 		start_era(2);
 
-		let set_id = Grandpa::current_set_id();
+		let set_id = CurrentSetId::<Test>::get();
 
 		// generate an equivocation proof at set id = 2
 		let equivocation_proof = generate_equivocation_proof(
@@ -568,7 +571,7 @@ fn report_equivocation_invalid_key_owner_proof() {
 		let equivocation_key = &authorities[equivocation_authority_index].0;
 		let equivocation_keyring = extract_keyring(equivocation_key);
 
-		let set_id = Grandpa::current_set_id();
+		let set_id = CurrentSetId::<Test>::get();
 
 		// generate an equivocation proof for the authority at index 0
 		let equivocation_proof = generate_equivocation_proof(
@@ -611,7 +614,7 @@ fn report_equivocation_invalid_equivocation_proof() {
 		let key_owner_proof =
 			Historical::prove((sp_consensus_grandpa::KEY_TYPE, &equivocation_key)).unwrap();
 
-		let set_id = Grandpa::current_set_id();
+		let set_id = CurrentSetId::<Test>::get();
 
 		let assert_invalid_equivocation_proof = |equivocation_proof| {
 			assert_err!(
@@ -675,7 +678,7 @@ fn report_equivocation_validate_unsigned_prevents_duplicates() {
 		let equivocation_authority_index = 0;
 		let equivocation_key = &authorities[equivocation_authority_index].0;
 		let equivocation_keyring = extract_keyring(equivocation_key);
-		let set_id = Grandpa::current_set_id();
+		let set_id = CurrentSetId::<Test>::get();
 
 		let equivocation_proof = generate_equivocation_proof(
 			set_id,
@@ -748,12 +751,12 @@ fn report_equivocation_validate_unsigned_prevents_duplicates() {
 #[test]
 fn on_new_session_doesnt_start_new_set_if_schedule_change_failed() {
 	new_test_ext(vec![(1, 1), (2, 1), (3, 1)]).execute_with(|| {
-		assert_eq!(Grandpa::current_set_id(), 0);
+		assert_eq!(CurrentSetId::<Test>::get(), 0);
 
 		// starting a new era should lead to a change in the session
 		// validators and trigger a new set
 		start_era(1);
-		assert_eq!(Grandpa::current_set_id(), 1);
+		assert_eq!(CurrentSetId::<Test>::get(), 1);
 
 		// we schedule a change delayed by 2 blocks, this should make it so that
 		// when we try to rotate the session at the beginning of the era we will
@@ -761,11 +764,11 @@ fn on_new_session_doesnt_start_new_set_if_schedule_change_failed() {
 		// not increment the set id.
 		Grandpa::schedule_change(to_authorities(vec![(1, 1)]), 2, None).unwrap();
 		start_era(2);
-		assert_eq!(Grandpa::current_set_id(), 1);
+		assert_eq!(CurrentSetId::<Test>::get(), 1);
 
 		// everything should go back to normal after.
 		start_era(3);
-		assert_eq!(Grandpa::current_set_id(), 2);
+		assert_eq!(CurrentSetId::<Test>::get(), 2);
 
 		// session rotation might also fail to schedule a change if it's for a
 		// forced change (i.e. grandpa is stalled) and it is too soon.
@@ -776,7 +779,7 @@ fn on_new_session_doesnt_start_new_set_if_schedule_change_failed() {
 		// defined will also trigger a new set (regardless of whether the
 		// session validators changed)
 		Grandpa::on_new_session(true, std::iter::empty(), std::iter::empty());
-		assert_eq!(Grandpa::current_set_id(), 2);
+		assert_eq!(CurrentSetId::<Test>::get(), 2);
 	});
 }
 
@@ -790,19 +793,19 @@ fn cleans_up_old_set_id_session_mappings() {
 		// we should have a session id mapping for all the set ids from
 		// `max_set_id_session_entries` eras we have observed
 		for i in 1..=max_set_id_session_entries {
-			assert!(Grandpa::session_for_set(i as u64).is_some());
+			assert!(SetIdSession::<Test>::get(i as u64).is_some());
 		}
 
 		start_era(max_set_id_session_entries * 2);
 
 		// we should keep tracking the new mappings for new eras
 		for i in max_set_id_session_entries + 1..=max_set_id_session_entries * 2 {
-			assert!(Grandpa::session_for_set(i as u64).is_some());
+			assert!(SetIdSession::<Test>::get(i as u64).is_some());
 		}
 
 		// but the old ones should have been pruned by now
 		for i in 1..=max_set_id_session_entries {
-			assert!(Grandpa::session_for_set(i as u64).is_none());
+			assert!(SetIdSession::<Test>::get(i as u64).is_none());
 		}
 	});
 }
@@ -812,24 +815,24 @@ fn always_schedules_a_change_on_new_session_when_stalled() {
 	new_test_ext(vec![(1, 1), (2, 1), (3, 1)]).execute_with(|| {
 		start_era(1);
 
-		assert!(Grandpa::pending_change().is_none());
-		assert_eq!(Grandpa::current_set_id(), 1);
+		assert!(PendingChange::<Test>::get().is_none());
+		assert_eq!(CurrentSetId::<Test>::get(), 1);
 
 		// if the session handler reports no change then we should not schedule
 		// any pending change
 		Grandpa::on_new_session(false, std::iter::empty(), std::iter::empty());
 
-		assert!(Grandpa::pending_change().is_none());
-		assert_eq!(Grandpa::current_set_id(), 1);
+		assert!(PendingChange::<Test>::get().is_none());
+		assert_eq!(CurrentSetId::<Test>::get(), 1);
 
 		// if grandpa is stalled then we should **always** schedule a forced
 		// change on a new session
 		<Stalled<Test>>::put((10, 1));
 		Grandpa::on_new_session(false, std::iter::empty(), std::iter::empty());
 
-		assert!(Grandpa::pending_change().is_some());
-		assert!(Grandpa::pending_change().unwrap().forced.is_some());
-		assert_eq!(Grandpa::current_set_id(), 2);
+		assert!(PendingChange::<Test>::get().is_some());
+		assert!(PendingChange::<Test>::get().unwrap().forced.is_some());
+		assert_eq!(CurrentSetId::<Test>::get(), 2);
 	});
 }
 
@@ -861,7 +864,7 @@ fn valid_equivocation_reports_dont_pay_fees() {
 
 		let equivocation_key = &Grandpa::grandpa_authorities()[0].0;
 		let equivocation_keyring = extract_keyring(equivocation_key);
-		let set_id = Grandpa::current_set_id();
+		let set_id = CurrentSetId::<Test>::get();
 
 		// generate an equivocation proof.
 		let equivocation_proof = generate_equivocation_proof(

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -158,7 +158,6 @@ pub mod pallet {
 	///
 	/// TWOX-NOTE: OK ― `AccountId` is a secure hash.
 	#[pallet::storage]
-	#[pallet::getter(fn identity)]
 	pub(super) type IdentityOf<T: Config> = StorageMap<
 		_,
 		Twox64Concat,
@@ -170,7 +169,6 @@ pub mod pallet {
 	/// The super-identity of an alternative "sub" identity together with its name, within that
 	/// context. If the account is not some other account's sub-identity, then just `None`.
 	#[pallet::storage]
-	#[pallet::getter(fn super_of)]
 	pub(super) type SuperOf<T: Config> =
 		StorageMap<_, Blake2_128Concat, T::AccountId, (T::AccountId, Data), OptionQuery>;
 
@@ -976,5 +974,18 @@ impl<T: Config> Pallet<T> {
 	pub fn has_identity(who: &T::AccountId, fields: u64) -> bool {
 		IdentityOf::<T>::get(who)
 			.map_or(false, |registration| (registration.info.fields().0.bits() & fields) == fields)
+	}
+
+	/// Information that is pertinent to identify the entity behind an account.
+	pub fn identity(
+		who: &T::AccountId,
+	) -> Option<Registration<BalanceOf<T>, T::MaxRegistrars, T::MaxAdditionalFields>> {
+		IdentityOf::<T>::get(who)
+	}
+
+	/// The super-identity of an alternative "sub" identity together with its name, within that
+	/// context. If the account is not some other account's sub-identity, then just `None`.
+	pub fn super_of(who: &T::AccountId) -> Option<(T::AccountId, Data)> {
+		SuperOf::<T>::get(who)
 	}
 }

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -404,7 +404,6 @@ pub mod pallet {
 
 	/// The current set of keys that may issue a heartbeat.
 	#[pallet::storage]
-	#[pallet::getter(fn keys)]
 	pub(crate) type Keys<T: Config> =
 		StorageValue<_, WeakBoundedVec<T::AuthorityId, T::MaxKeys>, ValueQuery>;
 
@@ -605,6 +604,11 @@ impl<T: Config + pallet_authorship::Config>
 }
 
 impl<T: Config> Pallet<T> {
+	/// The current set of keys that may issue a heartbeat.
+	pub fn keys() -> WeakBoundedVec<T::AuthorityId, T::MaxKeys> {
+		Keys::<T>::get()
+	}
+
 	/// Returns `true` if a heartbeat has been received for the authority at
 	/// `authority_index` in the authorities series or if the authority has
 	/// authored at least one block, during the current session. Otherwise

--- a/frame/im-online/src/mock.rs
+++ b/frame/im-online/src/mock.rs
@@ -232,7 +232,10 @@ pub fn advance_session() {
 	let now = System::block_number().max(1);
 	System::set_block_number(now + 1);
 	Session::rotate_session();
-	let keys = Session::validators().into_iter().map(UintAuthorityId).collect();
+	let keys = pallet_session::Validators::<Runtime>::get()
+		.into_iter()
+		.map(UintAuthorityId)
+		.collect();
 	ImOnline::set_keys(keys);
-	assert_eq!(Session::current_index(), (now / Period::get()) as u32);
+	assert_eq!(pallet_session::CurrentIndex::<Runtime>::get(), (now / Period::get()) as u32);
 }

--- a/frame/insecure-randomness-collective-flip/src/lib.rs
+++ b/frame/insecure-randomness-collective-flip/src/lib.rs
@@ -255,7 +255,7 @@ mod tests {
 
 			setup_blocks(38);
 
-			let random_material = CollectiveFlip::random_material();
+			let random_material = RandomMaterial::<Test>::get();
 
 			assert_eq!(random_material.len(), 38);
 			assert_eq!(random_material[0], genesis_hash);
@@ -269,7 +269,7 @@ mod tests {
 
 			setup_blocks(81);
 
-			let random_material = CollectiveFlip::random_material();
+			let random_material = RandomMaterial::<Test>::get();
 
 			assert_eq!(random_material.len(), 81);
 			assert_ne!(random_material[0], random_material[1]);
@@ -284,7 +284,7 @@ mod tests {
 
 			setup_blocks(162);
 
-			let random_material = CollectiveFlip::random_material();
+			let random_material = RandomMaterial::<Test>::get();
 
 			assert_eq!(random_material.len(), 81);
 			assert_ne!(random_material[0], random_material[1]);
@@ -305,7 +305,7 @@ mod tests {
 
 			assert_eq!(known_since, 162 - RANDOM_MATERIAL_LEN as u64);
 			assert_ne!(random, H256::zero());
-			assert!(!CollectiveFlip::random_material().contains(&random));
+			assert!(!RandomMaterial::<Test>::get().contains(&random));
 		});
 	}
 }

--- a/frame/merkle-mountain-range/src/lib.rs
+++ b/frame/merkle-mountain-range/src/lib.rs
@@ -220,7 +220,7 @@ pub mod pallet {
 	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {
 		fn on_initialize(_n: T::BlockNumber) -> Weight {
 			use primitives::LeafDataProvider;
-			let leaves = Self::mmr_leaves();
+			let leaves = NumberOfLeaves::<T, I>::get();
 			let peaks_before = sp_mmr_primitives::utils::NodesUtils::new(leaves).number_of_peaks();
 			let data = T::LeafData::leaf_data();
 
@@ -321,7 +321,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	{
 		let first_mmr_block = utils::first_mmr_block_num::<T::Header>(
 			<frame_system::Pallet<T>>::block_number(),
-			Self::mmr_leaves(),
+			NumberOfLeaves::<T, I>::get(),
 		)?;
 
 		utils::block_num_to_leaf_index::<T::Header>(block_num, first_mmr_block)
@@ -361,7 +361,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	/// Return the on-chain MMR root hash.
 	pub fn mmr_root() -> <T as Config<I>>::Hash {
-		Self::mmr_root_hash()
+		RootHash::<T, I>::get()
 	}
 
 	/// Verify MMR proof for given `leaves`.
@@ -374,7 +374,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		leaves: Vec<LeafOf<T, I>>,
 		proof: primitives::Proof<<T as Config<I>>::Hash>,
 	) -> Result<(), primitives::Error> {
-		if proof.leaf_count > Self::mmr_leaves() ||
+		if proof.leaf_count > NumberOfLeaves::<T, I>::get() ||
 			proof.leaf_count == 0 ||
 			(proof.items.len().saturating_add(leaves.len())) as u64 > proof.leaf_count
 		{

--- a/frame/nomination-pools/test-staking/src/lib.rs
+++ b/frame/nomination-pools/test-staking/src/lib.rs
@@ -32,7 +32,7 @@ use sp_runtime::traits::Zero;
 fn pool_lifecycle_e2e() {
 	new_test_ext().execute_with(|| {
 		assert_eq!(Balances::minimum_balance(), 5);
-		assert_eq!(Staking::current_era(), None);
+		assert_eq!(CurrentEra::<Runtime>::get(), None);
 
 		// create the pool, we know this has id 1.
 		assert_ok!(Pools::create(RuntimeOrigin::signed(10), 50, 10, 10, 10));
@@ -196,7 +196,7 @@ fn pool_slash_e2e() {
 	new_test_ext().execute_with(|| {
 		ExistentialDeposit::set(1);
 		assert_eq!(Balances::minimum_balance(), 1);
-		assert_eq!(Staking::current_era(), None);
+		assert_eq!(CurrentEra::<Runtime>::get(), None);
 
 		// create the pool, we know this has id 1.
 		assert_ok!(Pools::create(RuntimeOrigin::signed(10), 40, 10, 10, 10));
@@ -403,7 +403,7 @@ fn pool_slash_proportional() {
 		ExistentialDeposit::set(1);
 		BondingDuration::set(28);
 		assert_eq!(Balances::minimum_balance(), 1);
-		assert_eq!(Staking::current_era(), None);
+		assert_eq!(CurrentEra::<Runtime>::get(), None);
 
 		// create the pool, we know this has id 1.
 		assert_ok!(Pools::create(RuntimeOrigin::signed(10), 40, 10, 10, 10));
@@ -540,7 +540,7 @@ fn pool_slash_non_proportional_only_bonded_pool() {
 		ExistentialDeposit::set(1);
 		BondingDuration::set(28);
 		assert_eq!(Balances::minimum_balance(), 1);
-		assert_eq!(Staking::current_era(), None);
+		assert_eq!(CurrentEra::<Runtime>::get(), None);
 
 		// create the pool, we know this has id 1.
 		assert_ok!(Pools::create(RuntimeOrigin::signed(10), 40, 10, 10, 10));
@@ -619,7 +619,7 @@ fn pool_slash_non_proportional_bonded_pool_and_chunks() {
 		ExistentialDeposit::set(1);
 		BondingDuration::set(28);
 		assert_eq!(Balances::minimum_balance(), 1);
-		assert_eq!(Staking::current_era(), None);
+		assert_eq!(CurrentEra::<Runtime>::get(), None);
 
 		// create the pool, we know this has id 1.
 		assert_ok!(Pools::create(RuntimeOrigin::signed(10), 40, 10, 10, 10));

--- a/frame/offences/benchmarking/src/lib.rs
+++ b/frame/offences/benchmarking/src/lib.rs
@@ -303,7 +303,7 @@ benchmarks! {
 		Staking::<T>::set_slash_reward_fraction(Perbill::one());
 
 		let (offenders, raw_offenders) = make_offenders_im_online::<T>(o, n)?;
-		let keys =  ImOnline::<T>::keys();
+		let keys = ImOnline::<T>::keys();
 		let validator_set_count = keys.len() as u32;
 		let offenders_count = offenders.len() as u32;
 		let offence = UnresponsivenessOffence {
@@ -453,7 +453,7 @@ benchmarks! {
 		Staking::<T>::set_slash_reward_fraction(Perbill::one());
 
 		let (mut offenders, raw_offenders) = make_offenders::<T>(1, n)?;
-		let keys =  ImOnline::<T>::keys();
+		let keys = ImOnline::<T>::keys();
 
 		let offence = BabeEquivocationOffence {
 			slot: 0u64.into(),

--- a/frame/recovery/src/lib.rs
+++ b/frame/recovery/src/lib.rs
@@ -388,7 +388,7 @@ pub mod pallet {
 			let who = ensure_signed(origin)?;
 			let account = T::Lookup::lookup(account)?;
 			// Check `who` is allowed to make a call on behalf of `account`
-			let target = Self::proxy(&who).ok_or(Error::<T>::NotAllowed)?;
+			let target = Proxy::<T>::get(&who).ok_or(Error::<T>::NotAllowed)?;
 			ensure!(target == account, Error::<T>::NotAllowed);
 			call.dispatch(frame_system::RawOrigin::Signed(account).into())
 				.map(|_| ())
@@ -546,10 +546,10 @@ pub mod pallet {
 			let lost = T::Lookup::lookup(lost)?;
 			let rescuer = T::Lookup::lookup(rescuer)?;
 			// Get the recovery configuration for the lost account.
-			let recovery_config = Self::recovery_config(&lost).ok_or(Error::<T>::NotRecoverable)?;
+			let recovery_config = Recoverable::<T>::get(&lost).ok_or(Error::<T>::NotRecoverable)?;
 			// Get the active recovery process for the rescuer.
 			let mut active_recovery =
-				Self::active_recovery(&lost, &rescuer).ok_or(Error::<T>::NotStarted)?;
+				ActiveRecoveries::<T>::get(&lost, &rescuer).ok_or(Error::<T>::NotStarted)?;
 			// Make sure the voter is a friend
 			ensure!(Self::is_friend(&recovery_config.friends, &who), Error::<T>::NotFriend);
 			// Either insert the vouch, or return an error that the user already vouched.
@@ -589,10 +589,10 @@ pub mod pallet {
 			let account = T::Lookup::lookup(account)?;
 			// Get the recovery configuration for the lost account
 			let recovery_config =
-				Self::recovery_config(&account).ok_or(Error::<T>::NotRecoverable)?;
+				Recoverable::<T>::get(&account).ok_or(Error::<T>::NotRecoverable)?;
 			// Get the active recovery process for the rescuer
 			let active_recovery =
-				Self::active_recovery(&account, &who).ok_or(Error::<T>::NotStarted)?;
+				ActiveRecoveries::<T>::get(&account, &who).ok_or(Error::<T>::NotStarted)?;
 			ensure!(!Proxy::<T>::contains_key(&who), Error::<T>::AlreadyProxy);
 			// Make sure the delay period has passed
 			let current_block_number = <frame_system::Pallet<T>>::block_number();
@@ -697,7 +697,7 @@ pub mod pallet {
 			let who = ensure_signed(origin)?;
 			let account = T::Lookup::lookup(account)?;
 			// Check `who` is allowed to make a call on behalf of `account`
-			ensure!(Self::proxy(&who) == Some(account), Error::<T>::NotAllowed);
+			ensure!(Proxy::<T>::get(&who) == Some(account), Error::<T>::NotAllowed);
 			Proxy::<T>::remove(&who);
 
 			frame_system::Pallet::<T>::dec_consumers(&who);

--- a/frame/recovery/src/tests.rs
+++ b/frame/recovery/src/tests.rs
@@ -29,9 +29,9 @@ use sp_runtime::traits::BadOrigin;
 fn basic_setup_works() {
 	new_test_ext().execute_with(|| {
 		// Nothing in storage to start
-		assert_eq!(Recovery::proxy(&2), None);
-		assert_eq!(Recovery::active_recovery(&1, &2), None);
-		assert_eq!(Recovery::recovery_config(&1), None);
+		assert_eq!(Proxy::<Test>::get(&2), None);
+		assert_eq!(ActiveRecoveries::<Test>::get(&1, &2), None);
+		assert_eq!(Recoverable::<Test>::get(&1), None);
 		// Everyone should have starting balance of 100
 		assert_eq!(Balances::free_balance(1), 100);
 	});
@@ -244,7 +244,7 @@ fn create_recovery_works() {
 			friends: friends.try_into().unwrap(),
 			threshold,
 		};
-		assert_eq!(Recovery::recovery_config(5), Some(recovery_config));
+		assert_eq!(Recoverable::<Test>::get(5), Some(recovery_config));
 	});
 }
 

--- a/frame/root-offences/src/lib.rs
+++ b/frame/root-offences/src/lib.rs
@@ -28,7 +28,7 @@ mod mock;
 mod tests;
 
 use pallet_session::historical::IdentificationTuple;
-use pallet_staking::{BalanceOf, Exposure, ExposureOf, Pallet as Staking};
+use pallet_staking::{BalanceOf, Exposure, ExposureOf};
 use sp_runtime::Perbill;
 use sp_staking::offence::{DisableStrategy, OnOffenceHandler};
 
@@ -103,7 +103,7 @@ pub mod pallet {
 		fn get_offence_details(
 			offenders: Vec<(T::AccountId, Perbill)>,
 		) -> Result<Vec<OffenceDetails<T>>, DispatchError> {
-			let now = Staking::<T>::active_era()
+			let now = pallet_staking::ActiveEra::<T>::get()
 				.map(|e| e.index)
 				.ok_or(Error::<T>::FailedToGetActiveEra)?;
 
@@ -111,7 +111,7 @@ pub mod pallet {
 				.clone()
 				.into_iter()
 				.map(|(o, _)| OffenceDetails::<T> {
-					offender: (o.clone(), Staking::<T>::eras_stakers(now, o)),
+					offender: (o.clone(), pallet_staking::ErasStakers::<T>::get(now, o)),
 					reporters: vec![],
 				})
 				.collect())

--- a/frame/root-offences/src/mock.rs
+++ b/frame/root-offences/src/mock.rs
@@ -327,10 +327,10 @@ pub(crate) fn start_session(session_index: SessionIndex) {
 	run_to_block(end);
 	// session must have progressed properly.
 	assert_eq!(
-		Session::current_index(),
+		pallet_session::CurrentIndex::<Test>::get(),
 		session_index,
 		"current session index = {}, expected = {}",
-		Session::current_index(),
+		pallet_session::CurrentIndex::<Test>::get(),
 		session_index,
 	);
 }
@@ -354,5 +354,5 @@ pub(crate) fn run_to_block(n: BlockNumber) {
 }
 
 pub(crate) fn active_era() -> EraIndex {
-	Staking::active_era().unwrap().index
+	pallet_staking::ActiveEra::<Test>::get().unwrap().index
 }

--- a/frame/scored-pool/src/mock.rs
+++ b/frame/scored-pool/src/mock.rs
@@ -163,11 +163,11 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
 /// Fetch an entity from the pool, if existent.
 pub fn fetch_from_pool(who: u64) -> Option<(u64, Option<u64>)> {
-	<Pallet<Test>>::pool().into_iter().find(|item| item.0 == who)
+	<Pool<Test>>::get().into_iter().find(|item| item.0 == who)
 }
 
 /// Find an entity in the pool.
 /// Returns its position in the `Pool` vec, if existent.
 pub fn find_in_pool(who: u64) -> Option<usize> {
-	<Pallet<Test>>::pool().into_iter().position(|item| item.0 == who)
+	<Pool<Test>>::get().into_iter().position(|item| item.0 == who)
 }

--- a/frame/session/README.md
+++ b/frame/session/README.md
@@ -69,10 +69,8 @@ for next session rotation.
 The [Staking pallet](https://docs.rs/pallet-staking/latest/pallet_staking/) uses the Session pallet to get the validator set.
 
 ```rust
-use pallet_session as session;
-
 fn validators<T: pallet_session::Config>() -> Vec<<T as pallet_session::Config>::ValidatorId> {
-	<pallet_session::Pallet<T>>::validators()
+    pallet_session::Validators::<T>::get()
 }
 ```
 

--- a/frame/session/benchmarking/src/lib.rs
+++ b/frame/session/benchmarking/src/lib.rs
@@ -61,7 +61,7 @@ benchmarks! {
 			false,
 			RewardDestination::Staked,
 		)?;
-		let v_controller = pallet_staking::Pallet::<T>::bonded(&v_stash).ok_or("not stash")?;
+		let v_controller = pallet_staking::Bonded::<T>::get(&v_stash).ok_or("not stash")?;
 
 		let keys = T::Keys::decode(&mut TrailingZeroInput::zeroes()).unwrap();
 		let proof: Vec<u8> = vec![0,1,2,3];
@@ -78,7 +78,7 @@ benchmarks! {
 			false,
 			RewardDestination::Staked
 		)?;
-		let v_controller = pallet_staking::Pallet::<T>::bonded(&v_stash).ok_or("not stash")?;
+		let v_controller = pallet_staking::Bonded::<T>::get(&v_stash).ok_or("not stash")?;
 		let keys = T::Keys::decode(&mut TrailingZeroInput::zeroes()).unwrap();
 		let proof: Vec<u8> = vec![0,1,2,3];
 		Session::<T>::set_keys(RawOrigin::Signed(v_controller.clone()).into(), keys, proof)?;
@@ -134,7 +134,7 @@ fn check_membership_proof_setup<T: Config>(
 		use rand::{RngCore, SeedableRng};
 
 		let validator = T::Lookup::lookup(who).unwrap();
-		let controller = pallet_staking::Pallet::<T>::bonded(validator).unwrap();
+		let controller = pallet_staking::Bonded::<T>::get(validator).unwrap();
 
 		let keys = {
 			let mut keys = [0u8; 128];
@@ -157,7 +157,7 @@ fn check_membership_proof_setup<T: Config>(
 	Pallet::<T>::on_initialize(T::BlockNumber::one());
 
 	// skip sessions until the new validator set is enacted
-	while Session::<T>::validators().len() < n as usize {
+	while Validators::<T>::get().len() < n as usize {
 		Session::<T>::rotate_session();
 	}
 

--- a/frame/session/src/historical/offchain.rs
+++ b/frame/session/src/historical/offchain.rs
@@ -33,7 +33,7 @@ use sp_session::MembershipProof;
 use sp_std::prelude::*;
 
 use super::{shared, Config, IdentificationTuple, ProvingTrie};
-use crate::{Pallet as SessionModule, SessionIndex};
+use crate::{CurrentIndex, SessionIndex};
 
 /// A set of validators, which was used for a fixed session index.
 struct ValidatorSet<T: Config> {
@@ -129,7 +129,7 @@ pub fn prune_older_than<T: Config>(first_to_keep: SessionIndex) {
 
 /// Keep the newest `n` items, and prune all items older than that.
 pub fn keep_newest<T: Config>(n_to_keep: usize) {
-	let session_index = <SessionModule<T>>::current_index();
+	let session_index = CurrentIndex::<T>::get();
 	let n_to_keep = n_to_keep as SessionIndex;
 	if n_to_keep < session_index {
 		prune_older_than::<T>(session_index - n_to_keep)
@@ -239,7 +239,7 @@ mod tests {
 
 			// "on-chain"
 			onchain::store_current_session_validator_set_to_offchain::<Test>();
-			assert_eq!(<SessionModule<Test>>::current_index(), 1);
+			assert_eq!(CurrentIndex::<Test>::get(), 1);
 
 			set_next_validators(vec![7, 8]);
 
@@ -251,7 +251,7 @@ mod tests {
 		ext.execute_with(|| {
 			System::set_block_number(2);
 			Session::on_initialize(2);
-			assert_eq!(<SessionModule<Test>>::current_index(), 2);
+			assert_eq!(CurrentIndex::<Test>::get(), 2);
 
 			// "off-chain"
 			let proof = prove_session_membership::<Test, _>(1, (DUMMY, &encoded_key_1));

--- a/frame/session/src/historical/onchain.rs
+++ b/frame/session/src/historical/onchain.rs
@@ -22,7 +22,7 @@ use sp_runtime::traits::Convert;
 use sp_std::prelude::*;
 
 use super::{shared, Config as HistoricalConfig};
-use crate::{Config as SessionConfig, Pallet as SessionModule, SessionIndex};
+use crate::{Config as SessionConfig, CurrentIndex, SessionIndex, Validators};
 
 /// Store the validator-set associated to the `session_index` to the off-chain database.
 ///
@@ -35,7 +35,7 @@ use crate::{Config as SessionConfig, Pallet as SessionModule, SessionIndex};
 pub fn store_session_validator_set_to_offchain<T: HistoricalConfig + SessionConfig>(
 	session_index: SessionIndex,
 ) {
-	let encoded_validator_list = <SessionModule<T>>::validators()
+	let encoded_validator_list = Validators::<T>::get()
 		.into_iter()
 		.filter_map(|validator_id: <T as SessionConfig>::ValidatorId| {
 			let full_identification =
@@ -55,5 +55,5 @@ pub fn store_session_validator_set_to_offchain<T: HistoricalConfig + SessionConf
 /// See [`store_session_validator_set_to_offchain`]
 /// for further information and restrictions.
 pub fn store_current_session_validator_set_to_offchain<T: HistoricalConfig + SessionConfig>() {
-	store_session_validator_set_to_offchain::<T>(<SessionModule<T>>::current_index());
+	store_session_validator_set_to_offchain::<T>(CurrentIndex::<T>::get());
 }

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -92,10 +92,8 @@
 //! set.
 //!
 //! ```
-//! use pallet_session as session;
-//!
 //! fn validators<T: pallet_session::Config>() -> Vec<<T as pallet_session::Config>::ValidatorId> {
-//! 	<pallet_session::Pallet<T>>::validators()
+//! 	pallet_session::Validators::<T>::get()
 //! }
 //! # fn main(){}
 //! ```
@@ -729,7 +727,7 @@ impl<T: Config> Pallet<T> {
 	/// Returns `false` either if the validator could not be found or it was already
 	/// disabled.
 	pub fn disable(c: &T::ValidatorId) -> bool {
-		Self::validators()
+		Validators::<T>::get()
 			.iter()
 			.position(|i| i == c)
 			.map(|i| Self::disable_index(i as u32))
@@ -899,11 +897,11 @@ impl<T: Config> ValidatorSet<T::AccountId> for Pallet<T> {
 	type ValidatorIdOf = T::ValidatorIdOf;
 
 	fn session_index() -> sp_staking::SessionIndex {
-		Pallet::<T>::current_index()
+		CurrentIndex::<T>::get()
 	}
 
 	fn validators() -> Vec<Self::ValidatorId> {
-		Pallet::<T>::validators()
+		Validators::<T>::get()
 	}
 }
 
@@ -921,7 +919,7 @@ impl<T: Config> EstimateNextNewSession<T::BlockNumber> for Pallet<T> {
 
 impl<T: Config> frame_support::traits::DisabledValidators for Pallet<T> {
 	fn is_disabled(index: u32) -> bool {
-		<Pallet<T>>::disabled_validators().binary_search(&index).is_ok()
+		DisabledValidators::<T>::get().binary_search(&index).is_ok()
 	}
 }
 
@@ -939,7 +937,7 @@ impl<T: Config, Inner: FindAuthor<u32>> FindAuthor<T::ValidatorId>
 	{
 		let i = Inner::find_author(digests)?;
 
-		let validators = <Pallet<T>>::validators();
+		let validators = Validators::<T>::get();
 		validators.get(i as usize).cloned()
 	}
 }

--- a/frame/session/src/tests.rs
+++ b/frame/session/src/tests.rs
@@ -44,7 +44,7 @@ fn initialize_block(block: u64) {
 fn simple_setup_should_work() {
 	new_test_ext().execute_with(|| {
 		assert_eq!(authorities(), vec![UintAuthorityId(1), UintAuthorityId(2), UintAuthorityId(3)]);
-		assert_eq!(Session::validators(), vec![1, 2, 3]);
+		assert_eq!(Validators::<Test>::get(), vec![1, 2, 3]);
 	});
 }
 
@@ -60,7 +60,7 @@ fn put_get_keys() {
 fn keys_cleared_on_kill() {
 	let mut ext = new_test_ext();
 	ext.execute_with(|| {
-		assert_eq!(Session::validators(), vec![1, 2, 3]);
+		assert_eq!(Validators::<Test>::get(), vec![1, 2, 3]);
 		assert_eq!(Session::load_keys(&1), Some(UintAuthorityId(1).into()));
 
 		let id = DUMMY;
@@ -79,7 +79,7 @@ fn keys_cleared_on_kill() {
 fn purge_keys_works_for_stash_id() {
 	let mut ext = new_test_ext();
 	ext.execute_with(|| {
-		assert_eq!(Session::validators(), vec![1, 2, 3]);
+		assert_eq!(Validators::<Test>::get(), vec![1, 2, 3]);
 		TestValidatorIdOf::set(vec![(10, 1), (20, 2), (3, 3)].into_iter().collect());
 		assert_eq!(Session::load_keys(&1), Some(UintAuthorityId(1).into()));
 		assert_eq!(Session::load_keys(&2), Some(UintAuthorityId(2).into()));
@@ -108,10 +108,10 @@ fn authorities_should_track_validators() {
 		force_new_session();
 		initialize_block(1);
 		assert_eq!(
-			Session::queued_keys(),
+			QueuedKeys::<Test>::get(),
 			vec![(1, UintAuthorityId(1).into()), (2, UintAuthorityId(2).into()),]
 		);
-		assert_eq!(Session::validators(), vec![1, 2, 3]);
+		assert_eq!(Validators::<Test>::get(), vec![1, 2, 3]);
 		assert_eq!(authorities(), vec![UintAuthorityId(1), UintAuthorityId(2), UintAuthorityId(3)]);
 		assert!(before_session_end_called());
 		reset_before_session_end_called();
@@ -119,10 +119,10 @@ fn authorities_should_track_validators() {
 		force_new_session();
 		initialize_block(2);
 		assert_eq!(
-			Session::queued_keys(),
+			QueuedKeys::<Test>::get(),
 			vec![(1, UintAuthorityId(1).into()), (2, UintAuthorityId(2).into()),]
 		);
-		assert_eq!(Session::validators(), vec![1, 2]);
+		assert_eq!(Validators::<Test>::get(), vec![1, 2]);
 		assert_eq!(authorities(), vec![UintAuthorityId(1), UintAuthorityId(2)]);
 		assert!(before_session_end_called());
 		reset_before_session_end_called();
@@ -132,28 +132,28 @@ fn authorities_should_track_validators() {
 		force_new_session();
 		initialize_block(3);
 		assert_eq!(
-			Session::queued_keys(),
+			QueuedKeys::<Test>::get(),
 			vec![
 				(1, UintAuthorityId(1).into()),
 				(2, UintAuthorityId(2).into()),
 				(4, UintAuthorityId(4).into()),
 			]
 		);
-		assert_eq!(Session::validators(), vec![1, 2]);
+		assert_eq!(Validators::<Test>::get(), vec![1, 2]);
 		assert_eq!(authorities(), vec![UintAuthorityId(1), UintAuthorityId(2)]);
 		assert!(before_session_end_called());
 
 		force_new_session();
 		initialize_block(4);
 		assert_eq!(
-			Session::queued_keys(),
+			QueuedKeys::<Test>::get(),
 			vec![
 				(1, UintAuthorityId(1).into()),
 				(2, UintAuthorityId(2).into()),
 				(4, UintAuthorityId(4).into()),
 			]
 		);
-		assert_eq!(Session::validators(), vec![1, 2, 4]);
+		assert_eq!(Validators::<Test>::get(), vec![1, 2, 4]);
 		assert_eq!(authorities(), vec![UintAuthorityId(1), UintAuthorityId(2), UintAuthorityId(4)]);
 	});
 }
@@ -164,20 +164,20 @@ fn should_work_with_early_exit() {
 		set_session_length(10);
 
 		initialize_block(1);
-		assert_eq!(Session::current_index(), 0);
+		assert_eq!(CurrentIndex::<Test>::get(), 0);
 
 		initialize_block(2);
-		assert_eq!(Session::current_index(), 0);
+		assert_eq!(CurrentIndex::<Test>::get(), 0);
 
 		force_new_session();
 		initialize_block(3);
-		assert_eq!(Session::current_index(), 1);
+		assert_eq!(CurrentIndex::<Test>::get(), 1);
 
 		initialize_block(9);
-		assert_eq!(Session::current_index(), 1);
+		assert_eq!(CurrentIndex::<Test>::get(), 1);
 
 		initialize_block(10);
-		assert_eq!(Session::current_index(), 2);
+		assert_eq!(CurrentIndex::<Test>::get(), 2);
 	});
 }
 
@@ -446,7 +446,7 @@ fn upgrade_keys() {
 
 		// Check queued keys.
 		assert_eq!(
-			Session::queued_keys(),
+			QueuedKeys::<Test>::get(),
 			vec![(1, mock_keys_for(1)), (2, mock_keys_for(2)), (3, mock_keys_for(3)),],
 		);
 

--- a/frame/society/src/tests.rs
+++ b/frame/society/src/tests.rs
@@ -28,27 +28,27 @@ use sp_runtime::traits::BadOrigin;
 fn founding_works() {
 	EnvBuilder::new().with_max_members(0).with_members(vec![]).execute(|| {
 		// Not set up initially.
-		assert_eq!(Society::founder(), None);
-		assert_eq!(Society::max_members(), 0);
-		assert_eq!(Society::pot(), 0);
+		assert_eq!(Founder::<Test>::get(), None);
+		assert_eq!(MaxMembers::<Test>::get(), 0);
+		assert_eq!(Pot::<Test>::get(), 0);
 		// Account 1 is set as the founder origin
 		// Account 5 cannot start a society
 		assert_noop!(Society::found(RuntimeOrigin::signed(5), 20, 100, vec![]), BadOrigin);
 		// Account 1 can start a society, where 10 is the founding member
 		assert_ok!(Society::found(RuntimeOrigin::signed(1), 10, 100, b"be cool".to_vec()));
 		// Society members only include 10
-		assert_eq!(Society::members(), vec![10]);
+		assert_eq!(Members::<Test>::get(), vec![10]);
 		// 10 is the head of the society
-		assert_eq!(Society::head(), Some(10));
+		assert_eq!(Head::<Test>::get(), Some(10));
 		// ...and also the founder
-		assert_eq!(Society::founder(), Some(10));
+		assert_eq!(Founder::<Test>::get(), Some(10));
 		// 100 members max
-		assert_eq!(Society::max_members(), 100);
+		assert_eq!(MaxMembers::<Test>::get(), 100);
 		// rules are correct
-		assert_eq!(Society::rules(), Some(blake2_256(b"be cool").into()));
+		assert_eq!(Rules::<Test>::get(), Some(blake2_256(b"be cool").into()));
 		// Pot grows after first rotation period
 		run_to_block(4);
-		assert_eq!(Society::pot(), 1000);
+		assert_eq!(Pot::<Test>::get(), 1000);
 		// Cannot start another society
 		assert_noop!(
 			Society::found(RuntimeOrigin::signed(1), 20, 100, vec![]),
@@ -91,13 +91,13 @@ fn basic_new_member_works() {
 		// Rotate period every 4 blocks
 		run_to_block(4);
 		// 20 is now a candidate
-		assert_eq!(Society::candidates(), vec![create_bid(0, 20, BidKind::Deposit(25))]);
+		assert_eq!(Candidates::<Test>::get(), vec![create_bid(0, 20, BidKind::Deposit(25))]);
 		// 10 (a member) can vote for the candidate
 		assert_ok!(Society::vote(RuntimeOrigin::signed(10), 20, true));
 		// Rotate period every 4 blocks
 		run_to_block(8);
 		// 20 is now a member of the society
-		assert_eq!(Society::members(), vec![10, 20]);
+		assert_eq!(Members::<Test>::get(), vec![10, 20]);
 		// Reserved balance is returned
 		assert_eq!(Balances::free_balance(20), 50);
 		assert_eq!(Balances::reserved_balance(20), 0);
@@ -115,11 +115,11 @@ fn bidding_works() {
 		// Rotate period
 		run_to_block(4);
 		// Pot is 1000 after "PeriodSpend"
-		assert_eq!(Society::pot(), 1000);
+		assert_eq!(Pot::<Test>::get(), 1000);
 		assert_eq!(Balances::free_balance(Society::account_id()), 10_000);
 		// Choose smallest bidding users whose total is less than pot
 		assert_eq!(
-			Society::candidates(),
+			Candidates::<Test>::get(),
 			vec![
 				create_bid(300, 30, BidKind::Deposit(25)),
 				create_bid(400, 40, BidKind::Deposit(25)),
@@ -130,40 +130,40 @@ fn bidding_works() {
 		assert_ok!(Society::vote(RuntimeOrigin::signed(10), 40, true));
 		run_to_block(8);
 		// Candidates become members after a period rotation
-		assert_eq!(Society::members(), vec![10, 30, 40]);
+		assert_eq!(Members::<Test>::get(), vec![10, 30, 40]);
 		// Pot is increased by 1000, but pays out 700 to the members
 		assert_eq!(Balances::free_balance(Society::account_id()), 9_300);
-		assert_eq!(Society::pot(), 1_300);
+		assert_eq!(Pot::<Test>::get(), 1_300);
 		// Left over from the original bids is 50 who satisfies the condition of bid less than pot.
-		assert_eq!(Society::candidates(), vec![create_bid(500, 50, BidKind::Deposit(25))]);
+		assert_eq!(Candidates::<Test>::get(), vec![create_bid(500, 50, BidKind::Deposit(25))]);
 		// 40, now a member, can vote for 50
 		assert_ok!(Society::vote(RuntimeOrigin::signed(40), 50, true));
 		run_to_block(12);
 		// 50 is now a member
-		assert_eq!(Society::members(), vec![10, 30, 40, 50]);
+		assert_eq!(Members::<Test>::get(), vec![10, 30, 40, 50]);
 		// Pot is increased by 1000, and 500 is paid out. Total payout so far is 1200.
-		assert_eq!(Society::pot(), 1_800);
+		assert_eq!(Pot::<Test>::get(), 1_800);
 		assert_eq!(Balances::free_balance(Society::account_id()), 8_800);
 		// No more candidates satisfy the requirements
-		assert_eq!(Society::candidates(), vec![]);
+		assert_eq!(Candidates::<Test>::get(), vec![]);
 		assert_ok!(Society::defender_vote(RuntimeOrigin::signed(10), true)); // Keep defender around
 																	 // Next period
 		run_to_block(16);
 		// Same members
-		assert_eq!(Society::members(), vec![10, 30, 40, 50]);
+		assert_eq!(Members::<Test>::get(), vec![10, 30, 40, 50]);
 		// Pot is increased by 1000 again
-		assert_eq!(Society::pot(), 2_800);
+		assert_eq!(Pot::<Test>::get(), 2_800);
 		// No payouts
 		assert_eq!(Balances::free_balance(Society::account_id()), 8_800);
 		// Candidate 60 now qualifies based on the increased pot size.
-		assert_eq!(Society::candidates(), vec![create_bid(1900, 60, BidKind::Deposit(25))]);
+		assert_eq!(Candidates::<Test>::get(), vec![create_bid(1900, 60, BidKind::Deposit(25))]);
 		// Candidate 60 is voted in.
 		assert_ok!(Society::vote(RuntimeOrigin::signed(50), 60, true));
 		run_to_block(20);
 		// 60 joins as a member
-		assert_eq!(Society::members(), vec![10, 30, 40, 50, 60]);
+		assert_eq!(Members::<Test>::get(), vec![10, 30, 40, 50, 60]);
 		// Pay them
-		assert_eq!(Society::pot(), 1_900);
+		assert_eq!(Pot::<Test>::get(), 1_900);
 		assert_eq!(Balances::free_balance(Society::account_id()), 6_900);
 	});
 }
@@ -186,7 +186,7 @@ fn unbidding_works() {
 		assert_eq!(Balances::reserved_balance(30), 0);
 		// 20 wins candidacy
 		run_to_block(4);
-		assert_eq!(Society::candidates(), vec![create_bid(1000, 20, BidKind::Deposit(25))]);
+		assert_eq!(Candidates::<Test>::get(), vec![create_bid(1000, 20, BidKind::Deposit(25))]);
 	});
 }
 
@@ -217,9 +217,9 @@ fn basic_new_member_skeptic_works() {
 		assert_eq!(Strikes::<Test>::get(10), 0);
 		assert_ok!(Society::bid(RuntimeOrigin::signed(20), 0));
 		run_to_block(4);
-		assert_eq!(Society::candidates(), vec![create_bid(0, 20, BidKind::Deposit(25))]);
+		assert_eq!(Candidates::<Test>::get(), vec![create_bid(0, 20, BidKind::Deposit(25))]);
 		run_to_block(8);
-		assert_eq!(Society::members(), vec![10]);
+		assert_eq!(Members::<Test>::get(), vec![10]);
 		assert_eq!(Strikes::<Test>::get(10), 1);
 
 		System::assert_last_event(mock::RuntimeEvent::Society(crate::Event::SkepticsChosen {
@@ -239,15 +239,15 @@ fn basic_new_member_reject_works() {
 		assert_eq!(Balances::reserved_balance(20), 25);
 		// Rotation Period
 		run_to_block(4);
-		assert_eq!(Society::candidates(), vec![create_bid(0, 20, BidKind::Deposit(25))]);
+		assert_eq!(Candidates::<Test>::get(), vec![create_bid(0, 20, BidKind::Deposit(25))]);
 		// We say no
 		assert_ok!(Society::vote(RuntimeOrigin::signed(10), 20, false));
 		run_to_block(8);
 		// User is not added as member
-		assert_eq!(Society::members(), vec![10]);
+		assert_eq!(Members::<Test>::get(), vec![10]);
 		// User is suspended
-		assert_eq!(Society::candidates(), vec![]);
-		assert_eq!(Society::suspended_candidate(20).is_some(), true);
+		assert_eq!(Candidates::<Test>::get(), vec![]);
+		assert_eq!(SuspendedCandidates::<Test>::get(20).is_some(), true);
 	});
 }
 
@@ -352,15 +352,15 @@ fn suspended_candidate_rejected_works() {
 		assert_eq!(Balances::reserved_balance(20), 25);
 		// Rotation Period
 		run_to_block(4);
-		assert_eq!(Society::candidates(), vec![create_bid(0, 20, BidKind::Deposit(25))]);
+		assert_eq!(Candidates::<Test>::get(), vec![create_bid(0, 20, BidKind::Deposit(25))]);
 		// We say no
 		assert_ok!(Society::vote(RuntimeOrigin::signed(10), 20, false));
 		run_to_block(8);
 		// User is not added as member
-		assert_eq!(Society::members(), vec![10]);
+		assert_eq!(Members::<Test>::get(), vec![10]);
 		// User is suspended
-		assert_eq!(Society::candidates(), vec![]);
-		assert_eq!(Society::suspended_candidate(20).is_some(), true);
+		assert_eq!(Candidates::<Test>::get(), vec![]);
+		assert_eq!(SuspendedCandidates::<Test>::get(20).is_some(), true);
 
 		// Normal user cannot make judgement on suspended candidate
 		assert_noop!(
@@ -377,15 +377,15 @@ fn suspended_candidate_rejected_works() {
 		// They are placed back in bid pool, repeat suspension process
 		// Rotation Period
 		run_to_block(12);
-		assert_eq!(Society::candidates(), vec![create_bid(0, 20, BidKind::Deposit(25))]);
+		assert_eq!(Candidates::<Test>::get(), vec![create_bid(0, 20, BidKind::Deposit(25))]);
 		// We say no
 		assert_ok!(Society::vote(RuntimeOrigin::signed(10), 20, false));
 		run_to_block(16);
 		// User is not added as member
-		assert_eq!(Society::members(), vec![10]);
+		assert_eq!(Members::<Test>::get(), vec![10]);
 		// User is suspended
-		assert_eq!(Society::candidates(), vec![]);
-		assert_eq!(Society::suspended_candidate(20).is_some(), true);
+		assert_eq!(Candidates::<Test>::get(), vec![]);
+		assert_eq!(SuspendedCandidates::<Test>::get(20).is_some(), true);
 
 		// Suspension judgement origin rejects the candidate
 		assert_ok!(Society::judge_suspended_candidate(
@@ -399,7 +399,7 @@ fn suspended_candidate_rejected_works() {
 		// Funds are deposited to society account
 		assert_eq!(Balances::free_balance(Society::account_id()), 10025);
 		// Cleaned up
-		assert_eq!(Society::candidates(), vec![]);
+		assert_eq!(Candidates::<Test>::get(), vec![]);
 		assert_eq!(<SuspendedCandidates<Test>>::get(20), None);
 	});
 }
@@ -408,7 +408,7 @@ fn suspended_candidate_rejected_works() {
 fn vouch_works() {
 	EnvBuilder::new().execute(|| {
 		// 10 is the only member
-		assert_eq!(Society::members(), vec![10]);
+		assert_eq!(Members::<Test>::get(), vec![10]);
 		// A non-member cannot vouch
 		assert_noop!(
 			Society::vouch(RuntimeOrigin::signed(1), 20, 1000, 100),
@@ -426,12 +426,12 @@ fn vouch_works() {
 		assert_eq!(<Bids<Test>>::get(), vec![create_bid(1000, 20, BidKind::Vouch(10, 100))]);
 		// Vouched user can become candidate
 		run_to_block(4);
-		assert_eq!(Society::candidates(), vec![create_bid(1000, 20, BidKind::Vouch(10, 100))]);
+		assert_eq!(Candidates::<Test>::get(), vec![create_bid(1000, 20, BidKind::Vouch(10, 100))]);
 		// Vote yes
 		assert_ok!(Society::vote(RuntimeOrigin::signed(10), 20, true));
 		// Vouched user can win
 		run_to_block(8);
-		assert_eq!(Society::members(), vec![10, 20]);
+		assert_eq!(Members::<Test>::get(), vec![10, 20]);
 		// Voucher wins a portion of the payment
 		assert_eq!(<Payouts<Test>>::get(10), vec![(9, 100)]);
 		// Vouched user wins the rest
@@ -445,19 +445,19 @@ fn vouch_works() {
 fn voucher_cannot_win_more_than_bid() {
 	EnvBuilder::new().execute(|| {
 		// 10 is the only member
-		assert_eq!(Society::members(), vec![10]);
+		assert_eq!(Members::<Test>::get(), vec![10]);
 		// 10 vouches, but asks for more than the bid
 		assert_ok!(Society::vouch(RuntimeOrigin::signed(10), 20, 100, 1000));
 		// Vouching creates the right kind of bid
 		assert_eq!(<Bids<Test>>::get(), vec![create_bid(100, 20, BidKind::Vouch(10, 1000))]);
 		// Vouched user can become candidate
 		run_to_block(4);
-		assert_eq!(Society::candidates(), vec![create_bid(100, 20, BidKind::Vouch(10, 1000))]);
+		assert_eq!(Candidates::<Test>::get(), vec![create_bid(100, 20, BidKind::Vouch(10, 1000))]);
 		// Vote yes
 		assert_ok!(Society::vote(RuntimeOrigin::signed(10), 20, true));
 		// Vouched user can win
 		run_to_block(8);
-		assert_eq!(Society::members(), vec![10, 20]);
+		assert_eq!(Members::<Test>::get(), vec![10, 20]);
 		// Voucher wins as much as the bid
 		assert_eq!(<Payouts<Test>>::get(10), vec![(9, 100)]);
 		// Vouched user gets nothing
@@ -469,7 +469,7 @@ fn voucher_cannot_win_more_than_bid() {
 fn unvouch_works() {
 	EnvBuilder::new().execute(|| {
 		// 10 is the only member
-		assert_eq!(Society::members(), vec![10]);
+		assert_eq!(Members::<Test>::get(), vec![10]);
 		// 10 vouches for 20
 		assert_ok!(Society::vouch(RuntimeOrigin::signed(10), 20, 100, 0));
 		// 20 has a bid
@@ -488,14 +488,14 @@ fn unvouch_works() {
 		// Cannot unvouch after they become candidate
 		assert_ok!(Society::vouch(RuntimeOrigin::signed(10), 20, 100, 0));
 		run_to_block(4);
-		assert_eq!(Society::candidates(), vec![create_bid(100, 20, BidKind::Vouch(10, 0))]);
+		assert_eq!(Candidates::<Test>::get(), vec![create_bid(100, 20, BidKind::Vouch(10, 0))]);
 		assert_noop!(Society::unvouch(RuntimeOrigin::signed(10), 0), Error::<Test, _>::BadPosition);
 		// 10 is still vouching until candidate is approved or rejected
 		assert_eq!(<Vouching<Test>>::get(10), Some(VouchingStatus::Vouching));
 		run_to_block(8);
 		// In this case candidate is denied and suspended
-		assert!(Society::suspended_candidate(&20).is_some());
-		assert_eq!(Society::members(), vec![10]);
+		assert!(SuspendedCandidates::<Test>::get(&20).is_some());
+		assert_eq!(Members::<Test>::get(), vec![10]);
 		// User is stuck vouching until judgement origin resolves suspended candidate
 		assert_eq!(<Vouching<Test, _>>::get(10), Some(VouchingStatus::Vouching));
 		// Judge denies candidate
@@ -506,7 +506,7 @@ fn unvouch_works() {
 		));
 		// 10 is banned from vouching
 		assert_eq!(<Vouching<Test, _>>::get(10), Some(VouchingStatus::Banned));
-		assert_eq!(Society::members(), vec![10]);
+		assert_eq!(Members::<Test>::get(), vec![10]);
 
 		// 10 cannot vouch again
 		assert_noop!(
@@ -522,7 +522,7 @@ fn unvouch_works() {
 fn unbid_vouch_works() {
 	EnvBuilder::new().execute(|| {
 		// 10 is the only member
-		assert_eq!(Society::members(), vec![10]);
+		assert_eq!(Members::<Test>::get(), vec![10]);
 		// 10 vouches for 20
 		assert_ok!(Society::vouch(RuntimeOrigin::signed(10), 20, 100, 0));
 		// 20 has a bid
@@ -541,9 +541,9 @@ fn unbid_vouch_works() {
 fn founder_and_head_cannot_be_removed() {
 	EnvBuilder::new().execute(|| {
 		// 10 is the only member, founder, and head
-		assert_eq!(Society::members(), vec![10]);
-		assert_eq!(Society::founder(), Some(10));
-		assert_eq!(Society::head(), Some(10));
+		assert_eq!(Members::<Test>::get(), vec![10]);
+		assert_eq!(Founder::<Test>::get(), Some(10));
+		assert_eq!(Head::<Test>::get(), Some(10));
 		// 10 can still accumulate strikes
 		assert_ok!(Society::bid(RuntimeOrigin::signed(20), 0));
 		run_to_block(8);
@@ -562,10 +562,10 @@ fn founder_and_head_cannot_be_removed() {
 		assert_ok!(Society::vote(RuntimeOrigin::signed(10), 50, true));
 		assert_ok!(Society::defender_vote(RuntimeOrigin::signed(10), true)); // Keep defender around
 		run_to_block(32);
-		assert_eq!(Society::members(), vec![10, 50]);
-		assert_eq!(Society::head(), Some(50));
+		assert_eq!(Members::<Test>::get(), vec![10, 50]);
+		assert_eq!(Head::<Test>::get(), Some(50));
 		// Founder is unchanged
-		assert_eq!(Society::founder(), Some(10));
+		assert_eq!(Founder::<Test>::get(), Some(10));
 
 		// 50 can still accumulate strikes
 		assert_ok!(Society::bid(RuntimeOrigin::signed(60), 0));
@@ -582,9 +582,9 @@ fn founder_and_head_cannot_be_removed() {
 		assert_ok!(Society::vote(RuntimeOrigin::signed(50), 80, true));
 		assert_ok!(Society::defender_vote(RuntimeOrigin::signed(10), true)); // Keep defender around
 		run_to_block(56);
-		assert_eq!(Society::members(), vec![10, 50, 80]);
-		assert_eq!(Society::head(), Some(80));
-		assert_eq!(Society::founder(), Some(10));
+		assert_eq!(Members::<Test>::get(), vec![10, 50, 80]);
+		assert_eq!(Head::<Test>::get(), Some(80));
+		assert_eq!(Founder::<Test>::get(), Some(10));
 
 		// 50 can now be suspended for strikes
 		assert_ok!(Society::bid(RuntimeOrigin::signed(90), 0));
@@ -594,7 +594,7 @@ fn founder_and_head_cannot_be_removed() {
 		run_to_block(64);
 		assert_eq!(Strikes::<Test>::get(50), 0);
 		assert_eq!(<SuspendedMembers<Test>>::get(50), true);
-		assert_eq!(Society::members(), vec![10, 80]);
+		assert_eq!(Members::<Test>::get(), vec![10, 80]);
 	});
 }
 
@@ -611,18 +611,18 @@ fn challenges_work() {
 		assert_eq!(<DefenderVotes<Test>>::get(30), None);
 		assert_eq!(<DefenderVotes<Test>>::get(40), None);
 		// Check starting point
-		assert_eq!(Society::members(), vec![10, 20, 30, 40]);
-		assert_eq!(Society::defender(), None);
+		assert_eq!(Members::<Test>::get(), vec![10, 20, 30, 40]);
+		assert_eq!(Defender::<Test>::get(), None);
 		// 20 will be challenged during the challenge rotation
 		run_to_block(8);
-		assert_eq!(Society::defender(), Some(30));
+		assert_eq!(Defender::<Test>::get(), Some(30));
 		// They can always free vote for themselves
 		assert_ok!(Society::defender_vote(RuntimeOrigin::signed(30), true));
 		// If no one else votes, nothing happens
 		run_to_block(16);
-		assert_eq!(Society::members(), vec![10, 20, 30, 40]);
+		assert_eq!(Members::<Test>::get(), vec![10, 20, 30, 40]);
 		// New challenge period
-		assert_eq!(Society::defender(), Some(30));
+		assert_eq!(Defender::<Test>::get(), Some(30));
 		// Non-member cannot challenge
 		assert_noop!(
 			Society::defender_vote(RuntimeOrigin::signed(1), true),
@@ -635,14 +635,14 @@ fn challenges_work() {
 		assert_ok!(Society::defender_vote(RuntimeOrigin::signed(40), false));
 		run_to_block(24);
 		// 20 survives
-		assert_eq!(Society::members(), vec![10, 20, 30, 40]);
+		assert_eq!(Members::<Test>::get(), vec![10, 20, 30, 40]);
 		// Votes are reset
 		assert_eq!(<DefenderVotes<Test>>::get(10), None);
 		assert_eq!(<DefenderVotes<Test>>::get(20), None);
 		assert_eq!(<DefenderVotes<Test>>::get(30), None);
 		assert_eq!(<DefenderVotes<Test>>::get(40), None);
 		// One more time
-		assert_eq!(Society::defender(), Some(30));
+		assert_eq!(Defender::<Test>::get(), Some(30));
 		// 2 people say accept, 2 reject
 		assert_ok!(Society::defender_vote(RuntimeOrigin::signed(10), true));
 		assert_ok!(Society::defender_vote(RuntimeOrigin::signed(20), true));
@@ -650,10 +650,10 @@ fn challenges_work() {
 		assert_ok!(Society::defender_vote(RuntimeOrigin::signed(40), false));
 		run_to_block(32);
 		// 20 is suspended
-		assert_eq!(Society::members(), vec![10, 20, 40]);
-		assert_eq!(Society::suspended_member(30), true);
+		assert_eq!(Members::<Test>::get(), vec![10, 20, 40]);
+		assert_eq!(SuspendedMembers::<Test>::get(30), true);
 		// New defender is chosen
-		assert_eq!(Society::defender(), Some(20));
+		assert_eq!(Defender::<Test>::get(), Some(20));
 		// Votes are reset
 		assert_eq!(<DefenderVotes<Test>>::get(10), None);
 		assert_eq!(<DefenderVotes<Test>>::get(20), None);
@@ -675,7 +675,7 @@ fn bad_vote_slash_works() {
 		Society::bump_payout(&30, 5, 100);
 		Society::bump_payout(&40, 5, 100);
 		// Check starting point
-		assert_eq!(Society::members(), vec![10, 20, 30, 40]);
+		assert_eq!(Members::<Test>::get(), vec![10, 20, 30, 40]);
 		assert_eq!(<Payouts<Test>>::get(10), vec![(5, 100)]);
 		assert_eq!(<Payouts<Test>>::get(20), vec![(5, 100)]);
 		assert_eq!(<Payouts<Test>>::get(30), vec![(5, 100)]);
@@ -755,22 +755,22 @@ fn vouching_handles_removed_member_with_candidate() {
 		assert_eq!(<Vouching<Test>>::get(20), Some(VouchingStatus::Vouching));
 		// Make that bid a candidate
 		run_to_block(4);
-		assert_eq!(Society::candidates(), vec![create_bid(1000, 30, BidKind::Vouch(20, 100))]);
+		assert_eq!(Candidates::<Test>::get(), vec![create_bid(1000, 30, BidKind::Vouch(20, 100))]);
 		// Suspend that member
 		Society::suspend_member(&20);
 		assert_eq!(<SuspendedMembers<Test>>::get(20), true);
 		// Nothing changes yet
-		assert_eq!(Society::candidates(), vec![create_bid(1000, 30, BidKind::Vouch(20, 100))]);
+		assert_eq!(Candidates::<Test>::get(), vec![create_bid(1000, 30, BidKind::Vouch(20, 100))]);
 		assert_eq!(<Vouching<Test>>::get(20), Some(VouchingStatus::Vouching));
 		// Remove member
 		assert_ok!(Society::judge_suspended_member(RuntimeOrigin::signed(2), 20, false));
 		// Vouching status is removed, but candidate is still in the queue
 		assert_eq!(<Vouching<Test>>::get(20), None);
-		assert_eq!(Society::candidates(), vec![create_bid(1000, 30, BidKind::Vouch(20, 100))]);
+		assert_eq!(Candidates::<Test>::get(), vec![create_bid(1000, 30, BidKind::Vouch(20, 100))]);
 		// Candidate wins
 		assert_ok!(Society::vote(RuntimeOrigin::signed(10), 30, true));
 		run_to_block(8);
-		assert_eq!(Society::members(), vec![10, 30]);
+		assert_eq!(Members::<Test>::get(), vec![10, 30]);
 		// Payout does not go to removed member
 		assert_eq!(<Payouts<Test>>::get(20), vec![]);
 		assert_eq!(<Payouts<Test>>::get(30), vec![(9, 1000)]);
@@ -800,7 +800,7 @@ fn votes_are_working() {
 		assert_eq!(<Votes<Test>>::get(50, 10), None);
 		run_to_block(8);
 		// Candidates become members after a period rotation
-		assert_eq!(Society::members(), vec![10, 30, 40]);
+		assert_eq!(Members::<Test>::get(), vec![10, 30, 40]);
 		// Votes are cleaned up
 		assert_eq!(<Votes<Test>>::get(30, 10), None);
 		assert_eq!(<Votes<Test>>::get(40, 10), None);
@@ -827,17 +827,17 @@ fn max_limits_work() {
 		// Rotate period
 		run_to_block(4);
 		// Max of 10 candidates
-		assert_eq!(Society::candidates().len(), 10);
+		assert_eq!(Candidates::<Test>::get().len(), 10);
 		// Fill up membership, max 100, we will do just 95
 		for i in 2000..2095 {
 			assert_ok!(Society::add_member(&(i as u128)));
 		}
 		// Remember there was 1 original member, so 96 total
-		assert_eq!(Society::members().len(), 96);
+		assert_eq!(Members::<Test>::get().len(), 96);
 		// Rotate period
 		run_to_block(8);
 		// Only of 4 candidates possible now
-		assert_eq!(Society::candidates().len(), 4);
+		assert_eq!(Candidates::<Test>::get().len(), 4);
 		// Fill up members with suspended candidates from the first rotation
 		for i in 100..104 {
 			assert_ok!(Society::judge_suspended_candidate(
@@ -846,12 +846,12 @@ fn max_limits_work() {
 				Judgement::Approve
 			));
 		}
-		assert_eq!(Society::members().len(), 100);
+		assert_eq!(Members::<Test>::get().len(), 100);
 		// Can't add any more members
 		assert_noop!(Society::add_member(&98), Error::<Test, _>::MaxMembers);
 		// However, a fringe scenario allows for in-progress candidates to increase the membership
 		// pool, but it has no real after-effects.
-		for i in Society::members().iter() {
+		for i in Members::<Test>::get().iter() {
 			assert_ok!(Society::vote(RuntimeOrigin::signed(*i), 110, true));
 			assert_ok!(Society::vote(RuntimeOrigin::signed(*i), 111, true));
 			assert_ok!(Society::vote(RuntimeOrigin::signed(*i), 112, true));
@@ -859,15 +859,15 @@ fn max_limits_work() {
 		// Rotate period
 		run_to_block(12);
 		// Members length is over 100, no problem...
-		assert_eq!(Society::members().len(), 103);
+		assert_eq!(Members::<Test>::get().len(), 103);
 		// No candidates because full
-		assert_eq!(Society::candidates().len(), 0);
+		assert_eq!(Candidates::<Test>::get().len(), 0);
 		// Increase member limit
 		assert_ok!(Society::set_max_members(RuntimeOrigin::root(), 200));
 		// Rotate period
 		run_to_block(16);
 		// Candidates are back!
-		assert_eq!(Society::candidates().len(), 10);
+		assert_eq!(Candidates::<Test>::get().len(), 10);
 	});
 }
 
@@ -887,11 +887,11 @@ fn zero_bid_works() {
 		// Rotate period
 		run_to_block(4);
 		// Pot is 1000 after "PeriodSpend"
-		assert_eq!(Society::pot(), 1000);
+		assert_eq!(Pot::<Test>::get(), 1000);
 		assert_eq!(Balances::free_balance(Society::account_id()), 10_000);
 		// Choose smallest bidding users whose total is less than pot, with only one zero bid.
 		assert_eq!(
-			Society::candidates(),
+			Candidates::<Test>::get(),
 			vec![
 				create_bid(0, 30, BidKind::Deposit(25)),
 				create_bid(300, 50, BidKind::Deposit(25)),
@@ -908,9 +908,9 @@ fn zero_bid_works() {
 		assert_ok!(Society::vote(RuntimeOrigin::signed(10), 60, true));
 		run_to_block(8);
 		// Candidates become members after a period rotation
-		assert_eq!(Society::members(), vec![10, 30, 50, 60]);
+		assert_eq!(Members::<Test>::get(), vec![10, 30, 50, 60]);
 		// The zero bid is selected as head
-		assert_eq!(Society::head(), Some(30));
+		assert_eq!(Head::<Test>::get(), Some(30));
 	});
 }
 

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -556,7 +556,7 @@ benchmarks! {
 
 		let current_era = CurrentEra::<T>::get().unwrap();
 		// set the commission for this particular era as well.
-		<ErasValidatorPrefs<T>>::insert(current_era, validator.clone(), <Staking<T>>::validators(&validator));
+		<ErasValidatorPrefs<T>>::insert(current_era, validator.clone(), Validators::<T>::get(&validator));
 
 		let caller = whitelisted_caller();
 		let validator_controller = <Bonded<T>>::get(&validator).unwrap();
@@ -589,7 +589,7 @@ benchmarks! {
 
 		let current_era = CurrentEra::<T>::get().unwrap();
 		// set the commission for this particular era as well.
-		<ErasValidatorPrefs<T>>::insert(current_era, validator.clone(), <Staking<T>>::validators(&validator));
+		<ErasValidatorPrefs<T>>::insert(current_era, validator.clone(), Validators::<T>::get(&validator));
 
 		let caller = whitelisted_caller();
 		let balance_before = T::Currency::free_balance(&validator);

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -793,7 +793,7 @@ where
 	}
 
 	fn validators() -> Vec<<T as frame_system::Config>::AccountId> {
-		<pallet_session::Pallet<T>>::validators()
+		pallet_session::Validators::<T>::get()
 	}
 
 	fn prune_historical_up_to(up_to: SessionIndex) {
@@ -887,7 +887,7 @@ pub struct StashOf<T>(sp_std::marker::PhantomData<T>);
 
 impl<T: Config> Convert<T::AccountId, Option<T::AccountId>> for StashOf<T> {
 	fn convert(controller: T::AccountId) -> Option<T::AccountId> {
-		<Pallet<T>>::ledger(&controller).map(|l| l.stash)
+		Ledger::<T>::get(&controller).map(|l| l.stash)
 	}
 }
 
@@ -902,8 +902,7 @@ impl<T: Config> Convert<T::AccountId, Option<Exposure<T::AccountId, BalanceOf<T>
 	for ExposureOf<T>
 {
 	fn convert(validator: T::AccountId) -> Option<Exposure<T::AccountId, BalanceOf<T>>> {
-		<Pallet<T>>::active_era()
-			.map(|active_era| <Pallet<T>>::eras_stakers(active_era.index, &validator))
+		ActiveEra::<T>::get().map(|active_era| ErasStakers::<T>::get(active_era.index, &validator))
 	}
 }
 

--- a/frame/staking/src/slashing.rs
+++ b/frame/staking/src/slashing.rs
@@ -50,7 +50,7 @@
 //! Based on research at <https://research.web3.foundation/en/latest/polkadot/slashing/npos.html>
 
 use crate::{
-	BalanceOf, Config, Error, Exposure, NegativeImbalanceOf, NominatorSlashInEra,
+	BalanceOf, Bonded, Config, Error, Exposure, Ledger, NegativeImbalanceOf, NominatorSlashInEra,
 	OffendingValidators, Pallet, Perbill, SessionInterface, SpanSlash, UnappliedSlash,
 	ValidatorSlashInEra,
 };
@@ -597,12 +597,12 @@ pub fn do_slash<T: Config>(
 	slashed_imbalance: &mut NegativeImbalanceOf<T>,
 	slash_era: EraIndex,
 ) {
-	let controller = match <Pallet<T>>::bonded(stash).defensive() {
+	let controller = match Bonded::<T>::get(stash).defensive() {
 		None => return,
 		Some(c) => c,
 	};
 
-	let mut ledger = match <Pallet<T>>::ledger(&controller) {
+	let mut ledger = match Ledger::<T>::get(&controller) {
 		Some(ledger) => ledger,
 		None => return, // nothing to do.
 	};

--- a/frame/staking/src/testing_utils.rs
+++ b/frame/staking/src/testing_utils.rs
@@ -227,5 +227,5 @@ pub fn create_validators_with_nominators_for_era<T: Config>(
 
 /// get the current era.
 pub fn current_era<T: Config>() -> EraIndex {
-	<Pallet<T>>::current_era().unwrap_or(0)
+	CurrentEra::<T>::get().unwrap_or(0)
 }

--- a/frame/sudo/src/extension.rs
+++ b/frame/sudo/src/extension.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{Config, Pallet};
+use crate::{Config, Key};
 use codec::{Decode, Encode};
 use frame_support::{dispatch::DispatchInfo, ensure};
 use scale_info::TypeInfo;
@@ -86,7 +86,7 @@ where
 		info: &DispatchInfoOf<Self::Call>,
 		_len: usize,
 	) -> TransactionValidity {
-		let sudo_key: T::AccountId = <Pallet<T>>::key().ok_or(UnknownTransaction::CannotLookup)?;
+		let sudo_key: T::AccountId = Key::<T>::get().ok_or(UnknownTransaction::CannotLookup)?;
 		ensure!(*who == sudo_key, InvalidTransaction::BadSigner);
 
 		Ok(ValidTransaction {

--- a/frame/sudo/src/lib.rs
+++ b/frame/sudo/src/lib.rs
@@ -154,7 +154,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			// This is a public call, so we ensure that the origin is some signed account.
 			let sender = ensure_signed(origin)?;
-			ensure!(Self::key().map_or(false, |k| sender == k), Error::<T>::RequireSudo);
+			ensure!(Key::<T>::get().map_or(false, |k| sender == k), Error::<T>::RequireSudo);
 
 			let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Root.into());
 			Self::deposit_event(Event::Sudid { sudo_result: res.map(|_| ()).map_err(|e| e.error) });
@@ -179,7 +179,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			// This is a public call, so we ensure that the origin is some signed account.
 			let sender = ensure_signed(origin)?;
-			ensure!(Self::key().map_or(false, |k| sender == k), Error::<T>::RequireSudo);
+			ensure!(Key::<T>::get().map_or(false, |k| sender == k), Error::<T>::RequireSudo);
 
 			let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Root.into());
 			Self::deposit_event(Event::Sudid { sudo_result: res.map(|_| ()).map_err(|e| e.error) });
@@ -202,7 +202,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			// This is a public call, so we ensure that the origin is some signed account.
 			let sender = ensure_signed(origin)?;
-			ensure!(Self::key().map_or(false, |k| sender == k), Error::<T>::RequireSudo);
+			ensure!(Key::<T>::get().map_or(false, |k| sender == k), Error::<T>::RequireSudo);
 			let new = T::Lookup::lookup(new)?;
 
 			Self::deposit_event(Event::KeyChanged { old_sudoer: Key::<T>::get() });
@@ -235,7 +235,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			// This is a public call, so we ensure that the origin is some signed account.
 			let sender = ensure_signed(origin)?;
-			ensure!(Self::key().map_or(false, |k| sender == k), Error::<T>::RequireSudo);
+			ensure!(Key::<T>::get().map_or(false, |k| sender == k), Error::<T>::RequireSudo);
 
 			let who = T::Lookup::lookup(who)?;
 

--- a/frame/sudo/src/mock.rs
+++ b/frame/sudo/src/mock.rs
@@ -81,13 +81,11 @@ pub mod logger {
 	}
 
 	#[pallet::storage]
-	#[pallet::getter(fn account_log)]
-	pub(super) type AccountLog<T: Config> =
+	pub type AccountLog<T: Config> =
 		StorageValue<_, BoundedVec<T::AccountId, ConstU32<1_000>>, ValueQuery>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn i32_log)]
-	pub(super) type I32Log<T> = StorageValue<_, BoundedVec<i32, ConstU32<1_000>>, ValueQuery>;
+	pub type I32Log<T> = StorageValue<_, BoundedVec<i32, ConstU32<1_000>>, ValueQuery>;
 }
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;

--- a/frame/support/procedural/src/pallet/expand/storage.rs
+++ b/frame/support/procedural/src/pallet/expand/storage.rs
@@ -395,6 +395,7 @@ pub fn expand_storages(def: &mut Def) -> proc_macro2::TokenStream {
 						#(#cfg_attrs)*
 						impl<#type_impl_gen> #pallet_ident<#type_use_gen> #completed_where_clause {
 							#( #docs )*
+							#[deprecated = "#[pallet::getter] is deprecated and will be unavailable in future versions.\nFor more information, see https://github.com/paritytech/substrate/pull/13365"]
 							pub fn #getter() -> #query {
 								<
 									#full_ident as #frame_support::storage::StorageValue<#value>

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -339,11 +339,9 @@ pub mod pallet {
 	>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn nmap)]
 	pub type NMap<T> = StorageNMap<_, storage::Key<Blake2_128Concat, u8>, u32>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn nmap2)]
 	pub type NMap2<T> = StorageNMap<
 		Key = (NMapKey<Twox64Concat, u16>, NMapKey<Blake2_128Concat, u32>),
 		Value = u64,
@@ -351,7 +349,6 @@ pub mod pallet {
 	>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn nmap3)]
 	pub type NMap3<T> = StorageNMap<
 		_,
 		(NMapKey<Blake2_128Concat, u8>, NMapKey<Twox64Concat, u16>),
@@ -360,31 +357,26 @@ pub mod pallet {
 	>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn conditional_value)]
 	#[cfg(feature = "frame-feature-testing")]
 	pub type ConditionalValue<T> = StorageValue<_, u32>;
 
 	#[cfg(feature = "frame-feature-testing")]
 	#[pallet::storage]
-	#[pallet::getter(fn conditional_map)]
 	pub type ConditionalMap<T> =
 		StorageMap<_, Twox64Concat, u16, u32, OptionQuery, GetDefault, ConstU32<12>>;
 
 	#[cfg(feature = "frame-feature-testing")]
 	#[pallet::storage]
-	#[pallet::getter(fn conditional_double_map)]
 	pub type ConditionalDoubleMap<T> =
 		StorageDoubleMap<_, Blake2_128Concat, u8, Twox64Concat, u16, u32>;
 
 	#[cfg(feature = "frame-feature-testing")]
 	#[pallet::storage]
-	#[pallet::getter(fn conditional_nmap)]
 	pub type ConditionalNMap<T> =
 		StorageNMap<_, (storage::Key<Blake2_128Concat, u8>, storage::Key<Twox64Concat, u16>), u32>;
 
 	#[pallet::storage]
 	#[pallet::storage_prefix = "RenamedCountedMap"]
-	#[pallet::getter(fn counted_storage_map)]
 	pub type SomeCountedStorageMap<T> =
 		CountedStorageMap<Hasher = Twox64Concat, Key = u8, Value = u32>;
 

--- a/frame/support/test/tests/pallet_instance.rs
+++ b/frame/support/test/tests/pallet_instance.rs
@@ -165,16 +165,13 @@ pub mod pallet {
 	>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn nmap)]
 	pub type NMap<T, I = ()> = StorageNMap<_, storage::Key<Blake2_128Concat, u8>, u32>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn nmap2)]
 	pub type NMap2<T, I = ()> =
 		StorageNMap<_, (storage::Key<Twox64Concat, u16>, storage::Key<Blake2_128Concat, u32>), u64>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn nmap3)]
 	pub type NMap3<T, I = ()> = StorageNMap<
 		_,
 		(NMapKey<Blake2_128Concat, u8>, NMapKey<Twox64Concat, u16>),

--- a/frame/support/test/tests/pallet_ui/storage_multiple_getters.rs
+++ b/frame/support/test/tests/pallet_ui/storage_multiple_getters.rs
@@ -21,5 +21,4 @@ mod pallet {
 	type Foo<T> = StorageValue<_, u8>;
 }
 
-fn main() {
-}
+fn main() {}

--- a/frame/system/src/extensions/check_genesis.rs
+++ b/frame/system/src/extensions/check_genesis.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{Config, Pallet};
+use crate::{BlockHash, Config};
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::{
@@ -60,7 +60,7 @@ impl<T: Config + Send + Sync> SignedExtension for CheckGenesis<T> {
 	const IDENTIFIER: &'static str = "CheckGenesis";
 
 	fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
-		Ok(<Pallet<T>>::block_hash(T::BlockNumber::zero()))
+		Ok(BlockHash::<T>::get(T::BlockNumber::zero()))
 	}
 
 	fn pre_dispatch(

--- a/frame/system/src/extensions/check_mortality.rs
+++ b/frame/system/src/extensions/check_mortality.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{BlockHash, Config, Pallet};
+use crate::{BlockHash, Config, Number};
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::{
@@ -68,7 +68,7 @@ impl<T: Config + Send + Sync> SignedExtension for CheckMortality<T> {
 		_info: &DispatchInfoOf<Self::Call>,
 		_len: usize,
 	) -> TransactionValidity {
-		let current_u64 = <Pallet<T>>::block_number().saturated_into::<u64>();
+		let current_u64 = Number::<T>::get().saturated_into::<u64>();
 		let valid_till = self.0.death(current_u64);
 		Ok(ValidTransaction {
 			longevity: valid_till.saturating_sub(current_u64),
@@ -77,12 +77,12 @@ impl<T: Config + Send + Sync> SignedExtension for CheckMortality<T> {
 	}
 
 	fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
-		let current_u64 = <Pallet<T>>::block_number().saturated_into::<u64>();
+		let current_u64 = Number::<T>::get().saturated_into::<u64>();
 		let n = self.0.birth(current_u64).saturated_into::<T::BlockNumber>();
 		if !<BlockHash<T>>::contains_key(n) {
 			Err(InvalidTransaction::AncientBirthBlock.into())
 		} else {
-			Ok(<Pallet<T>>::block_hash(n))
+			Ok(BlockHash::<T>::get(n))
 		}
 	}
 

--- a/frame/system/src/extensions/check_weight.rs
+++ b/frame/system/src/extensions/check_weight.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{limits::BlockWeights, Config, Pallet};
+use crate::{limits::BlockWeights, BlockWeight, Config, Pallet};
 use codec::{Decode, Encode};
 use frame_support::{
 	dispatch::{DispatchInfo, PostDispatchInfo},
@@ -63,7 +63,7 @@ where
 		info: &DispatchInfoOf<T::RuntimeCall>,
 	) -> Result<crate::ConsumedWeight, TransactionValidityError> {
 		let maximum_weight = T::BlockWeights::get();
-		let all_weight = Pallet::<T>::block_weight();
+		let all_weight = BlockWeight::<T>::get();
 		calculate_consumed_weight::<T::RuntimeCall>(maximum_weight, all_weight, info)
 	}
 

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -544,7 +544,6 @@ pub mod pallet {
 	/// The current weight for the block.
 	#[pallet::storage]
 	#[pallet::whitelist_storage]
-	#[pallet::getter(fn block_weight)]
 	pub(super) type BlockWeight<T: Config> = StorageValue<_, ConsumedWeight, ValueQuery>;
 
 	/// Total length (in bytes) for all extrinsics put together, for the current block.
@@ -559,7 +558,6 @@ pub mod pallet {
 
 	/// Extrinsics data for the current block (maps an extrinsic's index to its data).
 	#[pallet::storage]
-	#[pallet::getter(fn extrinsic_data)]
 	#[pallet::unbounded]
 	pub(super) type ExtrinsicData<T: Config> =
 		StorageMap<_, Twox64Concat, u32, Vec<u8>, ValueQuery>;
@@ -567,18 +565,15 @@ pub mod pallet {
 	/// The current block number being processed. Set by `execute_block`.
 	#[pallet::storage]
 	#[pallet::whitelist_storage]
-	#[pallet::getter(fn block_number)]
 	pub(super) type Number<T: Config> = StorageValue<_, T::BlockNumber, ValueQuery>;
 
 	/// Hash of the previous block.
 	#[pallet::storage]
-	#[pallet::getter(fn parent_hash)]
 	pub(super) type ParentHash<T: Config> = StorageValue<_, T::Hash, ValueQuery>;
 
 	/// Digest of the current block, also part of the block header.
 	#[pallet::storage]
 	#[pallet::unbounded]
-	#[pallet::getter(fn digest)]
 	pub(super) type Digest<T: Config> = StorageValue<_, generic::Digest, ValueQuery>;
 
 	/// Events deposited for the current block.
@@ -597,7 +592,6 @@ pub mod pallet {
 	/// The number of events in the `Events<T>` list.
 	#[pallet::storage]
 	#[pallet::whitelist_storage]
-	#[pallet::getter(fn event_count)]
 	pub(super) type EventCount<T: Config> = StorageValue<_, EventIndex, ValueQuery>;
 
 	/// Mapping between a topic (represented by T::Hash) and a vector of indexes
@@ -612,7 +606,6 @@ pub mod pallet {
 	/// no notification will be triggered thus the event might be lost.
 	#[pallet::storage]
 	#[pallet::unbounded]
-	#[pallet::getter(fn event_topics)]
 	pub(super) type EventTopics<T: Config> =
 		StorageMap<_, Blake2_128Concat, T::Hash, Vec<(T::BlockNumber, EventIndex)>, ValueQuery>;
 
@@ -996,6 +989,42 @@ pub enum DecRefStatus {
 impl<T: Config> Pallet<T> {
 	pub fn account_exists(who: &T::AccountId) -> bool {
 		Account::<T>::contains_key(who)
+	}
+
+	/// The current weight for the block.
+	pub fn block_weight() -> ConsumedWeight {
+		BlockWeight::<T>::get()
+	}
+
+	/// Extrinsics data for the current block (maps an extrinsic's index to its data).
+	pub fn extrinsic_data(i: u32) -> Vec<u8> {
+		ExtrinsicData::<T>::get(i)
+	}
+
+	/// The current block number being processed. Set by `execute_block`.
+	pub fn block_number() -> T::BlockNumber {
+		Number::<T>::get()
+	}
+
+	/// Hash of the previous block.
+	pub fn parent_hash() -> T::Hash {
+		ParentHash::<T>::get()
+	}
+
+	/// Digest of the current block, also part of the block header.
+	pub fn digest() -> generic::Digest {
+		Digest::<T>::get()
+	}
+
+	/// The number of events in the `Events<T>` list.
+	pub fn event_count() -> EventIndex {
+		EventCount::<T>::get()
+	}
+
+	/// Mapping between a topic (represented by T::Hash) and a vector of indexes
+	/// of events in the `<Events<T>>` list.
+	pub fn event_topics(topic: &T::Hash) -> Vec<(T::BlockNumber, EventIndex)> {
+		EventTopics::<T>::get(topic)
 	}
 
 	/// Write code to the storage and emit related events and digest items.

--- a/frame/timestamp/src/benchmarking.rs
+++ b/frame/timestamp/src/benchmarking.rs
@@ -24,7 +24,7 @@ use frame_benchmarking::v1::{benchmarks, TrackedStorageKey};
 use frame_support::{ensure, traits::OnFinalize};
 use frame_system::RawOrigin;
 
-use crate::Pallet as Timestamp;
+use crate::{Now, Pallet as Timestamp};
 
 const MAX_TIME: u32 = 100;
 
@@ -41,7 +41,7 @@ benchmarks! {
 		});
 	}: _(RawOrigin::None, t.into())
 	verify {
-		ensure!(Timestamp::<T>::now() == t.into(), "Time was not set.");
+		ensure!(Now::<T>::get() == t.into(), "Time was not set.");
 	}
 
 	on_finalize {

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -202,7 +202,7 @@ pub mod pallet {
 		pub fn set(origin: OriginFor<T>, #[pallet::compact] now: T::Moment) -> DispatchResult {
 			ensure_none(origin)?;
 			assert!(!DidUpdate::<T>::exists(), "Timestamp must be updated only once in the block");
-			let prev = Self::now();
+			let prev = Now::<T>::get();
 			assert!(
 				prev.is_zero() || now >= prev + T::MinimumPeriod::get(),
 				"Timestamp must increment by at least <MinimumPeriod> between sequential blocks"
@@ -229,7 +229,7 @@ pub mod pallet {
 				.expect("Timestamp inherent data must be provided");
 			let data = (*inherent_data).saturated_into::<T::Moment>();
 
-			let next_time = cmp::max(data, Self::now() + T::MinimumPeriod::get());
+			let next_time = cmp::max(data, Now::<T>::get() + T::MinimumPeriod::get());
 			Some(Call::set { now: next_time })
 		}
 
@@ -250,7 +250,7 @@ pub mod pallet {
 				.expect("Timestamp inherent data not correctly encoded")
 				.expect("Timestamp inherent data must be provided");
 
-			let minimum = (Self::now() + T::MinimumPeriod::get()).saturated_into::<u64>();
+			let minimum = (Now::<T>::get() + T::MinimumPeriod::get()).saturated_into::<u64>();
 			if t > *(data + MAX_TIMESTAMP_DRIFT_MILLIS) {
 				Err(InherentError::TooFarInFuture)
 			} else if t < minimum {
@@ -272,7 +272,7 @@ impl<T: Config> Pallet<T> {
 	/// NOTE: if this function is called prior to setting the timestamp,
 	/// it will return the timestamp of the previous block.
 	pub fn get() -> T::Moment {
-		Self::now()
+		Now::<T>::get()
 	}
 
 	/// Set the timestamp to something in particular. Only used for tests.
@@ -289,7 +289,7 @@ impl<T: Config> Time for Pallet<T> {
 
 	/// Before the first set of now with inherent the value returned is zero.
 	fn now() -> Self::Moment {
-		Self::now()
+		Now::<T>::get()
 	}
 }
 
@@ -300,7 +300,7 @@ impl<T: Config> UnixTime for Pallet<T> {
 	fn now() -> core::time::Duration {
 		// now is duration since unix epoch in millisecond as documented in
 		// `sp_timestamp::InherentDataProvider`.
-		let now = Self::now();
+		let now = Now::<T>::get();
 		sp_std::if_std! {
 			if now == T::Moment::zero() {
 				log::error!(

--- a/frame/timestamp/src/tests.rs
+++ b/frame/timestamp/src/tests.rs
@@ -17,7 +17,7 @@
 
 //! Tests for the Timestamp module.
 
-use crate::mock::*;
+use crate::{mock::*, Now};
 use frame_support::assert_ok;
 
 #[test]
@@ -25,7 +25,7 @@ fn timestamp_works() {
 	new_test_ext().execute_with(|| {
 		crate::Now::<Test>::put(46);
 		assert_ok!(Timestamp::set(RuntimeOrigin::none(), 69));
-		assert_eq!(Timestamp::now(), 69);
+		assert_eq!(Now::<Test>::get(), 69);
 		assert_eq!(Some(69), get_captured_moment());
 	});
 }

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -594,7 +594,7 @@ where
 		if pays_fee == Pays::Yes {
 			// the adjustable part of the fee.
 			let unadjusted_weight_fee = Self::weight_to_fee(weight);
-			let multiplier = Self::next_fee_multiplier();
+			let multiplier = NextFeeMultiplier::<T>::get();
 			// final adjusted weight fee.
 			let adjusted_weight_fee = multiplier.saturating_mul_int(unadjusted_weight_fee);
 

--- a/frame/treasury/src/benchmarking.rs
+++ b/frame/treasury/src/benchmarking.rs
@@ -124,7 +124,7 @@ benchmarks_instance_pallet! {
 			value,
 			beneficiary_lookup
 		)?;
-		let proposal_id = Treasury::<T, _>::proposal_count() - 1;
+		let proposal_id = ProposalCount::<T, _>::get() - 1;
 		Treasury::<T, I>::approve_proposal(RawOrigin::Root.into(), proposal_id)?;
 		let reject_origin =
 			T::RejectOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -162,7 +162,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 fn genesis_config_works() {
 	new_test_ext().execute_with(|| {
 		assert_eq!(Treasury::pot(), 0);
-		assert_eq!(Treasury::proposal_count(), 0);
+		assert_eq!(ProposalCount::<Test>::get(), 0);
 	});
 }
 
@@ -475,9 +475,9 @@ fn remove_already_removed_approval_fails() {
 
 		assert_ok!(Treasury::propose_spend(RuntimeOrigin::signed(0), 100, 3));
 		assert_ok!(Treasury::approve_proposal(RuntimeOrigin::root(), 0));
-		assert_eq!(Treasury::approvals(), vec![0]);
+		assert_eq!(Approvals::<Test>::get(), vec![0]);
 		assert_ok!(Treasury::remove_approval(RuntimeOrigin::root(), 0));
-		assert_eq!(Treasury::approvals(), vec![]);
+		assert_eq!(Approvals::<Test>::get(), vec![]);
 
 		assert_noop!(
 			Treasury::remove_approval(RuntimeOrigin::root(), 0),

--- a/frame/vesting/src/benchmarking.rs
+++ b/frame/vesting/src/benchmarking.rs
@@ -25,7 +25,7 @@ use frame_system::{Pallet as System, RawOrigin};
 use sp_runtime::traits::{Bounded, CheckedDiv, CheckedMul};
 
 use super::*;
-use crate::Pallet as Vesting;
+use crate::{Pallet as Vesting, Vesting as VestingStorage};
 
 const SEED: u32 = 0;
 
@@ -291,7 +291,7 @@ benchmarks! {
 			"Vesting balance should equal sum locked of all schedules",
 		);
 		assert_eq!(
-			Vesting::<T>::vesting(&caller).unwrap().len(),
+			VestingStorage::<T>::get(&caller).unwrap().len(),
 			s as usize,
 			"There should be exactly max vesting schedules"
 		);
@@ -304,7 +304,7 @@ benchmarks! {
 		);
 		let expected_index = (s - 2) as usize;
 		assert_eq!(
-			Vesting::<T>::vesting(&caller).unwrap()[expected_index],
+			VestingStorage::<T>::get(&caller).unwrap()[expected_index],
 			expected_schedule
 		);
 		assert_eq!(
@@ -313,7 +313,7 @@ benchmarks! {
 			"Vesting balance should equal total locked of all schedules",
 		);
 		assert_eq!(
-			Vesting::<T>::vesting(&caller).unwrap().len(),
+			VestingStorage::<T>::get(&caller).unwrap().len(),
 			(s - 1) as usize,
 			"Schedule count should reduce by 1"
 		);
@@ -344,7 +344,7 @@ benchmarks! {
 			"Vesting balance should reflect that we are half way through all schedules duration",
 		);
 		assert_eq!(
-			Vesting::<T>::vesting(&caller).unwrap().len(),
+			VestingStorage::<T>::get(&caller).unwrap().len(),
 			s as usize,
 			"There should be exactly max vesting schedules"
 		);
@@ -359,12 +359,12 @@ benchmarks! {
 		);
 		let expected_index = (s - 2) as usize;
 		assert_eq!(
-			Vesting::<T>::vesting(&caller).unwrap()[expected_index],
+			VestingStorage::<T>::get(&caller).unwrap()[expected_index],
 			expected_schedule,
 			"New schedule is properly created and placed"
 		);
 		assert_eq!(
-			Vesting::<T>::vesting(&caller).unwrap()[expected_index],
+			VestingStorage::<T>::get(&caller).unwrap()[expected_index],
 			expected_schedule
 		);
 		assert_eq!(
@@ -373,7 +373,7 @@ benchmarks! {
 			"Vesting balance should equal half total locked of all schedules",
 		);
 		assert_eq!(
-			Vesting::<T>::vesting(&caller).unwrap().len(),
+			VestingStorage::<T>::get(&caller).unwrap().len(),
 			(s - 1) as usize,
 			"Schedule count should reduce by 1"
 		);

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -421,7 +421,7 @@ pub mod pallet {
 			let schedule1_index = schedule1_index as usize;
 			let schedule2_index = schedule2_index as usize;
 
-			let schedules = Self::vesting(&who).ok_or(Error::<T>::NotVesting)?;
+			let schedules = Vesting::<T>::get(&who).ok_or(Error::<T>::NotVesting)?;
 			let merge_action =
 				VestingAction::Merge { index1: schedule1_index, index2: schedule2_index };
 
@@ -594,7 +594,7 @@ impl<T: Config> Pallet<T> {
 
 	/// Unlock any vested funds of `who`.
 	fn do_vest(who: T::AccountId) -> DispatchResult {
-		let schedules = Self::vesting(&who).ok_or(Error::<T>::NotVesting)?;
+		let schedules = Vesting::<T>::get(&who).ok_or(Error::<T>::NotVesting)?;
 
 		let (schedules, locked_now) =
 			Self::exec_action(schedules.to_vec(), VestingAction::Passive)?;
@@ -659,7 +659,7 @@ where
 
 	/// Get the amount that is currently being vested and cannot be transferred out of this account.
 	fn vesting_balance(who: &T::AccountId) -> Option<BalanceOf<T>> {
-		if let Some(v) = Self::vesting(who) {
+		if let Some(v) = Vesting::<T>::get(who) {
 			let now = <frame_system::Pallet<T>>::block_number();
 			let total_locked_now = v.iter().fold(Zero::zero(), |total, schedule| {
 				schedule.locked_at::<T::BlockNumberToBalance>(now).saturating_add(total)
@@ -698,7 +698,7 @@ where
 			return Err(Error::<T>::InvalidScheduleParams.into())
 		};
 
-		let mut schedules = Self::vesting(who).unwrap_or_default();
+		let mut schedules = Vesting::<T>::get(who).unwrap_or_default();
 
 		// NOTE: we must push the new schedule so that `exec_action`
 		// will give the correct new locked amount.
@@ -736,7 +736,7 @@ where
 
 	/// Remove a vesting schedule for a given account.
 	fn remove_vesting_schedule(who: &T::AccountId, schedule_index: u32) -> DispatchResult {
-		let schedules = Self::vesting(who).ok_or(Error::<T>::NotVesting)?;
+		let schedules = Vesting::<T>::get(who).ok_or(Error::<T>::NotVesting)?;
 		let remove_action = VestingAction::Remove { index: schedule_index as usize };
 
 		let (schedules, locked_now) = Self::exec_action(schedules.to_vec(), remove_action)?;

--- a/frame/vesting/src/tests.rs
+++ b/frame/vesting/src/tests.rs
@@ -64,9 +64,9 @@ fn check_vesting_status() {
 			64, // Vesting over 20 blocks
 			10,
 		);
-		assert_eq!(Vesting::vesting(&1).unwrap(), vec![user1_vesting_schedule]); // Account 1 has a vesting schedule
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![user2_vesting_schedule]); // Account 2 has a vesting schedule
-		assert_eq!(Vesting::vesting(&12).unwrap(), vec![user12_vesting_schedule]); // Account 12 has a vesting schedule
+		assert_eq!(VestingStorage::<Test>::get(&1).unwrap(), vec![user1_vesting_schedule]); // Account 1 has a vesting schedule
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![user2_vesting_schedule]); // Account 2 has a vesting schedule
+		assert_eq!(VestingStorage::<Test>::get(&12).unwrap(), vec![user12_vesting_schedule]); // Account 12 has a vesting schedule
 
 		// Account 1 has only 128 units vested from their illiquid ED * 5 units at block 1
 		assert_eq!(Vesting::vesting_balance(&1), Some(128 * 9));
@@ -109,7 +109,7 @@ fn check_vesting_status_for_multi_schedule_account() {
 			10,
 		);
 		// Account 2 already has a vesting schedule.
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched0]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched0]);
 
 		// Account 2's free balance is from sched0.
 		let free_balance = Balances::free_balance(&2);
@@ -127,7 +127,7 @@ fn check_vesting_status_for_multi_schedule_account() {
 		let free_balance = Balances::free_balance(&2);
 		assert_eq!(free_balance, ED * (10 + 20));
 		// The most recently added schedule exists.
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched0, sched1]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched0, sched1]);
 		// sched1 has free funds at block #1, but nothing else.
 		assert_eq!(Vesting::vesting_balance(&2), Some(free_balance - sched1.per_block()));
 
@@ -170,7 +170,7 @@ fn check_vesting_status_for_multi_schedule_account() {
 		assert_eq!(Vesting::vesting_balance(&2), Some(0));
 		// Since we have not called any extrinsics that would unlock funds the schedules
 		// are still in storage,
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched0, sched1, sched2]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched0, sched1, sched2]);
 		// but once we unlock the funds, they are removed from storage.
 		vest_and_assert_no_vesting::<Test>(2);
 	});
@@ -206,7 +206,7 @@ fn vested_balance_should_transfer_with_multi_sched() {
 		let sched0 = VestingInfo::new(5 * ED, 128, 0);
 		assert_ok!(Vesting::vested_transfer(Some(13).into(), 1, sched0));
 		// Total 10*ED locked for all the schedules.
-		assert_eq!(Vesting::vesting(&1).unwrap(), vec![sched0, sched0]);
+		assert_eq!(VestingStorage::<Test>::get(&1).unwrap(), vec![sched0, sched0]);
 
 		let user1_free_balance = Balances::free_balance(&1);
 		assert_eq!(user1_free_balance, 3840); // Account 1 has free balance
@@ -244,7 +244,7 @@ fn vested_balance_should_transfer_using_vest_other_with_multi_sched() {
 		let sched0 = VestingInfo::new(5 * ED, 128, 0);
 		assert_ok!(Vesting::vested_transfer(Some(13).into(), 1, sched0));
 		// Total of 10*ED of locked for all the schedules.
-		assert_eq!(Vesting::vesting(&1).unwrap(), vec![sched0, sched0]);
+		assert_eq!(VestingStorage::<Test>::get(&1).unwrap(), vec![sched0, sched0]);
 
 		let user1_free_balance = Balances::free_balance(&1);
 		assert_eq!(user1_free_balance, 3840); // Account 1 has free balance
@@ -304,7 +304,7 @@ fn liquid_funds_should_transfer_with_delayed_vesting() {
 			64, // Vesting over 20 blocks
 			10,
 		);
-		assert_eq!(Vesting::vesting(&12).unwrap(), vec![user12_vesting_schedule]);
+		assert_eq!(VestingStorage::<Test>::get(&12).unwrap(), vec![user12_vesting_schedule]);
 
 		// Account 12 can still send liquid funds
 		assert_ok!(Balances::transfer_allow_death(Some(12).into(), 3, 256 * 5));
@@ -319,7 +319,7 @@ fn vested_transfer_works() {
 		assert_eq!(user3_free_balance, 256 * 30);
 		assert_eq!(user4_free_balance, 256 * 40);
 		// Account 4 should not have any vesting yet.
-		assert_eq!(Vesting::vesting(&4), None);
+		assert_eq!(VestingStorage::<Test>::get(&4), None);
 		// Make the schedule for the new transfer.
 		let new_vesting_schedule = VestingInfo::new(
 			256 * 5,
@@ -328,7 +328,7 @@ fn vested_transfer_works() {
 		);
 		assert_ok!(Vesting::vested_transfer(Some(3).into(), 4, new_vesting_schedule));
 		// Now account 4 should have vesting.
-		assert_eq!(Vesting::vesting(&4).unwrap(), vec![new_vesting_schedule]);
+		assert_eq!(VestingStorage::<Test>::get(&4).unwrap(), vec![new_vesting_schedule]);
 		// Ensure the transfer happened correctly.
 		let user3_free_balance_updated = Balances::free_balance(&3);
 		assert_eq!(user3_free_balance_updated, 256 * 25);
@@ -367,7 +367,7 @@ fn vested_transfer_correctly_fails() {
 			ED, // Vesting over 20 blocks
 			10,
 		);
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![user2_vesting_schedule]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![user2_vesting_schedule]);
 
 		// Fails due to too low transfer amount.
 		let new_vesting_schedule_too_low =
@@ -449,7 +449,7 @@ fn force_vested_transfer_works() {
 		assert_eq!(user3_free_balance, ED * 30);
 		assert_eq!(user4_free_balance, ED * 40);
 		// Account 4 should not have any vesting yet.
-		assert_eq!(Vesting::vesting(&4), None);
+		assert_eq!(VestingStorage::<Test>::get(&4), None);
 		// Make the schedule for the new transfer.
 		let new_vesting_schedule = VestingInfo::new(
 			ED * 5,
@@ -468,8 +468,8 @@ fn force_vested_transfer_works() {
 			new_vesting_schedule
 		));
 		// Now account 4 should have vesting.
-		assert_eq!(Vesting::vesting(&4).unwrap()[0], new_vesting_schedule);
-		assert_eq!(Vesting::vesting(&4).unwrap().len(), 1);
+		assert_eq!(VestingStorage::<Test>::get(&4).unwrap()[0], new_vesting_schedule);
+		assert_eq!(VestingStorage::<Test>::get(&4).unwrap().len(), 1);
 		// Ensure the transfer happened correctly.
 		let user3_free_balance_updated = Balances::free_balance(&3);
 		assert_eq!(user3_free_balance_updated, ED * 25);
@@ -507,7 +507,7 @@ fn force_vested_transfer_correctly_fails() {
 			ED, // Vesting over 20 blocks
 			10,
 		);
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![user2_vesting_schedule]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![user2_vesting_schedule]);
 
 		// Too low transfer amount.
 		let new_vesting_schedule_too_low =
@@ -593,12 +593,12 @@ fn merge_schedules_that_have_not_started() {
 			ED, // Vest over 20 blocks.
 			10,
 		);
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched0]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched0]);
 		assert_eq!(Balances::usable_balance(&2), 0);
 
 		// Add a schedule that is identical to the one that already exists.
 		assert_ok!(Vesting::vested_transfer(Some(3).into(), 2, sched0));
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched0, sched0]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched0, sched0]);
 		assert_eq!(Balances::usable_balance(&2), 0);
 		assert_ok!(Vesting::merge_schedules(Some(2).into(), 0, 1));
 
@@ -609,7 +609,7 @@ fn merge_schedules_that_have_not_started() {
 			sched0.per_block() * 2,
 			10, // Starts at the block the schedules are merged/
 		);
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched1]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched1]);
 
 		assert_eq!(Balances::usable_balance(&2), 0);
 	});
@@ -625,7 +625,7 @@ fn merge_ongoing_schedules() {
 			ED, // Vest over 20 blocks.
 			10,
 		);
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched0]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched0]);
 
 		let sched1 = VestingInfo::new(
 			ED * 10,
@@ -633,7 +633,7 @@ fn merge_ongoing_schedules() {
 			sched0.starting_block() + 5, // Start at block 15.
 		);
 		assert_ok!(Vesting::vested_transfer(Some(4).into(), 2, sched1));
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched0, sched1]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched0, sched1]);
 
 		// Got to half way through the second schedule where both schedules are actively vesting.
 		let cur_block = 20;
@@ -665,7 +665,7 @@ fn merge_ongoing_schedules() {
 		let sched2_per_block = sched2_locked / sched2_duration;
 
 		let sched2 = VestingInfo::new(sched2_locked, sched2_per_block, cur_block);
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched2]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched2]);
 
 		// And just to double check, we assert the new merged schedule we be cleaned up as expected.
 		System::set_block_number(30);
@@ -695,7 +695,7 @@ fn merging_shifts_other_schedules_index() {
 		);
 
 		// Account 3 starts out with no schedules,
-		assert_eq!(Vesting::vesting(&3), None);
+		assert_eq!(VestingStorage::<Test>::get(&3), None);
 		// and some usable balance.
 		let usable_balance = Balances::usable_balance(&3);
 		assert_eq!(usable_balance, 30 * ED);
@@ -709,7 +709,7 @@ fn merging_shifts_other_schedules_index() {
 		assert_ok!(Vesting::vested_transfer(Some(4).into(), 3, sched2));
 
 		// With no schedules vested or merged they are in the order they are created
-		assert_eq!(Vesting::vesting(&3).unwrap(), vec![sched0, sched1, sched2]);
+		assert_eq!(VestingStorage::<Test>::get(&3).unwrap(), vec![sched0, sched1, sched2]);
 		// and the usable balance has not changed.
 		assert_eq!(usable_balance, Balances::usable_balance(&3));
 
@@ -730,7 +730,7 @@ fn merging_shifts_other_schedules_index() {
 		let sched3 = VestingInfo::new(sched3_locked, sched3_per_block, sched3_start);
 
 		// The not touched schedule moves left and the new merged schedule is appended.
-		assert_eq!(Vesting::vesting(&3).unwrap(), vec![sched1, sched3]);
+		assert_eq!(VestingStorage::<Test>::get(&3).unwrap(), vec![sched1, sched3]);
 		// The usable balance hasn't changed since none of the schedules have started.
 		assert_eq!(Balances::usable_balance(&3), usable_balance);
 	});
@@ -747,7 +747,7 @@ fn merge_ongoing_and_yet_to_be_started_schedules() {
 			ED, // Vesting over 20 blocks
 			10,
 		);
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched0]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched0]);
 
 		// Fast forward to half way through the life of sched1.
 		let mut cur_block =
@@ -799,7 +799,7 @@ fn merge_ongoing_and_yet_to_be_started_schedules() {
 		let sched2_per_block = sched2_locked / sched2_duration;
 
 		let sched2 = VestingInfo::new(sched2_locked, sched2_per_block, sched2_start);
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched2]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched2]);
 	});
 }
 
@@ -814,7 +814,7 @@ fn merge_finished_and_ongoing_schedules() {
 			ED, // Vesting over 20 blocks.
 			10,
 		);
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched0]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched0]);
 
 		let sched1 = VestingInfo::new(
 			ED * 40,
@@ -833,7 +833,7 @@ fn merge_finished_and_ongoing_schedules() {
 		assert_ok!(Vesting::vested_transfer(Some(3).into(), 2, sched2));
 
 		// The schedules are in expected order prior to merging.
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched0, sched1, sched2]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched0, sched1, sched2]);
 
 		// Fast forward to sched0's end block.
 		let cur_block = sched0.ending_block_as_balance::<Identity>();
@@ -848,7 +848,7 @@ fn merge_finished_and_ongoing_schedules() {
 		// sched2 is now the first, since sched0 & sched1 get filtered out while "merging".
 		// sched1 gets treated like the new merged schedule by getting pushed onto back
 		// of the vesting schedules vec. Note: sched0 finished at the current block.
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched2, sched1]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched2, sched1]);
 
 		// sched0 has finished, so its funds are fully unlocked.
 		let sched0_unlocked_now = sched0.locked();
@@ -876,7 +876,7 @@ fn merge_finishing_schedules_does_not_create_a_new_one() {
 			ED, // 20 block duration.
 			10,
 		);
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched0]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched0]);
 
 		// Create sched1 and transfer it to account 2.
 		let sched1 = VestingInfo::new(
@@ -885,7 +885,7 @@ fn merge_finishing_schedules_does_not_create_a_new_one() {
 			10,
 		);
 		assert_ok!(Vesting::vested_transfer(Some(3).into(), 2, sched1));
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched0, sched1]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched0, sched1]);
 
 		let all_scheds_end = sched0
 			.ending_block_as_balance::<Identity>()
@@ -918,7 +918,7 @@ fn merge_finished_and_yet_to_be_started_schedules() {
 			ED, // 20 block duration.
 			10, // Ends at block 30
 		);
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched0]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched0]);
 
 		let sched1 = VestingInfo::new(
 			ED * 30,
@@ -926,7 +926,7 @@ fn merge_finished_and_yet_to_be_started_schedules() {
 			35,
 		);
 		assert_ok!(Vesting::vested_transfer(Some(13).into(), 2, sched1));
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched0, sched1]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched0, sched1]);
 
 		let sched2 = VestingInfo::new(
 			ED * 40,
@@ -935,7 +935,7 @@ fn merge_finished_and_yet_to_be_started_schedules() {
 		);
 		// Add a 3rd schedule to demonstrate how sched1 shifts.
 		assert_ok!(Vesting::vested_transfer(Some(13).into(), 2, sched2));
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched0, sched1, sched2]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched0, sched1, sched2]);
 
 		System::set_block_number(30);
 
@@ -950,7 +950,7 @@ fn merge_finished_and_yet_to_be_started_schedules() {
 
 		// sched0 is removed since it finished, and sched1 is removed and then pushed on the back
 		// because it is treated as the merged schedule
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched2, sched1]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched2, sched1]);
 
 		// The usable balance is updated because merging fully unlocked sched0.
 		assert_eq!(Balances::usable_balance(&2), sched0.locked());
@@ -966,7 +966,7 @@ fn merge_schedules_throws_proper_errors() {
 			ED, // 20 block duration.
 			10,
 		);
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched0]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched0]);
 
 		// Account 2 only has 1 vesting schedule.
 		assert_noop!(
@@ -975,12 +975,12 @@ fn merge_schedules_throws_proper_errors() {
 		);
 
 		// Account 4 has 0 vesting schedules.
-		assert_eq!(Vesting::vesting(&4), None);
+		assert_eq!(VestingStorage::<Test>::get(&4), None);
 		assert_noop!(Vesting::merge_schedules(Some(4).into(), 0, 1), Error::<Test>::NotVesting);
 
 		// There are enough schedules to merge but an index is non-existent.
 		Vesting::vested_transfer(Some(3).into(), 2, sched0).unwrap();
-		assert_eq!(Vesting::vesting(&2).unwrap(), vec![sched0, sched0]);
+		assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![sched0, sched0]);
 		assert_noop!(
 			Vesting::merge_schedules(Some(2).into(), 0, 2),
 			Error::<Test>::ScheduleIndexOutOfBounds
@@ -1013,17 +1013,17 @@ fn generates_multiple_schedules_from_genesis_config() {
 		.build()
 		.execute_with(|| {
 			let user1_sched1 = VestingInfo::new(5 * ED, 128, 0u64);
-			assert_eq!(Vesting::vesting(&1).unwrap(), vec![user1_sched1]);
+			assert_eq!(VestingStorage::<Test>::get(&1).unwrap(), vec![user1_sched1]);
 
 			let user2_sched1 = VestingInfo::new(1 * ED, 12, 10u64);
 			let user2_sched2 = VestingInfo::new(2 * ED, 25, 10u64);
-			assert_eq!(Vesting::vesting(&2).unwrap(), vec![user2_sched1, user2_sched2]);
+			assert_eq!(VestingStorage::<Test>::get(&2).unwrap(), vec![user2_sched1, user2_sched2]);
 
 			let user12_sched1 = VestingInfo::new(1 * ED, 12, 10u64);
 			let user12_sched2 = VestingInfo::new(2 * ED, 25, 10u64);
 			let user12_sched3 = VestingInfo::new(3 * ED, 38, 10u64);
 			assert_eq!(
-				Vesting::vesting(&12).unwrap(),
+				VestingStorage::<Test>::get(&12).unwrap(),
 				vec![user12_sched1, user12_sched2, user12_sched3]
 			);
 		});

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -25,10 +25,9 @@ pub mod system;
 
 use codec::{Decode, Encode, Error, Input, MaxEncodedLen};
 use scale_info::TypeInfo;
-use sp_std::{marker::PhantomData, prelude::*};
-
 use sp_application_crypto::{ecdsa, ed25519, sr25519, RuntimeAppPublic};
 use sp_core::{OpaqueMetadata, RuntimeDebug};
+use sp_std::{marker::PhantomData, prelude::*};
 use sp_trie::{
 	trie_types::{TrieDBBuilder, TrieDBMutBuilderV1},
 	PrefixedMemoryDB, StorageProof,
@@ -898,7 +897,7 @@ cfg_if! {
 						c: (3, 10),
 						authorities: system::authorities()
 							.into_iter().map(|x|(x, 1)).collect(),
-						randomness: <pallet_babe::Pallet<Runtime>>::randomness(),
+						randomness: <pallet_babe::Randomness<Runtime>>::get(),
 						allowed_slots: AllowedSlots::PrimaryAndSecondaryPlainSlots,
 					}
 				}
@@ -1202,7 +1201,7 @@ cfg_if! {
 						c: (3, 10),
 						authorities: system::authorities()
 							.into_iter().map(|x|(x, 1)).collect(),
-						randomness: <pallet_babe::Pallet<Runtime>>::randomness(),
+						randomness: <pallet_babe::Randomness<Runtime>>::get(),
 						allowed_slots: AllowedSlots::PrimaryAndSecondaryPlainSlots,
 					}
 				}


### PR DESCRIPTION
resolves paritytech/polkadot-sdk#223

I added the deprecation message, removed every usage of `#[pallet::getter]` and refactored everything accordingly.
Since a few getters for non-public maps were used in runtime or other situations, I manually wrote those functions and removed the getter. 
I generally used the `pallet_name::StorageItem::<T>::get()` syntax, I don't like the `use pallet_name::StorageItem;` because it's less explicit.
I removed the getters from the examples, because since we don't want users to use them anymore, I think it's a better UX if we just don't mention them. 


Companions:
[Cumulus paritytech/substrate#2216](https://github.com/paritytech/cumulus/pull/2216)
Polkadot TBD
