### PR TITLE
client/beefy: drop justification on block import if pallet-beefy not enabled

### DIFF
--- a/client/beefy/src/import.rs
+++ b/client/beefy/src/import.rs
@@ -92,13 +92,23 @@ where
 		number: NumberFor<Block>,
 		hash: <Block as BlockT>::Hash,
 	) -> Result<BeefyVersionedFinalityProof<Block>, ConsensusError> {
+		use ConsensusError::ClientImport as ImportError;
 		let block_id = BlockId::hash(hash);
+		let beefy_genesis = self
+			.runtime
+			.runtime_api()
+			.beefy_genesis(&block_id)
+			.map_err(|e| ImportError(e.to_string()))?
+			.ok_or_else(|| ImportError("Unknown BEEFY genesis".to_string()))?;
+		if number < beefy_genesis {
+			return Err(ImportError("BEEFY genesis is set for future block".to_string()))
+		}
 		let validator_set = self
 			.runtime
 			.runtime_api()
 			.validator_set(&block_id)
-			.map_err(|e| ConsensusError::ClientImport(e.to_string()))?
-			.ok_or_else(|| ConsensusError::ClientImport("Unknown validator set".to_string()))?;
+			.map_err(|e| ImportError(e.to_string()))?
+			.ok_or_else(|| ImportError("Unknown validator set".to_string()))?;
 
 		decode_and_verify_finality_proof::<Block>(&encoded[..], number, &validator_set)
 	}
@@ -142,26 +152,28 @@ where
 
 		match (beefy_encoded, &inner_import_result) {
 			(Some(encoded), ImportResult::Imported(_)) => {
-				if let Ok(proof) = self.decode_and_verify(&encoded, number, hash) {
-					// The proof is valid and the block is imported and final, we can import.
-					debug!(
-						target: LOG_TARGET,
-						"🥩 import justif {:?} for block number {:?}.", proof, number
-					);
-					// Send the justification to the BEEFY voter for processing.
-					self.justification_sender
-						.notify(|| Ok::<_, ()>(proof))
-						.expect("forwards closure result; the closure always returns Ok; qed.");
-
-					metric_inc!(self, beefy_good_justification_imports);
-				} else {
-					debug!(
-						target: LOG_TARGET,
-						"🥩 error decoding justification: {:?} for imported block {:?}",
-						encoded,
-						number,
-					);
-					metric_inc!(self, beefy_bad_justification_imports);
+				match self.decode_and_verify(&encoded, number, hash) {
+					Ok(proof) => {
+						// The proof is valid and the block is imported and final, we can import.
+						debug!(
+							target: LOG_TARGET,
+							"🥩 import justif {:?} for block number {:?}.", proof, number
+						);
+						// Send the justification to the BEEFY voter for processing.
+						self.justification_sender
+							.notify(|| Ok::<_, ()>(proof))
+							.expect("the closure always returns Ok; qed.");
+						metric_inc!(self, beefy_good_justification_imports);
+					},
+					Err(err) => {
+						debug!(
+							target: LOG_TARGET,
+							"🥩 error importing BEEFY justification for block {:?}: {:?}",
+							number,
+							err,
+						);
+						metric_inc!(self, beefy_bad_justification_imports);
+					},
 				}
 			},
 			_ => (),


### PR DESCRIPTION
BEEFY pallet allows setting on-chain BEEFY genesis to some future block.

Disregard any BEEFY justifications attached to imported blocks that predate configured BEEFY genesis.

Fixes a memory "leak" or bloat where before this PR, "invalid/stale" justifications are enqueued on some channel to be processed by the voter, but the voter task doesn't process the queue until pallet is enabled.
With this PR, justifications are no longer enqueued until pallet is enabled; stale justifications are simply dropped.