### PR TITLE
Fix typos in example pallet

### DIFF
--- a/frame/examples/offchain-worker/src/lib.rs
+++ b/frame/examples/offchain-worker/src/lib.rs
@@ -167,7 +167,7 @@ pub mod pallet {
 		///
 		/// By implementing `fn offchain_worker` you declare a new offchain worker.
 		/// This function will be called when the node is fully synced and a new best block is
-		/// succesfuly imported.
+		/// successfully imported.
 		/// Note that it's not guaranteed for offchain workers to run on EVERY block, there might
 		/// be cases where some blocks are skipped, or for some the worker runs twice (re-orgs),
 		/// so the code should be able to handle that.
@@ -225,7 +225,7 @@ pub mod pallet {
 		/// The transaction needs to be signed (see `ensure_signed`) check, so that the caller
 		/// pays a fee to execute it.
 		/// This makes sure that it's not easy (or rather cheap) to attack the chain by submitting
-		/// excesive transactions, but note that it doesn't ensure the price oracle is actually
+		/// excessive transactions, but note that it doesn't ensure the price oracle is actually
 		/// working and receives (and provides) meaningful data.
 		/// This example is not focused on correctness of the oracle itself, but rather its
 		/// purpose is to showcase offchain worker capabilities.
@@ -337,7 +337,7 @@ pub mod pallet {
 
 	/// Defines the block when next unsigned transaction will be accepted.
 	///
-	/// To prevent spam of unsigned (and unpayed!) transactions on the network,
+	/// To prevent spam of unsigned (and unpaid!) transactions on the network,
 	/// we only allow one transaction every `T::UnsignedInterval` blocks.
 	/// This storage entry defines when new transaction is going to be accepted.
 	#[pallet::storage]
@@ -571,12 +571,12 @@ impl<T: Config> Pallet<T> {
 	fn fetch_price() -> Result<u32, http::Error> {
 		// We want to keep the offchain worker execution time reasonable, so we set a hard-coded
 		// deadline to 2s to complete the external call.
-		// You can also wait idefinitely for the response, however you may still get a timeout
+		// You can also wait indefinitely for the response, however you may still get a timeout
 		// coming from the host machine.
 		let deadline = sp_io::offchain::timestamp().add(Duration::from_millis(2_000));
 		// Initiate an external HTTP GET request.
 		// This is using high-level wrappers from `sp_runtime`, for the low-level calls that
-		// you can find in `sp_io`. The API is trying to be similar to `reqwest`, but
+		// you can find in `sp_io`. The API is trying to be similar to `request`, but
 		// since we are running in a custom WASM execution environment we can't simply
 		// import the library here.
 		let request =


### PR DESCRIPTION
Fixes a few typos caught while I was looking through the example pallet.