### PR TITLE
CI: Removal of Prometheus alerting rules deployment in cloud-infra

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -311,28 +311,6 @@ include:
     rules:
       - if: $PIPELINE != "automatic-crate-publishing"
 
-#### stage:                        deploy
-
-deploy-prometheus-alerting-rules:
-  stage: deploy
-  needs:
-    - job: test-prometheus-alerting-rules
-      artifacts: false
-  allow_failure: true
-  trigger:
-    project: parity/infrastructure/cloud-infra
-  variables:
-    SUBSTRATE_CI_COMMIT_NAME: "${CI_COMMIT_REF_NAME}"
-    SUBSTRATE_CI_COMMIT_REF: "${CI_COMMIT_SHORT_SHA}"
-    UPSTREAM_TRIGGER_PROJECT: "${CI_PROJECT_PATH}"
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "pipeline"
-      when: never
-    - if: $CI_COMMIT_REF_NAME == "master"
-      changes:
-        - .gitlab-ci.yml
-        - ./scripts/ci/monitoring/**/*
-
 #### stage:                        notify
 
 # This job notifies rusty-cachier about the latest commit with the cache.


### PR DESCRIPTION
An overhaul of alerting rules is on-going in cloud-infra repo which makes this job obsolete