### PR TITLE
BEEFY: gossip finality proofs

### DIFF
--- a/client/consensus/beefy/src/communication/gossip.rs
+++ b/client/consensus/beefy/src/communication/gossip.rs
@@ -28,10 +28,17 @@ use log::{debug, trace};
 use parking_lot::{Mutex, RwLock};
 use wasm_timer::Instant;
 
-use crate::{communication::peers::KnownPeers, keystore::BeefyKeystore, LOG_TARGET};
+use crate::{
+	communication::peers::KnownPeers,
+	justification::{
+		proof_block_num_and_set_id, verify_with_validator_set, BeefyVersionedFinalityProof,
+	},
+	keystore::BeefyKeystore,
+	LOG_TARGET,
+};
 use sp_consensus_beefy::{
-	crypto::{Public, Signature},
-	SignedCommitment, ValidatorSetId, VoteMessage,
+	crypto::{AuthorityId, Signature},
+	ValidatorSet, ValidatorSetId, VoteMessage,
 };
 
 // Timeout for rebroadcasting messages.
@@ -44,9 +51,9 @@ const REBROADCAST_AFTER: Duration = Duration::from_secs(5);
 #[derive(Debug, Encode, Decode)]
 pub(crate) enum GossipMessage<B: Block> {
 	/// BEEFY message with commitment and single signature.
-	Vote(VoteMessage<NumberFor<B>, Public, Signature>),
+	Vote(VoteMessage<NumberFor<B>, AuthorityId, Signature>),
 	/// BEEFY justification with commitment and signatures.
-	SignedCommitment(SignedCommitment<NumberFor<B>, Signature>),
+	FinalityProof(BeefyVersionedFinalityProof<B>),
 }
 
 /// Gossip engine votes messages topic
@@ -58,58 +65,73 @@ where
 }
 
 /// Gossip engine justifications messages topic
-pub(crate) fn justifs_topic<B: Block>() -> B::Hash
+pub(crate) fn proofs_topic<B: Block>() -> B::Hash
 where
 	B: Block,
 {
 	<<B::Header as Header>::Hashing as Hash>::hash(b"beefy-justifications")
 }
 
