### PR TITLE
FRAME: add a basic readme

### DIFF
--- a/frame/README.md
+++ b/frame/README.md
@@ -1,0 +1,11 @@
+# FRAME
+
+The FRAME development environment provides modules (called "pallets") and support libraries that you can use, modify, and extend to build the runtime logic to suit the needs of your blockchain.
+
+### Documentation
+
+https://docs.substrate.io/reference/frame-pallets/
+
+### Issues
+
+https://github.com/orgs/paritytech/projects/40


### PR DESCRIPTION
**Streamlining** dev processes starts with trivial things - like a readme.



### Context

https://forum.polkadot.network/t/ecosystem-wide-frame-project-manager/1856

> calling out for the ecosystem to put forth and/or agree upon a candidate to do this task, and have this person also be funded directly by the treasury, not Parity. With this person being outside of Parity, I hope that we can achieve a higher degree of uniformity across pallet repositories such as Substrate and ORML etc.

No need for inaction during the wait.

I would like to do some basic work around FRAME, thus the future project-manager can be more efficient.

My work would involve mostly the technical stuff (repository, issue-trackers, automations etc.). At some point I would "dive deep", e.g. providing abstractions to reduce duplications / dev-effort etc.

But it all starts with the basics - like a tiny subsystem readme.

To speed things up (and avoid "time evaporated" on both sides) I'm asking here for a budget (via bounty/tip) and I would start (or better: continue) right away. 

Polkadot address: 13mDFYievQov7ie1257v9bXHDyLvpXWPrgYopnUjYxgD9DnZ
