### PR TITLE
Adds ConstGet trait and impl in parameter types

### DIFF
--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -50,6 +50,8 @@ pub use paste;
 pub use scale_info;
 #[cfg(feature = "std")]
 pub use serde;
+#[doc(hidden)]
+pub use sp_core::ConstGet;
 pub use sp_core::Void;
 #[doc(hidden)]
 pub use sp_core_hashing_proc_macro;
@@ -67,8 +69,6 @@ pub use sp_state_machine::BasicExternalities;
 pub use sp_std;
 #[doc(hidden)]
 pub use tt_call::*;
-#[doc(hidden)]
-pub use sp_core::ConstGet;
 
 #[macro_use]
 pub mod dispatch;

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -67,6 +67,8 @@ pub use sp_state_machine::BasicExternalities;
 pub use sp_std;
 #[doc(hidden)]
 pub use tt_call::*;
+#[doc(hidden)]
+pub use sp_core::ConstGet;
 
 #[macro_use]
 pub mod dispatch;
@@ -336,6 +338,12 @@ macro_rules! parameter_types {
 			type Type = $type;
 			fn get() -> $type {
 				Self::get()
+			}
+		}
+
+		impl<_I: From<$type> $(, $ty_params)*> $crate::ConstGet<_I> for $name< $($ty_params),* > {
+			fn get() -> _I {
+				_I::from(Self::get())
 			}
 		}
 	};

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -1492,6 +1492,7 @@ pub mod pallet_prelude {
 	};
 	pub use sp_std::marker::PhantomData;
 	pub use sp_weights::Weight;
+	pub use sp_core::ConstGet;
 }
 
 /// The `pallet` attribute macro defines a pallet that can be used with

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -438,3 +438,11 @@ macro_rules! generate_feature_enabled_macro {
 		}
 	};
 }
+
+/// A trait for querying a single value from a type.
+///
+/// The value should be a constant.
+pub trait ConstGet<T> {
+	/// Return the constant value.
+	fn get() -> T;
+}


### PR DESCRIPTION
Fixes 1st and 6th tasks for #9967 
1. Adds `ConstGet<T>` trait
2. Update `parameter_types!` macro to generate `ConstGet<T>` on `const`