### PR TITLE
refactor: state RPC remove `max_rpc_payload_size`

### DIFF
--- a/client/rpc/src/state/mod.rs
+++ b/client/rpc/src/state/mod.rs
@@ -169,7 +169,6 @@ pub fn new_full<BE, Block: BlockT, Client>(
 	client: Arc<Client>,
 	executor: SubscriptionTaskExecutor,
 	deny_unsafe: DenyUnsafe,
-	rpc_max_payload: Option<usize>,
 ) -> (State<Block, Client>, ChildState<Block, Client>)
 where
 	Block: BlockT + 'static,
@@ -189,12 +188,9 @@ where
 		+ 'static,
 	Client::Api: Metadata<Block>,
 {
-	let child_backend = Box::new(self::state_full::FullState::new(
-		client.clone(),
-		executor.clone(),
-		rpc_max_payload,
-	));
-	let backend = Box::new(self::state_full::FullState::new(client, executor, rpc_max_payload));
+	let child_backend =
+		Box::new(self::state_full::FullState::new(client.clone(), executor.clone()));
+	let backend = Box::new(self::state_full::FullState::new(client, executor));
 	(State { backend, deny_unsafe }, ChildState { backend: child_backend })
 }
 

--- a/client/rpc/src/state/state_full.rs
+++ b/client/rpc/src/state/state_full.rs
@@ -66,7 +66,6 @@ pub struct FullState<BE, Block: BlockT, Client> {
 	client: Arc<Client>,
 	executor: SubscriptionTaskExecutor,
 	_phantom: PhantomData<(BE, Block)>,
-	rpc_max_payload: Option<usize>,
 }
 
 impl<BE, Block: BlockT, Client> FullState<BE, Block, Client>
