### PR TITLE
Ranked Collective: constructor for MemberRecord

### DIFF
--- a/frame/ranked-collective/src/lib.rs
+++ b/frame/ranked-collective/src/lib.rs
@@ -170,6 +170,13 @@ pub struct MemberRecord {
 	rank: Rank,
 }
 
+impl MemberRecord {
+	// Constructs a new instance of [`MemberRecord`].
+	pub fn new(rank: Rank) -> Self {
+		Self { rank }
+	}
+}
+
 /// Record needed for every vote.
 #[derive(PartialEq, Eq, Clone, Copy, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub enum VoteRecord {


### PR DESCRIPTION
The rank field of `MemberRecord` is private. 
I need to construct the `MemberRecord` outside of the pallet, for a migration. 
I propose to introduce a constructor.  