### PR TITLE
frame/beefy: prune entries in set id session mapping

### DIFF
--- a/frame/beefy-mmr/src/mock.rs
+++ b/frame/beefy-mmr/src/mock.rs
@@ -133,6 +133,7 @@ impl pallet_beefy::Config for Test {
 	)>>::IdentificationTuple;
 	type HandleEquivocation = ();
 	type MaxAuthorities = ConstU32<100>;
+	type MaxSetIdSessionEntries = ConstU64<100>;
 	type OnNewValidatorSet = BeefyMmr;
 	type WeightInfo = ();
 }

--- a/frame/beefy/src/mock.rs
+++ b/frame/beefy/src/mock.rs
@@ -111,6 +111,7 @@ parameter_types! {
 	pub const Period: u64 = 1;
 	pub const ReportLongevity: u64 =
 		BondingDuration::get() as u64 * SessionsPerEra::get() as u64 * Period::get();
+	pub const MaxSetIdSessionEntries: u32 = BondingDuration::get() * SessionsPerEra::get();
 }
 
 impl pallet_beefy::Config for Test {
@@ -125,6 +126,7 @@ impl pallet_beefy::Config for Test {
 	type HandleEquivocation =
 		super::EquivocationHandler<u64, Self::KeyOwnerIdentification, Offences, ReportLongevity>;
 	type MaxAuthorities = ConstU32<100>;
+	type MaxSetIdSessionEntries = MaxSetIdSessionEntries;
 	type OnNewValidatorSet = ();
 	type WeightInfo = ();
 }


### PR DESCRIPTION
Add limit for the number of entries in the `SetIdSession` mapping.

For example, it can be set to the bonding duration (in sessions).

Closes https://github.com/paritytech/substrate/issues/13404

Polkadot companion: https://github.com/paritytech/polkadot/pull/6743