-#[derive(Debug)]
-pub(crate) struct GossipVoteFilter<B: Block> {
+#[derive(Clone, Debug)]
+pub(crate) struct GossipFilter<B: Block> {
 	pub start: NumberFor<B>,
 	pub end: NumberFor<B>,
-	pub validator_set_id: ValidatorSetId,
+	pub validator_set: ValidatorSet<AuthorityId>,
 }
 
 /// A type that represents hash of the message.
 pub type MessageHash = [u8; 8];
 
-struct GossipFilter<B: Block> {
-	filter: Option<GossipVoteFilter<B>>,
-	live: BTreeMap<NumberFor<B>, fnv::FnvHashSet<MessageHash>>,
+struct Filter<B: Block> {
+	filter: Option<GossipFilter<B>>,
+	live_votes: BTreeMap<NumberFor<B>, fnv::FnvHashSet<MessageHash>>,
 }
 
-impl<B: Block> GossipFilter<B> {
+impl<B: Block> Filter<B> {
 	pub fn new() -> Self {
-		Self { filter: None, live: BTreeMap::new() }
+		Self { filter: None, live_votes: BTreeMap::new() }
 	}
 
 	/// Update filter to new `start` and `set_id`.
-	fn update(&mut self, filter: GossipVoteFilter<B>) {
-		self.live.retain(|&round, _| round >= filter.start && round <= filter.end);
+	fn update(&mut self, filter: GossipFilter<B>) {
+		self.live_votes.retain(|&round, _| round >= filter.start && round <= filter.end);
 		self.filter = Some(filter);
 	}
 
-	/// Return true if `round` is >= than `max(session_start, best_beefy)`,
-	/// and vote set id matches session set id.
+	/// Return true if `max(session_start, best_beefy) <= round <= best_grandpa`,
+	/// and vote `set_id` matches session set id.
 	///
 	/// Latest concluded round is still considered alive to allow proper gossiping for it.
-	fn is_live(&self, round: NumberFor<B>, set_id: ValidatorSetId) -> bool {
+	fn is_vote_accepted(&self, round: NumberFor<B>, set_id: ValidatorSetId) -> bool {
 		self.filter
 			.as_ref()
-			.map(|f| set_id == f.validator_set_id && round >= f.start && round <= f.end)
+			.map(|f| set_id == f.validator_set.id() && round >= f.start && round <= f.end)
+			.unwrap_or(false)
+	}
+
+	/// Return true if `round` is >= than `max(session_start, best_beefy)`,
+	/// and proof `set_id` matches session set id.
+	///
+	/// Latest concluded round is still considered alive to allow proper gossiping for it.
+	fn is_finality_proof_accepted(&self, round: NumberFor<B>, set_id: ValidatorSetId) -> bool {
+		self.filter
+			.as_ref()
+			.map(|f| set_id == f.validator_set.id() && round >= f.start)
 			.unwrap_or(false)
 	}
 
 	/// Add new _known_ `hash` to the round's known votes.
-	fn add_known(&mut self, round: NumberFor<B>, hash: MessageHash) {
-		self.live.entry(round).or_default().insert(hash);
+	fn add_known_vote(&mut self, round: NumberFor<B>, hash: MessageHash) {
+		self.live_votes.entry(round).or_default().insert(hash);
 	}
 
 	/// Check if `hash` is already part of round's known votes.
-	fn is_known(&self, round: NumberFor<B>, hash: &MessageHash) -> bool {
-		self.live.get(&round).map(|known| known.contains(hash)).unwrap_or(false)
+	fn is_known_vote(&self, round: NumberFor<B>, hash: &MessageHash) -> bool {
+		self.live_votes.get(&round).map(|known| known.contains(hash)).unwrap_or(false)
+	}
+
+	fn gossip_filter(&self) -> Option<GossipFilter<B>> {
+		self.filter.clone()
 	}
 }
 
@@ -127,7 +149,7 @@ where
 {
 	votes_topic: B::Hash,
 	justifs_topic: B::Hash,
-	gossip_filter: RwLock<GossipFilter<B>>,
+	gossip_filter: RwLock<Filter<B>>,
 	next_rebroadcast: Mutex<Instant>,
 	known_peers: Arc<Mutex<KnownPeers<B>>>,
 }
@@ -139,8 +161,8 @@ where
 	pub fn new(known_peers: Arc<Mutex<KnownPeers<B>>>) -> GossipValidator<B> {
 		GossipValidator {
 			votes_topic: votes_topic::<B>(),
-			justifs_topic: justifs_topic::<B>(),
-			gossip_filter: RwLock::new(GossipFilter::new()),
+			justifs_topic: proofs_topic::<B>(),
+			gossip_filter: RwLock::new(Filter::new()),
 			next_rebroadcast: Mutex::new(Instant::now() + REBROADCAST_AFTER),
 			known_peers,
 		}
@@ -149,9 +171,81 @@ where
 	/// Update gossip validator filter.
 	///
 	/// Only votes for `set_id` and rounds `start <= round <= end` will be accepted.
-	pub(crate) fn update_filter(&self, filter: GossipVoteFilter<B>) {
+	pub(crate) fn update_filter(&self, filter: GossipFilter<B>) {
 		debug!(target: LOG_TARGET, "🥩 New gossip filter {:?}", filter);
 		self.gossip_filter.write().update(filter);
+	}
+
+	fn validate_vote(
+		&self,
+		vote: VoteMessage<NumberFor<B>, AuthorityId, Signature>,
+		sender: &PeerId,
+		data: &[u8],
+	) -> ValidationResult<B::Hash> {
+		let msg_hash = twox_64(data);
+		let round = vote.commitment.block_number;
+		let set_id = vote.commitment.validator_set_id;
+		self.known_peers.lock().note_vote_for(*sender, round);
+
+		// Verify general usefulness of the message.
+		// We are going to discard old votes right away (without verification)
+		// Also we keep track of already received votes to avoid verifying duplicates.
+		{
+			let filter = self.gossip_filter.read();
+
+			if !filter.is_vote_accepted(round, set_id) {
+				return ValidationResult::Discard
+			}
+
+			if filter.is_known_vote(round, &msg_hash) {
+				return ValidationResult::ProcessAndKeep(self.votes_topic)
+			}
+		}
+
+		if BeefyKeystore::verify(&vote.id, &vote.signature, &vote.commitment.encode()) {
+			self.gossip_filter.write().add_known_vote(round, msg_hash);
+			ValidationResult::ProcessAndKeep(self.votes_topic)
+		} else {
+			// TODO: report peer
+			debug!(
+				target: LOG_TARGET,
+				"🥩 Bad signature on message: {:?}, from: {:?}", vote, sender
+			);
+			ValidationResult::Discard
+		}
+	}
+
+	fn validate_finality_proof(
+		&self,
+		proof: BeefyVersionedFinalityProof<B>,
+		sender: &PeerId,
+	) -> ValidationResult<B::Hash> {
+		let (round, set_id) = proof_block_num_and_set_id::<B>(&proof);
+		self.known_peers.lock().note_vote_for(*sender, round);
+
+		let filter = if let Some(filter) = self.gossip_filter.read().gossip_filter() {
+			filter
+		} else {
+			return ValidationResult::Discard
+		};
+		// Verify general usefulness of the justifications.
+		// We are going to discard old justifications right away (without verification).
+		// We are going to accept only justifications for current set id.
+		if set_id != filter.validator_set.id() || round < filter.start {
+			return ValidationResult::Discard
+		}
+
+		// Verify justification signatures.
+		if let Ok(()) = verify_with_validator_set::<B>(round, &filter.validator_set, &proof) {
+			ValidationResult::ProcessAndKeep(self.justifs_topic)
+		} else {
+			// TODO: report peer
+			debug!(
+				target: LOG_TARGET,
+				"🥩 Bad signatures on message: {:?}, from: {:?}", proof, sender
+			);
+			ValidationResult::Discard
+		}
 	}
 }
 
@@ -170,40 +264,8 @@ where
 		mut data: &[u8],
 	) -> ValidationResult<B::Hash> {
 		match GossipMessage::<B>::decode(&mut data) {
-			Ok(GossipMessage::Vote(msg)) => {
-				let msg_hash = twox_64(data);
-				let round = msg.commitment.block_number;
-				let set_id = msg.commitment.validator_set_id;
-				self.known_peers.lock().note_vote_for(*sender, round);
-
-				// Verify general usefulness of the message.
-				// We are going to discard old votes right away (without verification)
-				// Also we keep track of already received votes to avoid verifying duplicates.
-				{
-					let filter = self.gossip_filter.read();
-
-					if !filter.is_live(round, set_id) {
-						return ValidationResult::Discard
-					}
-
-					if filter.is_known(round, &msg_hash) {
-						return ValidationResult::ProcessAndKeep(self.votes_topic)
-					}
-				}
-
-				if BeefyKeystore::verify(&msg.id, &msg.signature, &msg.commitment.encode()) {
-					self.gossip_filter.write().add_known(round, msg_hash);
-					ValidationResult::ProcessAndKeep(self.votes_topic)
-				} else {
-					// TODO: report peer
-					debug!(
-						target: LOG_TARGET,
-						"🥩 Bad signature on message: {:?}, from: {:?}", msg, sender
-					);
-					ValidationResult::Discard
-				}
-			},
-			Ok(GossipMessage::SignedCommitment(_justification)) => ValidationResult::Discard,
+			Ok(GossipMessage::Vote(msg)) => self.validate_vote(msg, sender, data),
+			Ok(GossipMessage::FinalityProof(proof)) => self.validate_finality_proof(proof, sender),
 			Err(e) => {
 				debug!(target: LOG_TARGET, "Error decoding message: {}", e);
 				ValidationResult::Discard
@@ -217,18 +279,21 @@ where
 			Ok(GossipMessage::Vote(msg)) => {
 				let round = msg.commitment.block_number;
 				let set_id = msg.commitment.validator_set_id;
-				let expired = !filter.is_live(round, set_id);
-
+				let expired = !filter.is_vote_accepted(round, set_id);
+				trace!(target: LOG_TARGET, "🥩 Vote for round #{} expired: {}", round, expired);
+				expired
+			},
+			Ok(GossipMessage::FinalityProof(proof)) => {
+				let (round, set_id) = proof_block_num_and_set_id::<B>(&proof);
+				let expired = !filter.is_finality_proof_accepted(round, set_id);
 				trace!(
 					target: LOG_TARGET,
-					"🥩 Vote message for round #{} expired: {}",
+					"🥩 Finality proof for round #{} expired: {}",
 					round,
 					expired
 				);
-
 				expired
 			},
-			Ok(GossipMessage::SignedCommitment(_justification)) => true,
 			Err(_) => true,
 		})
 	}
@@ -258,18 +323,21 @@ where
 				Ok(GossipMessage::Vote(msg)) => {
 					let round = msg.commitment.block_number;
 					let set_id = msg.commitment.validator_set_id;
-					let allowed = filter.is_live(round, set_id);
-
+					let allowed = filter.is_vote_accepted(round, set_id);
+					trace!(target: LOG_TARGET, "🥩 Vote for round #{} allowed: {}", round, allowed);
+					allowed
+				},
+				Ok(GossipMessage::FinalityProof(proof)) => {
+					let (round, set_id) = proof_block_num_and_set_id::<B>(&proof);
+					let allowed = filter.is_finality_proof_accepted(round, set_id);
 					trace!(
 						target: LOG_TARGET,
-						"🥩 Message for round #{} allowed: {}",
+						"🥩 Finality proof for round #{} allowed: {}",
 						round,
 						allowed
 					);
-
 					allowed
 				},
-				Ok(GossipMessage::SignedCommitment(_justification)) => false,
 				Err(_) => false,
 			}
 		})
@@ -282,40 +350,43 @@ mod tests {
 	use crate::keystore::BeefyKeystore;
 	use sc_network_test::Block;
 	use sp_consensus_beefy::{
-		crypto::Signature, known_payloads, Commitment, Keyring, MmrRootHash, Payload, VoteMessage,
-		KEY_TYPE,
+		crypto::Signature, known_payloads, Commitment, Keyring, MmrRootHash, Payload,
+		SignedCommitment, VoteMessage, KEY_TYPE,
 	};
 	use sp_keystore::{testing::MemoryKeystore, Keystore};
 
 	#[test]
 	fn known_votes_insert_remove() {
-		let mut filter = GossipFilter::<Block>::new();
+		let mut filter = Filter::<Block>::new();
 		let msg_hash = twox_64(b"data");
+		let keys = vec![Keyring::Alice.public()];
+		let validator_set = ValidatorSet::<AuthorityId>::new(keys.clone(), 1).unwrap();
 
-		filter.add_known(1, msg_hash);
-		filter.add_known(1, msg_hash);
-		filter.add_known(2, msg_hash);
-		assert_eq!(filter.live.len(), 2);
+		filter.add_known_vote(1, msg_hash);
+		filter.add_known_vote(1, msg_hash);
+		filter.add_known_vote(2, msg_hash);
+		assert_eq!(filter.live_votes.len(), 2);
 
-		filter.add_known(3, msg_hash);
-		assert!(filter.is_known(3, &msg_hash));
-		assert!(!filter.is_known(3, &twox_64(b"other")));
-		assert!(!filter.is_known(4, &msg_hash));
-		assert_eq!(filter.live.len(), 3);
+		filter.add_known_vote(3, msg_hash);
+		assert!(filter.is_known_vote(3, &msg_hash));
+		assert!(!filter.is_known_vote(3, &twox_64(b"other")));
+		assert!(!filter.is_known_vote(4, &msg_hash));
+		assert_eq!(filter.live_votes.len(), 3);
 
 		assert!(filter.filter.is_none());
-		assert!(!filter.is_live(1, 1));
+		assert!(!filter.is_vote_accepted(1, 1));
 
-		filter.update(GossipVoteFilter { start: 3, end: 10, validator_set_id: 1 });
-		assert_eq!(filter.live.len(), 1);
-		assert!(filter.live.contains_key(&3));
-		assert!(!filter.is_live(2, 1));
-		assert!(filter.is_live(3, 1));
-		assert!(filter.is_live(4, 1));
-		assert!(!filter.is_live(4, 2));
+		filter.update(GossipFilter { start: 3, end: 10, validator_set });
+		assert_eq!(filter.live_votes.len(), 1);
+		assert!(filter.live_votes.contains_key(&3));
+		assert!(!filter.is_vote_accepted(2, 1));
+		assert!(filter.is_vote_accepted(3, 1));
+		assert!(filter.is_vote_accepted(4, 1));
+		assert!(!filter.is_vote_accepted(4, 2));
 
-		filter.update(GossipVoteFilter { start: 5, end: 10, validator_set_id: 2 });
-		assert!(filter.live.is_empty());
+		let validator_set = ValidatorSet::<AuthorityId>::new(keys, 2).unwrap();
+		filter.update(GossipFilter { start: 5, end: 10, validator_set });
+		assert!(filter.live_votes.is_empty());
 	}
 
 	struct TestContext;
@@ -344,7 +415,7 @@ mod tests {
 		beefy_keystore.sign(&who.public(), &commitment.encode()).unwrap()
 	}
 
-	fn dummy_vote(block_number: u64) -> VoteMessage<u64, Public, Signature> {
+	fn dummy_vote(block_number: u64) -> VoteMessage<u64, AuthorityId, Signature> {
 		let payload = Payload::from_single_entry(
 			known_payloads::MMR_ROOT_ID,
 			MmrRootHash::default().encode(),
@@ -355,10 +426,32 @@ mod tests {
 		VoteMessage { commitment, id: Keyring::Alice.public(), signature }
 	}
 
+	fn dummy_proof(
+		block_number: u64,
+		validator_set: &ValidatorSet<AuthorityId>,
+	) -> BeefyVersionedFinalityProof<Block> {
+		let payload = Payload::from_single_entry(
+			known_payloads::MMR_ROOT_ID,
+			MmrRootHash::default().encode(),
+		);
+		let commitment = Commitment { payload, block_number, validator_set_id: validator_set.id() };
+		let signatures = validator_set
+			.validators()
+			.iter()
+			.map(|validator: &AuthorityId| {
+				Some(sign_commitment(&Keyring::from_public(validator).unwrap(), &commitment))
+			})
+			.collect();
+
+		BeefyVersionedFinalityProof::<Block>::V1(SignedCommitment { commitment, signatures })
+	}
+
 	#[test]
-	fn should_avoid_verifying_signatures_twice() {
+	fn should_validate_messages() {
+		let keys = vec![Keyring::Alice.public()];
+		let validator_set = ValidatorSet::<AuthorityId>::new(keys.clone(), 0).unwrap();
 		let gv = GossipValidator::<Block>::new(Arc::new(Mutex::new(KnownPeers::new())));
-		gv.update_filter(GossipVoteFilter { start: 0, end: 10, validator_set_id: 0 });
+		gv.update_filter(GossipFilter { start: 0, end: 10, validator_set: validator_set.clone() });
 		let sender = sc_network::PeerId::random();
 		let mut context = TestContext;
 
@@ -370,37 +463,74 @@ mod tests {
 
 		assert!(matches!(res, ValidationResult::ProcessAndKeep(_)));
 		assert_eq!(
-			gv.gossip_filter.read().live.get(&vote.commitment.block_number).map(|x| x.len()),
+			gv.gossip_filter
+				.read()
+				.live_votes
+				.get(&vote.commitment.block_number)
+				.map(|x| x.len()),
 			Some(1)
 		);
 
 		// second time we should hit the cache
 		let res = gv.validate(&mut context, &sender, &gossip_vote.encode());
-
 		assert!(matches!(res, ValidationResult::ProcessAndKeep(_)));
 
 		// next we should quickly reject if the round is not live
-		gv.update_filter(GossipVoteFilter { start: 7, end: 10, validator_set_id: 0 });
+		gv.update_filter(GossipFilter { start: 7, end: 10, validator_set: validator_set.clone() });
 
 		let number = vote.commitment.block_number;
 		let set_id = vote.commitment.validator_set_id;
-		assert!(!gv.gossip_filter.read().is_live(number, set_id));
+		assert!(!gv.gossip_filter.read().is_vote_accepted(number, set_id));
 
 		let res = gv.validate(&mut context, &sender, &vote.encode());
+		assert!(matches!(res, ValidationResult::Discard));
 
+		// reject old proof
+		let proof = dummy_proof(5, &validator_set);
+		let encoded_proof = GossipMessage::<Block>::FinalityProof(proof).encode();
+		let res = gv.validate(&mut context, &sender, &encoded_proof);
+		assert!(matches!(res, ValidationResult::Discard));
+
+		// accept next proof with good set_id
+		let proof = dummy_proof(7, &validator_set);
+		let encoded_proof = GossipMessage::<Block>::FinalityProof(proof).encode();
+		let res = gv.validate(&mut context, &sender, &encoded_proof);
+		assert!(matches!(res, ValidationResult::ProcessAndKeep(_)));
+
+		// accept future proof with good set_id
+		let proof = dummy_proof(20, &validator_set);
+		let encoded_proof = GossipMessage::<Block>::FinalityProof(proof).encode();
+		let res = gv.validate(&mut context, &sender, &encoded_proof);
+		assert!(matches!(res, ValidationResult::ProcessAndKeep(_)));
+
+		// reject proof, wrong set_id
+		let bad_validator_set = ValidatorSet::<AuthorityId>::new(keys, 1).unwrap();
+		let proof = dummy_proof(20, &bad_validator_set);
+		let encoded_proof = GossipMessage::<Block>::FinalityProof(proof).encode();
+		let res = gv.validate(&mut context, &sender, &encoded_proof);
+		assert!(matches!(res, ValidationResult::Discard));
+
+		// reject proof, bad signatures (Bob instead of Alice)
+		let bad_validator_set =
+			ValidatorSet::<AuthorityId>::new(vec![Keyring::Bob.public()], 0).unwrap();
+		let proof = dummy_proof(20, &bad_validator_set);
+		let encoded_proof = GossipMessage::<Block>::FinalityProof(proof).encode();
+		let res = gv.validate(&mut context, &sender, &encoded_proof);
 		assert!(matches!(res, ValidationResult::Discard));
 	}
 
 	#[test]
 	fn messages_allowed_and_expired() {
+		let keys = vec![Keyring::Alice.public()];
+		let validator_set = ValidatorSet::<AuthorityId>::new(keys.clone(), 0).unwrap();
 		let gv = GossipValidator::<Block>::new(Arc::new(Mutex::new(KnownPeers::new())));
-		gv.update_filter(GossipVoteFilter { start: 0, end: 10, validator_set_id: 0 });
+		gv.update_filter(GossipFilter { start: 0, end: 10, validator_set: validator_set.clone() });
 		let sender = sc_network::PeerId::random();
 		let topic = Default::default();
 		let intent = MessageIntent::Broadcast;
 
 		// conclude 2
-		gv.update_filter(GossipVoteFilter { start: 2, end: 10, validator_set_id: 0 });
+		gv.update_filter(GossipFilter { start: 2, end: 10, validator_set: validator_set.clone() });
 		let mut allowed = gv.message_allowed();
 		let mut expired = gv.message_expired();
 
@@ -413,30 +543,65 @@ mod tests {
 		let mut encoded_vote = GossipMessage::<Block>::Vote(vote).encode();
 		assert!(!allowed(&sender, intent, &topic, &mut encoded_vote));
 		assert!(expired(topic, &mut encoded_vote));
+		let proof = dummy_proof(1, &validator_set);
+		let mut encoded_proof = GossipMessage::<Block>::FinalityProof(proof).encode();
+		assert!(!allowed(&sender, intent, &topic, &mut encoded_proof));
+		assert!(expired(topic, &mut encoded_proof));
 
 		// active round 2 -> !expired - concluded but still gossiped
 		let vote = dummy_vote(2);
 		let mut encoded_vote = GossipMessage::<Block>::Vote(vote).encode();
 		assert!(allowed(&sender, intent, &topic, &mut encoded_vote));
 		assert!(!expired(topic, &mut encoded_vote));
+		let proof = dummy_proof(2, &validator_set);
+		let mut encoded_proof = GossipMessage::<Block>::FinalityProof(proof).encode();
+		assert!(allowed(&sender, intent, &topic, &mut encoded_proof));
+		assert!(!expired(topic, &mut encoded_proof));
+		// using wrong set_id -> !allowed, expired
+		let bad_validator_set = ValidatorSet::<AuthorityId>::new(keys.clone(), 1).unwrap();
+		let proof = dummy_proof(2, &bad_validator_set);
+		let mut encoded_proof = GossipMessage::<Block>::FinalityProof(proof).encode();
+		assert!(!allowed(&sender, intent, &topic, &mut encoded_proof));
+		assert!(expired(topic, &mut encoded_proof));
 
 		// in progress round 3 -> !expired
 		let vote = dummy_vote(3);
 		let mut encoded_vote = GossipMessage::<Block>::Vote(vote).encode();
 		assert!(allowed(&sender, intent, &topic, &mut encoded_vote));
 		assert!(!expired(topic, &mut encoded_vote));
+		let proof = dummy_proof(3, &validator_set);
+		let mut encoded_proof = GossipMessage::<Block>::FinalityProof(proof).encode();
+		assert!(allowed(&sender, intent, &topic, &mut encoded_proof));
+		assert!(!expired(topic, &mut encoded_proof));
 
 		// unseen round 4 -> !expired
-		let vote = dummy_vote(3);
+		let vote = dummy_vote(4);
 		let mut encoded_vote = GossipMessage::<Block>::Vote(vote).encode();
 		assert!(allowed(&sender, intent, &topic, &mut encoded_vote));
 		assert!(!expired(topic, &mut encoded_vote));
+		let proof = dummy_proof(4, &validator_set);
+		let mut encoded_proof = GossipMessage::<Block>::FinalityProof(proof).encode();
+		assert!(allowed(&sender, intent, &topic, &mut encoded_proof));
+		assert!(!expired(topic, &mut encoded_proof));
+
+		// future round 11 -> expired
+		let vote = dummy_vote(11);
+		let mut encoded_vote = GossipMessage::<Block>::Vote(vote).encode();
+		assert!(!allowed(&sender, intent, &topic, &mut encoded_vote));
+		assert!(expired(topic, &mut encoded_vote));
+		// future proofs allowed while same set_id -> allowed
+		let proof = dummy_proof(11, &validator_set);
+		let mut encoded_proof = GossipMessage::<Block>::FinalityProof(proof).encode();
+		assert!(allowed(&sender, intent, &topic, &mut encoded_proof));
+		assert!(!expired(topic, &mut encoded_proof));
 	}
 
 	#[test]
 	fn messages_rebroadcast() {
+		let keys = vec![Keyring::Alice.public()];
+		let validator_set = ValidatorSet::<AuthorityId>::new(keys.clone(), 0).unwrap();
 		let gv = GossipValidator::<Block>::new(Arc::new(Mutex::new(KnownPeers::new())));
-		gv.update_filter(GossipVoteFilter { start: 0, end: 10, validator_set_id: 0 });
+		gv.update_filter(GossipFilter { start: 0, end: 10, validator_set });
 		let sender = sc_network::PeerId::random();
 		let topic = Default::default();
 

--- a/client/consensus/beefy/src/communication/gossip.rs
+++ b/client/consensus/beefy/src/communication/gossip.rs
@@ -345,7 +345,7 @@ where
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
 	use super::*;
 	use crate::keystore::BeefyKeystore;
 	use sc_network_test::Block;
@@ -426,7 +426,7 @@ mod tests {
 		VoteMessage { commitment, id: Keyring::Alice.public(), signature }
 	}
 
-	fn dummy_proof(
+	pub fn dummy_proof(
 		block_number: u64,
 		validator_set: &ValidatorSet<AuthorityId>,
 	) -> BeefyVersionedFinalityProof<Block> {

--- a/client/consensus/beefy/src/communication/mod.rs
+++ b/client/consensus/beefy/src/communication/mod.rs
@@ -29,7 +29,7 @@ pub(crate) mod beefy_protocol_name {
 	use sc_network::ProtocolName;
 
 	/// BEEFY votes gossip protocol name suffix.
-	const GOSSIP_NAME: &str = "/beefy/1";
+	const GOSSIP_NAME: &str = "/beefy/2";
 	/// BEEFY justifications protocol name suffix.
 	const JUSTIFICATIONS_NAME: &str = "/beefy/justifications/1";
 
@@ -86,7 +86,7 @@ mod tests {
 		let genesis_hash = H256::random();
 		let genesis_hex = array_bytes::bytes2hex("", genesis_hash.as_ref());
 
-		let expected_gossip_name = format!("/{}/beefy/1", genesis_hex);
+		let expected_gossip_name = format!("/{}/beefy/2", genesis_hex);
 		let gossip_proto_name = gossip_protocol_name(&genesis_hash, None);
 		assert_eq!(gossip_proto_name.to_string(), expected_gossip_name);
 
@@ -101,7 +101,7 @@ mod tests {
 		];
 		let genesis_hex = "32043c7b3a6ad8f6c2bc8bc121d4caab09377b5e082b0cfbbb39ad13bc4acd93";
 
-		let expected_gossip_name = format!("/{}/beefy/1", genesis_hex);
+		let expected_gossip_name = format!("/{}/beefy/2", genesis_hex);
 		let gossip_proto_name = gossip_protocol_name(&genesis_hash, None);
 		assert_eq!(gossip_proto_name.to_string(), expected_gossip_name);
 

--- a/client/consensus/beefy/src/tests.rs
+++ b/client/consensus/beefy/src/tests.rs
@@ -21,15 +21,16 @@
 use crate::{
 	aux_schema::{load_persistent, tests::verify_persisted_version},
 	beefy_block_import_and_links,
-	communication::request_response::{
-		on_demand_justifications_protocol_config, BeefyJustifsRequestHandler,
+	communication::{
+		gossip::{proofs_topic, GossipFilter, GossipMessage},
+		request_response::{on_demand_justifications_protocol_config, BeefyJustifsRequestHandler},
 	},
 	gossip_protocol_name,
 	justification::*,
 	load_or_init_voter_state, wait_for_runtime_pallet, BeefyRPCLinks, BeefyVoterLinks, KnownPeers,
 	PersistedState,
 };
-use futures::{future, stream::FuturesUnordered, Future, StreamExt};
+use futures::{future, stream::FuturesUnordered, Future, FutureExt, StreamExt};
 use parking_lot::Mutex;
 use sc_client_api::{Backend as BackendT, BlockchainEvents, FinalityNotifications, HeaderBackend};
 use sc_consensus::{
@@ -57,7 +58,7 @@ use sp_core::H256;
 use sp_keystore::{testing::MemoryKeystore, Keystore, KeystorePtr};
 use sp_mmr_primitives::{Error as MmrError, MmrApi};
 use sp_runtime::{
-	codec::Encode,
+	codec::{Decode, Encode},
 	traits::{Header as HeaderT, NumberFor},
 	BuildStorage, DigestItem, EncodedJustification, Justifications, Storage,
 };
@@ -503,16 +504,15 @@ async fn wait_for_beefy_signed_commitments(
 	run_until(wait_for, net).await;
 }
 
-async fn streams_empty_after_timeout<T>(
+async fn streams_empty_after_future<T>(
 	streams: Vec<NotificationReceiver<T>>,
-	net: &Arc<Mutex<BeefyTestNet>>,
-	timeout: Option<Duration>,
+	future: Option<impl Future + Unpin>,
 ) where
 	T: std::fmt::Debug,
 	T: std::cmp::PartialEq,
 {
-	if let Some(timeout) = timeout {
-		run_for(timeout, net).await;
+	if let Some(future) = future {
+		future.await;
 	}
 	for mut stream in streams.into_iter() {
 		future::poll_fn(move |cx| {
@@ -521,6 +521,18 @@ async fn streams_empty_after_timeout<T>(
 		})
 		.await;
 	}
+}
+
+async fn streams_empty_after_timeout<T>(
+	streams: Vec<NotificationReceiver<T>>,
+	net: &Arc<Mutex<BeefyTestNet>>,
+	timeout: Option<Duration>,
+) where
+	T: std::fmt::Debug,
+	T: std::cmp::PartialEq,
+{
+	let timeout = timeout.map(|timeout| Box::pin(run_for(timeout, net)));
+	streams_empty_after_future(streams, timeout).await;
 }
 
 async fn finalize_block_and_wait_for_beefy(
@@ -1228,4 +1240,113 @@ async fn beefy_reports_equivocations() {
 	let equivocation_proof = alice_reported_equivocations.get(0).unwrap();
 	assert_eq!(equivocation_proof.first.id, BeefyKeyring::Bob.public());
 	assert_eq!(equivocation_proof.first.commitment.block_number, 1);
+}
+
+#[tokio::test]
+async fn gossipped_finality_proofs() {
+	sp_tracing::try_init_simple();
+
+	let validators = [BeefyKeyring::Alice, BeefyKeyring::Bob, BeefyKeyring::Charlie];
+	// Only Alice and Bob are running the voter -> finality threshold not reached
+	let peers = [BeefyKeyring::Alice, BeefyKeyring::Bob];
+	let validator_set = ValidatorSet::new(make_beefy_ids(&validators), 0).unwrap();
+	let session_len = 30;
+	let min_block_delta = 1;
+
+	let mut net = BeefyTestNet::new(3);
+	let api = Arc::new(TestApi::with_validator_set(&validator_set));
+	let beefy_peers = peers.iter().enumerate().map(|(id, key)| (id, key, api.clone())).collect();
+
+	let charlie = &net.peers[2];
+	let known_peers = Arc::new(Mutex::new(KnownPeers::<Block>::new()));
+	// Charlie will run just the gossip engine and not the full voter.
+	let charlie_gossip_validator =
+		Arc::new(crate::communication::gossip::GossipValidator::new(known_peers));
+	charlie_gossip_validator.update_filter(GossipFilter::<Block> {
+		start: 1,
+		end: 10,
+		validator_set: validator_set.clone(),
+	});
+	let mut charlie_gossip_engine = sc_network_gossip::GossipEngine::new(
+		charlie.network_service().clone(),
+		charlie.sync_service().clone(),
+		beefy_gossip_proto_name(),
+		charlie_gossip_validator.clone(),
+		None,
+	);
+
+	// Alice and Bob run full voter.
+	tokio::spawn(initialize_beefy(&mut net, beefy_peers, min_block_delta));
+
+	let net = Arc::new(Mutex::new(net));
+
+	// Pump net + Charlie gossip to see peers.
+	let timeout = Box::pin(tokio::time::sleep(Duration::from_millis(200)));
+	let gossip_engine_pump = &mut charlie_gossip_engine;
+	let pump_with_timeout = future::select(gossip_engine_pump, timeout);
+	run_until(pump_with_timeout, &net).await;
+
+	// push 10 blocks
+	let hashes = net.lock().generate_blocks_and_sync(10, session_len, &validator_set, true).await;
+
+	let peers = peers.into_iter().enumerate();
+
+	// Alice, Bob and Charlie finalize #2, Alice and Bob vote on it, but not Charlie.
+	let finalize = hashes[1];
+	let (best_blocks, versioned_finality_proof) = get_beefy_streams(&mut net.lock(), peers.clone());
+	net.lock().peer(0).client().as_client().finalize_block(finalize, None).unwrap();
+	net.lock().peer(1).client().as_client().finalize_block(finalize, None).unwrap();
+	net.lock().peer(2).client().as_client().finalize_block(finalize, None).unwrap();
+	// verify nothing gets finalized by BEEFY
+	let timeout = Box::pin(tokio::time::sleep(Duration::from_millis(100)));
+	let pump_net = futures::future::poll_fn(|cx| {
+		net.lock().poll(cx);
+		Poll::<()>::Pending
+	});
+	let pump_gossip = &mut charlie_gossip_engine;
+	let pump_with_timeout = future::select(pump_gossip, future::select(pump_net, timeout));
+	streams_empty_after_future(best_blocks, Some(pump_with_timeout)).await;
+	streams_empty_after_timeout(versioned_finality_proof, &net, None).await;
+
+	let (best_blocks, versioned_finality_proof) = get_beefy_streams(&mut net.lock(), peers.clone());
+	// Charlie gossips finality proof for #1 -> Alice and Bob also finalize.
+	let proof = crate::communication::gossip::tests::dummy_proof(1, &validator_set);
+	let gossip_proof = GossipMessage::<Block>::FinalityProof(proof);
+	let encoded_proof = gossip_proof.encode();
+	charlie_gossip_engine.gossip_message(proofs_topic::<Block>(), encoded_proof, true);
+	// Expect #1 is finalized.
+	wait_for_best_beefy_blocks(best_blocks, &net, &[1]).await;
+	wait_for_beefy_signed_commitments(versioned_finality_proof, &net, &[1]).await;
+
+	// Now verify Charlie also sees the gossipped proof.
+	let mut charlie_gossip_proofs = Box::pin(
+		charlie_gossip_engine
+			.messages_for(proofs_topic::<Block>())
+			.filter_map(|notification| async move {
+				GossipMessage::<Block>::decode(&mut &notification.message[..]).ok().and_then(
+					|message| match message {
+						GossipMessage::<Block>::Vote(_) => unreachable!(),
+						GossipMessage::<Block>::FinalityProof(proof) => Some(proof),
+					},
+				)
+			})
+			.fuse(),
+	);
+	let pump_net = futures::future::poll_fn(|cx| {
+		net.lock().poll(cx);
+		Poll::<()>::Pending
+	});
+	let mut gossip_engine = &mut charlie_gossip_engine;
+	futures::select! {
+		// pump gossip engine
+		_ = gossip_engine => unreachable!(),
+		// pump network
+		_ = pump_net.fuse() => unreachable!(),
+		// verify finality proof has been gossipped
+		proof = charlie_gossip_proofs.next() => {
+			let proof = proof.unwrap();
+			let (round, _) = proof_block_num_and_set_id::<Block>(&proof);
+			assert_eq!(round, 1);
+		},
+	}
 }


### PR DESCRIPTION
Adds gossiping BEEFY finality proofs to the BEEFY gossip protocol.

- bumps protocol version since message format is changed,
- gossip validator accepts finality proofs for rounds within current set_id with `round_num >= current_best_beefy`,
- gossip validator verifies incoming finality proofs - including signatures against validator set keys,
- finality proofs have their own topic,
- voter imports gossip finality proofs using same logic as block-import or on-demand finality proofs,
- after creating a vote, if finality threshold is reached, instead of gossiping newly created vote, the voter gossips finality proof containing `threshold` validator signatures.