### PR TITLE
FRAME: Fix the Referenda confirming alarm

### DIFF
--- a/frame/referenda/src/lib.rs
+++ b/frame/referenda/src/lib.rs
@@ -1206,7 +1206,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			let until_approval = track.min_approval.delay(approval);
 			let until_support = track.min_support.delay(support);
 			let offset = until_support.max(until_approval);
-			deciding.since.saturating_add(offset * track.decision_period)
+			deciding.since.saturating_add(offset.mul_ceil(track.decision_period))
 		})
 	}
 

--- a/frame/referenda/src/tests.rs
+++ b/frame/referenda/src/tests.rs
@@ -287,6 +287,24 @@ fn alarm_interval_works() {
 }
 
 #[test]
+fn decision_time_is_correct() {
+	new_test_ext().execute_with(|| {
+		let decision_time = |since: u64| {
+			Pallet::<Test>::decision_time(
+				&DecidingStatus { since: since.into(), confirming: None },
+				&Tally { ayes: 100, nays: 5 },
+				TestTracksInfo::tracks()[0].0,
+				&TestTracksInfo::tracks()[0].1,
+			)
+		};
+
+		for i in 0u64..=100 {
+			assert!(decision_time(i) > i, "The decision time should be delayed by the curve");
+		}
+	});
+}
+
+#[test]
 fn auto_timeout_should_happen_with_nothing_but_submit() {
 	new_test_ext().execute_with(|| {
 		// #1: submit


### PR DESCRIPTION
We were doing a straight `mul` to get the block number from a `Perbill`, which will round down if the fractional part is half or less. We should always be rounding up, though, to ensure that when the alarm goes off the confirmation period is definitely ready to begin.

It would be good to write a fuzzer to ensure the issue manifested itself prior and no longer manifests after these changes. It is also possible that the issue was fixed by #13660, so if a fuzzer doesn't find this has fixed anything we might want to try testing with the [commit](https://github.com/paritytech/substrate/commit/bf395c8308c481a9774373e0b0b14bd7a2e4b8d2) immediately before.

Possible fix for https://github.com/paritytech/substrate/issues/13658