### PR TITLE
core: remove unused localized signature type

### DIFF
--- a/primitives/core/src/ed25519.rs
+++ b/primitives/core/src/ed25519.rs
@@ -332,16 +332,6 @@ impl Signature {
 	}
 }
 
-/// A localized signature also contains sender information.
-#[cfg(feature = "std")]
-#[derive(PartialEq, Eq, Clone, Debug, Encode, Decode)]
-pub struct LocalizedSignature {
-	/// The signer of the signature.
-	pub signer: Public,
-	/// The signature itself.
-	pub signature: Signature,
-}
-
 impl Public {
 	/// A new instance from the given 32-byte `data`.
 	///

--- a/primitives/core/src/sr25519.rs
+++ b/primitives/core/src/sr25519.rs
@@ -307,17 +307,6 @@ impl sp_std::fmt::Debug for Signature {
 	}
 }
 
-/// A localized signature also contains sender information.
-/// NOTE: Encode and Decode traits are supported in ed25519 but not possible for now here.
-#[cfg(feature = "std")]
-#[derive(PartialEq, Eq, Clone, Debug)]
-pub struct LocalizedSignature {
-	/// The signer of the signature.
-	pub signer: Public,
-	/// The signature itself.
-	pub signature: Signature,
-}
-
 impl UncheckedFrom<[u8; 64]> for Signature {
 	fn unchecked_from(data: [u8; 64]) -> Signature {
 		Signature(data)


### PR DESCRIPTION
I believe this was used in rhododendron and it's unused ever since. It's just a plain type with no functionality attached, I don't see any reason to keep it around.