@@ -79,12 +78,8 @@ where
 	Block: BlockT + 'static,
 {
 	/// Create new state API backend for full nodes.
-	pub fn new(
-		client: Arc<Client>,
-		executor: SubscriptionTaskExecutor,
-		rpc_max_payload: Option<usize>,
-	) -> Self {
-		Self { client, executor, _phantom: PhantomData, rpc_max_payload }
+	pub fn new(client: Arc<Client>, executor: SubscriptionTaskExecutor) -> Self {
+		Self { client, executor, _phantom: PhantomData }
 	}
 
 	/// Returns given block hash or best block hash if None is passed.
@@ -481,7 +476,6 @@ where
 			targets,
 			storage_keys,
 			methods,
-			self.rpc_max_payload,
 		)
 		.trace_block()
 		.map_err(|e| invalid_block::<Block>(block, None, e.to_string()))

--- a/client/rpc/src/state/tests.rs
+++ b/client/rpc/src/state/tests.rs
@@ -55,7 +55,7 @@ async fn should_return_storage() {
 		.add_extra_storage(b":map:acc2".to_vec(), vec![1, 2, 3])
 		.build();
 	let genesis_hash = client.genesis_hash();
-	let (client, child) = new_full(Arc::new(client), test_executor(), DenyUnsafe::No, None);
+	let (client, child) = new_full(Arc::new(client), test_executor(), DenyUnsafe::No);
 	let key = StorageKey(KEY.to_vec());
 
 	assert_eq!(
@@ -103,7 +103,7 @@ async fn should_return_storage_entries() {
 		.add_extra_child_storage(&child_info, KEY2.to_vec(), CHILD_VALUE2.to_vec())
 		.build();
 	let genesis_hash = client.genesis_hash();
-	let (_client, child) = new_full(Arc::new(client), test_executor(), DenyUnsafe::No, None);
+	let (_client, child) = new_full(Arc::new(client), test_executor(), DenyUnsafe::No);
 
 	let keys = &[StorageKey(KEY1.to_vec()), StorageKey(KEY2.to_vec())];
 	assert_eq!(
@@ -134,7 +134,7 @@ async fn should_return_child_storage() {
 			.build(),
 	);
 	let genesis_hash = client.genesis_hash();
-	let (_client, child) = new_full(client, test_executor(), DenyUnsafe::No, None);
+	let (_client, child) = new_full(client, test_executor(), DenyUnsafe::No);
 	let child_key = prefixed_storage_key();
 	let key = StorageKey(b"key".to_vec());
 
@@ -165,7 +165,7 @@ async fn should_return_child_storage_entries() {
 			.build(),
 	);
 	let genesis_hash = client.genesis_hash();
-	let (_client, child) = new_full(client, test_executor(), DenyUnsafe::No, None);
+	let (_client, child) = new_full(client, test_executor(), DenyUnsafe::No);
 	let child_key = prefixed_storage_key();
 	let keys = vec![StorageKey(b"key1".to_vec()), StorageKey(b"key2".to_vec())];
 
@@ -196,7 +196,7 @@ async fn should_return_child_storage_entries() {
 async fn should_call_contract() {
 	let client = Arc::new(substrate_test_runtime_client::new());
 	let genesis_hash = client.genesis_hash();
-	let (client, _child) = new_full(client, test_executor(), DenyUnsafe::No, None);
+	let (client, _child) = new_full(client, test_executor(), DenyUnsafe::No);
 
 	use jsonrpsee::{core::Error, types::error::CallError};
 
@@ -210,7 +210,7 @@ async fn should_call_contract() {
 async fn should_notify_about_storage_changes() {
 	let mut sub = {
 		let mut client = Arc::new(substrate_test_runtime_client::new());
-		let (api, _child) = new_full(client.clone(), test_executor(), DenyUnsafe::No, None);
+		let (api, _child) = new_full(client.clone(), test_executor(), DenyUnsafe::No);
 
 		let api_rpc = api.into_rpc();
 		let sub = api_rpc.subscribe("state_subscribeStorage", EmptyParams::new()).await.unwrap();
@@ -242,7 +242,7 @@ async fn should_notify_about_storage_changes() {
 async fn should_send_initial_storage_changes_and_notifications() {
 	let mut sub = {
 		let mut client = Arc::new(substrate_test_runtime_client::new());
-		let (api, _child) = new_full(client.clone(), test_executor(), DenyUnsafe::No, None);
+		let (api, _child) = new_full(client.clone(), test_executor(), DenyUnsafe::No);
 
 		let alice_balance_key =
 			blake2_256(&runtime::system::balance_of_key(AccountKeyring::Alice.into()));
@@ -278,7 +278,7 @@ async fn should_send_initial_storage_changes_and_notifications() {
 #[tokio::test]
 async fn should_query_storage() {
 	async fn run_tests(mut client: Arc<TestClient>) {
-		let (api, _child) = new_full(client.clone(), test_executor(), DenyUnsafe::No, None);
+		let (api, _child) = new_full(client.clone(), test_executor(), DenyUnsafe::No);
 
 		let mut add_block = |nonce| {
 			let mut builder = client.new_block(Default::default()).unwrap();
@@ -480,7 +480,7 @@ async fn should_query_storage() {
 #[tokio::test]
 async fn should_return_runtime_version() {
 	let client = Arc::new(substrate_test_runtime_client::new());
-	let (api, _child) = new_full(client.clone(), test_executor(), DenyUnsafe::No, None);
+	let (api, _child) = new_full(client.clone(), test_executor(), DenyUnsafe::No);
 
 	let result = "{\"specName\":\"test\",\"implName\":\"parity-test\",\"authoringVersion\":1,\
 		\"specVersion\":2,\"implVersion\":2,\"apis\":[[\"0xdf6acb689907609b\",4],\
@@ -501,7 +501,7 @@ async fn should_return_runtime_version() {
 async fn should_notify_on_runtime_version_initially() {
 	let mut sub = {
 		let client = Arc::new(substrate_test_runtime_client::new());
-		let (api, _child) = new_full(client, test_executor(), DenyUnsafe::No, None);
+		let (api, _child) = new_full(client, test_executor(), DenyUnsafe::No);
 
 		let api_rpc = api.into_rpc();
 		let sub = api_rpc
@@ -530,7 +530,7 @@ fn should_deserialize_storage_key() {
 #[tokio::test]
 async fn wildcard_storage_subscriptions_are_rpc_unsafe() {
 	let client = Arc::new(substrate_test_runtime_client::new());
-	let (api, _child) = new_full(client, test_executor(), DenyUnsafe::Yes, None);
+	let (api, _child) = new_full(client, test_executor(), DenyUnsafe::Yes);
 
 	let api_rpc = api.into_rpc();
 	let err = api_rpc.subscribe("state_subscribeStorage", EmptyParams::new()).await;
@@ -540,7 +540,7 @@ async fn wildcard_storage_subscriptions_are_rpc_unsafe() {
 #[tokio::test]
 async fn concrete_storage_subscriptions_are_rpc_safe() {
 	let client = Arc::new(substrate_test_runtime_client::new());
-	let (api, _child) = new_full(client, test_executor(), DenyUnsafe::Yes, None);
+	let (api, _child) = new_full(client, test_executor(), DenyUnsafe::Yes);
 	let api_rpc = api.into_rpc();
 
 	let key = StorageKey(STORAGE_KEY.to_vec());

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -671,12 +671,8 @@ where
 
 	let (chain, state, child_state) = {
 		let chain = sc_rpc::chain::new_full(client.clone(), task_executor.clone()).into_rpc();
-		let (state, child_state) = sc_rpc::state::new_full(
-			client.clone(),
-			task_executor.clone(),
-			deny_unsafe,
-			config.rpc_max_payload,
-		);
+		let (state, child_state) =
+			sc_rpc::state::new_full(client.clone(), task_executor.clone(), deny_unsafe);
 		let state = state.into_rpc();
 		let child_state = child_state.into_rpc();
 


### PR DESCRIPTION
Close #13623 

This limit on `state_traceBlock RPC` is not needed anymore as the JSON-RPC servers doesn't terminate the connection if the RPC max limit is exceeded anymore

Until this PR is merged, it's also possible to run `--rpc-max-payload <LIMIT>` for the limit in the state RPC to work properly.