### PR TITLE
construct_runtime fix: Sort pallets by pallet index

### DIFF
--- a/frame/support/procedural/src/construct_runtime/mod.rs
+++ b/frame/support/procedural/src/construct_runtime/mod.rs
@@ -214,9 +214,12 @@ fn construct_runtime_final_expansion(
 	let ExplicitRuntimeDeclaration {
 		name,
 		where_section: WhereSection { block, node_block, unchecked_extrinsic },
-		pallets,
+		mut pallets,
 		pallets_token,
 	} = definition;
+
+	// Ensure that the code is generated based on the pallet index ordering:
+	pallets.sort_by_key(|p| p.index);
 
 	let system_pallet =
 		pallets.iter().find(|decl| decl.name == SYSTEM_PALLET_NAME).ok_or_else(|| {


### PR DESCRIPTION
Generated code should be ordered by pallet index rather than lexical ordering.

! This will change certain things in the runtime - ordering of pallets in `AllPalletsWithSystem` for example and ordering of the arms in the Call enum but it's for the best !

Fixes #13491