### PR TITLE
chore: reduce copy bytes for core-hashing

### DIFF
--- a/primitives/core/hashing/src/lib.rs
+++ b/primitives/core/hashing/src/lib.rs
@@ -35,48 +35,51 @@ pub fn blake2_512_into(data: &[u8], dest: &mut [u8; 64]) {
 
 /// Do a Blake2 512-bit hash and return result.
 pub fn blake2_512(data: &[u8]) -> [u8; 64] {
-	let mut r = [0; 64];
-	blake2_512_into(data, &mut r);
-	r
+	let mut h = blake2::Blake2b512::new();
+	h.update(data);
+	h.finalize().into()
 }
+
+type Blake2b256 = blake2::Blake2b<U32>;
 
 /// Do a Blake2 256-bit hash and place result in `dest`.
 pub fn blake2_256_into(data: &[u8], dest: &mut [u8; 32]) {
-	type Blake2b256 = blake2::Blake2b<U32>;
 	dest.copy_from_slice(Blake2b256::digest(data).as_slice());
 }
 
 /// Do a Blake2 256-bit hash and return result.
 pub fn blake2_256(data: &[u8]) -> [u8; 32] {
-	let mut r = [0; 32];
-	blake2_256_into(data, &mut r);
-	r
+	let mut h = Blake2b256::new();
+	h.update(data);
+	h.finalize().into()
 }
+
+type Blake2b128 = blake2::Blake2b<U16>;
 
 /// Do a Blake2 128-bit hash and place result in `dest`.
 pub fn blake2_128_into(data: &[u8], dest: &mut [u8; 16]) {
-	type Blake2b128 = blake2::Blake2b<U16>;
 	dest.copy_from_slice(Blake2b128::digest(data).as_slice());
 }
 
 /// Do a Blake2 128-bit hash and return result.
 pub fn blake2_128(data: &[u8]) -> [u8; 16] {
-	let mut r = [0; 16];
-	blake2_128_into(data, &mut r);
-	r
+	let mut h = Blake2b128::new();
+	h.update(data);
+	h.finalize().into()
 }
+
+type Blake2b64 = blake2::Blake2b<U8>;
 
 /// Do a Blake2 64-bit hash and place result in `dest`.
 pub fn blake2_64_into(data: &[u8], dest: &mut [u8; 8]) {
-	type Blake2b64 = blake2::Blake2b<U8>;
 	dest.copy_from_slice(Blake2b64::digest(data).as_slice());
 }
 
 /// Do a Blake2 64-bit hash and return result.
 pub fn blake2_64(data: &[u8]) -> [u8; 8] {
-	let mut r = [0; 8];
-	blake2_64_into(data, &mut r);
-	r
+	let mut h = Blake2b64::new();
+	h.update(data);
+	h.finalize().into()
 }
 
 /// Do a XX 64-bit hash and place result in `dest`.
@@ -128,21 +131,21 @@ pub fn twox_256(data: &[u8]) -> [u8; 32] {
 
 /// Do a keccak 256-bit hash and return result.
 pub fn keccak_256(data: &[u8]) -> [u8; 32] {
-	let mut output = [0u8; 32];
-	output.copy_from_slice(sha3::Keccak256::digest(data).as_slice());
-	output
+	let mut h = sha3::Keccak256::new();
+	h.update(data);
+	h.finalize().into()
 }
 
 /// Do a keccak 512-bit hash and return result.
 pub fn keccak_512(data: &[u8]) -> [u8; 64] {
-	let mut output = [0u8; 64];
-	output.copy_from_slice(sha3::Keccak512::digest(data).as_slice());
-	output
+	let mut h = sha3::Keccak512::new();
+	h.update(data);
+	h.finalize().into()
 }
 
 /// Do a sha2 256-bit hash and return result.
 pub fn sha2_256(data: &[u8]) -> [u8; 32] {
-	let mut output = [0u8; 32];
-	output.copy_from_slice(sha2::Sha256::digest(data).as_slice());
-	output
+	let mut h = sha2::Sha256::new();
+	h.update(data);
+	h.finalize().into()
 }


### PR DESCRIPTION
I do not if the cost will be erased by rust compiler, so I improve the code by hand.