### PR TITLE
Remove unused light-client leftover

### DIFF
--- a/client/network/sync/src/engine.rs
+++ b/client/network/sync/src/engine.rs
@@ -58,10 +58,7 @@ use sc_network_common::{
 use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnboundedSender};
 use sp_blockchain::HeaderMetadata;
 use sp_consensus::block_validation::BlockAnnounceValidator;
-use sp_runtime::{
-	traits::{Block as BlockT, CheckedSub, Header, NumberFor, Zero},
-	SaturatedConversion,
-};
+use sp_runtime::traits::{Block as BlockT, Header, NumberFor, Zero};
 
 use std::{
 	collections::{HashMap, HashSet},
@@ -82,14 +79,10 @@ const MAX_KNOWN_BLOCKS: usize = 1024; // ~32kb per peer + LruHashSet overhead
 
 mod rep {
 	use sc_peerset::ReputationChange as Rep;
-	/// Reputation change when we are a light client and a peer is behind us.
-	pub const PEER_BEHIND_US_LIGHT: Rep = Rep::new(-(1 << 8), "Useless for a light peer");
 	/// We received a message that failed to decode.
 	pub const BAD_MESSAGE: Rep = Rep::new(-(1 << 12), "Bad message");
 	/// Peer has different genesis.
 	pub const GENESIS_MISMATCH: Rep = Rep::new_fatal("Genesis mismatch");
-	/// Peer role does not match (e.g. light peer connecting to another light peer).
-	pub const BAD_ROLE: Rep = Rep::new_fatal("Unsupported role");
 	/// Peer send us a block announcement that failed at validation.
 	pub const BAD_BLOCK_ANNOUNCEMENT: Rep = Rep::new(-(1 << 12), "Bad block announcement");
 }


### PR DESCRIPTION
Remove some leftover light-client code.

`SyncingEngine` instantiated here: https://github.com/paritytech/substrate/blob/91e0d66258a5143e2f4fa9bbf591d0ded4cd44b0/client/service/src/builder.rs#L830 
Can not be light client : https://github.com/paritytech/substrate/blob/91e0d66258a5143e2f4fa9bbf591d0ded4cd44b0/client/network/common/src/role.rs#L100-L107