### PR TITLE
Further storage iterator refactoring

### DIFF
--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -309,7 +309,6 @@ where
 {
 	inner: <State as StateBackend<HashFor<Block>>>::RawIter,
 	state: State,
-	skip_if_first: Option<StorageKey>,
 }
 
 impl<State, Block> KeysIter<State, Block>
@@ -326,13 +325,9 @@ where
 		let mut args = IterArgs::default();
 		args.prefix = prefix.as_ref().map(|prefix| prefix.0.as_slice());
 		args.start_at = start_at.as_ref().map(|start_at| start_at.0.as_slice());
+		args.start_at_exclusive = true;
 
-		let start_at = args.start_at;
-		Ok(Self {
-			inner: state.raw_iter(args)?,
-			state,
-			skip_if_first: start_at.map(|key| StorageKey(key.to_vec())),
-		})
+		Ok(Self { inner: state.raw_iter(args)?, state })
 	}
 
 	/// Create a new iterator over a child storage's keys.
@@ -346,13 +341,9 @@ where
 		args.prefix = prefix.as_ref().map(|prefix| prefix.0.as_slice());
 		args.start_at = start_at.as_ref().map(|start_at| start_at.0.as_slice());
 		args.child_info = Some(child_info);
+		args.start_at_exclusive = true;
 
-		let start_at = args.start_at;
-		Ok(Self {
-			inner: state.raw_iter(args)?,
-			state,
-			skip_if_first: start_at.map(|key| StorageKey(key.to_vec())),
-		})
+		Ok(Self { inner: state.raw_iter(args)?, state })
 	}
 }
 
@@ -364,15 +355,7 @@ where
 	type Item = StorageKey;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		let key = self.inner.next_key(&self.state)?.ok().map(StorageKey)?;
-
-		if let Some(skipped_key) = self.skip_if_first.take() {
-			if key == skipped_key {
-				return self.next()
-			}
-		}
-
-		Some(key)
+		self.inner.next_key(&self.state)?.ok().map(StorageKey)
 	}
 }
 
@@ -384,7 +367,6 @@ where
 {
 	inner: <State as StateBackend<HashFor<Block>>>::RawIter,
 	state: State,
-	skip_if_first: Option<StorageKey>,
 }
 
 impl<State, Block> Iterator for PairsIter<State, Block>
@@ -395,19 +377,10 @@ where
 	type Item = (StorageKey, StorageData);
 
 	fn next(&mut self) -> Option<Self::Item> {
-		let (key, value) = self
-			.inner
+		self.inner
 			.next_pair(&self.state)?
 			.ok()
-			.map(|(key, value)| (StorageKey(key), StorageData(value)))?;
-
-		if let Some(skipped_key) = self.skip_if_first.take() {
-			if key == skipped_key {
-				return self.next()
-			}
-		}
-
-		Some((key, value))
+			.map(|(key, value)| (StorageKey(key), StorageData(value)))
 	}
 }
 
@@ -425,13 +398,9 @@ where
 		let mut args = IterArgs::default();
 		args.prefix = prefix.as_ref().map(|prefix| prefix.0.as_slice());
 		args.start_at = start_at.as_ref().map(|start_at| start_at.0.as_slice());
+		args.start_at_exclusive = true;
 
-		let start_at = args.start_at;
-		Ok(Self {
-			inner: state.raw_iter(args)?,
-			state,
-			skip_if_first: start_at.map(|key| StorageKey(key.to_vec())),
-		})
+		Ok(Self { inner: state.raw_iter(args)?, state })
 	}
 }
 

