### PR TITLE
pallet-assets callback improvement

### DIFF
--- a/frame/assets/src/functions.rs
+++ b/frame/assets/src/functions.rs
@@ -661,8 +661,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				status: AssetStatus::Live,
 			},
 		);
+		ensure!(T::CallbackHandle::created(&id, &owner).is_ok(), Error::<T, I>::CallbackFailed);
 		Self::deposit_event(Event::ForceCreated { asset_id: id, owner: owner.clone() });
-		T::CallbackHandle::created(&id, &owner);
 		Ok(())
 	}
 
@@ -752,7 +752,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					approvals_destroyed: removed_approvals as u32,
 					approvals_remaining: details.approvals as u32,
 				});
-				T::CallbackHandle::destroyed(&id);
 				Ok(())
 			})?;
 		Ok(removed_approvals)
@@ -767,6 +766,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			ensure!(details.status == AssetStatus::Destroying, Error::<T, I>::IncorrectStatus);
 			ensure!(details.accounts == 0, Error::<T, I>::InUse);
 			ensure!(details.approvals == 0, Error::<T, I>::InUse);
+			ensure!(T::CallbackHandle::destroyed(&id).is_ok(), Error::<T, I>::CallbackFailed);
 
 			let metadata = Metadata::<T, I>::take(&id);
 			T::Currency::unreserve(

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -178,10 +178,14 @@ const LOG_TARGET: &str = "runtime::assets";
 /// Trait with callbacks that are executed after successfull asset creation or destruction.
 pub trait AssetsCallback<AssetId, AccountId> {
 	/// Indicates that asset with `id` was successfully created by the `owner`
-	fn created(_id: &AssetId, _owner: &AccountId) {}
+	fn created(_id: &AssetId, _owner: &AccountId) -> Result<(), ()> {
+		Ok(())
+	}
 
 	/// Indicates that asset with `id` has just been destroyed
-	fn destroyed(_id: &AssetId) {}
+	fn destroyed(_id: &AssetId) -> Result<(), ()> {
+		Ok(())
+	}
 }
 
 /// Empty implementation in case no callbacks are required.
@@ -561,6 +565,8 @@ pub mod pallet {
 		IncorrectStatus,
 		/// The asset should be frozen before the given operation.
 		NotFrozen,
+		/// Callback action resulted in error
+		CallbackFailed,
 	}
 
 	#[pallet::call]
@@ -619,13 +625,12 @@ pub mod pallet {
 					status: AssetStatus::Live,
 				},
 			);
-
+			ensure!(T::CallbackHandle::created(&id, &owner).is_ok(), Error::<T, I>::CallbackFailed);
 			Self::deposit_event(Event::Created {
 				asset_id: id,
 				creator: owner.clone(),
 				owner: admin,
 			});
-			T::CallbackHandle::created(&id, &owner);
 
 			Ok(())
 		}

--- a/frame/assets/src/mock.rs
+++ b/frame/assets/src/mock.rs
@@ -91,12 +91,44 @@ impl pallet_balances::Config for Test {
 
 pub struct AssetsCallbackHandle;
 impl AssetsCallback<AssetId, AccountId> for AssetsCallbackHandle {
-	fn created(_id: &AssetId, _owner: &AccountId) {
-		storage::set(b"asset_created", &().encode());
+	fn created(_id: &AssetId, _owner: &AccountId) -> Result<(), ()> {
+		if Self::should_err() {
+			Err(())
+		} else {
+			storage::set(Self::CREATED.as_bytes(), &().encode());
+			Ok(())
+		}
 	}
 
-	fn destroyed(_id: &AssetId) {
-		storage::set(b"asset_destroyed", &().encode());
+	fn destroyed(_id: &AssetId) -> Result<(), ()> {
+		if Self::should_err() {
+			Err(())
+		} else {
+			storage::set(Self::DESTROYED.as_bytes(), &().encode());
+			Ok(())
+		}
+	}
+}
+
+impl AssetsCallbackHandle {
+	pub const CREATED: &'static str = "asset_created";
+	pub const DESTROYED: &'static str = "asset_destroyed";
+
+	const RETURN_ERROR: &'static str = "return_error";
+
+	// Configures `Self` to return `Ok` when callbacks are invoked
+	pub fn set_return_ok() {
+		storage::clear(Self::RETURN_ERROR.as_bytes());
+	}
+
+	// Configures `Self` to return `Err` when callbacks are invoked
+	pub fn set_return_error() {
+		storage::set(Self::RETURN_ERROR.as_bytes(), &().encode());
+	}
+
+	// If `true`, callback should return `Err`, `Ok` otherwise.
+	fn should_err() -> bool {
+		storage::exists(Self::RETURN_ERROR.as_bytes())
 	}
 }
 


### PR DESCRIPTION
Improves `AssetsCallback` trait by introducing `Result<(), ()>` as the return type.
This allows callback to inform the pallet whether the asset creation (or destruction) should complete or not.

Also moves the `destroyed` callback invocation to `do_finish_destroy` function.