### PR TITLE
CI add subkey docker image description and CI job to publish it to the hub.docker.com

### DIFF
--- a/scripts/ci/docker/subkey.Dockerfile.README.md
+++ b/scripts/ci/docker/subkey.Dockerfile.README.md
@@ -1,0 +1,8 @@
+# The subkey program is a key management utility for Substrate-based blockchains. You can use the subkey program to perform the following tasks:
+
+* Generate and inspect cryptographically-secure public and private key pairs.
+* Restore keys from secret phrases and raw seeds.
+* Sign and verify signatures on messages.
+* Sign and verify signatures for encoded transactions.
+* Derive hierarchical deterministic child key pairs.
+* Documentation

--- a/scripts/ci/docker/subkey.Dockerfile.README.md
+++ b/scripts/ci/docker/subkey.Dockerfile.README.md
@@ -1,4 +1,4 @@
-# The subkey program is a key management utility for Substrate-based blockchains. You can use the subkey program to perform the following tasks:
+# The `subkey` program is a key management utility for Substrate-based blockchains. You can use the `subkey` program to perform the following tasks:
 
 * Generate and inspect cryptographically-secure public and private key pairs.
 * Restore keys from secret phrases and raw seeds.

--- a/scripts/ci/docker/subkey.Dockerfile.README.md
+++ b/scripts/ci/docker/subkey.Dockerfile.README.md
@@ -5,4 +5,4 @@
 * Sign and verify signatures on messages.
 * Sign and verify signatures for encoded transactions.
 * Derive hierarchical deterministic child key pairs.
-* Documentation
+* [Documentation](https://docs.substrate.io/reference/command-line-tools/subkey/)

--- a/scripts/ci/gitlab/pipeline/publish.yml
+++ b/scripts/ci/gitlab/pipeline/publish.yml
@@ -50,6 +50,7 @@
     DOCKER_PASS:                   $Docker_Hub_Pass_Parity
 
 .push-docker-image-description:
+  stage:                           publish
   extends:
     - .kubernetes-env
     - .publish-refs

--- a/scripts/ci/gitlab/pipeline/publish.yml
+++ b/scripts/ci/gitlab/pipeline/publish.yml
@@ -49,6 +49,18 @@
     DOCKER_USER:                   $Docker_Hub_User_Parity
     DOCKER_PASS:                   $Docker_Hub_Pass_Parity
 
+.push-docker-image-description:
+  extends:
+    - .kubernetes-env
+    - .publish-refs
+  variables:
+    CI_IMAGE:                      paritytech/docker-description
+    DOCKERHUB_REPOSITORY:          parity/$PRODUCT
+    DOCKER_USERNAME:               $Docker_Hub_User_Parity
+    DOCKER_PASSWORD:               $Docker_Hub_Pass_Parity
+    README_FILEPATH:               $CI_PROJECT_DIR/scripts/ci/docker/$PRODUCT.Dockerfile.README.md
+  script:
+    - echo # Dummy command to satisfy GitLab CI linter.
 
 # publish image to docker.io/paritypr, (e.g. for later use in zombienet testing)
 .build-push-image-temporary:
@@ -89,6 +101,14 @@ publish-docker-subkey:
       artifacts:                   true
   variables:
     PRODUCT:                       subkey
+
+publish-docker-description-subkey:
+  extends:                         .push-docker-image-description
+  needs:
+    - job:                         build-subkey-linux
+  variables:
+    PRODUCT:                       subkey
+    SHORT_DESCRIPTION:             "The subkey program is a key management utility for Substrate-based blockchains."
 
 publish-s3-release:
   stage:                           publish


### PR DESCRIPTION
Added `subkey` Docker image description for hub.docker.com. More like a draft. Please review and feel free to propose changes.

CI: added GitLab job to push above-mentioned description to the hub.docker.com 