### PR TITLE
basic nix support, builds subkey and provides it to other packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ rls*.log
 scripts/ci/node-template-release/Cargo.lock
 bin/node-template/Cargo.lock
 substrate.code-workspace
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,67 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1679710833,
+        "narHash": "sha256-9yKVvGX1oAnlc8vTVvN2lRH35q6ETudQbM1w9ragMRU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "83607dae4e05e1de755bbc7d7949b33fc1cfbbb9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1679710743,
+        "narHash": "sha256-zB6vEMoOmXZyqD/yNu1DYqtYvQaPERjWEnmhK8ovlWk=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "8ba8bdaee0dfb4b7ad8b1f398e4f24d4dee89760",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,83 @@
+# nix run github:paritytech/substrate#subkey
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+      };
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    let
+      per_system = flake-utils.lib.eachDefaultSystem (system:
+        let
+          overlays = [ (import rust-overlay) ];
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
+          rust-native-build-inputs = with pkgs; [ clang pkg-config ];
+          rust-src = pkgs.lib.cleanSourceWith {
+            src = pkgs.lib.cleanSource ./.;
+            filter = pkgs.nix-gitignore.gitignoreFilterPure
+              (name: type:
+                (
+                  (type == "regular" && pkgs.lib.strings.hasSuffix ".nix" name)
+                  == false
+                  &&
+                  (type == "directory" && ".github" == name) == false
+                )
+              )
+              [ ./.gitignore ] ./.;
+          };
+          rust-env = with pkgs; {
+            LD_LIBRARY_PATH = pkgs.lib.strings.makeLibraryPath [
+              pkgs.stdenv.cc.cc.lib
+              pkgs.llvmPackages.libclang.lib
+            ];
+            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+            PROTOC = "${pkgs.protobuf}/bin/protoc";
+            ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib";
+          };
+
+          darwin = pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk; [
+            frameworks.Security
+          ]);
+
+          rust-libs = {
+            buildInputs = with pkgs; [ openssl ] ++ darwin;
+            nativeBuildInputs = rust-native-build-inputs;
+            doCheck = false;
+          };
+          rust-deps = pkgs.makeRustPlatform {
+            inherit pkgs;
+            cargo = pkgs.rust-bin.beta.latest.default;
+            rustc = pkgs.rust-bin.beta.latest.default;
+          };
+          subkey = with pkgs; rust-deps.buildRustPackage (rust-libs // rust-env // rec {
+            name = "subkey";
+            src = rust-src;
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+            };
+            doCheck = false;
+            cargoBuildFlags = "--package subkey";
+          });
+
+        in
+        {
+          packages = {
+            inherit subkey;
+          };
+        }
+      );
+    in
+    per_system // {
+      overlays = final: prev: {
+        subkey = per_system.packages.${prev.system}.subkey;
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
               lockFile = ./Cargo.lock;
             };
             doCheck = false;
-            cargoBuildFlags = "--package subkey";
+            cargoBuildFlags = "--package ${name}";
           });
 
         in


### PR DESCRIPTION
Basic nix support.
  
- What does it do? 

Builds subkey via nix

- What important points should reviewers know? 

`nix run .#subkey`, ensure flakes enabled (zero to nix installer is default)

Is there something left for follow-up PRs?
no follow up, so may build other tools if there are later

other usage of nix can be seen here https://github.com/paritytech/zombienet for example
