### PR TITLE
Expose `new_full_parts_with_genesis_builder` from sc-service

### DIFF
--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -58,8 +58,9 @@ use sp_runtime::{
 pub use self::{
 	builder::{
 		build_network, build_offchain_workers, new_client, new_db_backend, new_full_client,
-		new_full_parts, spawn_tasks, BuildNetworkParams, KeystoreContainer, NetworkStarter,
-		SpawnTasksParams, TFullBackend, TFullCallExecutor, TFullClient,
+		new_full_parts, new_full_parts_with_genesis_builder, spawn_tasks, BuildNetworkParams,
+		KeystoreContainer, NetworkStarter, SpawnTasksParams, TFullBackend, TFullCallExecutor,
+		TFullClient,
 	},
 	client::{ClientConfig, LocalCallExecutor},
 	error::Error,


### PR DESCRIPTION
I forgot this in https://github.com/paritytech/substrate/pull/12291