### PR TITLE
state-db: Print warning when using large pruning window on RocksDb

### DIFF
--- a/client/state-db/src/lib.rs
+++ b/client/state-db/src/lib.rs
@@ -56,6 +56,8 @@ use std::{
 	fmt,
 };
 
+const LOG_TARGET: &str = "state-db";
+const LOG_TARGET_PIN: &str = "state-db::pin";
 const PRUNING_MODE: &[u8] = b"mode";
 const PRUNING_MODE_ARCHIVE: &[u8] = b"archive";
 const PRUNING_MODE_ARCHIVE_CANON: &[u8] = b"archive_canonical";
@@ -309,7 +311,7 @@ impl<BlockHash: Hash, Key: Hash, D: MetaDb> StateDbSync<BlockHash, Key, D> {
 		ref_counting: bool,
 		db: D,
 	) -> Result<StateDbSync<BlockHash, Key, D>, Error<D::Error>> {
-		trace!(target: "state-db", "StateDb settings: {:?}. Ref-counting: {}", mode, ref_counting);
+		trace!(target: LOG_TARGET, "StateDb settings: {:?}. Ref-counting: {}", mode, ref_counting);
 
 		let non_canonical: NonCanonicalOverlay<BlockHash, Key> = NonCanonicalOverlay::new(&db)?;
 		let pruning: Option<RefWindow<BlockHash, Key, D>> = match mode {

--- a/client/state-db/src/pruning.rs
+++ b/client/state-db/src/pruning.rs
@@ -321,15 +321,15 @@ impl<BlockHash: Hash, Key: Hash, D: MetaDb> RefWindow<BlockHash, Key, D> {
 
 		let queue = if count_insertions {
 			// Highly scientific crafted number for deciding when to print the warning!
+			//
+			// Rocksdb doesn't support refcounting and requires that we load the entire pruning
+			// window into the memory.
 			if window_size > 1000 {
 				log::warn!(
 					target: LOG_TARGET,
-					"Detected large pruning window of {window_size} blocks while running with a database \n
-					that isn't supporting ref counting, e.g. RocksDb. \n\
-					This means that all the blocks in the pruning window are stored in memory which \n\
-					may leads to a high memory usage and to possible out of memory crashes. \n\
-					Use for example ParityDb to not store the entire pruning window in memory.\
-				");
+					"Large pruning window of {window_size} detected! THIS CAN LEAD TO HIGH MEMORY USAGE AND CRASHES. \
+					Reduce the pruning window or switch your database to paritydb."
+				);
 			}
 
 			DeathRowQueue::new_mem(&db, base)?

--- a/client/state-db/src/pruning.rs
+++ b/client/state-db/src/pruning.rs
@@ -26,7 +26,7 @@
 
 use crate::{
 	noncanonical::LAST_CANONICAL, to_meta_key, CommitSet, Error, Hash, MetaDb, StateDbError,
-	DEFAULT_MAX_BLOCK_CONSTRAINT,
+	DEFAULT_MAX_BLOCK_CONSTRAINT, LOG_TARGET,
 };
 use codec::{Decode, Encode};
 use log::trace;
@@ -79,14 +79,24 @@ impl<BlockHash: Hash, Key: Hash, D: MetaDb> DeathRowQueue<BlockHash, Key, D> {
 			death_index: HashMap::new(),
 		};
 		// read the journal
-		trace!(target: "state-db", "Reading pruning journal for the memory queue. Pending #{}", base);
+		trace!(
+			target: LOG_TARGET,
+			"Reading pruning journal for the memory queue. Pending #{}",
+			base,
+		);
 		loop {
 			let journal_key = to_journal_key(block);
 			match db.get_meta(&journal_key).map_err(Error::Db)? {
 				Some(record) => {
 					let record: JournalRecord<BlockHash, Key> =
 						Decode::decode(&mut record.as_slice())?;
-					trace!(target: "state-db", "Pruning journal entry {} ({} inserted, {} deleted)", block, record.inserted.len(), record.deleted.len());
+					trace!(
+						target: LOG_TARGET,
+						"Pruning journal entry {} ({} inserted, {} deleted)",
+						block,
+						record.inserted.len(),
+						record.deleted.len(),
+					);
 					queue.import(base, block, record);
 				},
 				None => break,
@@ -107,7 +117,11 @@ impl<BlockHash: Hash, Key: Hash, D: MetaDb> DeathRowQueue<BlockHash, Key, D> {
 		// limit the cache capacity from 1 to `DEFAULT_MAX_BLOCK_CONSTRAINT`
 		let cache_capacity = window_size.clamp(1, DEFAULT_MAX_BLOCK_CONSTRAINT) as usize;
 		let mut cache = VecDeque::with_capacity(cache_capacity);
-		trace!(target: "state-db", "Reading pruning journal for the database-backed queue. Pending #{}", base);
+		trace!(
+			target: LOG_TARGET,
+			"Reading pruning journal for the database-backed queue. Pending #{}",
+			base
+		);
 		DeathRowQueue::load_batch_from_db(&db, &mut cache, base, cache_capacity)?;
 		Ok(DeathRowQueue::DbBacked { db, cache, cache_capacity, last })
 	}
@@ -115,13 +129,13 @@ impl<BlockHash: Hash, Key: Hash, D: MetaDb> DeathRowQueue<BlockHash, Key, D> {
 	/// import a new block to the back of the queue
 	fn import(&mut self, base: u64, num: u64, journal_record: JournalRecord<BlockHash, Key>) {
 		let JournalRecord { hash, inserted, deleted } = journal_record;
-		trace!(target: "state-db", "Importing {}, base={}", num, base);
+		trace!(target: LOG_TARGET, "Importing {}, base={}", num, base);
 		match self {
 			DeathRowQueue::DbBacked { cache, cache_capacity, last, .. } => {
 				// If the new block continues cached range and there is space, load it directly into
 				// cache.
 				if num == base + cache.len() as u64 && cache.len() < *cache_capacity {
-					trace!(target: "state-db", "Adding to DB backed cache {:?} (#{})", hash, num);
+					trace!(target: LOG_TARGET, "Adding to DB backed cache {:?} (#{})", hash, num);
 					cache.push_back(DeathRow { hash, deleted: deleted.into_iter().collect() });
 				}
 				*last = Some(num);
@@ -306,6 +320,18 @@ impl<BlockHash: Hash, Key: Hash, D: MetaDb> RefWindow<BlockHash, Key, D> {
 			};
 
 		let queue = if count_insertions {
+			// Highly scientific crafted number for deciding when to print the warning!
+			if window_size > 1000 {
+				log::warn!(
+					target: LOG_TARGET,
+					"Detected large pruning window of {window_size} blocks while running with a database \n
+					that isn't supporting ref counting, e.g. RocksDb. \n\
+					This means that all the blocks in the pruning window are stored in memory which \n\
+					may leads to a high memory usage and to possible out of memory crashes. \n\
+					Use for example ParityDb to not store the entire pruning window in memory.\
+				");
+			}
+
 			DeathRowQueue::new_mem(&db, base)?
 		} else {
 			let last = match last_canonicalized_number {


### PR DESCRIPTION
This pr changes state-db to print a warning when using a large pruning window and running with a database that isn't supporting ref-counting like RocksDb. This makes the user aware of potential out of memory errors because this option together with RocksDb etc puts the entire pruning window into memory. Besides that the pr introduces `LOG_TARGET` for having the target declared central!

