### PR TITLE
core-fellowship: promote dev-dependencies to regular dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5804,8 +5804,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "pallet-ranked-collective",
- "pallet-salary",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",

--- a/frame/core-fellowship/Cargo.toml
+++ b/frame/core-fellowship/Cargo.toml
@@ -25,10 +25,6 @@ sp-io = { version = "7.0.0", default-features = false, path = "../../primitives/
 sp-runtime = { version = "7.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-std = { version = "5.0.0", default-features = false, path = "../../primitives/std" }
 
-[dev-dependencies]
-pallet-ranked-collective = { version = "4.0.0-dev", default-features = false, path = "../ranked-collective" }
-pallet-salary = { version = "4.0.0-dev", default-features = false, path = "../salary" }
-
 [features]
 default = ["std"]
 std = [
@@ -49,7 +45,5 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
-	"pallet-ranked-collective/runtime-benchmarks",
-	"pallet-salary/runtime-benchmarks",
 ]
 try-runtime = ["frame-support/try-runtime"]


### PR DESCRIPTION
These pallets are not just required for tests, but also for the runtime-benchmarks feature.

CI is currently [failing on master](https://gitlab.parity.io/parity/mirrors/substrate/-/jobs/2559380) due to this.