### PR TITLE
Build wasm for mvp cpu

### DIFF
--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -632,7 +632,7 @@ fn build_project(
 	let mut build_cmd = cargo_cmd.command();
 
 	let rustflags = format!(
-		"-C link-arg=--export-table {} {}",
+		"-C target-cpu=mvp -C link-arg=--export-table {} {}",
 		default_rustflags,
 		env::var(crate::WASM_BUILD_RUSTFLAGS_ENV).unwrap_or_default(),
 	);


### PR DESCRIPTION
In order to prevent wasm features being silently enabled with newer LLVM versions we want to set the `target-cpu` to `mvp`. We can still explicitly enable wasm features. Additionally, we get an explicit error if LLVM decides to remove MVP support.

Related: https://github.com/paritytech/substrate/issues/13636 