### PR TITLE
CI: rephrase `RUSTFLAGS`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -105,6 +105,8 @@ variables:
     # $WASM_BUILD_WORKSPACE_HINT enables wasm-builder to find the Cargo.lock from within generated
     # packages
     - export WASM_BUILD_WORKSPACE_HINT="$PWD"
+    # ensure that RUSTFLAGS are set correctly
+    - echo $RUSTFLAGS
 
 .job-switcher:
   before_script:

--- a/scripts/ci/gitlab/pipeline/test.yml
+++ b/scripts/ci/gitlab/pipeline/test.yml
@@ -202,10 +202,10 @@ test-linux-stable:
   variables:
     # Enable debug assertions since we are running optimized builds for testing
     # but still want to have debug assertions.
-    RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+    RUSTFLAGS: "-C debug-assertions -D warnings"
     RUST_BACKTRACE: 1
     WASM_BUILD_NO_COLOR: 1
-    WASM_BUILD_RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+    WASM_BUILD_RUSTFLAGS: "-C debug-assertions -D warnings"
     # Ensure we run the UI tests.
     RUN_UI_TESTS: 1
     # needed for rusty-cachier to keep cache in test-linux-stable folder and not in test-linux-stable-1/3
@@ -243,7 +243,6 @@ test-frame-support:
     # Ensure we run the UI tests.
     RUN_UI_TESTS: 1
   script:
-    - echo $RUSTFLAGS
     - rusty-cachier snapshot create
     - cat /cargo_target_dir/debug/.fingerprint/memory_units-759eddf317490d2b/lib-memory_units.json || true
     - time cargo test --verbose --locked -p frame-support-test --features=frame-feature-testing,no-metadata-docs --manifest-path ./frame/support/test/Cargo.toml --test pallet
@@ -261,10 +260,10 @@ test-linux-stable-extra:
   variables:
     # Enable debug assertions since we are running optimized builds for testing
     # but still want to have debug assertions.
-    RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+    RUSTFLAGS: "-C debug-assertions -D warnings"
     RUST_BACKTRACE: 1
     WASM_BUILD_NO_COLOR: 1
-    WASM_BUILD_RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+    WASM_BUILD_RUSTFLAGS: "-C debug-assertions -D warnings"
     # Ensure we run the UI tests.
     RUN_UI_TESTS: 1
   script:
@@ -286,10 +285,10 @@ quick-benchmarks:
   variables:
     # Enable debug assertions since we are running optimized builds for testing
     # but still want to have debug assertions.
-    RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+    RUSTFLAGS: "-C debug-assertions -D warnings"
     RUST_BACKTRACE: "full"
     WASM_BUILD_NO_COLOR: 1
-    WASM_BUILD_RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+    WASM_BUILD_RUSTFLAGS: "-C debug-assertions -D warnings"
   script:
     - rusty-cachier snapshot create
     - time cargo run --locked --release --features runtime-benchmarks -- benchmark pallet --execution wasm --wasm-execution compiled --chain dev --pallet "*" --extrinsic "*" --steps 2 --repeat 1
@@ -305,7 +304,7 @@ test-frame-examples-compile-to-wasm:
     RUSTY_CACHIER_TOOLCHAIN: nightly
     # Enable debug assertions since we are running optimized builds for testing
     # but still want to have debug assertions.
-    RUSTFLAGS: "-Cdebug-assertions=y"
+    RUSTFLAGS: "-C debug-assertions"
     RUST_BACKTRACE: 1
   script:
     - rusty-cachier snapshot create
@@ -324,10 +323,10 @@ test-linux-stable-int:
   variables:
     # Enable debug assertions since we are running optimized builds for testing
     # but still want to have debug assertions.
-    RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+    RUSTFLAGS: "-C debug-assertions -D warnings"
     RUST_BACKTRACE: 1
     WASM_BUILD_NO_COLOR: 1
-    WASM_BUILD_RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+    WASM_BUILD_RUSTFLAGS: "-C debug-assertions -D warnings"
     # Ensure we run the UI tests.
     RUN_UI_TESTS: 1
   script:
@@ -373,7 +372,7 @@ test-full-crypto-feature:
     RUSTY_CACHIER_TOOLCHAIN: nightly
     # Enable debug assertions since we are running optimized builds for testing
     # but still want to have debug assertions.
-    RUSTFLAGS: "-Cdebug-assertions=y"
+    RUSTFLAGS: "-C debug-assertions"
     RUST_BACKTRACE: 1
   script:
     - rusty-cachier snapshot create


### PR DESCRIPTION
For whatever reason `cargo` [started to receive](https://gitlab.parity.io/parity/mirrors/substrate/-/jobs/2599321#L979) truncated `RUSTFLAGS` on `master`, which led to the `RUSTFLAGS` inconsistency between `master` and PRs and further cache invalidation.

This PR reformats `RUSTFLAGS` in a more accepted way, which brings the flags consistency back.

Resolves https://github.com/paritytech/ci_cd/issues/762.