### PR TITLE
bump API versions of {Beefy,Mmr}Api

### DIFF
--- a/primitives/consensus/beefy/src/lib.rs
+++ b/primitives/consensus/beefy/src/lib.rs
@@ -302,6 +302,7 @@ impl OpaqueKeyOwnershipProof {
 
 sp_api::decl_runtime_apis! {
 	/// API necessary for BEEFY voters.
+	#[api_version(2)]
 	pub trait BeefyApi
 	{
 		/// Return the block number where BEEFY consensus is enabled/started

--- a/primitives/merkle-mountain-range/src/lib.rs
+++ b/primitives/merkle-mountain-range/src/lib.rs
@@ -422,6 +422,7 @@ impl Error {
 
 sp_api::decl_runtime_apis! {
 	/// API to interact with MMR pallet.
+	#[api_version(2)]
 	pub trait MmrApi<Hash: codec::Codec, BlockNumber: codec::Codec> {
 		/// Return the on-chain MMR root hash.
 		fn mmr_root() -> Result<Hash, Error>;


### PR DESCRIPTION
Both `BeefyApi` & `MmrApi` have so far been evolving without versioning. This PR sets the current API that's been stable at least since we've reset MMR storage to `api_version(2)`. `BeefyMmrApi` has not changed since inception hence I've left this at implicit `api_version(1)`.

polkadot companion: https://github.com/paritytech/polkadot/pull/6809
