### PR TITLE
only push docker descriptions on master branch pipelines

### DIFF
--- a/scripts/ci/gitlab/pipeline/publish.yml
+++ b/scripts/ci/gitlab/pipeline/publish.yml
@@ -60,7 +60,7 @@
     DOCKER_PASSWORD: $Docker_Hub_Pass_Parity
     README_FILEPATH: $CI_PROJECT_DIR/scripts/ci/docker/$PRODUCT.Dockerfile.README.md
   rules:
-    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push"
       changes:
         - scripts/ci/docker/$PRODUCT.Dockerfile.README.md
   script:


### PR DESCRIPTION
Currently those jobs also get included in multi-project pipelines such as https://gitlab.parity.io/parity/mirrors/scripts/-/pipelines/255546, even when the description hasn't actually changed, because `changes:` conditions always evaluate to true on non-branch pipelines.