### PR TITLE
Swap 'base58' with 'bs58'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,12 +491,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
-name = "base58"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10357,10 +10351,10 @@ name = "sp-core"
 version = "7.0.0"
 dependencies = [
  "array-bytes",
- "base58",
  "bitflags",
  "blake2",
  "bounded-collections",
+ "bs58",
  "criterion",
  "dyn-clonable",
  "ed25519-zebra",

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -22,7 +22,7 @@ primitive-types = { version = "0.12.0", default-features = false, features = ["c
 impl-serde = { version = "0.4.0", optional = true }
 hash-db = { version = "0.16.0", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
-bs58 = { version = "0.4.0", optional = true }
+bs58 = { version = "0.4.0", default-features = false, optional = true }
 rand = { version = "0.8.5", features = ["small_rng"],  optional = true }
 substrate-bip39 = { version = "0.4.4", optional = true }
 tiny-bip39 = { version = "1.0.0", optional = true }
@@ -90,7 +90,7 @@ std = [
 	"blake2/std",
 	"array-bytes",
 	"ed25519-zebra/std",
-	"bs58",
+	"bs58/std",
 	"substrate-bip39",
 	"tiny-bip39",
 	"rand",

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -13,10 +13,7 @@ documentation = "https://docs.rs/sp-core"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false, features = [
-	"derive",
-	"max-encoded-len",
-] }
+codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false, features = ["derive","max-encoded-len"] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
@@ -25,7 +22,7 @@ primitive-types = { version = "0.12.0", default-features = false, features = ["c
 impl-serde = { version = "0.4.0", optional = true }
 hash-db = { version = "0.16.0", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
-base58 = { version = "0.2.0", optional = true }
+bs58 = { version = "0.4.0", optional = true }
 rand = { version = "0.8.5", features = ["small_rng"],  optional = true }
 substrate-bip39 = { version = "0.4.4", optional = true }
 tiny-bip39 = { version = "1.0.0", optional = true }
@@ -47,10 +44,7 @@ bitflags = "1.3"
 array-bytes = { version = "4.1", optional = true }
 ed25519-zebra = { version = "3.1.0", default-features = false, optional = true }
 blake2 = { version = "0.10.4", default-features = false, optional = true }
-schnorrkel = { version = "0.9.1", features = [
-	"preaudit_deprecated",
-	"u64_backend",
-], default-features = false, optional = true }
+schnorrkel = { version = "0.9.1", features = ["preaudit_deprecated", "u64_backend"], default-features = false, optional = true }
 libsecp256k1 = { version = "0.7", default-features = false, features = ["static-context"], optional = true }
 merlin = { version = "2.0", default-features = false, optional = true }
 secp256k1 = { version = "0.24.0", default-features = false, features = ["recovery", "alloc"], optional = true }
@@ -96,7 +90,7 @@ std = [
 	"blake2/std",
 	"array-bytes",
 	"ed25519-zebra/std",
-	"base58",
+	"bs58",
 	"substrate-bip39",
 	"tiny-bip39",
 	"rand",

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -21,8 +21,6 @@
 
 use crate::{ed25519, sr25519};
 #[cfg(feature = "std")]
-use base58::{FromBase58, ToBase58};
-#[cfg(feature = "std")]
 use bip39::{Language, Mnemonic, MnemonicType};
 use codec::{Decode, Encode, MaxEncodedLen};
 #[cfg(feature = "std")]
@@ -276,7 +274,7 @@ pub trait Ss58Codec: Sized + AsMut<[u8]> + AsRef<[u8]> + ByteArray {
 		const CHECKSUM_LEN: usize = 2;
 		let body_len = Self::LEN;
 
-		let data = s.from_base58().map_err(|_| PublicError::BadBase58)?;
+		let data = bs58::decode(s.clone()).into_vec().map_err(|_| PublicError::BadBase58)?;
 		if data.len() < 2 {
 			return Err(PublicError::BadLength)
 		}
@@ -345,7 +343,7 @@ pub trait Ss58Codec: Sized + AsMut<[u8]> + AsRef<[u8]> + ByteArray {
 		v.extend(self.as_ref());
 		let r = ss58hash(&v);
 		v.extend(&r[0..2]);
-		v.to_base58()
+		bs58::encode(v).into_string()
 	}
 
 	/// Return the ss58-check string for this key.

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -274,7 +274,7 @@ pub trait Ss58Codec: Sized + AsMut<[u8]> + AsRef<[u8]> + ByteArray {
 		const CHECKSUM_LEN: usize = 2;
 		let body_len = Self::LEN;
 
-		let data = bs58::decode(s.clone()).into_vec().map_err(|_| PublicError::BadBase58)?;
+		let data = bs58::decode(s).into_vec().map_err(|_| PublicError::BadBase58)?;
 		if data.len() < 2 {
 			return Err(PublicError::BadLength)
 		}


### PR DESCRIPTION
Motivations:
- `base58` has hard limit of 128 bytes output (`bs58` doesn't have any limit)
   - with the introduction of https://github.com/paritytech/substrate/pull/13618 we require to decode longer strings
- (marginal) `bs58` is also used by `libp2p` so we depend on it anyway
- (marginal) `bs58` docs declares to be faster but I found the two almost equivalent.