### PR TITLE
sc-consensus-beefy: fix on-demand async state machine

### DIFF
--- a/client/consensus/beefy/src/communication/request_response/outgoing_requests_engine.rs
+++ b/client/consensus/beefy/src/communication/request_response/outgoing_requests_engine.rs
@@ -207,7 +207,7 @@ impl<B: Block> OnDemandJustificationsEngine<B> {
 	pub async fn next(&mut self) -> Option<BeefyVersionedFinalityProof<B>> {
 		let (peer, req_info, resp) = match &mut self.state {
 			State::Idle => {
-				futures::pending!();
+				futures::future::pending::<()>().await;
 				return None
 			},
 			State::AwaitingResponse(peer, req_info, receiver) => {

--- a/client/consensus/beefy/src/worker.rs
+++ b/client/consensus/beefy/src/worker.rs
@@ -887,11 +887,6 @@ where
 			// based on the new resulting 'state'.
 			futures::select_biased! {
 				// Use `select_biased!` to prioritize order below.
-				// Make sure to pump gossip engine.
-				_ = gossip_engine => {
-					error!(target: LOG_TARGET, "🥩 Gossip engine has terminated, closing worker.");
-					return;
-				},
 				// Process finality notifications first since these drive the voter.
 				notification = finality_notifications.next() => {
 					if let Some(notification) = notification {
@@ -900,6 +895,11 @@ where
 						error!(target: LOG_TARGET, "🥩 Finality stream terminated, closing worker.");
 						return;
 					}
+				},
+				// Make sure to pump gossip engine.
+				_ = gossip_engine => {
+					error!(target: LOG_TARGET, "🥩 Gossip engine has terminated, closing worker.");
+					return;
 				},
 				// Process incoming justifications as these can make some in-flight votes obsolete.
 				justif = self.on_demand_justifications.next().fuse() => {


### PR DESCRIPTION
`futures_util::pending!()` macro only yields to the event loop once, resulting in many calls to the `OnDemandJustificationsEngine::next()` made by the tokio reactor even though the on-demand-engine is idle.

Replace it with the correct `futures::future::pending::<()>()` function which forever yields to the event loop, which is what we want when the engine is idle.