### PR TITLE
Service::Error: Storage variant removed

### DIFF
--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -560,7 +560,8 @@ pub fn new_full(config: Configuration, cli: Cli) -> Result<TaskManager, ServiceE
 		cli.storage_monitor,
 		database_source,
 		&task_manager.spawn_essential_handle(),
-	)?;
+	)
+	.map_err(|e| ServiceError::Application(e.into()))?;
 
 	Ok(task_manager)
 }

--- a/client/service/src/error.rs
+++ b/client/service/src/error.rs
@@ -48,9 +48,6 @@ pub enum Error {
 	#[error(transparent)]
 	Telemetry(#[from] sc_telemetry::Error),
 
-	#[error(transparent)]
-	Storage(#[from] sc_storage_monitor::Error),
-
 	#[error("Best chain selection strategy (SelectChain) is not provided.")]
 	SelectChainRequired,
 


### PR DESCRIPTION
Removed `Service::Error::Storage` variant. Refer to: https://github.com/paritytech/substrate/pull/13082/files#r1118920136