### PR TITLE
fix publish docker description ci job

### DIFF
--- a/scripts/ci/gitlab/pipeline/publish.yml
+++ b/scripts/ci/gitlab/pipeline/publish.yml
@@ -63,6 +63,8 @@
     - if: $CI_COMMIT_REF_NAME == "master"
       changes:
         - scripts/ci/docker/$PRODUCT.Dockerfile.README.md
+  before_script:
+    - echo
   script:
     - cd / && sh entrypoint.sh
 

--- a/scripts/ci/gitlab/pipeline/publish.yml
+++ b/scripts/ci/gitlab/pipeline/publish.yml
@@ -52,7 +52,6 @@
   stage: publish
   extends:
     - .kubernetes-env
-    - .publish-refs
   variables:
     CI_IMAGE: paritytech/dockerhub-description
     DOCKERHUB_REPOSITORY: parity/$PRODUCT


### PR DESCRIPTION
Fixes CI jobs for publishing docker images description to hub.docker.com

Also removed `publish-refs` from those jobs, as we only should publish images description when its merged into master