### PR TITLE
add ensure_dispatch_as that propagates errors

### DIFF
--- a/frame/utility/src/benchmarking.rs
+++ b/frame/utility/src/benchmarking.rs
@@ -86,5 +86,13 @@ benchmarks! {
 		assert_last_event::<T>(Event::BatchCompleted.into())
 	}
 
+	ensure_dispatch_as {
+		let caller = account("caller", SEED, SEED);
+		let call = Box::new(frame_system::Call::remark { remark: vec![] }.into());
+		let origin: T::RuntimeOrigin = RawOrigin::Signed(caller).into();
+		let pallets_origin: <T::RuntimeOrigin as frame_support::traits::OriginTrait>::PalletsOrigin = origin.caller().clone();
+		let pallets_origin = Into::<T::PalletsOrigin>::into(pallets_origin);
+	}: _(RawOrigin::Root, Box::new(pallets_origin), call)
+
 	impl_benchmark_test_suite!(Pallet, crate::tests::new_test_ext(), crate::tests::Test);
 }

--- a/frame/utility/src/weights.rs
+++ b/frame/utility/src/weights.rs
@@ -53,6 +53,7 @@ pub trait WeightInfo {
 	fn batch_all(c: u32, ) -> Weight;
 	fn dispatch_as() -> Weight;
 	fn force_batch(c: u32, ) -> Weight;
+	fn ensure_dispatch_as() -> Weight;
 }
 
 /// Weights for pallet_utility using the Substrate node and recommended hardware.
@@ -102,6 +103,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			// Standard Error: 1_803
 			.saturating_add(Weight::from_ref_time(3_645_950).saturating_mul(c.into()))
 	}
+	fn ensure_dispatch_as() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 8_840 nanoseconds.
+		Weight::from_ref_time(9_280_000)
+	}
 }
 
 // For backwards compatibility and tests
@@ -149,5 +157,12 @@ impl WeightInfo for () {
 		Weight::from_ref_time(14_292_923)
 			// Standard Error: 1_803
 			.saturating_add(Weight::from_ref_time(3_645_950).saturating_mul(c.into()))
+	}
+	fn ensure_dispatch_as() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 8_840 nanoseconds.
+		Weight::from_ref_time(9_280_000)
 	}
 }


### PR DESCRIPTION
Addresses https://github.com/paritytech/substrate/issues/13309

This adds a new function `utility.ensure_dispatch_as` that is like `utility.dispatch_as`, except that it propagates errors returned by the wrapped call. 

Polkadot companion: https://github.com/paritytech/polkadot/pull/6723  
Cumulus companion: https://github.com/paritytech/cumulus/pull/2188