### PR TITLE
Nfts: Make ItemConfig members public

### DIFF
--- a/frame/nfts/src/types.rs
+++ b/frame/nfts/src/types.rs
@@ -399,7 +399,7 @@ impl_codec_bitflags!(ItemSettings, u64, ItemSetting);
 )]
 pub struct ItemConfig {
 	/// Item's settings.
-	pub(super) settings: ItemSettings,
+	pub settings: ItemSettings,
 }
 
 impl ItemConfig {


### PR DESCRIPTION
This would allow construct `ItemConfig` directly, e.g.

```
let config = ItemConfig {
  settings: ItemSettings::from_disabled(ItemSetting::Transferable | ItemSetting::UnlockedMetadata),
}
```

Opinions:
- `ItemConfig` default is ambiguous, you don't know by default `ItemSettings` is all enabled or disabled
- Maybe `mint_into` should allow optional `item_config`, when `None` it will use collection's `default_item_settings`