### PR TITLE
Reward pool migration fix

### DIFF
--- a/frame/nomination-pools/src/lib.rs
+++ b/frame/nomination-pools/src/lib.rs
@@ -1496,7 +1496,7 @@ pub mod pallet {
 	use sp_runtime::Perbill;
 
 	/// The current storage version.
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(4);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(5);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]

--- a/frame/nomination-pools/src/migration.rs
+++ b/frame/nomination-pools/src/migration.rs
@@ -502,7 +502,7 @@ pub mod v4 {
 				onchain
 			);
 
-			if current == 4 && onchain == 3 {
+			if onchain == 3 {
 				log!(warn, "Please run MigrateToV5 immediately after this migration. See github.com/paritytech/substrate/pull/13715");
 				let initial_global_max_commission = U::get();
 				GlobalMaxCommission::<T>::set(Some(initial_global_max_commission));
@@ -518,7 +518,7 @@ pub mod v4 {
 					Some(old_value.migrate_to_v4())
 				});
 
-				current.put::<Pallet<T>>();
+				StorageVersion::new(4).put::<Pallet<T>>();
 				log!(info, "Upgraded {} pools, storage to version {:?}", translated, current);
 
 				// reads: translated + onchain version.

--- a/frame/nomination-pools/src/migration.rs
+++ b/frame/nomination-pools/src/migration.rs
@@ -573,8 +573,8 @@ pub mod v5 {
 
 	/// This migration adds`total_commission_pending` and `total_commission_claimed` field to every
 	/// `RewardPool`, if any.
-	pub struct MigrateToV5<T, U>(sp_std::marker::PhantomData<(T, U)>);
-	impl<T: Config, U: Get<Perbill>> OnRuntimeUpgrade for MigrateToV5<T, U> {
+	pub struct MigrateToV5<T>(sp_std::marker::PhantomData<T>);
+	impl<T: Config> OnRuntimeUpgrade for MigrateToV5<T> {
 		fn on_runtime_upgrade() -> Weight {
 			let current = Pallet::<T>::current_storage_version();
 			let onchain = Pallet::<T>::on_chain_storage_version();

--- a/frame/nomination-pools/src/migration.rs
+++ b/frame/nomination-pools/src/migration.rs
@@ -588,7 +588,7 @@ pub mod v5 {
 
 			if current == 5 && onchain == 4 {
 				let mut translated = 0u64;
-				RewardPools::<T>::translate::<OldRewardPool<T>, _>(|_key, old_value| {
+				RewardPools::<T>::translate::<OldRewardPool<T>, _>(|_id, old_value| {
 					translated.saturating_inc();
 					Some(old_value.migrate_to_v5())
 				});
@@ -616,11 +616,14 @@ pub mod v5 {
 
 		#[cfg(feature = "try-runtime")]
 		fn post_upgrade(_: Vec<u8>) -> Result<(), &'static str> {
-			// ensure all BondedPools items now contain an `inner.commission: Commission` field.
+			// ensure all RewardPools items now contain `total_commission_pending` and
+			// `total_commission_claimed` field.
 			ensure!(
-				RewardPools::<T>::iter()
-					.all(|(_, inner)| inner.total_commission_pending.is_zero() &&
-						inner.total_commission_claimed.is_zero()),
+				RewardPools::<T>::iter().all(|(_, reward_pool)| reward_pool
+					.total_commission_pending
+					.is_zero() && reward_pool
+					.total_commission_claimed
+					.is_zero()),
 				"a commission value has been incorrectly set"
 			);
 			ensure!(Pallet::<T>::on_chain_storage_version() == 5, "wrong storage version");

--- a/frame/nomination-pools/src/migration.rs
+++ b/frame/nomination-pools/src/migration.rs
@@ -503,7 +503,7 @@ pub mod v4 {
 			);
 
 			if current == 4 && onchain == 3 {
-				log!(warning, "Please run MigrateToV5 immediately after this migration. See github.com/paritytech/substrate/pull/13715");
+				log!(warn, "Please run MigrateToV5 immediately after this migration. See github.com/paritytech/substrate/pull/13715");
 				let initial_global_max_commission = U::get();
 				GlobalMaxCommission::<T>::set(Some(initial_global_max_commission));
 				log!(
@@ -622,27 +622,27 @@ pub mod v5 {
 				"the on_chain version is equal or more than the current one"
 			);
 
-			let rpool_keys = RewardPools::<T>::iter_keys().len();
-			let rpool_values = RewardPools::<T>::iter_values().len();
+			let rpool_keys = RewardPools::<T>::iter_keys().count();
+			let rpool_values = RewardPools::<T>::iter_values().count();
 			if rpool_keys != rpool_values {
 				log!(info, "🔥 There are {} undecodable RewardPools in storage. This migration will try to correct them. keys: {}, values: {}", rpool_keys.saturating_sub(rpool_values), rpool_keys, rpool_values);
 			}
 
 			ensure!(
-				PoolMembers::<T>::iter_keys().len() == PoolMembers::iter_values().len(),
+				PoolMembers::<T>::iter_keys().count() == PoolMembers::<T>::iter_values().count(),
 				"There are undecodable PoolMembers in storage. This migration will not fix that."
 			);
 			ensure!(
-				BoundedPools::<T>::iter_keys().len() == BoundedPools::<T>::iter_values().len(),
-				"There are undecodable BoundedPools in storage. This migration will not fix that."
+				BondedPools::<T>::iter_keys().count() == BondedPools::<T>::iter_values().count(),
+				"There are undecodable BondedPools in storage. This migration will not fix that."
 			);
 			ensure!(
-				SubPoolsStorage::<T>::iter_keys().len() ==
-					SubPoolsStorage::<T>::iter_values().len(),
+				SubPoolsStorage::<T>::iter_keys().count() ==
+					SubPoolsStorage::<T>::iter_values().count(),
 				"There are undecodable SubPools in storage. This migration will not fix that."
 			);
 			ensure!(
-				Metadata::<T>::iter_keys().len() == Metadata::<T>::iter_values().len(),
+				Metadata::<T>::iter_keys().count() == Metadata::<T>::iter_values().count(),
 				"There are undecodable Metadata in storage. This migration will not fix that."
 			);
 
@@ -650,10 +650,10 @@ pub mod v5 {
 		}
 
 		#[cfg(feature = "try-runtime")]
-		fn post_upgrade(_: Vec<u8>) -> Result<(), &'static str> {
-			let old_rpool_values = Decode::<u64>::decode(&mut &data[..]).unwrap();
-			let rpool_keys = RewardPools::<T>::iter_keys().len();
-			let rpool_values = RewardPools::<T>::iter_values().len();
+		fn post_upgrade(data: Vec<u8>) -> Result<(), &'static str> {
+			let old_rpool_values: u64 = Decode::decode(&mut &data[..]).unwrap();
+			let rpool_keys = RewardPools::<T>::iter_keys().count() as u64;
+			let rpool_values = RewardPools::<T>::iter_values().count() as u64;
 			ensure!(
 				rpool_keys == rpool_values,
 				"There are STILL undecodable RewardPools - migration failed"
@@ -681,20 +681,20 @@ pub mod v5 {
 
 			// These should not have been touched - just in case.
 			ensure!(
-				PoolMembers::<T>::iter_keys().len() == PoolMembers::iter_values().len(),
+				PoolMembers::<T>::iter_keys().count() == PoolMembers::<T>::iter_values().count(),
 				"There are undecodable PoolMembers in storage."
 			);
 			ensure!(
-				BoundedPools::<T>::iter_keys().len() == BoundedPools::<T>::iter_values().len(),
-				"There are undecodable BoundedPools in storage."
+				BondedPools::<T>::iter_keys().count() == BondedPools::<T>::iter_values().count(),
+				"There are undecodable BondedPools in storage."
 			);
 			ensure!(
-				SubPoolsStorage::<T>::iter_keys().len() ==
-					SubPoolsStorage::<T>::iter_values().len(),
+				SubPoolsStorage::<T>::iter_keys().count() ==
+					SubPoolsStorage::<T>::iter_values().count(),
 				"There are undecodable SubPools in storage."
 			);
 			ensure!(
-				Metadata::<T>::iter_keys().len() == Metadata::<T>::iter_values().len(),
+				Metadata::<T>::iter_keys().count() == Metadata::<T>::iter_values().count(),
 				"There are undecodable Metadata in storage."
 			);
 

--- a/frame/nomination-pools/src/migration.rs
+++ b/frame/nomination-pools/src/migration.rs
@@ -581,7 +581,7 @@ pub mod v5 {
 		}
 	}
 
-	/// This migration adds`total_commission_pending` and `total_commission_claimed` field to every
+	/// This migration adds `total_commission_pending` and `total_commission_claimed` field to every
 	/// `RewardPool`, if any.
 	pub struct MigrateToV5<T>(sp_std::marker::PhantomData<T>);
 	impl<T: Config> OnRuntimeUpgrade for MigrateToV5<T> {

--- a/frame/nomination-pools/src/migration.rs
+++ b/frame/nomination-pools/src/migration.rs
@@ -620,7 +620,7 @@ pub mod v5 {
 			ensure!(
 				RewardPools::<T>::iter()
 					.all(|(_, inner)| inner.total_commission_pending.is_zero() &&
-						inner.total_commission_claimed.max.is_zero()),
+						inner.total_commission_claimed.is_zero()),
 				"a commission value has been incorrectly set"
 			);
 			ensure!(Pallet::<T>::on_chain_storage_version() == 5, "wrong storage version");

--- a/frame/nomination-pools/src/migration.rs
+++ b/frame/nomination-pools/src/migration.rs
@@ -572,7 +572,7 @@ pub mod v5 {
 	}
 
 	/// This migration adds`total_commission_pending` and `total_commission_claimed` field to every
-	/// `RewardPool`, if any. any.
+	/// `RewardPool`, if any.
 	pub struct MigrateToV5<T, U>(sp_std::marker::PhantomData<(T, U)>);
 	impl<T: Config, U: Get<Perbill>> OnRuntimeUpgrade for MigrateToV5<T, U> {
 		fn on_runtime_upgrade() -> Weight {

--- a/frame/nomination-pools/src/migration.rs
+++ b/frame/nomination-pools/src/migration.rs
@@ -478,9 +478,18 @@ pub mod v4 {
 		}
 	}
 
+	/// # Warning
+	///
+	/// Please update to V5 immediately afterwards via `MigrateToV5`. See
+	/// github.com/paritytech/substrate/pull/13715
+	///
 	/// This migration adds a `commission` field to every `BondedPoolInner`, if
 	/// any.
+	#[deprecated(
+		note = "This migration MUST be followed by `MigrateToV5` to avoid mangled storage. See: github.com/paritytech/substrate/pull/13715"
+	)]
 	pub struct MigrateToV4<T, U>(sp_std::marker::PhantomData<(T, U)>);
+	#[allow(deprecated)]
 	impl<T: Config, U: Get<Perbill>> OnRuntimeUpgrade for MigrateToV4<T, U> {
 		fn on_runtime_upgrade() -> Weight {
 			let current = Pallet::<T>::current_storage_version();
@@ -494,6 +503,7 @@ pub mod v4 {
 			);
 
 			if current == 4 && onchain == 3 {
+				log!(warning, "Please run MigrateToV5 immediately after this migration. See github.com/paritytech/substrate/pull/13715");
 				let initial_global_max_commission = U::get();
 				GlobalMaxCommission::<T>::set(Some(initial_global_max_commission));
 				log!(

--- a/frame/nomination-pools/src/migration.rs
+++ b/frame/nomination-pools/src/migration.rs
@@ -478,15 +478,19 @@ pub mod v4 {
 		}
 	}
 
+	/// Migrates from `v3` directly to `v5` to avoid the broken `v4` migration.
+	#[allow(deprecated)]
+	pub type MigrateV3ToV5<T, U> = (v4::MigrateToV4<T, U>, v5::MigrateToV5<T>);
+
 	/// # Warning
 	///
-	/// Please update to V5 immediately afterwards via `MigrateToV5`. See
-	/// github.com/paritytech/substrate/pull/13715
+	/// To avoid mangled storage please use `MigrateV3ToV5` instead.
+	/// See: github.com/paritytech/substrate/pull/13715
 	///
 	/// This migration adds a `commission` field to every `BondedPoolInner`, if
 	/// any.
 	#[deprecated(
-		note = "This migration MUST be followed by `MigrateToV5` to avoid mangled storage. See: github.com/paritytech/substrate/pull/13715"
+		note = "To avoid mangled storage please use `MigrateV3ToV5` instead. See: github.com/paritytech/substrate/pull/13715"
 	)]
 	pub struct MigrateToV4<T, U>(sp_std::marker::PhantomData<(T, U)>);
 	#[allow(deprecated)]


### PR DESCRIPTION
`RewardPools` are currently not being decoded on Westend. This may be because of a migration that was needed on `RewardPool` for new commission counter fields `total_commission_pending` and `total_commission_claimed`.

polkadot companion: https://github.com/paritytech/polkadot/pull/6957