### PR TITLE
Insert claim_commission weight

### DIFF
--- a/frame/nomination-pools/src/lib.rs
+++ b/frame/nomination-pools/src/lib.rs
@@ -2617,7 +2617,7 @@ pub mod pallet {
 		/// commission is paid out and added to total claimed commission`. Total pending commission
 		/// is reset to zero. the current.
 		#[pallet::call_index(20)]
-		#[pallet::weight(0)]
+		#[pallet::weight(T::WeightInfo::claim_commission())]
 		pub fn claim_commission(origin: OriginFor<T>, pool_id: PoolId) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Self::do_claim_commission(who, pool_id)


### PR DESCRIPTION
`claim_commission` did not have its calculated weight associated with the call. This PR fixes this.