--- a/primitives/state-machine/src/backend.rs
+++ b/primitives/state-machine/src/backend.rs
@@ -126,6 +126,7 @@ where
 	H: Hasher,
 	I: StorageIterator<H> + Default,
 {
+	#[cfg(feature = "std")]
 	pub(crate) fn was_complete(&self) -> bool {
 		self.raw_iter.was_complete()
 	}

--- a/primitives/state-machine/src/backend.rs
+++ b/primitives/state-machine/src/backend.rs
@@ -228,27 +228,6 @@ pub trait Backend<H: Hasher>: sp_std::fmt::Debug {
 		key: &[u8],
 	) -> Result<Option<StorageKey>, Self::Error>;
 
-	/// Retrieve all entries keys of storage and call `f` for each of those keys.
-	/// Aborts as soon as `f` returns false.
-	// TODO: Remove this.
-	fn apply_to_keys_while<F: FnMut(&[u8]) -> bool>(
-		&self,
-		child_info: Option<&ChildInfo>,
-		prefix: Option<&[u8]>,
-		start_at: Option<&[u8]>,
-		mut f: F,
-	) -> Result<(), Self::Error> {
-		let args =
-			IterArgs { child_info: child_info.cloned(), prefix, start_at, ..IterArgs::default() };
-
-		for key in self.keys(args)? {
-			if !f(&key?) {
-				return Ok(())
-			}
-		}
-		Ok(())
-	}
-
 	/// Retrieve all entries keys which start with the given prefix and
 	/// call `f` for each of those keys.
 	// TODO: Remove this.

--- a/primitives/state-machine/src/backend.rs
+++ b/primitives/state-machine/src/backend.rs
@@ -228,57 +228,6 @@ pub trait Backend<H: Hasher>: sp_std::fmt::Debug {
 		key: &[u8],
 	) -> Result<Option<StorageKey>, Self::Error>;
 
-	/// Retrieve all entries keys which start with the given prefix and
-	/// call `f` for each of those keys.
-	// TODO: Remove this.
-	fn for_keys_with_prefix<F: FnMut(&[u8])>(
-		&self,
-		prefix: &[u8],
-		mut f: F,
-	) -> Result<(), Self::Error> {
-		let args = IterArgs { prefix: Some(prefix), ..IterArgs::default() };
-		self.keys(args)?.try_for_each(|key| {
-			f(&key?);
-			Ok(())
-		})
-	}
-
-	/// Retrieve all entries keys and values of which start with the given prefix and
-	/// call `f` for each of those keys.
-	// TODO: Remove this.
-	fn for_key_values_with_prefix<F: FnMut(&[u8], &[u8])>(
-		&self,
-		prefix: &[u8],
-		mut f: F,
-	) -> Result<(), Self::Error> {
-		let args = IterArgs { prefix: Some(prefix), ..IterArgs::default() };
-		self.pairs(args)?.try_for_each(|key_value| {
-			let (key, value) = key_value?;
-			f(&key, &value);
-			Ok(())
-		})
-	}
-
-	/// Retrieve all child entries keys which start with the given prefix and
-	/// call `f` for each of those keys.
-	// TODO: Remove this.
-	fn for_child_keys_with_prefix<F: FnMut(&[u8])>(
-		&self,
-		child_info: &ChildInfo,
-		prefix: &[u8],
-		mut f: F,
-	) -> Result<(), Self::Error> {
-		let args = IterArgs {
-			child_info: Some(child_info.clone()),
-			prefix: Some(prefix),
-			..IterArgs::default()
-		};
-		self.keys(args)?.try_for_each(|key| {
-			f(&key?);
-			Ok(())
-		})
-	}
-
 	/// Calculate the storage root, with given delta over what is already stored in
 	/// the backend, and produce a "transaction" that can be used to commit.
 	/// Does not include child storage updates.

--- a/primitives/state-machine/src/backend.rs
+++ b/primitives/state-machine/src/backend.rs
@@ -43,6 +43,10 @@ pub struct IterArgs<'a> {
 	/// This is inclusive and the iteration will include the key which is specified here.
 	pub start_at: Option<&'a [u8]>,
 
+	/// If this is `true` then the iteration will *not* include
+	/// the key specified in `start_at`, if there is such a key.
+	pub start_at_exclusive: bool,
+
 	/// The info of the child trie over which to iterate over.
 	pub child_info: Option<ChildInfo>,
 

--- a/primitives/state-machine/src/ext.rs
+++ b/primitives/state-machine/src/ext.rs
@@ -19,7 +19,9 @@
 
 #[cfg(feature = "std")]
 use crate::overlayed_changes::OverlayedExtensions;
-use crate::{backend::Backend, IndexOperation, OverlayedChanges, StorageKey, StorageValue};
+use crate::{
+	backend::Backend, IndexOperation, IterArgs, OverlayedChanges, StorageKey, StorageValue,
+};
 use codec::{Decode, Encode, EncodeAppend};
 use hash_db::Hasher;
 #[cfg(feature = "std")]
@@ -750,40 +752,54 @@ where
 {
 	fn limit_remove_from_backend(
 		&mut self,
-		maybe_child: Option<&ChildInfo>,
-		maybe_prefix: Option<&[u8]>,
+		child_info: Option<&ChildInfo>,
+		prefix: Option<&[u8]>,
 		maybe_limit: Option<u32>,
-		maybe_cursor: Option<&[u8]>,
+		start_at: Option<&[u8]>,
 	) -> (Option<Vec<u8>>, u32, u32) {
+		let iter = match self.backend.keys(IterArgs {
+			child_info: child_info.cloned(),
+			prefix,
+			start_at,
+			..IterArgs::default()
+		}) {
+			Ok(iter) => iter,
+			Err(error) => {
+				log::debug!(target: "trie", "Error while iterating the storage: {}", error);
+				return (None, 0, 0)
+			},
+		};
+
 		let mut delete_count: u32 = 0;
 		let mut loop_count: u32 = 0;
 		let mut maybe_next_key = None;
-		let result =
-			self.backend
-				.apply_to_keys_while(maybe_child, maybe_prefix, maybe_cursor, |key| {
-					if maybe_limit.map_or(false, |limit| loop_count == limit) {
-						maybe_next_key = Some(key.to_vec());
-						return false
-					}
-					let overlay = match maybe_child {
-						Some(child_info) => self.overlay.child_storage(child_info, key),
-						None => self.overlay.storage(key),
-					};
-					if !matches!(overlay, Some(None)) {
-						// not pending deletion from the backend - delete it.
-						if let Some(child_info) = maybe_child {
-							self.overlay.set_child_storage(child_info, key.to_vec(), None);
-						} else {
-							self.overlay.set_storage(key.to_vec(), None);
-						}
-						delete_count = delete_count.saturating_add(1);
-					}
-					loop_count = loop_count.saturating_add(1);
-					true
-				});
+		for key in iter {
+			let key = match key {
+				Ok(key) => key,
+				Err(error) => {
+					log::debug!(target: "trie", "Error while iterating the storage: {}", error);
+					break
+				},
+			};
 
-		if let Err(error) = result {
-			log::debug!(target: "trie", "Error while iterating the storage: {}", error);
+			if maybe_limit.map_or(false, |limit| loop_count == limit) {
+				maybe_next_key = Some(key.to_vec());
+				break
+			}
+			let overlay = match child_info {
+				Some(child_info) => self.overlay.child_storage(child_info, &key),
+				None => self.overlay.storage(&key),
+			};
+			if !matches!(overlay, Some(None)) {
+				// not pending deletion from the backend - delete it.
+				if let Some(child_info) = child_info {
+					self.overlay.set_child_storage(child_info, key.to_vec(), None);
+				} else {
+					self.overlay.set_storage(key.to_vec(), None);
+				}
+				delete_count = delete_count.saturating_add(1);
+			}
+			loop_count = loop_count.saturating_add(1);
 		}
 
 		(maybe_next_key, delete_count, loop_count)

--- a/primitives/state-machine/src/ext.rs
+++ b/primitives/state-machine/src/ext.rs
@@ -783,7 +783,7 @@ where
 			};
 
 			if maybe_limit.map_or(false, |limit| loop_count == limit) {
-				maybe_next_key = Some(key.to_vec());
+				maybe_next_key = Some(key);
 				break
 			}
 			let overlay = match child_info {
@@ -793,9 +793,9 @@ where
 			if !matches!(overlay, Some(None)) {
 				// not pending deletion from the backend - delete it.
 				if let Some(child_info) = child_info {
-					self.overlay.set_child_storage(child_info, key.to_vec(), None);
+					self.overlay.set_child_storage(child_info, key, None);
 				} else {
-					self.overlay.set_storage(key.to_vec(), None);
+					self.overlay.set_storage(key, None);
 				}
 				delete_count = delete_count.saturating_add(1);
 			}

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -843,22 +843,17 @@ mod execution {
 
 			let start_at_ref = start_at.as_ref().map(AsRef::as_ref);
 			let mut switch_child_key = None;
-			let mut first = start_at.is_some();
 			let mut iter = proving_backend
-				.pairs(IterArgs { child_info, start_at: start_at_ref, ..IterArgs::default() })
+				.pairs(IterArgs {
+					child_info,
+					start_at: start_at_ref,
+					start_at_exclusive: true,
+					..IterArgs::default()
+				})
 				.map_err(|e| Box::new(e) as Box<dyn Error>)?;
 
 			while let Some(item) = iter.next() {
 				let (key, value) = item.map_err(|e| Box::new(e) as Box<dyn Error>)?;
-				if first &&
-					start_at_ref.as_ref().map(|start| &key.as_slice() > start).unwrap_or(true)
-				{
-					first = false;
-				}
-
-				if first {
-					continue
-				}
 
 				if depth < MAX_NESTED_TRIE_DEPTH &&
 					sp_core::storage::well_known_keys::is_child_storage_key(key.as_slice())
@@ -1249,12 +1244,12 @@ mod execution {
 			};
 			let start_at_ref = start_at.as_ref().map(AsRef::as_ref);
 			let mut switch_child_key = None;
-			let mut first = start_at.is_some();
 
 			let mut iter = proving_backend
 				.pairs(IterArgs {
 					child_info,
 					start_at: start_at_ref,
+					start_at_exclusive: true,
 					stop_on_incomplete_database: true,
 					..IterArgs::default()
 				})
@@ -1262,16 +1257,6 @@ mod execution {
 
 			while let Some(item) = iter.next() {
 				let (key, value) = item.map_err(|e| Box::new(e) as Box<dyn Error>)?;
-				if first &&
-					start_at_ref.as_ref().map(|start| &key.as_slice() > start).unwrap_or(true)
-				{
-					first = false;
-				}
-
-				if first {
-					continue
-				}
-
 				values.push((key.to_vec(), value.to_vec()));
 
 				if depth < MAX_NESTED_TRIE_DEPTH &&

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -1169,7 +1169,7 @@ mod execution {
 
 		while let Some(item) = iter.next() {
 			let (key, value) = item.map_err(|e| Box::new(e) as Box<dyn Error>)?;
-			values.push((key.to_vec(), value.to_vec()));
+			values.push((key, value));
 			if !count.as_ref().map_or(true, |c| (values.len() as u32) < *c) {
 				break
 			}

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -1926,12 +1926,14 @@ mod tests {
 		// Always contains at least some nodes.
 		assert_eq!(proof.to_memory_db::<BlakeTwo256>().drain().len(), 3);
 		assert_eq!(count, 1);
+		assert_eq!(proof.encoded_size(), 443);
 
 		let remote_backend = trie_backend::tests::test_trie(state_version, None, None);
 		let (proof, count) =
 			prove_range_read_with_size(remote_backend, None, None, 800, Some(&[])).unwrap();
 		assert_eq!(proof.to_memory_db::<BlakeTwo256>().drain().len(), 9);
 		assert_eq!(count, 85);
+		assert_eq!(proof.encoded_size(), 857);
 		let (results, completed) = read_range_proof_check::<BlakeTwo256>(
 			remote_root,
 			proof.clone(),
@@ -1955,6 +1957,8 @@ mod tests {
 			prove_range_read_with_size(remote_backend, None, None, 50000, Some(&[])).unwrap();
 		assert_eq!(proof.to_memory_db::<BlakeTwo256>().drain().len(), 11);
 		assert_eq!(count, 132);
+		assert_eq!(proof.encoded_size(), 990);
+
 		let (results, completed) =
 			read_range_proof_check::<BlakeTwo256>(remote_root, proof, None, None, None, None)
 				.unwrap();

--- a/primitives/state-machine/src/trie_backend.rs
+++ b/primitives/state-machine/src/trie_backend.rs
@@ -678,27 +678,6 @@ pub mod tests {
 		);
 	}
 
-	parameterized_test!(prefix_walking_works, prefix_walking_works_inner);
-	fn prefix_walking_works_inner(
-		state_version: StateVersion,
-		cache: Option<Cache>,
-		recorder: Option<Recorder>,
-	) {
-		let trie = test_trie(state_version, cache, recorder);
-
-		let mut seen = HashSet::new();
-		trie.for_keys_with_prefix(b"value", |key| {
-			let for_first_time = seen.insert(key.to_vec());
-			assert!(for_first_time, "Seen key '{:?}' more than once", key);
-		})
-		.unwrap();
-
-		let mut expected = HashSet::new();
-		expected.insert(b"value1".to_vec());
-		expected.insert(b"value2".to_vec());
-		assert_eq!(seen, expected);
-	}
-
 	parameterized_test!(
 		keys_with_empty_prefix_returns_all_keys,
 		keys_with_empty_prefix_returns_all_keys_inner

--- a/primitives/state-machine/src/trie_backend.rs
+++ b/primitives/state-machine/src/trie_backend.rs
@@ -643,58 +643,6 @@ pub mod tests {
 			.collect::<Vec<_>>(),
 			vec![b"value1".to_vec(), b"value2".to_vec(),]
 		);
-
-		// Also test out the wrapper methods.
-		// TODO: Remove this once these methods are gone.
-
-		let mut list = Vec::new();
-		trie.apply_to_keys_while(None, None, Some(b"key"), |key| {
-			list.push(key.to_vec());
-			true
-		})
-		.unwrap();
-		assert_eq!(list[0..3], vec![b"key".to_vec(), b"value1".to_vec(), b"value2".to_vec(),]);
-
-		let mut list = Vec::new();
-		trie.apply_to_keys_while(None, None, Some(b"k"), |key| {
-			list.push(key.to_vec());
-			true
-		})
-		.unwrap();
-		assert_eq!(list[0..3], vec![b"key".to_vec(), b"value1".to_vec(), b"value2".to_vec(),]);
-
-		let mut list = Vec::new();
-		trie.apply_to_keys_while(None, None, Some(b""), |key| {
-			list.push(key.to_vec());
-			true
-		})
-		.unwrap();
-		assert_eq!(
-			list[0..5],
-			vec![
-				b":child_storage:default:sub1".to_vec(),
-				b":code".to_vec(),
-				b"key".to_vec(),
-				b"value1".to_vec(),
-				b"value2".to_vec(),
-			]
-		);
-
-		let mut list = Vec::new();
-		trie.apply_to_keys_while(None, Some(b"value"), Some(b"key"), |key| {
-			list.push(key.to_vec());
-			true
-		})
-		.unwrap();
-		assert!(list.is_empty());
-
-		let mut list = Vec::new();
-		trie.apply_to_keys_while(None, Some(b"value"), Some(b"value"), |key| {
-			list.push(key.to_vec());
-			true
-		})
-		.unwrap();
-		assert_eq!(list, vec![b"value1".to_vec(), b"value2".to_vec(),]);
 	}
 
 	parameterized_test!(storage_root_is_non_default, storage_root_is_non_default_inner);

--- a/primitives/state-machine/src/trie_backend.rs
+++ b/primitives/state-machine/src/trie_backend.rs
@@ -357,7 +357,7 @@ pub mod tests {
 		trie_types::{TrieDBBuilder, TrieDBMutBuilderV0, TrieDBMutBuilderV1},
 		KeySpacedDBMut, PrefixedKey, PrefixedMemoryDB, Trie, TrieCache, TrieMut,
 	};
-	use std::{collections::HashSet, iter};
+	use std::iter;
 	use trie_db::NodeCodec;
 
 	const CHILD_KEY_1: &[u8] = b"sub1";

--- a/primitives/state-machine/src/trie_backend.rs
+++ b/primitives/state-machine/src/trie_backend.rs
@@ -648,21 +648,6 @@ pub mod tests {
 		// TODO: Remove this once these methods are gone.
 
 		let mut list = Vec::new();
-		assert!(trie
-			.apply_to_key_values_while(
-				None,
-				None,
-				Some(b"key"),
-				|key, _| {
-					list.push(key);
-					true
-				},
-				false
-			)
-			.unwrap());
-		assert_eq!(list[0..3], vec![b"key".to_vec(), b"value1".to_vec(), b"value2".to_vec(),]);
-
-		let mut list = Vec::new();
 		trie.apply_to_keys_while(None, None, Some(b"key"), |key| {
 			list.push(key.to_vec());
 			true


### PR DESCRIPTION
Followup of https://github.com/paritytech/substrate/pull/13284

This PR further cleans up the storage backend trait and gets rid of (now unnecessary) callback-based iteration methods.