### PR TITLE
[wip] frame/support: Run UI tests by CI

### DIFF
--- a/frame/election-provider-support/solution-type/tests/ui/fail/missing_accuracy.stderr
+++ b/frame/election-provider-support/solution-type/tests/ui/fail/missing_accuracy.stderr
@@ -3,3 +3,5 @@ error: Expected binding: `Accuracy = ...`
   |
 6 |     Perbill,
   |     ^^^^^^^
+
+fail

--- a/frame/support/test/tests/pallet_ui/attr_non_empty.stderr
+++ b/frame/support/test/tests/pallet_ui/attr_non_empty.stderr
@@ -3,3 +3,5 @@ error: Invalid pallet macro call: unexpected attribute. Macro call must be bare,
   |
 1 | #[frame_support::pallet [foo]]
   |                          ^^^
+
+fail

--- a/primitives/api/test/tests/ui/adding_self_parameter.stderr
+++ b/primitives/api/test/tests/ui/adding_self_parameter.stderr
@@ -3,3 +3,5 @@ error: `self` as argument not supported.
   |
 3 |         fn test(&self);
   |                 ^
+
+fail

--- a/primitives/runtime-interface/tests/ui/no_duplicate_versions.stderr
+++ b/primitives/runtime-interface/tests/ui/no_duplicate_versions.stderr
@@ -9,3 +9,5 @@ error: Previous version with the same number defined here
   |
 5 |     #[version(2)]
   |     ^
+
+fail

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -245,8 +245,11 @@ test-frame-support:
     RUN_UI_TESTS:                  1
   script:
     - rusty-cachier snapshot create
+    # Custom tests of the `pallet` regarding different features
     - time cargo test --locked -p frame-support-test --features=frame-feature-testing,no-metadata-docs --manifest-path ./frame/support/test/Cargo.toml --test pallet # does not reuse cache 1 min 44 sec
     - time cargo test --locked -p frame-support-test --features=frame-feature-testing,frame-feature-testing-2,no-metadata-docs --manifest-path ./frame/support/test/Cargo.toml --test pallet # does not reuse cache 1 min 44 sec
+    # Ensure we run all the tests from frame/support/test crate (including UI tests)
+    - time cargo test --locked -p frame-support-test
     - SUBSTRATE_TEST_TIMEOUT=1 time cargo test -p substrate-test-utils --release --verbose --locked -- --ignored timeout
     - rusty-cachier cache upload
 


### PR DESCRIPTION
I've noticed that some UI tests are failing locally and that the CI does not pick up on this failure.

This PR ensures that UI tests are part of `test-frame-support` CI step.