### PR TITLE
[WIP] Nomination Pool Rebonding

### DIFF
--- a/frame/nomination-pools/src/tests.rs
+++ b/frame/nomination-pools/src/tests.rs
@@ -402,6 +402,13 @@ mod unbond_pool {
 		let unbond_pool = UnbondPool::<Runtime> { points: 900, balance: 400 };
 		assert_eq!(unbond_pool.point_to_balance(90), 40);
 	}
+
+	#[test]
+	fn rebond_working() {
+		ExtBuilder::default().build_and_execute(|| {
+			// TODO: set up rebond scenario ready for extrinsic testing.
+		})
+	}
 }
 
 mod sub_pools {


### PR DESCRIPTION
This PR adds the ability of nomination pool members to rebond unlock chunks.

The validation checks here are two-fold:-

- The pool member must have `unbonding_eras` persent, of which the submitted amount of `points` to `rebond` must be within this summed value of unbonding points,  and
- The pool itself must have unlock chunks present with the balance representation of the rebond `points` amount available to rebond back into its nominator account.

#### New calls:
`rebond`

More to come...

Addresses #12060 

Related work: https://github.com/paritytech/substrate/pull/12141