### PR TITLE
chore: remove `ipc_path` config which is deprecated for a long time

### DIFF
--- a/bin/node/cli/benches/block_production.rs
+++ b/bin/node/cli/benches/block_production.rs
@@ -86,7 +86,6 @@ fn new_node(tokio_handle: Handle) -> node_cli::service::NewFullBase {
 		},
 		rpc_http: None,
 		rpc_ws: None,
-		rpc_ipc: None,
 		rpc_ws_max_connections: None,
 		rpc_cors: None,
 		rpc_methods: Default::default(),

--- a/bin/node/cli/benches/transaction_pool.rs
+++ b/bin/node/cli/benches/transaction_pool.rs
@@ -80,7 +80,6 @@ fn new_node(tokio_handle: Handle) -> node_cli::service::NewFullBase {
 		},
 		rpc_http: None,
 		rpc_ws: None,
-		rpc_ipc: None,
 		rpc_ws_max_connections: None,
 		rpc_cors: None,
 		rpc_methods: Default::default(),

--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -122,10 +122,6 @@ pub struct RunCmd {
 	#[arg(long)]
 	pub prometheus_external: bool,
 
-	/// DEPRECATED, IPC support has been removed.
-	#[arg(long, value_name = "PATH")]
-	pub ipc_path: Option<String>,
-
 	/// Specify HTTP RPC server TCP port.
 	#[arg(long, value_name = "PORT")]
 	pub rpc_port: Option<u16>,
@@ -428,10 +424,6 @@ impl CliConfiguration for RunCmd {
 		)?;
 
 		Ok(Some(SocketAddr::new(interface, self.rpc_port.unwrap_or(default_listen_port))))
-	}
-
-	fn rpc_ipc(&self) -> Result<Option<String>> {
-		Ok(self.ipc_path.clone())
 	}
 
 	fn rpc_ws(&self, default_listen_port: u16) -> Result<Option<SocketAddr>> {

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -309,13 +309,6 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		Ok(None)
 	}
 
-	/// Get the RPC IPC path (`None` if disabled).
-	///
-	/// By default this is `None`.
-	fn rpc_ipc(&self) -> Result<Option<String>> {
-		Ok(None)
-	}
-
 	/// Get the RPC websocket address (`None` if disabled).
 	///
 	/// By default this is `None`.
@@ -534,7 +527,6 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 			execution_strategies: self.execution_strategies(is_dev, is_validator)?,
 			rpc_http: self.rpc_http(DCV::rpc_http_listen_port())?,
 			rpc_ws: self.rpc_ws(DCV::rpc_ws_listen_port())?,
-			rpc_ipc: self.rpc_ipc()?,
 			rpc_methods: self.rpc_methods()?,
 			rpc_ws_max_connections: self.rpc_ws_max_connections()?,
 			rpc_cors: self.rpc_cors(is_dev)?,

--- a/client/cli/src/runner.rs
+++ b/client/cli/src/runner.rs
@@ -289,7 +289,6 @@ mod tests {
 				execution_strategies: Default::default(),
 				rpc_http: None,
 				rpc_ws: None,
-				rpc_ipc: None,
 				rpc_ws_max_connections: None,
 				rpc_cors: None,
 				rpc_methods: Default::default(),

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -87,8 +87,6 @@ pub struct Configuration {
 	pub rpc_http: Option<SocketAddr>,
 	/// RPC over Websockets binding address. `None` if disabled.
 	pub rpc_ws: Option<SocketAddr>,
-	/// RPC over IPC binding path. `None` if disabled.
-	pub rpc_ipc: Option<String>,
 	/// Maximum number of connections for WebSockets RPC server. `None` if default.
 	pub rpc_ws_max_connections: Option<usize>,
 	/// CORS settings for HTTP & WS servers. `None` if all origins are allowed.

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -572,10 +572,6 @@ fn legacy_cli_parsing(config: &Configuration) -> (Option<usize>, Option<usize>, 
 		(None, None) => None,
 	};
 
-	if config.rpc_ipc.is_some() {
-		eprintln!("DEPRECATED: `--ipc-path` has no effect anymore IPC support has been removed");
-	}
-
 	(max_request_size, ws_max_response_size, http_max_response_size)
 }
 

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -252,7 +252,6 @@ fn node_config<
 		wasm_runtime_overrides: Default::default(),
 		execution_strategies: Default::default(),
 		rpc_http: None,
-		rpc_ipc: None,
 		rpc_ws: None,
 		rpc_ws_max_connections: None,
 		rpc_cors: None,


### PR DESCRIPTION
I think `ipc_path` could be removed now.

--- 
polkadot address: 15ouFh2SHpGbHtDPsJ6cXQfes9Cx1gEFnJJsJVqPGzBSTudr