### PR TITLE
Add dedicated `FeePolynomial` struct

### DIFF
--- a/primitives/weights/src/lib.rs
+++ b/primitives/weights/src/lib.rs
@@ -128,7 +128,7 @@ where
 	/// ```ignore
 	/// (frac * x^(degree) + integer * x^(degree))
 	/// ```
-	/// Depending on the value of `negative`, it is added or subtracted from `result`.
+	/// Depending on the value of `negative`, it is added or subtracted from the `result`.
 	pub fn saturating_eval(&self, mut result: Balance, x: Balance) -> Balance {
 		let power = x.saturating_pow(self.degree.into());
 
@@ -161,11 +161,12 @@ pub type WeightToFeeCoefficients<T> = SmallVec<[WeightToFeeCoefficient<T>; 4]>;
 /// For visualization purposes, the formulas of the unsigned terms look like:
 ///
 /// ```ignore
-/// c[0].frac * x^(c[0].degree) + c[0].integer * x^(c[0].degree)
-/// c[1].frac * x^(c[1].degree) + c[1].integer * x^(c[1].degree)
+/// (c[0].frac * x^(c[0].degree) + c[0].integer * x^(c[0].degree))
+/// (c[1].frac * x^(c[1].degree) + c[1].integer * x^(c[1].degree))
 /// ...
 /// ```
-/// Depending on the value of `c[i].negative`, the term is added or subtracted from the result.
+/// Depending on the value of `c[i].negative`, each term is added or subtracted from the result.
+/// The result is initialized as zero.
 pub struct FeePolynomial<Balance> {
 	coefficients: SmallVec<[WeightToFeeCoefficient<Balance>; 4]>,
 }

--- a/primitives/weights/src/lib.rs
+++ b/primitives/weights/src/lib.rs
@@ -123,6 +123,12 @@ where
 	Balance: BaseArithmetic + From<u32> + Copy + Unsigned,
 {
 	/// Evaluate the term at `x` and saturatingly amalgamate into `result`.
+	///
+	/// The term is calculated as:
+	///
+	/// ```ignore
+	/// (frac * x^(degree) + integer * x^(degree)) * (-1 * c[0].negative)
+	/// ```
 	pub fn saturating_eval(&self, mut result: Balance, x: Balance) -> Balance {
 		let power = x.saturating_pow(self.degree.into());
 

--- a/primitives/weights/src/lib.rs
+++ b/primitives/weights/src/lib.rs
@@ -124,11 +124,11 @@ where
 {
 	/// Evaluate the term at `x` and saturatingly amalgamate into `result`.
 	///
-	/// The term is calculated as:
-	///
+	/// The unsigned value for the term is calculated as:
 	/// ```ignore
-	/// (frac * x^(degree) + integer * x^(degree)) * (-1 * c[0].negative)
+	/// (frac * x^(degree) + integer * x^(degree))
 	/// ```
+	/// Depending on the value of `negative`, it is added or subtracted from `result`.
 	pub fn saturating_eval(&self, mut result: Balance, x: Balance) -> Balance {
 		let power = x.saturating_pow(self.degree.into());
 
@@ -158,13 +158,14 @@ pub type WeightToFeeCoefficients<T> = SmallVec<[WeightToFeeCoefficient<T>; 4]>;
 /// coefficients matters since it uses saturating arithmetic. This struct does therefore not model a
 /// polynomial in the mathematical sense (polynomial ring).
 ///
-/// For visualization purposes, the formula looks like this:
+/// For visualization purposes, the formulas of the unsigned terms look like:
 ///
 /// ```ignore
-///   (c[0].frac * x^(c[0].degree) + c[0].integer * x^(c[0].degree)) * (-1 * c[0].negative)
-/// + (c[1].frac * x^(c[1].degree) + c[1].integer * x^(c[1].degree)) * (-1 * c[1].negative)
-/// + ...
+/// c[0].frac * x^(c[0].degree) + c[0].integer * x^(c[0].degree)
+/// c[1].frac * x^(c[1].degree) + c[1].integer * x^(c[1].degree)
+/// ...
 /// ```
+/// Depending on the value of `c[i].negative`, the term is added or subtracted from the result.
 pub struct FeePolynomial<Balance> {
 	coefficients: SmallVec<[WeightToFeeCoefficient<Balance>; 4]>,
 }

--- a/primitives/weights/src/lib.rs
+++ b/primitives/weights/src/lib.rs
@@ -121,7 +121,7 @@ pub struct WeightToFeeCoefficient<Balance> {
 /// A list of coefficients that represent one polynomial.
 pub type WeightToFeeCoefficients<T> = SmallVec<[WeightToFeeCoefficient<T>; 4]>;
 
-/// A list of coefficients that represent a polynomial to convert a `u64` to a fee.
+/// A list of coefficients that represent a polynomial.
 ///
 /// Can be [eval](Self::eval)uated at a specific `u64` to get the fee.
 pub struct FeePolynomial<Balance> {
@@ -138,6 +138,7 @@ impl<Balance> FeePolynomial<Balance>
 where
 	Balance: BaseArithmetic + From<u32> + Copy + Unsigned,
 {
+	/// Evaluate the polynomial at a specific `x`.
 	pub fn eval(&self, x: u64) -> Balance {
 		self.coefficients.iter().fold(Balance::saturated_from(0u32), |mut acc, args| {
 			let w = Balance::saturated_from(x).saturating_pow(args.degree.into());

--- a/primitives/weights/src/lib.rs
+++ b/primitives/weights/src/lib.rs
@@ -147,7 +147,18 @@ pub type WeightToFeeCoefficients<T> = SmallVec<[WeightToFeeCoefficient<T>; 4]>;
 
 /// A list of coefficients that represent a polynomial.
 ///
-/// Can be [eval](Self::eval)uated at a specific `u64` to get the fee.
+/// Can be [eval](Self::eval)uated at a specific `u64` to get the fee. The evaluations happens by
+/// summing up all term [results](`WeightToFeeCoefficient::saturating_eval`). The order of the
+/// coefficients matters since it uses saturating arithmetic. This struct does therefore not model a
+/// polynomial in the mathematical sense (polynomial ring).
+///
+/// For visualization purposes, the formula looks like this:
+///
+/// ```ignore
+///   (c[0].frac * x^(c[0].degree) + c[0].integer * x^(c[0].degree)) * (-1 * c[0].negative)
+/// + (c[1].frac * x^(c[1].degree) + c[1].integer * x^(c[1].degree)) * (-1 * c[1].negative)
+/// + ...
+/// ```
 pub struct FeePolynomial<Balance> {
 	coefficients: SmallVec<[WeightToFeeCoefficient<Balance>; 4]>,
 }

--- a/primitives/weights/src/weight_v2.rs
+++ b/primitives/weights/src/weight_v2.rs
@@ -74,6 +74,16 @@ impl Weight {
 		&mut self.proof_size
 	}
 
+	/// Return self but discard any reference time.
+	pub const fn without_ref_time(&self) -> Self {
+		Self { ref_time: 0, proof_size: self.proof_size }
+	}
+
+	/// Return self but discard any proof size.
+	pub const fn without_proof_size(&self) -> Self {
+		Self { ref_time: self.ref_time, proof_size: 0 }
+	}
+
 	pub const MAX: Self = Self { ref_time: u64::MAX, proof_size: u64::MAX };
 
 	/// Get the conservative min of `self` and `other` weight.


### PR DESCRIPTION
Zero logic refactor as preparation for https://github.com/paritytech/cumulus/pull/2326.  
Changes:
- add `Weight::{without_ref_time, without_proof_size}`.
- Add a  `FeePolynomial` to properly type the weight polynomial coefficients in a OOP manner to reusability downstream.

Eventually the `WeightToFeePolynomial` should be two dimensional, but i want to keep this MR minimal for now.