### PR TITLE
try-runtime: run migration checks per default

### DIFF
--- a/utils/frame/try-runtime/cli/src/commands/on_runtime_upgrade.rs
+++ b/utils/frame/try-runtime/cli/src/commands/on_runtime_upgrade.rs
@@ -40,8 +40,8 @@ pub struct OnRuntimeUpgradeCmd {
 	/// Performing any checks will potentially invalidate the measured PoV/Weight.
 	// NOTE: The clap attributes make it backwards compatible with the previous `--checks` flag.
 	#[clap(long,
-		default_value = "None",
-		default_missing_value = "All",
+		default_value = "pre-and-post",
+		default_missing_value = "all",
 		num_args = 0..=1,
 		require_equals = true,
 		verbatim_doc_comment)]

--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -134,10 +134,10 @@
 //!
 //! ```ignore
 //! 
-//! #[cfg(feature = try-runtime)]
+//! #[cfg(feature = "try-runtime")]
 //! fn pre_upgrade() -> Result<Vec<u8>, &'static str> {}
 //!
-//! #[cfg(feature = try-runtime)]
+//! #[cfg(feature = "try-runtime")]
 //! fn post_upgrade(state: Vec<u8>) -> Result<(), &'static str> {}
 //! ```
 //!
@@ -152,9 +152,9 @@
 //!
 //! Similarly, each pallet can expose a function in `#[pallet::hooks]` section as follows:
 //!
-//! ```
-//! #[cfg(feature = try-runtime)]
-//! fn try_state(_) -> Result<(), &'static str> {}
+//! ```ignore
+//! #[cfg(feature = "try-runtime")]
+//! fn try_state(_: BlockNumber) -> Result<(), &'static str> {}
 //! ```
 //!
 //! which is called on numerous code paths in the try-runtime tool. These checks should ensure that


### PR DESCRIPTION
Closes https://github.com/paritytech/substrate/issues/13681

The current behaviour of having to explicetly specify --checks seems
to cause confusion. Therefore bringing back the old behaviour of
running the pre- and post-upgrade checks per default.