### PR TITLE
Bump grandpa to 0.16.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2080,9 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "finality-grandpa"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24e6c429951433ccb7c87fd528c60084834dcd14763182c1f83291bcde24c34"
+checksum = "36530797b9bf31cd4ff126dcfee8170f86b00cfdcea3269d73133cc0415945c3"
 dependencies = [
  "either",
  "futures",

--- a/client/consensus/grandpa/Cargo.toml
+++ b/client/consensus/grandpa/Cargo.toml
@@ -18,7 +18,7 @@ ahash = "0.8.2"
 array-bytes = "4.1"
 async-trait = "0.1.57"
 dyn-clone = "1.0"
-finality-grandpa = { version = "0.16.1", features = ["derive-codec"] }
+finality-grandpa = { version = "0.16.2", features = ["derive-codec"] }
 futures = "0.3.21"
 futures-timer = "3.0.1"
 log = "0.4.17"
@@ -50,7 +50,7 @@ sp-runtime = { version = "7.0.0", path = "../../../primitives/runtime" }
 
 [dev-dependencies]
 assert_matches = "1.3.0"
-finality-grandpa = { version = "0.16.1", features = ["derive-codec", "test-helpers"] }
+finality-grandpa = { version = "0.16.2", features = ["derive-codec", "test-helpers"] }
 serde = "1.0.136"
 tokio = "1.22.0"
 sc-network = { version = "0.10.0-dev", path = "../../network" }

--- a/client/consensus/grandpa/rpc/Cargo.toml
+++ b/client/consensus/grandpa/rpc/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 homepage = "https://substrate.io"
 
 [dependencies]
-finality-grandpa = { version = "0.16.1", features = ["derive-codec"] }
+finality-grandpa = { version = "0.16.2", features = ["derive-codec"] }
 futures = "0.3.16"
 jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
 log = "0.4.8"

--- a/frame/grandpa/Cargo.toml
+++ b/frame/grandpa/Cargo.toml
@@ -31,7 +31,7 @@ sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../pr
 sp-std = { version = "5.0.0", default-features = false, path = "../../primitives/std" }
 
 [dev-dependencies]
-grandpa = { package = "finality-grandpa", version = "0.16.1", features = ["derive-codec"] }
+grandpa = { package = "finality-grandpa", version = "0.16.2", features = ["derive-codec"] }
 frame-benchmarking = { version = "4.0.0-dev", path = "../benchmarking" }
 frame-election-provider-support = { version = "4.0.0-dev", path = "../election-provider-support" }
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }

--- a/primitives/consensus/grandpa/Cargo.toml
+++ b/primitives/consensus/grandpa/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false, features = ["derive"] }
-grandpa = { package = "finality-grandpa", version = "0.16.1", default-features = false, features = ["derive-codec"] }
+grandpa = { package = "finality-grandpa", version = "0.16.2", default-features = false, features = ["derive-codec"] }
 log = { version = "0.4.17", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.136", features = ["derive"], optional = true }

--- a/primitives/consensus/grandpa/src/lib.rs
+++ b/primitives/consensus/grandpa/src/lib.rs
@@ -234,14 +234,11 @@ impl<N: Codec> ConsensusLog<N> {
 /// GRANDPA happens when a voter votes on the same round (either at prevote or
 /// precommit stage) for different blocks. Proving is achieved by collecting the
 /// signed messages of conflicting votes.
-#[derive(Clone, Debug, Decode, Encode, PartialEq, TypeInfo)]
+#[derive(Clone, Debug, Decode, Encode, PartialEq, Eq, TypeInfo)]
 pub struct EquivocationProof<H, N> {
 	set_id: SetId,
 	equivocation: Equivocation<H, N>,
 }
-
-// Don't bother the grandpa crate...
-impl<H: PartialEq, N: PartialEq> Eq for EquivocationProof<H, N> {}
 
 impl<H, N> EquivocationProof<H, N> {
 	/// Create a new `EquivocationProof` for the given set id and using the
@@ -271,7 +268,7 @@ impl<H, N> EquivocationProof<H, N> {
 
 /// Wrapper object for GRANDPA equivocation proofs, useful for unifying prevote
 /// and precommit equivocations under a common type.
-#[derive(Clone, Debug, Decode, Encode, PartialEq, TypeInfo)]
+#[derive(Clone, Debug, Decode, Encode, PartialEq, Eq, TypeInfo)]
 pub enum Equivocation<H, N> {
 	/// Proof of equivocation at prevote stage.
 	Prevote(grandpa::Equivocation<AuthorityId, grandpa::Prevote<H, N>, AuthoritySignature>),


### PR DESCRIPTION
This was required to remove a temporary implementation of `Eq` trait for the grandpa's equivocation struct.

Done this as soon as `finality-grandpa 0.16.2` has been published on crates.io (before I forget)
