### PR TITLE
contracts: make test work with debugger

### DIFF
--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -459,7 +459,7 @@ where
 	T: frame_system::Config,
 {
 	let fixture_path = [
-		// When `CARGO_MANIFEST_DIR` is not set, rust resolves relative paths from the root folder
+		// When `CARGO_MANIFEST_DIR` is not set, Rust resolves relative paths from the root folder
 		std::env::var("CARGO_MANIFEST_DIR").as_deref().unwrap_or("frame/contracts"),
 		"/fixtures/",
 		fixture_name,

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -458,12 +458,13 @@ fn compile_module<T>(fixture_name: &str) -> wat::Result<(Vec<u8>, <T::Hashing as
 where
 	T: frame_system::Config,
 {
-	let fixture_root = if std::env::var("CARGO_MANIFEST_DIR").is_ok() {
-		"fixtures/"
-	} else {
-		"frame/contracts/fixtures/"
-	};
-	let fixture_path = [fixture_root, fixture_name, ".wat"].concat();
+	let fixture_path = [
+		std::env::var("CARGO_MANIFEST_DIR").as_deref().unwrap_or("frame/contracts"),
+		"/fixtures/",
+		fixture_name,
+		".wat",
+	]
+	.concat();
 	let wasm_binary = wat::parse_file(fixture_path)?;
 	let code_hash = T::Hashing::hash(&wasm_binary);
 	Ok((wasm_binary, code_hash))

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -459,7 +459,7 @@ where
 	T: frame_system::Config,
 {
 	let fixture_path = [
-		// When `CARGO_MANIFEST_DIR`  is not set, rust resolve relative path from the root folder
+		// When `CARGO_MANIFEST_DIR` is not set, rust resolve relative path from the root folder
 		std::env::var("CARGO_MANIFEST_DIR").as_deref().unwrap_or("frame/contracts"),
 		"/fixtures/",
 		fixture_name,

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -458,7 +458,12 @@ fn compile_module<T>(fixture_name: &str) -> wat::Result<(Vec<u8>, <T::Hashing as
 where
 	T: frame_system::Config,
 {
-	let fixture_path = ["frame/contracts/fixtures/", fixture_name, ".wat"].concat();
+	let fixture_root = if std::env::var("CARGO_MANIFEST_DIR").is_ok() {
+		"fixtures/"
+	} else {
+		"frame/contracts/fixtures/"
+	};
+	let fixture_path = [fixture_root, fixture_name, ".wat"].concat();
 	let wasm_binary = wat::parse_file(fixture_path)?;
 	let code_hash = T::Hashing::hash(&wasm_binary);
 	Ok((wasm_binary, code_hash))

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -459,6 +459,7 @@ where
 	T: frame_system::Config,
 {
 	let fixture_path = [
+		// When `CARGO_MANIFEST_DIR`  is not set, rust resolve relative path from the root folder
 		std::env::var("CARGO_MANIFEST_DIR").as_deref().unwrap_or("frame/contracts"),
 		"/fixtures/",
 		fixture_name,

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -459,7 +459,7 @@ where
 	T: frame_system::Config,
 {
 	let fixture_path = [
-		// When `CARGO_MANIFEST_DIR` is not set, rust resolve relative path from the root folder
+		// When `CARGO_MANIFEST_DIR` is not set, rust resolves the relative path from the root folder
 		std::env::var("CARGO_MANIFEST_DIR").as_deref().unwrap_or("frame/contracts"),
 		"/fixtures/",
 		fixture_name,

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -459,7 +459,7 @@ where
 	T: frame_system::Config,
 {
 	let fixture_path = [
-		// When `CARGO_MANIFEST_DIR` is not set, rust resolves the relative path from the root folder
+		// When `CARGO_MANIFEST_DIR` is not set, rust resolves relative paths from the root folder
 		std::env::var("CARGO_MANIFEST_DIR").as_deref().unwrap_or("frame/contracts"),
 		"/fixtures/",
 		fixture_name,

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -458,7 +458,7 @@ fn compile_module<T>(fixture_name: &str) -> wat::Result<(Vec<u8>, <T::Hashing as
 where
 	T: frame_system::Config,
 {
-	let fixture_path = ["fixtures/", fixture_name, ".wat"].concat();
+	let fixture_path = ["frame/contracts/fixtures/", fixture_name, ".wat"].concat();
 	let wasm_binary = wat::parse_file(fixture_path)?;
 	let code_hash = T::Hashing::hash(&wasm_binary);
 	Ok((wasm_binary, code_hash))


### PR DESCRIPTION
When debugging tests, the CARGO_* environment variables are not set, and thus the relative path fails to resolve.
using a path relative to PWD should make things work