### PR TITLE
Nfts: minor fixes

### DIFF
--- a/frame/nfts/src/lib.rs
+++ b/frame/nfts/src/lib.rs
@@ -45,9 +45,7 @@ pub mod weights;
 
 use codec::{Decode, Encode};
 use frame_support::traits::{
-	tokens::{AttributeNamespace, Locker},
-	BalanceStatus::Reserved,
-	Currency, EnsureOriginWithArg, ReservableCurrency,
+	tokens::Locker, BalanceStatus::Reserved, Currency, EnsureOriginWithArg, ReservableCurrency,
 };
 use frame_system::Config as SystemConfig;
 use sp_runtime::{

--- a/frame/nfts/src/lib.rs
+++ b/frame/nfts/src/lib.rs
@@ -809,13 +809,13 @@ pub mod pallet {
 					match mint_settings.mint_type {
 						MintType::Issuer => return Err(Error::<T, I>::NoPermission.into()),
 						MintType::HolderOf(collection_id) => {
-							let MintWitness { owner_of_item } =
+							let MintWitness { owned_item } =
 								witness_data.ok_or(Error::<T, I>::BadWitness)?;
 
 							let owns_item = Account::<T, I>::contains_key((
 								&caller,
 								&collection_id,
-								&owner_of_item,
+								&owned_item,
 							));
 							ensure!(owns_item, Error::<T, I>::BadWitness);
 
@@ -824,7 +824,7 @@ pub mod pallet {
 
 							let key = (
 								&collection_id,
-								Some(owner_of_item),
+								Some(owned_item),
 								AttributeNamespace::Pallet,
 								&Self::construct_attribute_key(pallet_attribute.encode())?,
 							);

--- a/frame/nfts/src/tests.rs
+++ b/frame/nfts/src/tests.rs
@@ -335,7 +335,7 @@ fn mint_should_work() {
 				1,
 				42,
 				account(2),
-				Some(MintWitness { owner_of_item: 42 })
+				Some(MintWitness { owned_item: 42 })
 			),
 			Error::<Test>::BadWitness
 		);
@@ -344,7 +344,7 @@ fn mint_should_work() {
 			1,
 			42,
 			account(2),
-			Some(MintWitness { owner_of_item: 43 })
+			Some(MintWitness { owned_item: 43 })
 		));
 
 		// can't mint twice
@@ -354,7 +354,7 @@ fn mint_should_work() {
 				1,
 				46,
 				account(2),
-				Some(MintWitness { owner_of_item: 43 })
+				Some(MintWitness { owned_item: 43 })
 			),
 			Error::<Test>::AlreadyClaimed
 		);

--- a/frame/nfts/src/types.rs
+++ b/frame/nfts/src/types.rs
@@ -124,7 +124,7 @@ impl<AccountId, DepositBalance> CollectionDetails<AccountId, DepositBalance> {
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 pub struct MintWitness<ItemId> {
 	/// Provide the id of the item in a required collection.
-	pub owner_of_item: ItemId,
+	pub owned_item: ItemId,
 }
 
 /// Information concerning the ownership of a single unique item.

--- a/frame/nfts/src/types.rs
+++ b/frame/nfts/src/types.rs
@@ -317,6 +317,21 @@ impl<Price, BlockNumber, CollectionId> Default for MintSettings<Price, BlockNumb
 	}
 }
 
+/// Attribute namespaces for non-fungible tokens.
+#[derive(
+	Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, scale_info::TypeInfo, MaxEncodedLen,
+)]
+pub enum AttributeNamespace<AccountId> {
+	/// An attribute was set by the pallet.
+	Pallet,
+	/// An attribute was set by collection's owner.
+	CollectionOwner,
+	/// An attribute was set by item's owner.
+	ItemOwner,
+	/// An attribute was set by pre-approved account.
+	Account(AccountId),
+}
+
 /// A witness data to cancel attributes approval operation.
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 pub struct CancelAttributesApprovalWitness {

--- a/frame/support/src/traits/tokens.rs
+++ b/frame/support/src/traits/tokens.rs
@@ -28,7 +28,6 @@ pub mod nonfungibles;
 pub mod nonfungibles_v2;
 pub use imbalance::Imbalance;
 pub use misc::{
-	AssetId, AttributeNamespace, Balance, BalanceConversion, BalanceStatus, ConvertRank,
-	DepositConsequence, ExistenceRequirement, GetSalary, Locker, WithdrawConsequence,
-	WithdrawReasons,
+	AssetId, Balance, BalanceConversion, BalanceStatus, ConvertRank, DepositConsequence,
+	ExistenceRequirement, GetSalary, Locker, WithdrawConsequence, WithdrawReasons,
 };

--- a/frame/support/src/traits/tokens/misc.rs
+++ b/frame/support/src/traits/tokens/misc.rs
@@ -126,21 +126,6 @@ pub enum BalanceStatus {
 	Reserved,
 }
 
-/// Attribute namespaces for non-fungible tokens.
-#[derive(
-	Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, scale_info::TypeInfo, MaxEncodedLen,
-)]
-pub enum AttributeNamespace<AccountId> {
-	/// An attribute was set by the pallet.
-	Pallet,
-	/// An attribute was set by collection's owner.
-	CollectionOwner,
-	/// An attribute was set by item's owner.
-	ItemOwner,
-	/// An attribute was set by pre-approved account.
-	Account(AccountId),
-}
-
 bitflags::bitflags! {
 	/// Reasons for moving funds out of an account.
 	#[derive(Encode, Decode, MaxEncodedLen)]


### PR DESCRIPTION
1) Renames `let MintWitness { owner_of_item }` to `let MintWitness { owned_item }`
Since we need to specify here item's id, and not the owner
2) Moves AttributeNamespace into the pallet-nfts types file. At some point, we needed to have the `AttributeNamespace` defined in a general file in order to use them in nonfungible traits, but later we removed that dependency and could safely put that enum back 