### PR TITLE
proc-macro: check for non-args runtime calls added

### DIFF
--- a/primitives/api/proc-macro/src/impl_runtime_apis.rs
+++ b/primitives/api/proc-macro/src/impl_runtime_apis.rs
@@ -79,7 +79,14 @@ fn generate_impl_call(
 	let pborrow = params.iter().map(|v| &v.2);
 
 	let decode_params = if params.is_empty() {
-		quote!()
+		quote!(
+			if !#input.is_empty() {
+				panic!(
+					"Bad input data provided to {}: expected no parameters, input buffer is not empty.",
+					#fn_name_str
+				);
+			}
+		)
 	} else {
 		let let_binding = if params.len() == 1 {
 			quote! {


### PR DESCRIPTION
Following test [test](https://github.com/paritytech/substrate/blob/905861780ee0f6556d915a70a7a49371fc1fad2c/client/rpc-spec-v2/src/chain_head/tests.rs#L433-L445) is supposed to fail because of:

```
executor: Request for native execution succeeded native=test-2 (parity-test-2.tx1.au1) chain=test-2 (parity-test-2.tx1.au1)
wasm-runtime: Fresh runtime instance failed error=Runtime panicked: Bad input data provided to current_epoch: Input buffer has still data left after decoding!
state: Return ext_id=6b9e was_native=true result=Err(RuntimePanicked("Bad input data provided to current_epoch: Input buffer has still data left after decoding!"))
```

But on current master it fails because of:

```
mlog_version_1: runtime: panicked at 'EpochConfig is initialized in genesis; we never `take` or `kill` it; qed', /home/miszka/parity/09-test-runtime/substrate-master-2/frame/babe/    src/lib.rs:703:18
```

Meaning that scale-decoding didn't catch the error, and `current_epoch` was actually called (and crashed because `substrate-test-runtime` [does not initialize babe in its genesis](https://github.com/paritytech/substrate/blob/905861780ee0f6556d915a70a7a49371fc1fad2c/test-utils/runtime/src/genesismap.rs#L57-L92)).

The parameters decoding was changed in https://github.com/paritytech/substrate/commit/9eafc96a62d160cd97f8150b2742d7048e394bba , input buffer is not checked at all in case of non-args runtime call.

This PR adds a check.