### PR TITLE
Adding CallFilter to pallet-scheduler.

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -372,6 +372,7 @@ impl pallet_scheduler::Config for Runtime {
 	type WeightInfo = pallet_scheduler::weights::SubstrateWeight<Runtime>;
 	type OriginPrivilegeCmp = EqualPrivilegeOnly;
 	type Preimages = Preimage;
+	type CallFilter = Everything;
 }
 
 impl pallet_glutton::Config for Runtime {

--- a/frame/democracy/src/tests.rs
+++ b/frame/democracy/src/tests.rs
@@ -22,7 +22,7 @@ use crate as pallet_democracy;
 use frame_support::{
 	assert_noop, assert_ok, ord_parameter_types, parameter_types,
 	traits::{
-		ConstU32, ConstU64, Contains, EqualPrivilegeOnly, GenesisBuild, OnInitialize,
+		ConstU32, ConstU64, Contains, EqualPrivilegeOnly, Everything, GenesisBuild, OnInitialize,
 		SortedMembers, StorePreimage,
 	},
 	weights::Weight,
@@ -132,6 +132,7 @@ impl pallet_scheduler::Config for Test {
 	type WeightInfo = ();
 	type OriginPrivilegeCmp = EqualPrivilegeOnly;
 	type Preimages = ();
+	type CallFilter = Everything;
 }
 
 impl pallet_balances::Config for Test {

--- a/frame/referenda/src/mock.rs
+++ b/frame/referenda/src/mock.rs
@@ -23,8 +23,8 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
 	assert_ok, ord_parameter_types, parameter_types,
 	traits::{
-		ConstU32, ConstU64, Contains, EqualPrivilegeOnly, OnInitialize, OriginTrait, Polling,
-		SortedMembers,
+		ConstU32, ConstU64, Contains, EqualPrivilegeOnly, Everything, OnInitialize, OriginTrait,
+		Polling, SortedMembers,
 	},
 	weights::Weight,
 };
@@ -109,6 +109,7 @@ impl pallet_scheduler::Config for Test {
 	type WeightInfo = ();
 	type OriginPrivilegeCmp = EqualPrivilegeOnly;
 	type Preimages = Preimage;
+	type CallFilter = Everything;
 }
 impl pallet_balances::Config for Test {
 	type MaxReserves = ();

--- a/frame/scheduler/src/mock.rs
+++ b/frame/scheduler/src/mock.rs
@@ -90,6 +90,16 @@ pub mod logger {
 			});
 			Ok(())
 		}
+
+		#[pallet::call_index(2)]
+		#[pallet::weight(*weight)]
+		pub fn log_not_sheduled(origin: OriginFor<T>, i: u32, weight: Weight) -> DispatchResult {
+			Self::deposit_event(Event::Logged(i, weight));
+			Log::mutate(|log| {
+				log.push((origin.caller().clone(), i));
+			});
+			Ok(())
+		}
 	}
 }
 
@@ -114,6 +124,13 @@ pub struct BaseFilter;
 impl Contains<RuntimeCall> for BaseFilter {
 	fn contains(call: &RuntimeCall) -> bool {
 		!matches!(call, RuntimeCall::Logger(LoggerCall::log { .. }))
+	}
+}
+
+pub struct CallFilter;
+impl Contains<RuntimeCall> for CallFilter {
+	fn contains(call: &RuntimeCall) -> bool {
+		!matches!(call, RuntimeCall::Logger(LoggerCall::log_not_sheduled { .. }))
 	}
 }
 
@@ -220,6 +237,7 @@ impl Config for Test {
 	type WeightInfo = TestWeightInfo;
 	type OriginPrivilegeCmp = EqualPrivilegeOnly;
 	type Preimages = Preimage;
+	type CallFilter = CallFilter;
 }
 
 pub type LoggerCall = logger::Call<Test>;

--- a/frame/scheduler/src/tests.rs
+++ b/frame/scheduler/src/tests.rs
@@ -713,6 +713,39 @@ fn root_calls_works() {
 }
 
 #[test]
+fn fails_to_schedule_filtered_task() {
+	new_test_ext().execute_with(|| {
+		let call = Box::new(RuntimeCall::Logger(LoggerCall::log_not_sheduled {
+			i: 42,
+			weight: Weight::from_ref_time(10),
+		}));
+		assert_err!(
+			Scheduler::schedule(RuntimeOrigin::root(), 4, None, 127, call.clone(),),
+			frame_system::Error::<Test>::CallFiltered
+		);
+		assert_err!(
+			Scheduler::schedule_named(RuntimeOrigin::root(), [1u8; 32], 4, None, 127, call.clone(),),
+			frame_system::Error::<Test>::CallFiltered
+		);
+		assert_err!(
+			Scheduler::schedule_after(RuntimeOrigin::root(), 4, None, 127, call,),
+			frame_system::Error::<Test>::CallFiltered
+		);
+		assert_err!(
+			Scheduler::schedule_named_after(
+				RuntimeOrigin::root(),
+				[1u8; 32],
+				4,
+				None,
+				127,
+				call.clone(),
+			),
+			frame_system::Error::<Test>::CallFiltered
+		);
+	});
+}
+
+#[test]
 fn fails_to_schedule_task_in_the_past() {
 	new_test_ext().execute_with(|| {
 		run_to_block(3);

--- a/frame/scheduler/src/tests.rs
+++ b/frame/scheduler/src/tests.rs
@@ -728,7 +728,7 @@ fn fails_to_schedule_filtered_task() {
 			frame_system::Error::<Test>::CallFiltered
 		);
 		assert_err!(
-			Scheduler::schedule_after(RuntimeOrigin::root(), 4, None, 127, call,),
+			Scheduler::schedule_after(RuntimeOrigin::root(), 4, None, 127, call.clone(),),
 			frame_system::Error::<Test>::CallFiltered
 		);
 		assert_err!(


### PR DESCRIPTION
## Description

Adding CallFilter to pallet-scheduler. Partially resolves https://github.com/paritytech/polkadot-sdk/issues/197

## Motivation

Some calls may not be desirable for deferred execution. This may be due to both the implementation of an undesirable method and business logic.

## Behavior

This PR adds call filtering at the pallet level. Filtering occurs when setting a task by [frame_support::traits::Contains::contains](https://paritytech.github.io/substrate/master/frame_support/traits/trait.Contains.html#tymethod.contains). If the result is true, then the task will be scheduled, otherwise the error [frame_system::Error::CallFiltered](https://paritytech.github.io/substrate/master/frame_system/pallet/enum.Error.html#variant.CallFiltered) is returned.

--
Polkadot companion: https://github.com/paritytech/polkadot/pull/6830