### PR TITLE
Fix try_runtime_cli doc broken links

### DIFF
--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -29,9 +29,9 @@
 //!
 //! Some resources about the above:
 //!
-//! 1. <https://docs.substrate.io/v3/tools/try-runtime>
+//! 1. <https://docs.substrate.io/reference/command-line-tools/try-runtime/>
 //! 2. <https://www.crowdcast.io/e/substrate-seminar/41>
-//! 3. <https://docs.substrate.io/v3/advanced/executor>
+//! 3. <https://docs.substrate.io/fundamentals/runtime-development/>
 //!
 //! ---
 //!


### PR DESCRIPTION
Fixes broken links in the [try_runtime_cli docs (Resources)](https://paritytech.github.io/substrate/master/try_runtime_cli/index.html#resources).

I couldn't find a where the "executor" docs live now (seems like they were removed). I replaced the link to those with one to general runtime development which I feel is relevant, open to other suggestions for which.