### PR TITLE
Introduce EnsureOrigin to democracy.propose

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -943,6 +943,7 @@ impl pallet_democracy::Config for Runtime {
 	/// (NTB) vote.
 	type ExternalDefaultOrigin =
 		pallet_collective::EnsureProportionAtLeast<AccountId, CouncilCollective, 1, 1>;
+	type SubmitOrigin = EnsureSigned<AccountId>;
 	/// Two thirds of the technical committee can have an ExternalMajority/ExternalDefault vote
 	/// be tabled immediately and with a shorter voting/enactment period.
 	type FastTrackOrigin =

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -308,6 +308,10 @@ pub mod pallet {
 		/// of a negative-turnout-bias (default-carries) referendum.
 		type ExternalDefaultOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
+		/// Origin from which the new proposal can be made.
+		/// The Success is the account id of the depositor.
+		type SubmitOrigin: EnsureOrigin<Self::RuntimeOrigin, Success = Self::AccountId>;
+
 		/// Origin from which the next majority-carries (or more permissive) referendum may be
 		/// tabled to vote according to the `FastTrackVotingPeriod` asynchronously in a similar
 		/// manner to the emergency origin. It retains its threshold method.
@@ -590,7 +594,7 @@ pub mod pallet {
 			proposal: BoundedCallOf<T>,
 			#[pallet::compact] value: BalanceOf<T>,
 		) -> DispatchResult {
-			let who = ensure_signed(origin)?;
+			let who = T::SubmitOrigin::ensure_origin(origin)?;
 			ensure!(value >= T::MinimumDeposit::get(), Error::<T>::ValueLow);
 
 			let index = Self::public_prop_count();

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -309,7 +309,8 @@ pub mod pallet {
 		type ExternalDefaultOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
 		/// Origin from which the new proposal can be made.
-		/// The Success is the account id of the depositor.
+		///
+		/// The success variant is the account id of the depositor.
 		type SubmitOrigin: EnsureOrigin<Self::RuntimeOrigin, Success = Self::AccountId>;
 
 		/// Origin from which the next majority-carries (or more permissive) referendum may be

--- a/frame/democracy/src/tests.rs
+++ b/frame/democracy/src/tests.rs
@@ -27,7 +27,7 @@ use frame_support::{
 	},
 	weights::Weight,
 };
-use frame_system::{EnsureRoot, EnsureSignedBy};
+use frame_system::{EnsureRoot, EnsureSigned, EnsureSignedBy};
 use pallet_balances::{BalanceLock, Error as BalancesError};
 use sp_core::H256;
 use sp_runtime::{
@@ -177,6 +177,7 @@ impl Config for Test {
 	type MinimumDeposit = ConstU64<1>;
 	type MaxDeposits = ConstU32<1000>;
 	type MaxBlacklisted = ConstU32<5>;
+	type SubmitOrigin = EnsureSigned<Self::AccountId>;
 	type ExternalOrigin = EnsureSignedBy<Two, u64>;
 	type ExternalMajorityOrigin = EnsureSignedBy<Three, u64>;
 	type ExternalDefaultOrigin = EnsureSignedBy<One, u64>;


### PR DESCRIPTION
This PR adds a `SubmitOrigin` to the democracy pallet.
It replaces the plain `ensure_signed` within the `propose` extrinsic.

To achieve the old behavior, the users of the pallet can insert the following line into the Config:
```rust
type SubmitOrigin = EnsureSigned<AccountId>;
```

Polkadot companion: https://github.com/paritytech/polkadot/pull/6750