### PR TITLE
Get the correct number of connected peers in `SyncState`

### DIFF
--- a/client/informant/src/display.rs
+++ b/client/informant/src/display.rs
@@ -76,7 +76,7 @@ impl<B: BlockT> InformantDisplay<B> {
 		let best_number = info.chain.best_number;
 		let best_hash = info.chain.best_hash;
 		let finalized_number = info.chain.finalized_number;
-		let num_connected_peers = net_status.num_connected_peers;
+		let num_connected_peers = sync_status.num_connected_peers;
 		let speed = speed::<B>(best_number, self.last_number, self.last_update);
 		let total_bytes_inbound = net_status.total_bytes_inbound;
 		let total_bytes_outbound = net_status.total_bytes_outbound;

--- a/client/network/common/src/sync.rs
+++ b/client/network/common/src/sync.rs
@@ -94,6 +94,8 @@ pub struct SyncStatus<Block: BlockT> {
 	pub best_seen_block: Option<NumberFor<Block>>,
 	/// Number of peers participating in syncing.
 	pub num_peers: u32,
+	/// Number of peers known to `SyncingEngine` (both full and light).
+	pub num_connected_peers: u32,
 	/// Number of blocks queued for import
 	pub queued_blocks: u32,
 	/// State sync status in progress, if any.

--- a/client/network/sync/src/engine.rs
+++ b/client/network/sync/src/engine.rs
@@ -711,7 +711,9 @@ where
 				ToServiceCommand::NewBestBlockImported(hash, number) =>
 					self.new_best_block_imported(hash, number),
 				ToServiceCommand::Status(tx) => {
-					let _ = tx.send(self.chain_sync.status());
+					let mut status = self.chain_sync.status();
+					status.num_connected_peers = self.peers.len() as u32;
+					let _ = tx.send(status);
 				},
 				ToServiceCommand::NumActivePeers(tx) => {
 					let _ = tx.send(self.chain_sync.num_active_peers());

--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -523,6 +523,7 @@ where
 			state: sync_state,
 			best_seen_block,
 			num_peers: self.peers.len() as u32,
+			num_connected_peers: 0u32,
 			queued_blocks: self.queue_blocks.len() as u32,
 			state_sync: self.state_sync.as_ref().map(|s| s.progress()),
 			warp_sync: warp_sync_progress,


### PR DESCRIPTION
`Protocol` is not a reliable source for the information of connected peers because it does't have real-time information about the real connectivity state.

The way to address this properly would be to refactor `SyncingEngine` and `ChainSync`, remove duplicate peer counting and return a unified `SyncState` but I haven't found time for that refactoring yet, hopefully soon.