### PR TITLE
refactor(sc-cli): make cli more generic for non-classic substrate cli

### DIFF
--- a/bin/node-template/node/src/command.rs
+++ b/bin/node-template/node/src/command.rs
@@ -6,14 +6,14 @@ use crate::{
 };
 use frame_benchmarking_cli::{BenchmarkCmd, ExtrinsicFactory, SUBSTRATE_REFERENCE_HARDWARE};
 use node_template_runtime::{Block, EXISTENTIAL_DEPOSIT};
-use sc_cli::{ChainSpec, RuntimeVersion, SubstrateCli};
+use sc_cli::{ChainSpec, CommonCli, RuntimeVersion, SubstrateCli};
 use sc_service::PartialComponents;
 use sp_keyring::Sr25519Keyring;
 
 #[cfg(feature = "try-runtime")]
 use try_runtime_cli::block_building_info::timestamp_with_aura_info;
 
-impl SubstrateCli for Cli {
+impl CommonCli for Cli {
 	fn impl_name() -> String {
 		"Substrate Node".into()
 	}
@@ -37,7 +37,9 @@ impl SubstrateCli for Cli {
 	fn copyright_start_year() -> i32 {
 		2017
 	}
+}
 
+impl SubstrateCli for Cli {
 	fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
 		Ok(match id {
 			"dev" => Box::new(chain_spec::development_config()?),
@@ -208,7 +210,7 @@ pub fn run() -> sc_cli::Result<()> {
 		},
 		None => {
 			let runner = cli.create_runner(&cli.run)?;
-			runner.run_node_until_exit(|config| async move {
+			runner.run_node_until_exit::<Cli, _, _>(|config| async move {
 				service::new_full(config).map_err(sc_cli::Error::Service)
 			})
 		},

--- a/bin/node/cli/src/command.rs
+++ b/bin/node/cli/src/command.rs
@@ -26,7 +26,7 @@ use frame_benchmarking_cli::*;
 use kitchensink_runtime::{ExistentialDeposit, RuntimeApi};
 use node_executor::ExecutorDispatch;
 use node_primitives::Block;
-use sc_cli::{ChainSpec, Result, RuntimeVersion, SubstrateCli};
+use sc_cli::{ChainSpec, CommonCli, Result, RuntimeVersion, SubstrateCli};
 use sc_service::PartialComponents;
 use sp_keyring::Sr25519Keyring;
 
@@ -38,7 +38,7 @@ use {
 	try_runtime_cli::block_building_info::substrate_info,
 };
 
-impl SubstrateCli for Cli {
+impl CommonCli for Cli {
 	fn impl_name() -> String {
 		"Substrate Node".into()
 	}
@@ -62,7 +62,9 @@ impl SubstrateCli for Cli {
 	fn copyright_start_year() -> i32 {
 		2017
 	}
+}
 
+impl SubstrateCli for Cli {
 	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
 		let spec = match id {
 			"" =>
@@ -92,7 +94,7 @@ pub fn run() -> Result<()> {
 	match &cli.subcommand {
 		None => {
 			let runner = cli.create_runner(&cli.run)?;
-			runner.run_node_until_exit(|config| async move {
+			runner.run_node_until_exit::<Cli, _, _>(|config| async move {
 				service::new_full(config, cli).map_err(sc_cli::Error::Service)
 			})
 		},

--- a/client/cli/src/commands/insert_key.rs
+++ b/client/cli/src/commands/insert_key.rs
@@ -93,6 +93,7 @@ fn to_vec<P: sp_core::Pair>(uri: &str, pass: Option<SecretString>) -> Result<Vec
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::{CommonCli, SubstrateCli};
 	use sc_service::{ChainSpec, ChainType, GenericChainSpec, NoExtension};
 	use sp_core::{sr25519::Pair, ByteArray, Pair as _};
 	use sp_keystore::Keystore;
@@ -100,7 +101,7 @@ mod tests {
 
 	struct Cli;
 
-	impl SubstrateCli for Cli {
+	impl CommonCli for Cli {
 		fn impl_name() -> String {
 			"test".into()
 		}
@@ -124,7 +125,9 @@ mod tests {
 		fn author() -> String {
 			"test".into()
 		}
+	}
 
+	impl SubstrateCli for Cli {
 		fn native_runtime_version(_: &Box<dyn ChainSpec>) -> &'static sp_version::RuntimeVersion {
 			unimplemented!("Not required in tests")
 		}

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -609,22 +609,20 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 
 		logger.init()?;
 
-		raise_fd_limit()
+		raise_fd_limit(RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT)
 	}
 }
 
 /// Raise the soft open file descriptor resource limit to the smaller of the
 /// kernel limit and the hard resource limit.
 ///
-/// Print warning log if fd limit is smaller than `RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT`
-pub fn raise_fd_limit() -> Result<()> {
+/// Print warning log if fd limit is smaller than `limit`
+pub fn raise_fd_limit(limit: u64) -> Result<()> {
 	if let Some(new_limit) = fdlimit::raise_fd_limit() {
-		if new_limit < RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT {
+		if new_limit < limit {
 			log::warn!(
 				"Low open file descriptor limit configured for the process. \
-					Current value: {:?}, recommended value: {:?}.",
-				new_limit,
-				RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT,
+					Current value: {new_limit}, recommended value: {limit}.",
 			);
 		}
 	}

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -609,12 +609,15 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 
 		logger.init()?;
 
-		check_fd_limit()
+		raise_fd_limit()
 	}
 }
 
-/// Warning if fd limit is smaller than `RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT`
-pub fn check_fd_limit() -> Result<()> {
+/// Raise the soft open file descriptor resource limit to the smaller of the
+/// kernel limit and the hard resource limit.
+///
+/// Print warning log if fd limit is smaller than `RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT`
+pub fn raise_fd_limit() -> Result<()> {
 	if let Some(new_limit) = fdlimit::raise_fd_limit() {
 		if new_limit < RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT {
 			log::warn!(

--- a/client/cli/src/error.rs
+++ b/client/cli/src/error.rs
@@ -45,11 +45,8 @@ pub enum Error {
 	#[error("Invalid input: {0}")]
 	Input(String),
 
-	#[error("Invalid listen multiaddress")]
-	InvalidListenMultiaddress,
-
 	#[error("Invalid URI; expecting either a secret URI or a public URI.")]
-	InvalidUri(crypto::PublicError),
+	InvalidUri(#[from] crypto::PublicError),
 
 	#[error("Signature is an invalid format.")]
 	SignatureFormatInvalid,
@@ -66,7 +63,7 @@ pub enum Error {
 	#[error("Key store operation failed")]
 	KeystoreOperation,
 
-	#[error("Key storage issue encountered")]
+	#[error("Key storage issue encountered: {0:?}")]
 	KeyStorage(#[from] sc_keystore::Error),
 
 	#[error("Invalid hexadecimal string data, {0:?}")]
@@ -89,12 +86,6 @@ impl From<&str> for Error {
 impl From<String> for Error {
 	fn from(s: String) -> Error {
 		Error::Input(s)
-	}
-}
-
-impl From<crypto::PublicError> for Error {
-	fn from(e: crypto::PublicError) -> Error {
-		Error::InvalidUri(e)
 	}
 }
 

--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -200,7 +200,8 @@ pub trait CommonCli: Sized {
 ///
 /// This trait needs to be implemented on the root CLI struct of the application. It will provide
 /// the implementation `name`, `version`, `executable name`, `description`, `author`, `support_url`,
-/// `copyright start year` and most importantly: how to load the chain spec.
+/// `copyright start year` and most importantly:
+/// how to load the chain spec and create substrate node runner.
 pub trait SubstrateCli: CommonCli {
 	/// Native runtime version.
 	fn native_runtime_version(chain_spec: &Box<dyn ChainSpec>) -> &'static RuntimeVersion;

--- a/client/cli/src/params/keystore_params.rs
+++ b/client/cli/src/params/keystore_params.rs
@@ -87,7 +87,7 @@ impl KeystoreParams {
 	}
 
 	/// helper method to fetch password from `KeyParams` or read from stdin
-	pub fn read_password(&self) -> error::Result<Option<SecretString>> {
+	pub fn read_password(&self) -> Result<Option<SecretString>> {
 		let (password_interactive, password) = (self.password_interactive, self.password.clone());
 
 		let pass = if password_interactive {

--- a/client/cli/src/params/keystore_params.rs
+++ b/client/cli/src/params/keystore_params.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{error, error::Result};
+use crate::error::Result;
 use clap::Args;
 use sc_service::config::KeystoreConfig;
 use sp_core::crypto::SecretString;

--- a/client/cli/src/runner.rs
+++ b/client/cli/src/runner.rs
@@ -65,7 +65,9 @@ impl<Cfg> Runner<Cfg> {
 		F: Future<Output = std::result::Result<TaskManager, E>>,
 		E: std::error::Error + Send + Sync + 'static + From<ServiceError>,
 	{
-		let mut task_manager = self.tokio_runtime.block_on(initialize(self.config, self.tokio_runtime.handle().clone()))?;
+		let mut task_manager = self
+			.tokio_runtime
+			.block_on(initialize(self.config, self.tokio_runtime.handle().clone()))?;
 
 		let res = self
 			.tokio_runtime

--- a/client/cli/src/runner.rs
+++ b/client/cli/src/runner.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{error::Error as CliError, Result, Signals, SubstrateCli};
+use crate::{error::Error as CliError, CommonCli, Result, Signals, SubstrateCli};
 use chrono::prelude::*;
 use futures::{future::FutureExt, Future};
 use log::info;
@@ -189,9 +189,7 @@ impl Runner<Configuration> {
 /// 2020-06-03 16:14:21 ⛓  Native runtime: node-251 (substrate-node-1.tx1.au10)
 /// ```
 pub fn print_node_infos<C: SubstrateCli>(config: &Configuration) {
-	info!("{}", C::impl_name());
-	info!("✌️  version {}", C::impl_version());
-	info!("❤️  by {}, {}-{}", C::author(), C::copyright_start_year(), Local::now().year());
+	print_common_infos::<C>();
 	info!("📋 Chain specification: {}", config.chain_spec.name());
 	info!("🏷  Node name: {}", config.network.node_name);
 	info!("👤 Role: {}", config.display_role());
@@ -204,6 +202,21 @@ pub fn print_node_infos<C: SubstrateCli>(config: &Configuration) {
 			.map_or_else(|| "<unknown>".to_owned(), |p| p.display().to_string())
 	);
 	info!("⛓  Native runtime: {}", C::native_runtime_version(&config.chain_spec));
+}
+
+/// Log common information about the cli.
+///
+/// # Example:
+///
+/// ```text
+/// 2020-06-03 16:14:21 Substrate Node
+/// 2020-06-03 16:14:21 ✌️  version 2.0.0-rc3-f4940588c-x86_64-linux-gnu
+/// 2020-06-03 16:14:21 ❤️  by Parity Technologies <admin@parity.io>, 2017-2020
+/// ```
+pub fn print_common_infos<C: CommonCli>() {
+	info!("{}", C::impl_name());
+	info!("✌️  version {}", C::impl_version());
+	info!("❤️  by {}, {}-{}", C::author(), C::copyright_start_year(), Local::now().year());
 }
 
 #[cfg(test)]

--- a/client/cli/src/runner.rs
+++ b/client/cli/src/runner.rs
@@ -59,13 +59,13 @@ impl<Cfg> Runner<Cfg> {
 	/// signal `SIGTERM` or `SIGINT`.
 	pub fn run_until_exit<F, E>(
 		self,
-		initialize: impl FnOnce(Cfg) -> F,
+		initialize: impl FnOnce(Cfg, tokio::runtime::Handle) -> F,
 	) -> std::result::Result<(), E>
 	where
 		F: Future<Output = std::result::Result<TaskManager, E>>,
 		E: std::error::Error + Send + Sync + 'static + From<ServiceError>,
 	{
-		let mut task_manager = self.tokio_runtime.block_on(initialize(self.config))?;
+		let mut task_manager = self.tokio_runtime.block_on(initialize(self.config, self.tokio_runtime.handle().clone()))?;
 
 		let res = self
 			.tokio_runtime
@@ -168,7 +168,7 @@ impl Runner<Configuration> {
 	{
 		print_node_infos::<C>(self.config());
 
-		self.run_until_exit(initialize)
+		self.run_until_exit(|config, _| initialize(config))
 	}
 }
 


### PR DESCRIPTION
- For some cli usage, User do not care about runtime/chain spec infos, so I define  another trait to contain basic cli methods.
Also, for some cli usage, user maybe just want to run a non-classic substrate cli by runner that have their customed config.
- Improve some code details and export some useful functions.

TODO: need to update cumulus/polkadot related code.

--- 
polkadot address: 15ouFh2SHpGbHtDPsJ6cXQfes9Cx1gEFnJJsJVqPGzBSTudr