### PR TITLE
FRAME: Initialize `StorageVersion` on runtime upgrade

### DIFF
--- a/frame/support/procedural/src/pallet/expand/hooks.rs
+++ b/frame/support/procedural/src/pallet/expand/hooks.rs
@@ -140,6 +140,8 @@ pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 			for #pallet_ident<#type_use_gen> #where_clause
 		{
 			fn on_runtime_upgrade() -> #frame_support::weights::Weight {
+				use #frame_support::traits::Get;
+
 				#frame_support::sp_tracing::enter_span!(
 					#frame_support::sp_tracing::trace_span!("on_runtime_update")
 				);


### PR DESCRIPTION
The initial `StorageVersion` of a pallet is only set in its `OnGenesis` implementation. This works for pallets which exist at genesis. However, if a pallet is added later with a runtime upgrade the version will be uninitialized in storage.

Runtime authors need to manually make sure that they initialize this value when adding a pallet. If they forget it can have bad consequences: An uninitialized value will make `StorageVersion::get()` return `0`. This might lead to storage migrations falsely triggering. This actually happened to some chains adding `pallet-contracts`.

Downside is that this adds one storage read per pallet on runtime upgrades. The added safety and convenience might be worth it.

Maybe we should also write the genesis configuration of the added pallet (if it exists) to storage if no storage version was set (we assume the pallet was added).