### PR TITLE
Expose `ChargedAmount`

### DIFF
--- a/frame/contracts/src/chain_extension.rs
+++ b/frame/contracts/src/chain_extension.rs
@@ -80,7 +80,7 @@ use frame_support::weights::Weight;
 use sp_runtime::DispatchError;
 use sp_std::{marker::PhantomData, vec::Vec};
 
-pub use crate::{exec::Ext, Config};
+pub use crate::{exec::Ext, gas::ChargedAmount, Config};
 pub use frame_system::Config as SysConfig;
 pub use pallet_contracts_primitives::ReturnFlags;
 

--- a/frame/contracts/src/chain_extension.rs
+++ b/frame/contracts/src/chain_extension.rs
@@ -71,7 +71,6 @@
 //! on how to use a chain extension in order to provide new features to ink! contracts.
 
 use crate::{
-	gas::ChargedAmount,
 	wasm::{Runtime, RuntimeCosts},
 	Error,
 };


### PR DESCRIPTION
Exposing `ChargedAmount` type through `chain_extension` module. It shouldn't do anything harmful, since we still cannot construct it ourselves, guaranteeing that it was constructed by runtime internals.

### Examples of usage:

1. https://github.com/727-Ventures/obce/blob/liminal-v0.9.32/src/substrate/mod.rs#L190

`OBCE` generates glue code that automatically constructs `ExtensionContext`, with `ChargedAmount` passed to it when weight pre-charging is enabled. To actually refer to the `ChargedAmount` type, we need it exposed. 

2. https://github.com/Cardinal-Cryptography/aleph-node/blob/91d084ef04b82af1efa8c3a566fb4f7fe118ddab/bin/runtime/src/chain_extension/environment.rs#L19

For testing chain extension it is sometimes useful to mock charging. However, in order to abstract it, we also have to know appropriate type for real environment. 