### PR TITLE
Increase contracts bench stability

### DIFF
--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -716,7 +716,7 @@ benchmarks! {
 	// contract it cannot be used as an attack vector.
 	#[pov_mode = Measured]
 	seal_return {
-		let r in 0 .. 1;
+		let r in 0 .. API_BENCHMARK_BATCHES;
 		let code = WasmModule::<T>::from(ModuleDefinition {
 			memory: Some(ImportedMemory::max::<T>()),
 			imported_functions: vec![ImportedFunction {
@@ -2700,7 +2700,7 @@ benchmarks! {
 	// depends on how much memory is already allocated.
 	#[pov_mode = Ignored]
 	instr_memory_grow {
-		let r in 0 .. 1;
+		let r in 0 .. INSTR_BENCHMARK_BATCHES;
 		let max_pages = ImportedMemory::max::<T>().max_pages;
 		let mut sbox = Sandbox::from(&WasmModule::<T>::from(ModuleDefinition {
 			memory: Some(ImportedMemory {

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -1988,7 +1988,7 @@ benchmarks! {
 	// Only the overhead of calling the function itself with minimal arguments.
 	#[pov_mode = Measured]
 	seal_hash_sha2_256 {
-		let r in 0 .. 1;
+		let r in 0 .. API_BENCHMARK_BATCHES;
 		let instance = Contract::<T>::new(WasmModule::hasher(
 			"seal_hash_sha2_256", r * API_BENCHMARK_BATCH_SIZE, 0,
 		), vec![])?;
@@ -2008,7 +2008,7 @@ benchmarks! {
 	// Only the overhead of calling the function itself with minimal arguments.
 	#[pov_mode = Measured]
 	seal_hash_keccak_256 {
-		let r in 0 .. 1;
+		let r in 0 .. API_BENCHMARK_BATCHES;
 		let instance = Contract::<T>::new(WasmModule::hasher(
 			"seal_hash_keccak_256", r * API_BENCHMARK_BATCH_SIZE, 0,
 		), vec![])?;
@@ -2028,7 +2028,7 @@ benchmarks! {
 	// Only the overhead of calling the function itself with minimal arguments.
 	#[pov_mode = Measured]
 	seal_hash_blake2_256 {
-		let r in 0 .. 1;
+		let r in 0 .. API_BENCHMARK_BATCHES;
 		let instance = Contract::<T>::new(WasmModule::hasher(
 			"seal_hash_blake2_256", r * API_BENCHMARK_BATCH_SIZE, 0,
 		), vec![])?;
@@ -2048,7 +2048,7 @@ benchmarks! {
 	// Only the overhead of calling the function itself with minimal arguments.
 	#[pov_mode = Measured]
 	seal_hash_blake2_128 {
-		let r in 0 .. 1;
+		let r in 0 .. API_BENCHMARK_BATCHES;
 		let instance = Contract::<T>::new(WasmModule::hasher(
 			"seal_hash_blake2_128", r * API_BENCHMARK_BATCH_SIZE, 0,
 		), vec![])?;
@@ -2069,7 +2069,7 @@ benchmarks! {
 	// It generates different private keys and signatures for the message "Hello world".
 	#[pov_mode = Measured]
 	seal_ecdsa_recover {
-		let r in 0 .. 1;
+		let r in 0 .. API_BENCHMARK_BATCHES;
 
 		let message_hash = sp_io::hashing::blake2_256("Hello world".as_bytes());
 		let key_type = sp_core::crypto::KeyTypeId(*b"code");
@@ -2118,7 +2118,7 @@ benchmarks! {
 	// generated different ECDSA keys.
 	#[pov_mode = Measured]
 	seal_ecdsa_to_eth_address {
-		let r in 0 .. 1;
+		let r in 0 .. API_BENCHMARK_BATCHES;
 		let key_type = sp_core::crypto::KeyTypeId(*b"code");
 		let pub_keys_bytes = (0..r * API_BENCHMARK_BATCH_SIZE)
 			.flat_map(|_| {


### PR DESCRIPTION
The FRAME benchmarking does not handle the case well where a linear component as only a range of [0, =1] since in this case it has to calculate a linear formula from just two points which is unstable.

Now bumping these upper limits back `API_BENCHMARK_BATCHES` should improve stability. There are some more benches which could profit from this, but let's first see if we go into the right direction by re-benching.

This partially reverts https://github.com/paritytech/substrate/commit/2eb8ad273eeabea380fce00c10893ac788b1cbde