### PR TITLE
[ci] Add dependencies for publish-crates

### DIFF
--- a/scripts/ci/gitlab/pipeline/publish.yml
+++ b/scripts/ci/gitlab/pipeline/publish.yml
@@ -233,11 +233,19 @@ publish-draft-release:
 
 publish-crates:
   extends:                         .publish-crates-template
+  # publish-crates should only be run if publish-crates-locally passes
+  needs:
+    - job:                         publish-crates-locally
+      artifacts:                   false
 
 publish-crates-manual:
   extends:                         .publish-crates-template
   when:                            manual
   interruptible:                   false
+  # publish-crates should only be run if publish-crates-locally passes
+  needs:
+    - job:                         publish-crates-locally
+      artifacts:                   false
 
 publish-crates-locally:
   stage:                           publish

--- a/scripts/ci/gitlab/pipeline/publish.yml
+++ b/scripts/ci/gitlab/pipeline/publish.yml
@@ -235,7 +235,7 @@ publish-crates:
   extends:                         .publish-crates-template
   # publish-crates should only be run if publish-crates-locally passes
   needs:
-    - job:                         publish-crates-locally
+    - job:                         check-crate-publishing
       artifacts:                   false
 
 publish-crates-manual:

--- a/scripts/ci/gitlab/pipeline/publish.yml
+++ b/scripts/ci/gitlab/pipeline/publish.yml
@@ -242,12 +242,8 @@ publish-crates-manual:
   extends:                         .publish-crates-template
   when:                            manual
   interruptible:                   false
-  # publish-crates should only be run if publish-crates-locally passes
-  needs:
-    - job:                         publish-crates-locally
-      artifacts:                   false
 
-publish-crates-locally:
+check-crate-publishing:
   stage:                           publish
   extends:
     - .test-refs


### PR DESCRIPTION
Publishing crates depends on `publish-crates-locally`. If this job fails no publishing should be done