### PR TITLE
Keystore overhaul (final)

### DIFF
--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -592,7 +592,7 @@ mod tests {
 	use sc_service_test::TestNetNode;
 	use sc_transaction_pool_api::{ChainEvent, MaintainedTransactionPool};
 	use sp_consensus::{BlockOrigin, Environment, Proposer};
-	use sp_core::crypto::{Pair as CryptoPair, Wraps};
+	use sp_core::crypto::Pair;
 	use sp_inherents::InherentDataProvider;
 	use sp_keyring::AccountKeyring;
 	use sp_keystore::KeystorePtr;
@@ -737,11 +737,7 @@ mod tests {
 				// add it to a digest item.
 				let to_sign = pre_hash.encode();
 				let signature = keystore
-					.sr25519_sign(
-						sp_consensus_babe::AuthorityId::ID,
-						alice.as_inner_ref(),
-						&to_sign,
-					)
+					.sr25519_sign(sp_consensus_babe::AuthorityId::ID, alice.as_ref(), &to_sign)
 					.unwrap()
 					.unwrap();
 				let item = <DigestItem as CompatibleDigestItem>::babe_seal(signature.into());

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -592,7 +592,7 @@ mod tests {
 	use sc_service_test::TestNetNode;
 	use sc_transaction_pool_api::{ChainEvent, MaintainedTransactionPool};
 	use sp_consensus::{BlockOrigin, Environment, Proposer};
-	use sp_core::{crypto::Pair as CryptoPair, Public};
+	use sp_core::crypto::{Pair as CryptoPair, Wraps};
 	use sp_inherents::InherentDataProvider;
 	use sp_keyring::AccountKeyring;
 	use sp_keystore::KeystorePtr;
@@ -737,16 +737,14 @@ mod tests {
 				// add it to a digest item.
 				let to_sign = pre_hash.encode();
 				let signature = keystore
-					.sign_with(
+					.sr25519_sign(
 						sp_consensus_babe::AuthorityId::ID,
-						&alice.to_public_crypto_pair(),
+						alice.as_inner_ref(),
 						&to_sign,
 					)
 					.unwrap()
-					.unwrap()
-					.try_into()
 					.unwrap();
-				let item = <DigestItem as CompatibleDigestItem>::babe_seal(signature);
+				let item = <DigestItem as CompatibleDigestItem>::babe_seal(signature.into());
 				slot += 1;
 
 				let mut params = BlockImportParams::new(BlockOrigin::File, new_header);

--- a/bin/node/executor/tests/submit_transaction.rs
+++ b/bin/node/executor/tests/submit_transaction.rs
@@ -18,7 +18,7 @@
 use codec::Decode;
 use frame_system::offchain::{SendSignedTransaction, Signer, SubmitTransaction};
 use kitchensink_runtime::{Executive, Indices, Runtime, UncheckedExtrinsic};
-use sp_application_crypto::AppKey;
+use sp_application_crypto::AppCrypto;
 use sp_core::offchain::{testing::TestTransactionPoolExt, TransactionPoolExt};
 use sp_keyring::sr25519::Keyring::Alice;
 use sp_keystore::{testing::MemoryKeystore, Keystore, KeystoreExt};

--- a/client/authority-discovery/src/error.rs
+++ b/client/authority-discovery/src/error.rs
@@ -18,8 +18,6 @@
 
 //! Authority discovery errors.
 
-use sp_core::crypto::CryptoTypePublicPair;
-
 /// AuthorityDiscovery Result.
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -60,7 +58,7 @@ pub enum Error {
 	ParsingLibp2pIdentity(#[from] libp2p::identity::error::DecodingError),
 
 	#[error("Failed to sign using a specific public key.")]
-	MissingSignature(CryptoTypePublicPair),
+	MissingSignature(Vec<u8>),
 
 	#[error("Failed to sign using all public keys.")]
 	Signing,

--- a/client/authority-discovery/src/error.rs
+++ b/client/authority-discovery/src/error.rs
@@ -57,11 +57,8 @@ pub enum Error {
 	#[error("Failed to parse a libp2p key.")]
 	ParsingLibp2pIdentity(#[from] libp2p::identity::error::DecodingError),
 
-	#[error("Failed to sign network message. Reason: {0}.")]
-	CannotSignNetwork(String),
-
-	#[error("Failed to sign using key: {0:?}. Reason: {1}.")]
-	CannotSign(Vec<u8>, String),
+	#[error("Failed to sign: {0}.")]
+	CannotSign(String),
 
 	#[error("Failed to register Prometheus metric.")]
 	Prometheus(#[from] prometheus_endpoint::PrometheusError),

--- a/client/authority-discovery/src/error.rs
+++ b/client/authority-discovery/src/error.rs
@@ -57,11 +57,11 @@ pub enum Error {
 	#[error("Failed to parse a libp2p key.")]
 	ParsingLibp2pIdentity(#[from] libp2p::identity::error::DecodingError),
 
-	#[error("Failed to sign using a specific public key.")]
-	MissingSignature(Vec<u8>),
+	#[error("Failed to sign network message. Reason: {0}.")]
+	CannotSignNetwork(String),
 
-	#[error("Failed to sign using all public keys.")]
-	Signing,
+	#[error("Failed to sign using key: {0:?}. Reason: {1}.")]
+	CannotSign(Vec<u8>, String),
 
 	#[error("Failed to register Prometheus metric.")]
 	Prometheus(#[from] prometheus_endpoint::PrometheusError),

--- a/client/authority-discovery/src/worker.rs
+++ b/client/authority-discovery/src/worker.rs
@@ -52,7 +52,7 @@ use sp_authority_discovery::{
 	AuthorityDiscoveryApi, AuthorityId, AuthorityPair, AuthoritySignature,
 };
 use sp_blockchain::HeaderBackend;
-use sp_core::crypto::{key_types, ByteArray, Pair, Wraps};
+use sp_core::crypto::{key_types, ByteArray, Pair};
 use sp_keystore::{Keystore, KeystorePtr};
 use sp_runtime::traits::Block as BlockT;
 
@@ -670,7 +670,7 @@ fn sign_record_with_authority_ids(
 
 	for key in keys.iter() {
 		let auth_signature = key_store
-			.sr25519_sign(key_types::AUTHORITY_DISCOVERY, key.as_inner_ref(), &serialized_record)
+			.sr25519_sign(key_types::AUTHORITY_DISCOVERY, key.as_ref(), &serialized_record)
 			.map_err(|e| Error::CannotSign(format!("{}. Key: {:?}", e, key)))?
 			.ok_or_else(|| {
 				Error::CannotSign(format!("Could not find key in keystore. Key: {:?}", key))

--- a/client/authority-discovery/src/worker.rs
+++ b/client/authority-discovery/src/worker.rs
@@ -43,6 +43,7 @@ use log::{debug, error, log_enabled};
 use prometheus_endpoint::{register, Counter, CounterVec, Gauge, Opts, U64};
 use prost::Message;
 use rand::{seq::SliceRandom, thread_rng};
+
 use sc_network::{
 	event::DhtEvent, KademliaKey, NetworkDHTProvider, NetworkSigner, NetworkStateInfo, Signature,
 };
@@ -51,7 +52,6 @@ use sp_authority_discovery::{
 	AuthorityDiscoveryApi, AuthorityId, AuthorityPair, AuthoritySignature,
 };
 use sp_blockchain::HeaderBackend;
-
 use sp_core::crypto::{key_types, ByteArray, Pair, Wraps};
 use sp_keystore::{Keystore, KeystorePtr};
 use sp_runtime::traits::Block as BlockT;
@@ -654,7 +654,7 @@ fn sign_record_with_peer_id(
 ) -> Result<schema::PeerSignature> {
 	let signature = network
 		.sign_with_local_identity(serialized_record)
-		.map_err(|e| Error::CannotSignNetwork(e.to_string()))?;
+		.map_err(|e| Error::CannotSign(format!("{} (network packet)", e)))?;
 	let public_key = signature.public_key.to_protobuf_encoding();
 	let signature = signature.bytes;
 	Ok(schema::PeerSignature { signature, public_key })
@@ -671,9 +671,9 @@ fn sign_record_with_authority_ids(
 	for key in keys.iter() {
 		let auth_signature = key_store
 			.sr25519_sign(key_types::AUTHORITY_DISCOVERY, key.as_inner_ref(), &serialized_record)
-			.map_err(|e| Error::CannotSign(key.to_raw_vec(), e.to_string()))?
+			.map_err(|e| Error::CannotSign(format!("{}. Key: {:?}", e, key)))?
 			.ok_or_else(|| {
-				Error::CannotSign(key.to_raw_vec(), "Could not find key in keystore".into())
+				Error::CannotSign(format!("Could not find key in keystore. Key: {:?}", key))
 			})?;
 
 		// Scale encode

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -45,7 +45,7 @@ use sc_consensus_slots::{
 };
 use sc_telemetry::TelemetryHandle;
 use sp_api::{Core, ProvideRuntimeApi};
-use sp_application_crypto::{AppKey, AppPublic};
+use sp_application_crypto::{AppCrypto, AppPublic};
 use sp_blockchain::{HeaderBackend, Result as CResult};
 use sp_consensus::{BlockOrigin, Environment, Error as ConsensusError, Proposer, SelectChain};
 use sp_consensus_slots::Slot;
@@ -449,8 +449,8 @@ where
 		let signature = self
 			.keystore
 			.sign_with(
-				<AuthorityId<P> as AppKey>::ID,
-				<AuthorityId<P> as AppKey>::CRYPTO_ID,
+				<AuthorityId<P> as AppCrypto>::ID,
+				<AuthorityId<P> as AppCrypto>::CRYPTO_ID,
 				&public,
 				header_hash.as_ref(),
 			)

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -441,13 +441,12 @@ where
 		sc_consensus::BlockImportParams<B, <Self::BlockImport as BlockImport<B>>::Transaction>,
 		ConsensusError,
 	> {
-		let public = public.to_raw_vec();
 		let signature = self
 			.keystore
 			.sign_with(
 				<AuthorityId<P> as AppCrypto>::ID,
 				<AuthorityId<P> as AppCrypto>::CRYPTO_ID,
-				&public,
+				public.as_slice(),
 				header_hash.as_ref(),
 			)
 			.map_err(|e| ConsensusError::CannotSign(format!("{}. Key: {:?}", e, public)))?
@@ -460,7 +459,7 @@ where
 		let signature = signature
 			.clone()
 			.try_into()
-			.map_err(|_| ConsensusError::InvalidSignature(signature, public))?;
+			.map_err(|_| ConsensusError::InvalidSignature(signature, public.to_raw_vec()))?;
 
 		let signature_digest_item =
 			<DigestItem as CompatibleDigestItem<P::Signature>>::aura_seal(signature);

--- a/client/consensus/babe/rpc/src/lib.rs
+++ b/client/consensus/babe/rpc/src/lib.rs
@@ -30,7 +30,7 @@ use sc_consensus_epochs::{descendent_query, Epoch as EpochT, SharedEpochChanges}
 use sc_rpc_api::DenyUnsafe;
 use serde::{Deserialize, Serialize};
 use sp_api::ProvideRuntimeApi;
-use sp_application_crypto::AppKey;
+use sp_application_crypto::AppCrypto;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 use sp_consensus::{Error as ConsensusError, SelectChain};
 use sp_consensus_babe::{

--- a/client/consensus/babe/src/authorship.rs
+++ b/client/consensus/babe/src/authorship.rs
@@ -22,7 +22,7 @@ use super::Epoch;
 use codec::Encode;
 use sc_consensus_epochs::Epoch as EpochT;
 use schnorrkel::{keys::PublicKey, vrf::VRFInOut};
-use sp_application_crypto::AppKey;
+use sp_application_crypto::AppCrypto;
 use sp_consensus_babe::{
 	digests::{PreDigest, PrimaryPreDigest, SecondaryPlainPreDigest, SecondaryVRFPreDigest},
 	make_transcript, make_transcript_data, AuthorityId, BabeAuthorityWeight, Slot, BABE_VRF_PREFIX,

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -117,7 +117,7 @@ use sp_blockchain::{
 use sp_consensus::{BlockOrigin, Environment, Error as ConsensusError, Proposer, SelectChain};
 use sp_consensus_babe::inherents::BabeInherentData;
 use sp_consensus_slots::Slot;
-use sp_core::{crypto::Wraps, ExecutionContext};
+use sp_core::ExecutionContext;
 use sp_inherents::{CreateInherentDataProviders, InherentData, InherentDataProvider};
 use sp_keystore::KeystorePtr;
 use sp_runtime::{
@@ -832,11 +832,7 @@ where
 	> {
 		let signature = self
 			.keystore
-			.sr25519_sign(
-				<AuthorityId as AppCrypto>::ID,
-				public.as_inner_ref(),
-				header_hash.as_ref(),
-			)
+			.sr25519_sign(<AuthorityId as AppCrypto>::ID, public.as_ref(), header_hash.as_ref())
 			.map_err(|e| ConsensusError::CannotSign(format!("{}. Key: {:?}", e, public)))?
 			.ok_or_else(|| {
 				ConsensusError::CannotSign(format!(

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -894,7 +894,7 @@ where
 		Box::pin(
 			self.env
 				.init(block)
-				.map_err(|e| ConsensusError::ClientImport(format!("{:?}", e))),
+				.map_err(|e| ConsensusError::ClientImport(e.to_string())),
 		)
 	}
 

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -117,10 +117,7 @@ use sp_blockchain::{
 use sp_consensus::{BlockOrigin, Environment, Error as ConsensusError, Proposer, SelectChain};
 use sp_consensus_babe::inherents::BabeInherentData;
 use sp_consensus_slots::Slot;
-use sp_core::{
-	crypto::{ByteArray, Wraps},
-	ExecutionContext,
-};
+use sp_core::{crypto::Wraps, ExecutionContext};
 use sp_inherents::{CreateInherentDataProviders, InherentData, InherentDataProvider};
 use sp_keystore::KeystorePtr;
 use sp_runtime::{
@@ -840,12 +837,12 @@ where
 				public.as_inner_ref(),
 				header_hash.as_ref(),
 			)
-			.map_err(|e| ConsensusError::CannotSign(public.to_raw_vec(), e.to_string()))?
+			.map_err(|e| ConsensusError::CannotSign(format!("{}. Key: {:?}", e, public)))?
 			.ok_or_else(|| {
-				ConsensusError::CannotSign(
-					public.to_raw_vec(),
-					"Could not find key in keystore.".into(),
-				)
+				ConsensusError::CannotSign(format!(
+					"Could not find key in keystore. Key: {:?}",
+					public
+				))
 			})?;
 
 		let digest_item = <DigestItem as CompatibleDigestItem>::babe_seal(signature.into());
@@ -891,11 +888,7 @@ where
 	}
 
 	fn proposer(&mut self, block: &B::Header) -> Self::CreateProposer {
-		Box::pin(
-			self.env
-				.init(block)
-				.map_err(|e| ConsensusError::ClientImport(e.to_string())),
-		)
+		Box::pin(self.env.init(block).map_err(|e| ConsensusError::ClientImport(e.to_string())))
 	}
 
 	fn telemetry(&self) -> Option<TelemetryHandle> {

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -108,7 +108,7 @@ use sc_consensus_slots::{
 };
 use sc_telemetry::{telemetry, TelemetryHandle, CONSENSUS_DEBUG, CONSENSUS_TRACE};
 use sp_api::{ApiExt, ProvideRuntimeApi};
-use sp_application_crypto::AppKey;
+use sp_application_crypto::AppCrypto;
 use sp_block_builder::BlockBuilder as BlockBuilderApi;
 use sp_blockchain::{
 	Backend as _, BlockStatus, Error as ClientError, ForkBackend, HeaderBackend, HeaderMetadata,
@@ -835,7 +835,11 @@ where
 	> {
 		let signature = self
 			.keystore
-			.sr25519_sign(<AuthorityId as AppKey>::ID, public.as_inner_ref(), header_hash.as_ref())
+			.sr25519_sign(
+				<AuthorityId as AppCrypto>::ID,
+				public.as_inner_ref(),
+				header_hash.as_ref(),
+			)
 			.map_err(|e| ConsensusError::CannotSign(public.to_raw_vec(), e.to_string()))?
 			.ok_or_else(|| {
 				ConsensusError::CannotSign(

--- a/client/consensus/grandpa/src/lib.rs
+++ b/client/consensus/grandpa/src/lib.rs
@@ -72,7 +72,7 @@ use sc_network::types::ProtocolName;
 use sc_telemetry::{telemetry, TelemetryHandle, CONSENSUS_DEBUG, CONSENSUS_INFO};
 use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver};
 use sp_api::ProvideRuntimeApi;
-use sp_application_crypto::AppKey;
+use sp_application_crypto::AppCrypto;
 use sp_blockchain::{Error as ClientError, HeaderBackend, HeaderMetadata, Result as ClientResult};
 use sp_consensus::SelectChain;
 use sp_consensus_grandpa::{

--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -150,7 +150,7 @@ pub trait SimpleSlotWorker<B: BlockT> {
 		body: Vec<B::Extrinsic>,
 		storage_changes: StorageChanges<<Self::BlockImport as BlockImport<B>>::Transaction, B>,
 		public: Self::Claim,
-		epoch: Self::AuxData,
+		aux_data: Self::AuxData,
 	) -> Result<
 		sc_consensus::BlockImportParams<B, <Self::BlockImport as BlockImport<B>>::Transaction>,
 		sp_consensus::Error,

--- a/client/keystore/src/local.rs
+++ b/client/keystore/src/local.rs
@@ -18,7 +18,7 @@
 //! Local keystore implementation
 
 use parking_lot::RwLock;
-use sp_application_crypto::{ecdsa, ed25519, sr25519, AppKey, AppPair, IsWrappedBy};
+use sp_application_crypto::{ecdsa, ed25519, sr25519, AppCrypto, AppPair, IsWrappedBy};
 use sp_core::{
 	crypto::{ByteArray, ExposeSecret, KeyTypeId, Pair as PairT, SecretString},
 	sr25519::{Pair as Sr25519Pair, Public as Sr25519Public},
@@ -59,7 +59,7 @@ impl LocalKeystore {
 	/// `Err(_)` when something failed.
 	pub fn key_pair<Pair: AppPair>(
 		&self,
-		public: &<Pair as AppKey>::Public,
+		public: &<Pair as AppCrypto>::Public,
 	) -> Result<Option<Pair>> {
 		self.0.read().key_pair::<Pair>(public)
 	}
@@ -445,7 +445,7 @@ impl KeystoreInner {
 	/// when something failed.
 	pub fn key_pair<Pair: AppPair>(
 		&self,
-		public: &<Pair as AppKey>::Public,
+		public: &<Pair as AppCrypto>::Public,
 	) -> Result<Option<Pair>> {
 		self.key_pair_by_type::<Pair::Generic>(IsWrappedBy::from_ref(public), Pair::ID)
 			.map(|v| v.map(Into::into))

--- a/client/rpc/src/author/tests.rs
+++ b/client/rpc/src/author/tests.rs
@@ -31,8 +31,8 @@ use sc_transaction_pool_api::TransactionStatus;
 use sp_core::{
 	blake2_256,
 	bytes::to_hex,
-	crypto::{ByteArray, CryptoTypePublicPair, Pair},
-	ed25519, sr25519,
+	crypto::{ByteArray, Pair},
+	ed25519,
 	testing::{ED25519, SR25519},
 	H256,
 };
@@ -227,9 +227,7 @@ async fn author_should_insert_key() {
 	api.call::<_, ()>("author_insertKey", params).await.unwrap();
 	let pubkeys = setup.keystore.keys(ED25519).unwrap();
 
-	assert!(
-		pubkeys.contains(&CryptoTypePublicPair(ed25519::CRYPTO_ID, keypair.public().to_raw_vec()))
-	);
+	assert!(pubkeys.contains(&keypair.public().to_raw_vec()));
 }
 
 #[tokio::test]
@@ -242,10 +240,8 @@ async fn author_should_rotate_keys() {
 		SessionKeys::decode(&mut &new_pubkeys[..]).expect("SessionKeys decode successfully");
 	let ed25519_pubkeys = setup.keystore.keys(ED25519).unwrap();
 	let sr25519_pubkeys = setup.keystore.keys(SR25519).unwrap();
-	assert!(ed25519_pubkeys
-		.contains(&CryptoTypePublicPair(ed25519::CRYPTO_ID, session_keys.ed25519.to_raw_vec())));
-	assert!(sr25519_pubkeys
-		.contains(&CryptoTypePublicPair(sr25519::CRYPTO_ID, session_keys.sr25519.to_raw_vec())));
+	assert!(ed25519_pubkeys.contains(&session_keys.ed25519.to_raw_vec()));
+	assert!(sr25519_pubkeys.contains(&session_keys.sr25519.to_raw_vec()));
 }
 
 #[tokio::test]

--- a/primitives/application-crypto/src/lib.rs
+++ b/primitives/application-crypto/src/lib.rs
@@ -301,11 +301,7 @@ macro_rules! app_crypto_public_common {
 			const LEN: usize = <$public>::LEN;
 		}
 
-		impl $crate::Public for Public {
-			fn crypto_id(&self) -> $crate::CryptoTypeId {
-				$crypto_type
-			}
-		}
+		impl $crate::Public for Public {}
 
 		impl $crate::AppPublic for Public {
 			type Generic = $public;

--- a/primitives/application-crypto/src/lib.rs
+++ b/primitives/application-crypto/src/lib.rs
@@ -171,7 +171,6 @@ macro_rules! app_crypto_pair {
 		}
 
 		impl $crate::AppKey for Pair {
-			type UntypedGeneric = $pair;
 			type Public = Public;
 			type Pair = Pair;
 			type Signature = Signature;
@@ -239,7 +238,6 @@ macro_rules! app_crypto_public_full_crypto {
 		}
 
 		impl $crate::AppKey for Public {
-			type UntypedGeneric = $public;
 			type Public = Public;
 			type Pair = Pair;
 			type Signature = Signature;
@@ -273,7 +271,6 @@ macro_rules! app_crypto_public_not_full_crypto {
 		impl $crate::CryptoType for Public {}
 
 		impl $crate::AppKey for Public {
-			type UntypedGeneric = $public;
 			type Public = Public;
 			type Signature = Signature;
 			const ID: $crate::KeyTypeId = $key_type;
@@ -451,7 +448,6 @@ macro_rules! app_crypto_signature_full_crypto {
 		}
 
 		impl $crate::AppKey for Signature {
-			type UntypedGeneric = $sig;
 			type Public = Public;
 			type Pair = Pair;
 			type Signature = Signature;
@@ -483,7 +479,6 @@ macro_rules! app_crypto_signature_not_full_crypto {
 		impl $crate::CryptoType for Signature {}
 
 		impl $crate::AppKey for Signature {
-			type UntypedGeneric = $sig;
 			type Public = Public;
 			type Signature = Signature;
 			const ID: $crate::KeyTypeId = $key_type;

--- a/primitives/application-crypto/src/lib.rs
+++ b/primitives/application-crypto/src/lib.rs
@@ -27,10 +27,7 @@ pub use sp_core::crypto::{DeriveError, DeriveJunction, Pair, SecretStringError, 
 #[doc(hidden)]
 pub use sp_core::{
 	self,
-	crypto::{
-		ByteArray, CryptoType, CryptoTypePublicPair, Derive, IsWrappedBy, Public, UncheckedFrom,
-		Wraps,
-	},
+	crypto::{ByteArray, CryptoType, Derive, IsWrappedBy, Public, UncheckedFrom, Wraps},
 	RuntimeDebug,
 };
 
@@ -303,9 +300,10 @@ macro_rules! app_crypto_public_common {
 		impl $crate::ByteArray for Public {
 			const LEN: usize = <$public>::LEN;
 		}
+
 		impl $crate::Public for Public {
-			fn to_public_crypto_pair(&self) -> $crate::CryptoTypePublicPair {
-				$crate::CryptoTypePublicPair($crypto_type, $crate::ByteArray::to_raw_vec(self))
+			fn crypto_id(&self) -> $crate::CryptoTypeId {
+				$crypto_type
 			}
 		}
 
@@ -344,18 +342,6 @@ macro_rules! app_crypto_public_common {
 
 			fn to_raw_vec(&self) -> $crate::Vec<u8> {
 				<$public as $crate::RuntimePublic>::to_raw_vec(&self.0)
-			}
-		}
-
-		impl From<Public> for $crate::CryptoTypePublicPair {
-			fn from(key: Public) -> Self {
-				(&key).into()
-			}
-		}
-
-		impl From<&Public> for $crate::CryptoTypePublicPair {
-			fn from(key: &Public) -> Self {
-				$crate::CryptoTypePublicPair($crypto_type, $crate::ByteArray::to_raw_vec(key))
 			}
 		}
 

--- a/primitives/application-crypto/src/lib.rs
+++ b/primitives/application-crypto/src/lib.rs
@@ -167,7 +167,7 @@ macro_rules! app_crypto_pair {
 			}
 		}
 
-		impl $crate::AppKey for Pair {
+		impl $crate::AppCrypto for Pair {
 			type Public = Public;
 			type Pair = Pair;
 			type Signature = Signature;
@@ -234,7 +234,7 @@ macro_rules! app_crypto_public_full_crypto {
 			type Pair = Pair;
 		}
 
-		impl $crate::AppKey for Public {
+		impl $crate::AppCrypto for Public {
 			type Public = Public;
 			type Pair = Pair;
 			type Signature = Signature;
@@ -267,7 +267,7 @@ macro_rules! app_crypto_public_not_full_crypto {
 
 		impl $crate::CryptoType for Public {}
 
-		impl $crate::AppKey for Public {
+		impl $crate::AppCrypto for Public {
 			type Public = Public;
 			type Signature = Signature;
 			const ID: $crate::KeyTypeId = $key_type;
@@ -429,7 +429,7 @@ macro_rules! app_crypto_signature_full_crypto {
 			type Pair = Pair;
 		}
 
-		impl $crate::AppKey for Signature {
+		impl $crate::AppCrypto for Signature {
 			type Public = Public;
 			type Pair = Pair;
 			type Signature = Signature;
@@ -460,7 +460,7 @@ macro_rules! app_crypto_signature_not_full_crypto {
 
 		impl $crate::CryptoType for Signature {}
 
-		impl $crate::AppKey for Signature {
+		impl $crate::AppCrypto for Signature {
 			type Public = Public;
 			type Signature = Signature;
 			const ID: $crate::KeyTypeId = $key_type;

--- a/primitives/application-crypto/src/traits.rs
+++ b/primitives/application-crypto/src/traits.rs
@@ -23,7 +23,7 @@ use sp_core::crypto::{CryptoType, CryptoTypeId, IsWrappedBy, KeyTypeId, Public};
 use sp_std::{fmt::Debug, vec::Vec};
 
 /// An application-specific key.
-pub trait AppKey: 'static + Send + Sync + Sized + CryptoType + Clone {
+pub trait AppCrypto: 'static + Send + Sync + Sized + CryptoType + Clone {
 	/// Identifier for application-specific key type.
 	const ID: KeyTypeId;
 
@@ -61,7 +61,7 @@ impl<T: sp_std::hash::Hash> MaybeDebugHash for T {}
 
 /// A application's public key.
 pub trait AppPublic:
-	AppKey + Public + Ord + PartialOrd + Eq + PartialEq + Debug + MaybeHash + codec::Codec
+	AppCrypto + Public + Ord + PartialOrd + Eq + PartialEq + Debug + MaybeHash + codec::Codec
 {
 	/// The wrapped type which is just a plain instance of `Public`.
 	type Generic: IsWrappedBy<Self>
@@ -77,15 +77,15 @@ pub trait AppPublic:
 
 /// A application's key pair.
 #[cfg(feature = "full_crypto")]
-pub trait AppPair: AppKey + Pair<Public = <Self as AppKey>::Public> {
+pub trait AppPair: AppCrypto + Pair<Public = <Self as AppCrypto>::Public> {
 	/// The wrapped type which is just a plain instance of `Pair`.
 	type Generic: IsWrappedBy<Self>
-		+ Pair<Public = <<Self as AppKey>::Public as AppPublic>::Generic>
-		+ Pair<Signature = <<Self as AppKey>::Signature as AppSignature>::Generic>;
+		+ Pair<Public = <<Self as AppCrypto>::Public as AppPublic>::Generic>
+		+ Pair<Signature = <<Self as AppCrypto>::Signature as AppSignature>::Generic>;
 }
 
 /// A application's signature.
-pub trait AppSignature: AppKey + Eq + PartialEq + Debug + MaybeHash {
+pub trait AppSignature: AppCrypto + Eq + PartialEq + Debug + MaybeHash {
 	/// The wrapped type which is just a plain instance of `Signature`.
 	type Generic: IsWrappedBy<Self> + Eq + PartialEq + Debug + MaybeHash;
 }

--- a/primitives/application-crypto/src/traits.rs
+++ b/primitives/application-crypto/src/traits.rs
@@ -80,7 +80,8 @@ pub trait AppPublic:
 pub trait AppPair: AppKey + Pair<Public = <Self as AppKey>::Public> {
 	/// The wrapped type which is just a plain instance of `Pair`.
 	type Generic: IsWrappedBy<Self>
-		+ Pair<Public = <<Self as AppKey>::Public as AppPublic>::Generic>;
+		+ Pair<Public = <<Self as AppKey>::Public as AppPublic>::Generic>
+		+ Pair<Signature = <<Self as AppKey>::Signature as AppSignature>::Generic>;
 }
 
 /// A application's signature.

--- a/primitives/application-crypto/src/traits.rs
+++ b/primitives/application-crypto/src/traits.rs
@@ -24,23 +24,21 @@ use sp_std::{fmt::Debug, vec::Vec};
 
 /// An application-specific key.
 pub trait AppKey: 'static + Send + Sync + Sized + CryptoType + Clone {
-	/// The corresponding type as a generic crypto type.
-	type UntypedGeneric: IsWrappedBy<Self>;
+	/// Identifier for application-specific key type.
+	const ID: KeyTypeId;
+
+	/// Identifier of the crypto type of this application-specific key type.
+	const CRYPTO_ID: CryptoTypeId;
 
 	/// The corresponding public key type in this application scheme.
 	type Public: AppPublic;
 
-	/// The corresponding key pair type in this application scheme.
-	#[cfg(feature = "full_crypto")]
-	type Pair: AppPair;
-
 	/// The corresponding signature type in this application scheme.
 	type Signature: AppSignature;
 
-	/// An identifier for this application-specific key type.
-	const ID: KeyTypeId;
-	/// The identifier of the crypto type of this application-specific key type.
-	const CRYPTO_ID: CryptoTypeId;
+	/// The corresponding key pair type in this application scheme.
+	#[cfg(feature = "full_crypto")]
+	type Pair: AppPair;
 }
 
 /// Type which implements Hash in std, not when no-std (std variant).

--- a/primitives/application-crypto/test/src/ecdsa.rs
+++ b/primitives/application-crypto/test/src/ecdsa.rs
@@ -17,8 +17,11 @@
 
 //! Integration tests for ecdsa
 use sp_api::ProvideRuntimeApi;
-use sp_application_crypto::ecdsa::{AppPair, AppPublic};
-use sp_core::{crypto::Pair, testing::ECDSA};
+use sp_application_crypto::ecdsa::AppPair;
+use sp_core::{
+	crypto::{ByteArray, Pair},
+	testing::ECDSA,
+};
 use sp_keystore::{testing::MemoryKeystore, Keystore};
 use std::sync::Arc;
 use substrate_test_runtime_client::{
@@ -35,6 +38,6 @@ fn ecdsa_works_in_runtime() {
 		.expect("Tests `ecdsa` crypto.");
 
 	let supported_keys = keystore.keys(ECDSA).unwrap();
-	assert!(supported_keys.contains(&public.clone().into()));
-	assert!(AppPair::verify(&signature, "ecdsa", &AppPublic::from(public)));
+	assert!(supported_keys.contains(&public.to_raw_vec()));
+	assert!(AppPair::verify(&signature, "ecdsa", &public));
 }

--- a/primitives/application-crypto/test/src/ed25519.rs
+++ b/primitives/application-crypto/test/src/ed25519.rs
@@ -18,8 +18,11 @@
 //! Integration tests for ed25519
 
 use sp_api::ProvideRuntimeApi;
-use sp_application_crypto::ed25519::{AppPair, AppPublic};
-use sp_core::{crypto::Pair, testing::ED25519};
+use sp_application_crypto::ed25519::AppPair;
+use sp_core::{
+	crypto::{ByteArray, Pair},
+	testing::ED25519,
+};
 use sp_keystore::{testing::MemoryKeystore, Keystore};
 use std::sync::Arc;
 use substrate_test_runtime_client::{
@@ -36,6 +39,6 @@ fn ed25519_works_in_runtime() {
 		.expect("Tests `ed25519` crypto.");
 
 	let supported_keys = keystore.keys(ED25519).unwrap();
-	assert!(supported_keys.contains(&public.clone().into()));
-	assert!(AppPair::verify(&signature, "ed25519", &AppPublic::from(public)));
+	assert!(supported_keys.contains(&public.to_raw_vec()));
+	assert!(AppPair::verify(&signature, "ed25519", &public));
 }

--- a/primitives/application-crypto/test/src/sr25519.rs
+++ b/primitives/application-crypto/test/src/sr25519.rs
@@ -18,8 +18,11 @@
 //! Integration tests for sr25519
 
 use sp_api::ProvideRuntimeApi;
-use sp_application_crypto::sr25519::{AppPair, AppPublic};
-use sp_core::{crypto::Pair, testing::SR25519};
+use sp_application_crypto::sr25519::AppPair;
+use sp_core::{
+	crypto::{ByteArray, Pair},
+	testing::SR25519,
+};
 use sp_keystore::{testing::MemoryKeystore, Keystore};
 use std::sync::Arc;
 use substrate_test_runtime_client::{
@@ -36,6 +39,6 @@ fn sr25519_works_in_runtime() {
 		.expect("Tests `sr25519` crypto.");
 
 	let supported_keys = keystore.keys(SR25519).unwrap();
-	assert!(supported_keys.contains(&public.clone().into()));
-	assert!(AppPair::verify(&signature, "sr25519", &AppPublic::from(public)));
+	assert!(supported_keys.contains(&public.to_raw_vec()));
+	assert!(AppPair::verify(&signature, "sr25519", &public));
 }

--- a/primitives/consensus/common/src/error.rs
+++ b/primitives/consensus/common/src/error.rs
@@ -48,8 +48,8 @@ pub enum Error {
 	#[error("Chain lookup failed: {0}")]
 	ChainLookup(String),
 	/// Signing failed.
-	#[error("Failed to sign using key: {0:?}. Reason: {1}")]
-	CannotSign(Vec<u8>, String),
+	#[error("Failed to sign: {0}")]
+	CannotSign(String),
 	/// Some other error.
 	#[error(transparent)]
 	Other(#[from] Box<dyn std::error::Error + Sync + Send + 'static>),

--- a/primitives/consensus/grandpa/src/lib.rs
+++ b/primitives/consensus/grandpa/src/lib.rs
@@ -451,7 +451,7 @@ where
 	H: Encode,
 	N: Encode,
 {
-	use sp_application_crypto::AppKey;
+	use sp_application_crypto::AppCrypto;
 	use sp_core::crypto::Wraps;
 
 	let encoded = localized_payload(round, set_id, &message);

--- a/primitives/consensus/grandpa/src/lib.rs
+++ b/primitives/consensus/grandpa/src/lib.rs
@@ -452,11 +452,10 @@ where
 	N: Encode,
 {
 	use sp_application_crypto::AppCrypto;
-	use sp_core::crypto::Wraps;
 
 	let encoded = localized_payload(round, set_id, &message);
 	let signature = keystore
-		.ed25519_sign(AuthorityId::ID, public.as_inner_ref(), &encoded[..])
+		.ed25519_sign(AuthorityId::ID, public.as_ref(), &encoded[..])
 		.ok()
 		.flatten()?
 		.try_into()

--- a/primitives/consensus/grandpa/src/lib.rs
+++ b/primitives/consensus/grandpa/src/lib.rs
@@ -452,11 +452,11 @@ where
 	N: Encode,
 {
 	use sp_application_crypto::AppKey;
-	use sp_core::crypto::Public;
+	use sp_core::crypto::Wraps;
 
 	let encoded = localized_payload(round, set_id, &message);
 	let signature = keystore
-		.sign_with(AuthorityId::ID, &public.to_public_crypto_pair(), &encoded[..])
+		.ed25519_sign(AuthorityId::ID, public.as_inner_ref(), &encoded[..])
 		.ok()
 		.flatten()?
 		.try_into()

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -485,10 +485,7 @@ pub trait ByteArray: AsRef<[u8]> + AsMut<[u8]> + for<'a> TryFrom<&'a [u8], Error
 }
 
 /// Trait suitable for typical cryptographic PKI key public type.
-pub trait Public: ByteArray + Derive + CryptoType + PartialEq + Eq + Clone + Send + Sync {
-	/// Return `CryptoTypeId` from public key.
-	fn crypto_id(&self) -> CryptoTypeId;
-}
+pub trait Public: ByteArray + Derive + CryptoType + PartialEq + Eq + Clone + Send + Sync {}
 
 /// An opaque 32-byte cryptographic identifier.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, MaxEncodedLen, TypeInfo)]
@@ -687,11 +684,7 @@ mod dummy {
 			b""
 		}
 	}
-	impl Public for Dummy {
-		fn crypto_id(&self) -> CryptoTypeId {
-			CryptoTypeId(*b"dumm")
-		}
-	}
+	impl Public for Dummy {}
 
 	impl Pair for Dummy {
 		type Public = Dummy;
@@ -1203,11 +1196,7 @@ mod tests {
 			vec![]
 		}
 	}
-	impl Public for TestPublic {
-		fn crypto_id(&self) -> CryptoTypeId {
-			CryptoTypeId(*b"dumm")
-		}
-	}
+	impl Public for TestPublic {}
 	impl Pair for TestPair {
 		type Public = TestPublic;
 		type Seed = [u8; 8];

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -19,8 +19,6 @@
 //! Cryptographic utilities.
 // end::description[]
 
-#[cfg(feature = "std")]
-use crate::hexdisplay::HexDisplay;
 use crate::{ed25519, sr25519};
 #[cfg(feature = "std")]
 use base58::{FromBase58, ToBase58};
@@ -488,8 +486,8 @@ pub trait ByteArray: AsRef<[u8]> + AsMut<[u8]> + for<'a> TryFrom<&'a [u8], Error
 
 /// Trait suitable for typical cryptographic PKI key public type.
 pub trait Public: ByteArray + Derive + CryptoType + PartialEq + Eq + Clone + Send + Sync {
-	/// Return `CryptoTypePublicPair` from public key.
-	fn to_public_crypto_pair(&self) -> CryptoTypePublicPair;
+	/// Return `CryptoTypeId` from public key.
+	fn crypto_id(&self) -> CryptoTypeId;
 }
 
 /// An opaque 32-byte cryptographic identifier.
@@ -690,8 +688,8 @@ mod dummy {
 		}
 	}
 	impl Public for Dummy {
-		fn to_public_crypto_pair(&self) -> CryptoTypePublicPair {
-			CryptoTypePublicPair(CryptoTypeId(*b"dumm"), <Self as ByteArray>::to_raw_vec(self))
+		fn crypto_id(&self) -> CryptoTypeId {
+			CryptoTypeId(*b"dumm")
 		}
 	}
 
@@ -1118,24 +1116,6 @@ impl<'a> TryFrom<&'a str> for KeyTypeId {
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct CryptoTypeId(pub [u8; 4]);
 
-/// A type alias of CryptoTypeId & a public key
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Encode, Decode)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
-pub struct CryptoTypePublicPair(pub CryptoTypeId, pub Vec<u8>);
-
-#[cfg(feature = "std")]
-impl sp_std::fmt::Display for CryptoTypePublicPair {
-	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
-		let id = match str::from_utf8(&(self.0).0[..]) {
-			Ok(id) => id.to_string(),
-			Err(_) => {
-				format!("{:#?}", self.0)
-			},
-		};
-		write!(f, "{}-{}", id, HexDisplay::from(&self.1))
-	}
-}
-
 /// Known key types; this also functions as a global registry of key types for projects wishing to
 /// avoid collisions with each other.
 ///
@@ -1224,8 +1204,8 @@ mod tests {
 		}
 	}
 	impl Public for TestPublic {
-		fn to_public_crypto_pair(&self) -> CryptoTypePublicPair {
-			CryptoTypePublicPair(CryptoTypeId(*b"dumm"), self.to_raw_vec())
+		fn crypto_id(&self) -> CryptoTypeId {
+			CryptoTypeId(*b"dumm")
 		}
 	}
 	impl Pair for TestPair {

--- a/primitives/core/src/ecdsa.rs
+++ b/primitives/core/src/ecdsa.rs
@@ -102,11 +102,7 @@ impl ByteArray for Public {
 	const LEN: usize = 33;
 }
 
-impl TraitPublic for Public {
-	fn crypto_id(&self) -> CryptoTypeId {
-		CRYPTO_ID
-	}
-}
+impl TraitPublic for Public {}
 
 impl Derive for Public {}
 

--- a/primitives/core/src/ecdsa.rs
+++ b/primitives/core/src/ecdsa.rs
@@ -24,8 +24,7 @@ use sp_runtime_interface::pass_by::PassByInner;
 #[cfg(feature = "std")]
 use crate::crypto::Ss58Codec;
 use crate::crypto::{
-	ByteArray, CryptoType, CryptoTypeId, CryptoTypePublicPair, Derive, Public as TraitPublic,
-	UncheckedFrom,
+	ByteArray, CryptoType, CryptoTypeId, Derive, Public as TraitPublic, UncheckedFrom,
 };
 #[cfg(feature = "full_crypto")]
 use crate::{
@@ -104,20 +103,8 @@ impl ByteArray for Public {
 }
 
 impl TraitPublic for Public {
-	fn to_public_crypto_pair(&self) -> CryptoTypePublicPair {
-		CryptoTypePublicPair(CRYPTO_ID, self.to_raw_vec())
-	}
-}
-
-impl From<Public> for CryptoTypePublicPair {
-	fn from(key: Public) -> Self {
-		(&key).into()
-	}
-}
-
-impl From<&Public> for CryptoTypePublicPair {
-	fn from(key: &Public) -> Self {
-		CryptoTypePublicPair(CRYPTO_ID, key.to_raw_vec())
+	fn crypto_id(&self) -> CryptoTypeId {
+		CRYPTO_ID
 	}
 }
 

--- a/primitives/core/src/ed25519.rs
+++ b/primitives/core/src/ed25519.rs
@@ -353,11 +353,7 @@ impl ByteArray for Public {
 	const LEN: usize = 32;
 }
 
-impl TraitPublic for Public {
-	fn crypto_id(&self) -> CryptoTypeId {
-		CRYPTO_ID
-	}
-}
+impl TraitPublic for Public {}
 
 impl Derive for Public {}
 

--- a/primitives/core/src/ed25519.rs
+++ b/primitives/core/src/ed25519.rs
@@ -31,9 +31,7 @@ use scale_info::TypeInfo;
 
 #[cfg(feature = "std")]
 use crate::crypto::Ss58Codec;
-use crate::crypto::{
-	CryptoType, CryptoTypeId, CryptoTypePublicPair, Derive, Public as TraitPublic, UncheckedFrom,
-};
+use crate::crypto::{CryptoType, CryptoTypeId, Derive, Public as TraitPublic, UncheckedFrom};
 #[cfg(feature = "full_crypto")]
 use crate::crypto::{DeriveError, DeriveJunction, Pair as TraitPair, SecretStringError};
 #[cfg(feature = "full_crypto")]
@@ -356,24 +354,12 @@ impl ByteArray for Public {
 }
 
 impl TraitPublic for Public {
-	fn to_public_crypto_pair(&self) -> CryptoTypePublicPair {
-		CryptoTypePublicPair(CRYPTO_ID, self.to_raw_vec())
+	fn crypto_id(&self) -> CryptoTypeId {
+		CRYPTO_ID
 	}
 }
 
 impl Derive for Public {}
-
-impl From<Public> for CryptoTypePublicPair {
-	fn from(key: Public) -> Self {
-		(&key).into()
-	}
-}
-
-impl From<&Public> for CryptoTypePublicPair {
-	fn from(key: &Public) -> Self {
-		CryptoTypePublicPair(CRYPTO_ID, key.to_raw_vec())
-	}
-}
 
 /// Derive a single hard junction.
 #[cfg(feature = "full_crypto")]

--- a/primitives/core/src/sr25519.rs
+++ b/primitives/core/src/sr25519.rs
@@ -34,10 +34,7 @@ use schnorrkel::{
 use sp_std::vec::Vec;
 
 use crate::{
-	crypto::{
-		ByteArray, CryptoType, CryptoTypeId, CryptoTypePublicPair, Derive, Public as TraitPublic,
-		UncheckedFrom,
-	},
+	crypto::{ByteArray, CryptoType, CryptoTypeId, Derive, Public as TraitPublic, UncheckedFrom},
 	hash::{H256, H512},
 };
 use codec::{Decode, Encode, MaxEncodedLen};
@@ -387,20 +384,8 @@ impl ByteArray for Public {
 }
 
 impl TraitPublic for Public {
-	fn to_public_crypto_pair(&self) -> CryptoTypePublicPair {
-		CryptoTypePublicPair(CRYPTO_ID, self.to_raw_vec())
-	}
-}
-
-impl From<Public> for CryptoTypePublicPair {
-	fn from(key: Public) -> Self {
-		(&key).into()
-	}
-}
-
-impl From<&Public> for CryptoTypePublicPair {
-	fn from(key: &Public) -> Self {
-		CryptoTypePublicPair(CRYPTO_ID, key.to_raw_vec())
+	fn crypto_id(&self) -> CryptoTypeId {
+		CRYPTO_ID
 	}
 }
 

--- a/primitives/core/src/sr25519.rs
+++ b/primitives/core/src/sr25519.rs
@@ -383,11 +383,7 @@ impl ByteArray for Public {
 	const LEN: usize = 32;
 }
 
-impl TraitPublic for Public {
-	fn crypto_id(&self) -> CryptoTypeId {
-		CRYPTO_ID
-	}
-}
+impl TraitPublic for Public {}
 
 #[cfg(feature = "std")]
 impl From<MiniSecretKey> for Pair {

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -762,10 +762,9 @@ pub trait Crypto {
 	) -> Option<ed25519::Signature> {
 		self.extension::<KeystoreExt>()
 			.expect("No `keystore` associated for the current context!")
-			.sign_with(id, &pub_key.into(), msg)
+			.ed25519_sign(id, pub_key, msg)
 			.ok()
 			.flatten()
-			.and_then(|sig| ed25519::Signature::from_slice(&sig))
 	}
 
 	/// Verify `ed25519` signature.
@@ -902,10 +901,9 @@ pub trait Crypto {
 	) -> Option<sr25519::Signature> {
 		self.extension::<KeystoreExt>()
 			.expect("No `keystore` associated for the current context!")
-			.sign_with(id, &pub_key.into(), msg)
+			.sr25519_sign(id, pub_key, msg)
 			.ok()
 			.flatten()
-			.and_then(|sig| sr25519::Signature::from_slice(&sig))
 	}
 
 	/// Verify an `sr25519` signature.
@@ -949,10 +947,9 @@ pub trait Crypto {
 	) -> Option<ecdsa::Signature> {
 		self.extension::<KeystoreExt>()
 			.expect("No `keystore` associated for the current context!")
-			.sign_with(id, &pub_key.into(), msg)
+			.ecdsa_sign(id, pub_key, msg)
 			.ok()
 			.flatten()
-			.and_then(|sig| ecdsa::Signature::from_slice(&sig))
 	}
 
 	/// Sign the given a pre-hashed `msg` with the `ecdsa` key that corresponds to the given public

--- a/primitives/keystore/src/lib.rs
+++ b/primitives/keystore/src/lib.rs
@@ -45,40 +45,44 @@ pub enum Error {
 
 /// Something that generates, stores and provides access to secret keys.
 pub trait Keystore: Send + Sync {
-	/// Returns all sr25519 public keys for the given key type.
-	fn sr25519_public_keys(&self, id: KeyTypeId) -> Vec<sr25519::Public>;
+	/// Returns all the sr25519 public keys for the given key type.
+	fn sr25519_public_keys(&self, key_type: KeyTypeId) -> Vec<sr25519::Public>;
 
 	/// Generate a new sr25519 key pair for the given key type and an optional seed.
 	///
-	/// If the given seed is `Some(_)`, the key pair will only be stored in memory.
-	///
-	/// Returns the public key of the generated key pair.
+	/// Returns an `sr25519::Public` key of the generated key pair or an `Err` if
+	/// something failed during key generation.
 	fn sr25519_generate_new(
 		&self,
-		id: KeyTypeId,
+		key_type: KeyTypeId,
 		seed: Option<&str>,
 	) -> Result<sr25519::Public, Error>;
 
-	/// TODO
+	/// Generate an sr25519 signature for a given message.
+	///
+	/// Receives [`KeyTypeId`] and an [`sr25519::Public`] key to be able to map
+	/// them to a private key that exists in the keystore.
+	///
+	/// Returns an [`sr25519::Signature`] or `None` in case the given `key_type`
+	/// and `public` combination doesn't exist in the keystore.
+	/// An `Err` will be returned if generating the signature itself failed.
 	fn sr25519_sign(
 		&self,
-		id: KeyTypeId,
+		key_type: KeyTypeId,
 		public: &sr25519::Public,
 		msg: &[u8],
 	) -> Result<Option<sr25519::Signature>, Error>;
 
-	/// Generate VRF signature  for given transcript data.
+	/// Generate an sr25519 VRF signature for a given transcript data.
 	///
-	/// Receives KeyTypeId and Public key to be able to map
-	/// them to a private key that exists in the keystore which
-	/// is, in turn, used for signing the provided transcript.
+	/// Receives [`KeyTypeId`] and an [`sr25519::Public`] key to be able to map
+	/// them to a private key that exists in the keystore.
 	///
 	/// Returns a result containing the signature data.
-	/// Namely, VRFOutput and VRFProof which are returned
-	/// inside the `VRFSignature` container struct.
-	///
-	/// This function will return `None` if the given `key_type` and `public` combination
-	/// doesn't exist in the keystore or an `Err` when something failed.
+	/// Namely, VRFOutput and VRFProof which are returned inside the `VRFSignature`
+	/// container struct.
+	/// Returns `None` if the given `key_type` and `public` combination doesn't
+	/// exist in the keystore or an `Err` when something failed.
 	fn sr25519_vrf_sign(
 		&self,
 		key_type: KeyTypeId,
@@ -87,69 +91,72 @@ pub trait Keystore: Send + Sync {
 	) -> Result<Option<VRFSignature>, Error>;
 
 	/// Returns all ed25519 public keys for the given key type.
-	fn ed25519_public_keys(&self, id: KeyTypeId) -> Vec<ed25519::Public>;
+	fn ed25519_public_keys(&self, key_type: KeyTypeId) -> Vec<ed25519::Public>;
 
 	/// Generate a new ed25519 key pair for the given key type and an optional seed.
 	///
-	/// If the given seed is `Some(_)`, the key pair will only be stored in memory.
-	///
-	/// Returns the public key of the generated key pair.
+	/// Returns an `ed25519::Public` key of the generated key pair or an `Err` if
+	/// something failed during key generation.
 	fn ed25519_generate_new(
 		&self,
-		id: KeyTypeId,
+		key_type: KeyTypeId,
 		seed: Option<&str>,
 	) -> Result<ed25519::Public, Error>;
 
-	/// TODO
+	/// Generate an ed25519 signature for a given message.
+	///
+	/// Receives [`KeyTypeId`] and an [`ed25519::Public`] key to be able to map
+	/// them to a private key that exists in the keystore.
+	///
+	/// Returns an [`ed25519::Signature`] or `None` in case the given `key_type`
+	/// and `public` combination doesn't exist in the keystore.
+	/// An `Err` will be returned if generating the signature itself failed.
 	fn ed25519_sign(
 		&self,
-		id: KeyTypeId,
+		key_type: KeyTypeId,
 		public: &ed25519::Public,
 		msg: &[u8],
 	) -> Result<Option<ed25519::Signature>, Error>;
 
 	/// Returns all ecdsa public keys for the given key type.
-	fn ecdsa_public_keys(&self, id: KeyTypeId) -> Vec<ecdsa::Public>;
+	fn ecdsa_public_keys(&self, key_type: KeyTypeId) -> Vec<ecdsa::Public>;
 
 	/// Generate a new ecdsa key pair for the given key type and an optional seed.
 	///
-	/// If the given seed is `Some(_)`, the key pair will only be stored in memory.
-	///
-	/// Returns the public key of the generated key pair.
-	fn ecdsa_generate_new(&self, id: KeyTypeId, seed: Option<&str>)
-		-> Result<ecdsa::Public, Error>;
+	/// Returns an `ecdsa::Public` key of the generated key pair or an `Err` if
+	/// something failed during key generation.
+	fn ecdsa_generate_new(
+		&self,
+		key_type: KeyTypeId,
+		seed: Option<&str>,
+	) -> Result<ecdsa::Public, Error>;
 
-	/// Generate an ECDSA signature for a given message.
+	/// Generate an ecdsa signature for a given message.
 	///
 	/// Receives [`KeyTypeId`] and an [`ecdsa::Public`] key to be able to map
-	/// them to a private key that exists in the keystore. This private key is,
-	/// in turn, used for signing the provided pre-hashed message.
+	/// them to a private key that exists in the keystore.
 	///
-	/// Returns an [`ecdsa::Signature`] or `None` in case the given `id` and
-	/// `public` combination doesn't exist in the keystore. An `Err` will be
-	/// returned if generating the signature itself failed.
+	/// Returns an [`ecdsa::Signature`] or `None` in case the given `key_type`
+	/// and `public` combination doesn't exist in the keystore.
+	/// An `Err` will be returned if generating the signature itself failed.
 	fn ecdsa_sign(
 		&self,
-		id: KeyTypeId,
+		key_type: KeyTypeId,
 		public: &ecdsa::Public,
 		msg: &[u8],
 	) -> Result<Option<ecdsa::Signature>, Error>;
 
-	/// Generate an ECDSA signature for a given pre-hashed message.
+	/// Generate an ecdsa signature for a given pre-hashed message.
 	///
 	/// Receives [`KeyTypeId`] and an [`ecdsa::Public`] key to be able to map
-	/// them to a private key that exists in the keystore. This private key is,
-	/// in turn, used for signing the provided pre-hashed message.
+	/// them to a private key that exists in the keystore.
 	///
-	/// The `msg` argument provided should be a hashed message for which an
-	/// ECDSA signature should be generated.
-	///
-	/// Returns an [`ecdsa::Signature`] or `None` in case the given `id` and
-	/// `public` combination doesn't exist in the keystore. An `Err` will be
-	/// returned if generating the signature itself failed.
+	/// Returns an [`ecdsa::Signature`] or `None` in case the given `key_type`
+	/// and `public` combination doesn't exist in the keystore.
+	/// An `Err` will be returned if generating the signature itself failed.
 	fn ecdsa_sign_prehashed(
 		&self,
-		id: KeyTypeId,
+		key_type: KeyTypeId,
 		public: &ecdsa::Public,
 		msg: &[u8; 32],
 	) -> Result<Option<ecdsa::Signature>, Error>;
@@ -157,19 +164,20 @@ pub trait Keystore: Send + Sync {
 	/// Insert a new secret key.
 	fn insert(&self, key_type: KeyTypeId, suri: &str, public: &[u8]) -> Result<(), ()>;
 
-	/// List all supported keys
+	/// List all supported keys of a given type.
 	///
-	/// Returns a set of public keys the signer supports.
-	fn keys(&self, id: KeyTypeId) -> Result<Vec<Vec<u8>>, Error>;
+	/// Returns a set of public keys the signer supports in raw format.
+	fn keys(&self, key_type: KeyTypeId) -> Result<Vec<Vec<u8>>, Error>;
 
 	/// Checks if the private keys for the given public key and key type combinations exist.
 	///
 	/// Returns `true` iff all private keys could be found.
 	fn has_keys(&self, public_keys: &[(Vec<u8>, KeyTypeId)]) -> bool;
 
-	/// Convenience method to sign a message using an opaque key type.
+	/// Convenience method to sign a message using the given key type and a raw public key
+	/// for secret lookup.
 	///
-	/// The message is signed using the cryptographic primitive specified by `KeyCryptoId`.
+	/// The message is signed using the cryptographic primitive specified by `crypto_id`.
 	///
 	/// Schemes supported by the default trait implementation: sr25519, ed25519 and ecdsa.
 	/// To support more schemes you can overwrite this method.

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -30,7 +30,7 @@ use crate::{
 use impl_trait_for_tuples::impl_for_tuples;
 #[cfg(feature = "std")]
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use sp_application_crypto::{AppCrypto, AppPublic};
+use sp_application_crypto::AppCrypto;
 pub use sp_arithmetic::traits::{
 	checked_pow, ensure_pow, AtLeast32Bit, AtLeast32BitUnsigned, Bounded, CheckedAdd, CheckedDiv,
 	CheckedMul, CheckedShl, CheckedShr, CheckedSub, Ensure, EnsureAdd, EnsureAddAssign, EnsureDiv,

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -30,7 +30,7 @@ use crate::{
 use impl_trait_for_tuples::impl_for_tuples;
 #[cfg(feature = "std")]
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use sp_application_crypto::AppKey;
+use sp_application_crypto::{AppCrypto, AppPublic};
 pub use sp_arithmetic::traits::{
 	checked_pow, ensure_pow, AtLeast32Bit, AtLeast32BitUnsigned, Bounded, CheckedAdd, CheckedDiv,
 	CheckedMul, CheckedShl, CheckedShr, CheckedSub, Ensure, EnsureAdd, EnsureAddAssign, EnsureDiv,
@@ -148,10 +148,10 @@ pub trait AppVerify {
 }
 
 impl<
-		S: Verify<Signer = <<T as AppKey>::Public as sp_application_crypto::AppPublic>::Generic>
+		S: Verify<Signer = <<T as AppCrypto>::Public as sp_application_crypto::AppPublic>::Generic>
 			+ From<T>,
 		T: sp_application_crypto::Wraps<Inner = S>
-			+ sp_application_crypto::AppKey
+			+ sp_application_crypto::AppCrypto
 			+ sp_application_crypto::AppSignature
 			+ AsRef<S>
 			+ AsMut<S>
@@ -159,16 +159,18 @@ impl<
 	> AppVerify for T
 where
 	<S as Verify>::Signer: IdentifyAccount<AccountId = <S as Verify>::Signer>,
-	<<T as AppKey>::Public as sp_application_crypto::AppPublic>::Generic: IdentifyAccount<
-		AccountId = <<T as AppKey>::Public as sp_application_crypto::AppPublic>::Generic,
+	<<T as AppCrypto>::Public as sp_application_crypto::AppPublic>::Generic: IdentifyAccount<
+		AccountId = <<T as AppCrypto>::Public as sp_application_crypto::AppPublic>::Generic,
 	>,
 {
-	type AccountId = <T as AppKey>::Public;
-	fn verify<L: Lazy<[u8]>>(&self, msg: L, signer: &<T as AppKey>::Public) -> bool {
+	type AccountId = <T as AppCrypto>::Public;
+	fn verify<L: Lazy<[u8]>>(&self, msg: L, signer: &<T as AppCrypto>::Public) -> bool {
 		use sp_application_crypto::IsWrappedBy;
 		let inner: &S = self.as_ref();
 		let inner_pubkey =
-			<<T as AppKey>::Public as sp_application_crypto::AppPublic>::Generic::from_ref(signer);
+			<<T as AppCrypto>::Public as sp_application_crypto::AppPublic>::Generic::from_ref(
+				signer,
+			);
 		Verify::verify(inner, msg, inner_pubkey)
 	}
 }


### PR DESCRIPTION
Closes https://github.com/paritytech/substrate/issues/13556

polkadot companion: https://github.com/paritytech/polkadot/pull/6944

cumulus companion: https://github.com/paritytech/cumulus/pull/2371

---

Within this PR:
- Removal of `CryptoTypePublicId` type
- Introduce explicit signing methods to the `Keystore` trait
- `Keystore::sign_with` method has been retained. But a default implementation has been provided in the trait definition. In the end this is a convenience method that can be used in some specific use cases (to prevent code duplication in all the cases where the key is generic such as AURA).
    - nevertheless in all the places where we can use the explicit keystore methods we save the casts to and from raw byte vectors that by definition are fallible (but in our use cases were infallible)
 - Trivial renaming of `AppKey` trait to `AppCrypto`. The trait is implemented by types (signatures included) from whom the whole set of application crypto associated types and consts can be retrieved. Thus this new name fits better
- `CRYPTO_ID` in `AppCrypto` has been retained because without it `sign_with` can't work
- Wherever is possible prefer infallible sign methods over fallible `sign_with`
