### PR TITLE
Adjust the ratio of the `in-peers`/`out-peers`

### DIFF
--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -82,11 +82,11 @@ pub struct NetworkParams {
 	pub allow_private_ip: bool,
 
 	/// Specify the number of outgoing connections we're trying to maintain.
-	#[arg(long, value_name = "COUNT", default_value_t = 15)]
+	#[arg(long, value_name = "COUNT", default_value_t = 8)]
 	pub out_peers: u32,
 
 	/// Maximum number of inbound full nodes peers.
-	#[arg(long, value_name = "COUNT", default_value_t = 25)]
+	#[arg(long, value_name = "COUNT", default_value_t = 32)]
 	pub in_peers: u32,
 
 	/// Maximum number of inbound light nodes peers.


### PR DESCRIPTION
Establish fewer outbound connections in an attempt to allow publicly available nodes to accept more full nodes.

Maintain the overall number of connections node should establish.