### PR TITLE
Uniform pallet warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7515,8 +7515,6 @@ dependencies = [
 [[package]]
 name = "proc-macro-warning"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02947afd04953718e1b5ac72bd4237ec7305aec959b68763f3fbce61e0113ec4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2468,6 +2468,7 @@ dependencies = [
  "derive-syn-parse",
  "frame-support-procedural-tools",
  "itertools",
+ "proc-macro-warning",
  "proc-macro2",
  "quote",
  "syn",
@@ -7509,6 +7510,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-warning"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "163ecdb21ae408b772089d644160051dcf8905eac97a129380c0998847b6853b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7514,9 +7514,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-warning"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163ecdb21ae408b772089d644160051dcf8905eac97a129380c0998847b6853b"
+checksum = "02947afd04953718e1b5ac72bd4237ec7305aec959b68763f3fbce61e0113ec4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7514,7 +7514,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-warning"
-version = "0.1.2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d4f284d87b9cedc2ff57223cbc4e3937cd6063c01e92c8e2a8c080df0013933"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/frame/benchmarking/pov/src/lib.rs
+++ b/frame/benchmarking/pov/src/lib.rs
@@ -120,14 +120,14 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		#[pallet::call_index(0)]
-		#[pallet::weight(0)]
+		#[pallet::weight({0})]
 		pub fn emit_event(_origin: OriginFor<T>) -> DispatchResult {
 			Self::deposit_event(Event::TestEvent);
 			Ok(())
 		}
 
 		#[pallet::call_index(1)]
-		#[pallet::weight(0)]
+		#[pallet::weight({0})]
 		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
 			Ok(())
 		}

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -29,7 +29,7 @@ use sp_runtime::{
 use sp_std::prelude::*;
 use std::cell::RefCell;
 
-#[frame_support::pallet]
+#[frame_support::pallet(dev_mode)]
 mod pallet_test {
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;

--- a/frame/benchmarking/src/tests_instance.rs
+++ b/frame/benchmarking/src/tests_instance.rs
@@ -61,7 +61,7 @@ mod pallet_test {
 		<T as OtherConfig>::OtherEvent: Into<<T as Config<I>>::RuntimeEvent>,
 	{
 		#[pallet::call_index(0)]
-		#[pallet::weight(0)]
+		#[pallet::weight({0})]
 		pub fn set_value(origin: OriginFor<T>, n: u32) -> DispatchResult {
 			let _sender = ensure_signed(origin)?;
 			Value::<T, I>::put(n);
@@ -69,7 +69,7 @@ mod pallet_test {
 		}
 
 		#[pallet::call_index(1)]
-		#[pallet::weight(0)]
+		#[pallet::weight({0})]
 		pub fn dummy(origin: OriginFor<T>, _n: u32) -> DispatchResult {
 			let _sender = ensure_none(origin)?;
 			Ok(())

--- a/frame/collective/src/tests.rs
+++ b/frame/collective/src/tests.rs
@@ -51,7 +51,7 @@ frame_support::construct_runtime!(
 
 mod mock_democracy {
 	pub use pallet::*;
-	#[frame_support::pallet]
+	#[frame_support::pallet(dev_mode)]
 	pub mod pallet {
 		use frame_support::pallet_prelude::*;
 		use frame_system::pallet_prelude::*;

--- a/frame/examples/offchain-worker/src/lib.rs
+++ b/frame/examples/offchain-worker/src/lib.rs
@@ -229,7 +229,7 @@ pub mod pallet {
 		/// This example is not focused on correctness of the oracle itself, but rather its
 		/// purpose is to showcase offchain worker capabilities.
 		#[pallet::call_index(0)]
-		#[pallet::weight(0)]
+		#[pallet::weight({0})]
 		pub fn submit_price(origin: OriginFor<T>, price: u32) -> DispatchResultWithPostInfo {
 			// Retrieve sender of the transaction.
 			let who = ensure_signed(origin)?;
@@ -255,7 +255,7 @@ pub mod pallet {
 		/// This example is not focused on correctness of the oracle itself, but rather its
 		/// purpose is to showcase offchain worker capabilities.
 		#[pallet::call_index(1)]
-		#[pallet::weight(0)]
+		#[pallet::weight({0})]
 		pub fn submit_price_unsigned(
 			origin: OriginFor<T>,
 			_block_number: T::BlockNumber,
@@ -272,7 +272,7 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(2)]
-		#[pallet::weight(0)]
+		#[pallet::weight({0})]
 		pub fn submit_price_unsigned_with_signed_payload(
 			origin: OriginFor<T>,
 			price_payload: PricePayload<T::Public, T::BlockNumber>,

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -700,7 +700,7 @@ mod tests {
 
 	const TEST_KEY: &[u8] = b":test:key:";
 
-	#[frame_support::pallet]
+	#[frame_support::pallet(dev_mode)]
 	mod custom {
 		use frame_support::pallet_prelude::*;
 		use frame_system::pallet_prelude::*;

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -168,7 +168,7 @@ pub mod pallet {
 		///
 		/// May only be called from `T::AddOrigin`.
 		#[pallet::call_index(0)]
-		#[pallet::weight(50_000_000)]
+		#[pallet::weight({50_000_000})]
 		pub fn add_member(origin: OriginFor<T>, who: AccountIdLookupOf<T>) -> DispatchResult {
 			T::AddOrigin::ensure_origin(origin)?;
 			let who = T::Lookup::lookup(who)?;
@@ -191,7 +191,7 @@ pub mod pallet {
 		///
 		/// May only be called from `T::RemoveOrigin`.
 		#[pallet::call_index(1)]
-		#[pallet::weight(50_000_000)]
+		#[pallet::weight({50_000_000})]
 		pub fn remove_member(origin: OriginFor<T>, who: AccountIdLookupOf<T>) -> DispatchResult {
 			T::RemoveOrigin::ensure_origin(origin)?;
 			let who = T::Lookup::lookup(who)?;
@@ -215,7 +215,7 @@ pub mod pallet {
 		///
 		/// Prime membership is *not* passed from `remove` to `add`, if extant.
 		#[pallet::call_index(2)]
-		#[pallet::weight(50_000_000)]
+		#[pallet::weight({50_000_000})]
 		pub fn swap_member(
 			origin: OriginFor<T>,
 			remove: AccountIdLookupOf<T>,
@@ -249,7 +249,7 @@ pub mod pallet {
 		///
 		/// May only be called from `T::ResetOrigin`.
 		#[pallet::call_index(3)]
-		#[pallet::weight(50_000_000)]
+		#[pallet::weight({50_000_000})]
 		pub fn reset_members(origin: OriginFor<T>, members: Vec<T::AccountId>) -> DispatchResult {
 			T::ResetOrigin::ensure_origin(origin)?;
 
@@ -272,7 +272,7 @@ pub mod pallet {
 		///
 		/// Prime membership is passed from the origin account to `new`, if extant.
 		#[pallet::call_index(4)]
-		#[pallet::weight(50_000_000)]
+		#[pallet::weight({50_000_000})]
 		pub fn change_key(origin: OriginFor<T>, new: AccountIdLookupOf<T>) -> DispatchResult {
 			let remove = ensure_signed(origin)?;
 			let new = T::Lookup::lookup(new)?;
@@ -307,7 +307,7 @@ pub mod pallet {
 		///
 		/// May only be called from `T::PrimeOrigin`.
 		#[pallet::call_index(5)]
-		#[pallet::weight(50_000_000)]
+		#[pallet::weight({50_000_000})]
 		pub fn set_prime(origin: OriginFor<T>, who: AccountIdLookupOf<T>) -> DispatchResult {
 			T::PrimeOrigin::ensure_origin(origin)?;
 			let who = T::Lookup::lookup(who)?;
@@ -321,7 +321,7 @@ pub mod pallet {
 		///
 		/// May only be called from `T::PrimeOrigin`.
 		#[pallet::call_index(6)]
-		#[pallet::weight(50_000_000)]
+		#[pallet::weight({50_000_000})]
 		pub fn clear_prime(origin: OriginFor<T>) -> DispatchResult {
 			T::PrimeOrigin::ensure_origin(origin)?;
 			Prime::<T, I>::kill();

--- a/frame/nicks/src/lib.rs
+++ b/frame/nicks/src/lib.rs
@@ -131,7 +131,7 @@ pub mod pallet {
 		/// ## Complexity
 		/// - O(1).
 		#[pallet::call_index(0)]
-		#[pallet::weight(50_000_000)]
+		#[pallet::weight({50_000_000})]
 		pub fn set_name(origin: OriginFor<T>, name: Vec<u8>) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 
@@ -160,7 +160,7 @@ pub mod pallet {
 		/// ## Complexity
 		/// - O(1).
 		#[pallet::call_index(1)]
-		#[pallet::weight(70_000_000)]
+		#[pallet::weight({70_000_000})]
 		pub fn clear_name(origin: OriginFor<T>) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 
@@ -183,7 +183,7 @@ pub mod pallet {
 		/// ## Complexity
 		/// - O(1).
 		#[pallet::call_index(2)]
-		#[pallet::weight(70_000_000)]
+		#[pallet::weight({70_000_000})]
 		pub fn kill_name(origin: OriginFor<T>, target: AccountIdLookupOf<T>) -> DispatchResult {
 			T::ForceOrigin::ensure_origin(origin)?;
 
@@ -207,7 +207,7 @@ pub mod pallet {
 		/// ## Complexity
 		/// - O(1).
 		#[pallet::call_index(3)]
-		#[pallet::weight(70_000_000)]
+		#[pallet::weight({70_000_000})]
 		pub fn force_name(
 			origin: OriginFor<T>,
 			target: AccountIdLookupOf<T>,

--- a/frame/scored-pool/src/lib.rs
+++ b/frame/scored-pool/src/lib.rs
@@ -70,7 +70,7 @@
 //!
 //! 	#[pallet::call]
 //! 	impl<T: Config> Pallet<T> {
-//! 		#[pallet::weight(0)]
+//! 		#[pallet::weight({0})]
 //! 		pub fn candidate(origin: OriginFor<T>) -> DispatchResult {
 //! 			let who = ensure_signed(origin)?;
 //!
@@ -311,7 +311,7 @@ pub mod pallet {
 		/// The `index` parameter of this function must be set to
 		/// the index of the transactor in the `Pool`.
 		#[pallet::call_index(0)]
-		#[pallet::weight(0)]
+		#[pallet::weight({0})]
 		pub fn submit_candidacy(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			ensure!(!<CandidateExists<T, I>>::contains_key(&who), Error::<T, I>::AlreadyInPool);
@@ -341,7 +341,7 @@ pub mod pallet {
 		/// The `index` parameter of this function must be set to
 		/// the index of the transactor in the `Pool`.
 		#[pallet::call_index(1)]
-		#[pallet::weight(0)]
+		#[pallet::weight({0})]
 		pub fn withdraw_candidacy(origin: OriginFor<T>, index: u32) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
@@ -360,7 +360,7 @@ pub mod pallet {
 		/// The `index` parameter of this function must be set to
 		/// the index of `dest` in the `Pool`.
 		#[pallet::call_index(2)]
-		#[pallet::weight(0)]
+		#[pallet::weight({0})]
 		pub fn kick(
 			origin: OriginFor<T>,
 			dest: AccountIdLookupOf<T>,
@@ -385,7 +385,7 @@ pub mod pallet {
 		/// The `index` parameter of this function must be set to
 		/// the index of the `dest` in the `Pool`.
 		#[pallet::call_index(3)]
-		#[pallet::weight(0)]
+		#[pallet::weight({0})]
 		pub fn score(
 			origin: OriginFor<T>,
 			dest: AccountIdLookupOf<T>,
@@ -425,7 +425,7 @@ pub mod pallet {
 		///
 		/// May only be called from root.
 		#[pallet::call_index(4)]
-		#[pallet::weight(0)]
+		#[pallet::weight({0})]
 		pub fn change_member_count(origin: OriginFor<T>, count: u32) -> DispatchResult {
 			ensure_root(origin)?;
 			Self::update_member_count(count).map_err(Into::into)

--- a/frame/sudo/src/lib.rs
+++ b/frame/sudo/src/lib.rs
@@ -195,7 +195,7 @@ pub mod pallet {
 		/// ## Complexity
 		/// - O(1).
 		#[pallet::call_index(2)]
-		#[pallet::weight(0)]
+		#[pallet::weight({0})] // FIXME
 		pub fn set_key(
 			origin: OriginFor<T>,
 			new: AccountIdLookupOf<T>,

--- a/frame/support/procedural/Cargo.toml
+++ b/frame/support/procedural/Cargo.toml
@@ -23,7 +23,7 @@ proc-macro2 = "1.0.37"
 quote = "1.0.10"
 syn = { version = "1.0.98", features = ["full"] }
 frame-support-procedural-tools = { version = "4.0.0-dev", path = "./tools" }
-proc-macro-warning = { version = "0.1.0", default-features = false }
+proc-macro-warning = { version = "0.1.2", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/support/procedural/Cargo.toml
+++ b/frame/support/procedural/Cargo.toml
@@ -23,7 +23,7 @@ proc-macro2 = "1.0.37"
 quote = "1.0.10"
 syn = { version = "1.0.98", features = ["full"] }
 frame-support-procedural-tools = { version = "4.0.0-dev", path = "./tools" }
-proc-macro-warning = { version = "0.1.2", path = "../../../../proc-macro-warning", default-features = false }
+proc-macro-warning = { version = "0.2.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/support/procedural/Cargo.toml
+++ b/frame/support/procedural/Cargo.toml
@@ -23,6 +23,7 @@ proc-macro2 = "1.0.37"
 quote = "1.0.10"
 syn = { version = "1.0.98", features = ["full"] }
 frame-support-procedural-tools = { version = "4.0.0-dev", path = "./tools" }
+proc-macro-warning = { version = "0.1.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/support/procedural/Cargo.toml
+++ b/frame/support/procedural/Cargo.toml
@@ -23,7 +23,7 @@ proc-macro2 = "1.0.37"
 quote = "1.0.10"
 syn = { version = "1.0.98", features = ["full"] }
 frame-support-procedural-tools = { version = "4.0.0-dev", path = "./tools" }
-proc-macro-warning = { version = "0.1.2", default-features = false }
+proc-macro-warning = { version = "0.1.2", path = "../../../../proc-macro-warning", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/support/procedural/src/pallet/expand/call.rs
+++ b/frame/support/procedural/src/pallet/expand/call.rs
@@ -54,30 +54,45 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 		.map(|fn_name| format!("Create a call with the variant `{}`.", fn_name))
 		.collect::<Vec<_>>();
 
-	let mut warning_structs = Vec::new();
-	let mut warning_names = Vec::new();
+	let mut call_index_warnings = Vec::new();
 	// Emit a warning for each call that is missing `call_index` when not in dev-mode.
 	for method in &methods {
 		if method.explicit_call_index || def.dev_mode {
 			continue
 		}
 
-		let name = syn::Ident::new(&format!("{}", method.name), method.name.span());
-		let warning: syn::ItemStruct = syn::parse_quote!(
-			#[deprecated(note = r"
-			Implicit call indices are deprecated in favour of explicit ones.
-			Please ensure that all calls have the `pallet::call_index` attribute or that the
-			`dev-mode` of the pallet is enabled. For more info see:
-			<https://github.com/paritytech/substrate/pull/12891> and
-			<https://github.com/paritytech/substrate/pull/11381>.")]
-			#[allow(non_camel_case_types)]
-			struct #name;
-		);
-		warning_names.push(name);
-		warning_structs.push(warning);
+		let warning = proc_macro_warning::Warning::new_deprecated("ImplicitCallIndex")
+			.old("use implicit call indices")
+			.alternative("ensure that all calls have the `pallet::call_index` attribute or that the `dev-mode` of the pallet is enabled")
+			.help_links(&[
+				"https://github.com/paritytech/substrate/pull/12891",
+				"https://github.com/paritytech/substrate/pull/11381"
+			])
+			.span(method.name.span())
+			.build();
+		call_index_warnings.push(warning);
 	}
 
 	let fn_weight = methods.iter().map(|method| &method.weight);
+	let mut weight_warnings = Vec::new();
+	for weight in fn_weight.clone() {
+		if def.dev_mode {
+			continue
+		}
+
+		match weight {
+			syn::Expr::Lit(lit) => {
+				let warning = proc_macro_warning::Warning::new_deprecated("ConstantWeight")
+					.old("use hard-coded constant as call weight")
+					.alternative("benchmark all calls or put the pallet into `dev` mode")
+					.help_link("TODO")
+					.span(lit.span())
+					.build();
+				weight_warnings.push(warning);
+			},
+			_ => {},
+		}
+	}
 
 	let fn_doc = methods.iter().map(|method| &method.docs).collect::<Vec<_>>();
 
@@ -203,9 +218,10 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 	quote::quote_spanned!(span =>
 		mod warnings {
 			#(
-				#warning_structs
-				// This triggers each deprecated warning once.
-				const _: Option<#warning_names> = None;
+				#call_index_warnings
+			)*
+			#(
+				#weight_warnings
 			)*
 		}
 

--- a/frame/support/procedural/src/pallet/expand/call.rs
+++ b/frame/support/procedural/src/pallet/expand/call.rs
@@ -62,6 +62,7 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 		}
 
 		let warning = proc_macro_warning::Warning::new_deprecated("ImplicitCallIndex")
+			.index(call_index_warnings.len())
 			.old("use implicit call indices")
 			.alternative("ensure that all calls have the `pallet::call_index` attribute or that the `dev-mode` of the pallet is enabled")
 			.help_links(&[
@@ -83,9 +84,10 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 		match weight {
 			syn::Expr::Lit(lit) => {
 				let warning = proc_macro_warning::Warning::new_deprecated("ConstantWeight")
+					.index(weight_warnings.len())
 					.old("use hard-coded constant as call weight")
 					.alternative("benchmark all calls or put the pallet into `dev` mode")
-					.help_link("TODO")
+					.help_link("https://github.com/paritytech/substrate/pull/13798")
 					.span(lit.span())
 					.build();
 				weight_warnings.push(warning);

--- a/frame/support/procedural/src/pallet/expand/call.rs
+++ b/frame/support/procedural/src/pallet/expand/call.rs
@@ -64,7 +64,7 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 		let warning = proc_macro_warning::Warning::new_deprecated("ImplicitCallIndex")
 			.index(call_index_warnings.len())
 			.old("use implicit call indices")
-			.alternative("ensure that all calls have the `pallet::call_index` attribute or that the `dev-mode` of the pallet is enabled")
+			.new("ensure that all calls have a `pallet::call_index` attribute or put the pallet into `dev` mode")
 			.help_links(&[
 				"https://github.com/paritytech/substrate/pull/12891",
 				"https://github.com/paritytech/substrate/pull/11381"
@@ -86,7 +86,7 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 				let warning = proc_macro_warning::Warning::new_deprecated("ConstantWeight")
 					.index(weight_warnings.len())
 					.old("use hard-coded constant as call weight")
-					.alternative("benchmark all calls or put the pallet into `dev` mode")
+					.new("benchmark all calls or put the pallet into `dev` mode")
 					.help_link("https://github.com/paritytech/substrate/pull/13798")
 					.span(lit.span())
 					.build();

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -218,7 +218,7 @@ pub mod pallet {
 
 		/// Doc comment put in metadata
 		#[pallet::call_index(1)]
-		#[pallet::weight(1)]
+		#[pallet::weight({1})]
 		pub fn foo_storage_layer(
 			_origin: OriginFor<T>,
 			#[pallet::compact] foo: u32,
@@ -232,20 +232,20 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(4)]
-		#[pallet::weight(1)]
+		#[pallet::weight({1})]
 		pub fn foo_index_out_of_order(_origin: OriginFor<T>) -> DispatchResult {
 			Ok(())
 		}
 
 		// Test for DispatchResult return type
 		#[pallet::call_index(2)]
-		#[pallet::weight(1)]
+		#[pallet::weight({1})]
 		pub fn foo_no_post_info(_origin: OriginFor<T>) -> DispatchResult {
 			Ok(())
 		}
 
 		#[pallet::call_index(3)]
-		#[pallet::weight(1)]
+		#[pallet::weight({1})]
 		pub fn check_for_dispatch_context(_origin: OriginFor<T>) -> DispatchResult {
 			with_context::<(), _>(|_| ()).ok_or_else(|| DispatchError::Unavailable)
 		}

--- a/frame/support/test/tests/pallet_instance.rs
+++ b/frame/support/test/tests/pallet_instance.rs
@@ -27,7 +27,7 @@ use sp_io::{
 };
 use sp_runtime::{DispatchError, ModuleError};
 
-#[frame_support::pallet]
+#[frame_support::pallet(dev_mode)]
 pub mod pallet {
 	use codec::MaxEncodedLen;
 	use frame_support::{pallet_prelude::*, parameter_types, scale_info};

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
@@ -1,3 +1,16 @@
+error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
+               It is deprecated to use hard-coded constant as call weight.
+               Please instead benchmark all calls or put the pallet into `dev` mode.
+
+               For more info see:
+                   <https://github.com/paritytech/substrate/pull/13798>
+  --> tests/pallet_ui/call_argument_invalid_bound.rs:19:20
+   |
+19 |         #[pallet::weight(0)]
+   |                          ^
+   |
+   = note: `-D deprecated` implied by `-D warnings`
+
 error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
   --> tests/pallet_ui/call_argument_invalid_bound.rs:21:36
    |

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
@@ -1,3 +1,16 @@
+error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
+               It is deprecated to use hard-coded constant as call weight.
+               Please instead benchmark all calls or put the pallet into `dev` mode.
+
+               For more info see:
+                   <https://github.com/paritytech/substrate/pull/13798>
+  --> tests/pallet_ui/call_argument_invalid_bound_2.rs:19:20
+   |
+19 |         #[pallet::weight(0)]
+   |                          ^
+   |
+   = note: `-D deprecated` implied by `-D warnings`
+
 error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
   --> tests/pallet_ui/call_argument_invalid_bound_2.rs:21:36
    |

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.stderr
@@ -1,3 +1,16 @@
+error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
+               It is deprecated to use hard-coded constant as call weight.
+               Please instead benchmark all calls or put the pallet into `dev` mode.
+
+               For more info see:
+                   <https://github.com/paritytech/substrate/pull/13798>
+  --> tests/pallet_ui/call_argument_invalid_bound_3.rs:21:20
+   |
+21 |         #[pallet::weight(0)]
+   |                          ^
+   |
+   = note: `-D deprecated` implied by `-D warnings`
+
 error[E0277]: `Bar` doesn't implement `std::fmt::Debug`
   --> tests/pallet_ui/call_argument_invalid_bound_3.rs:23:36
    |

--- a/frame/support/test/tests/pallet_ui/call_missing_index.stderr
+++ b/frame/support/test/tests/pallet_ui/call_missing_index.stderr
@@ -1,12 +1,47 @@
-error: use of deprecated struct `pallet::warnings::foo`:
-                   Implicit call indices are deprecated in favour of explicit ones.
-                   Please ensure that all calls have the `pallet::call_index` attribute or that the
-                   `dev-mode` of the pallet is enabled. For more info see:
-                   <https://github.com/paritytech/substrate/pull/12891> and
-                   <https://github.com/paritytech/substrate/pull/11381>.
+error: use of deprecated constant `pallet::warnings::ImplicitCallIndex_0::_w`:
+               It is deprecated to use implicit call indices.
+               Please instead ensure that all calls have a `pallet::call_index` attribute or put the pallet into `dev` mode.
+
+               For more info see:
+                   <https://github.com/paritytech/substrate/pull/12891>
+                   <https://github.com/paritytech/substrate/pull/11381>
   --> tests/pallet_ui/call_missing_index.rs:15:10
    |
 15 |         pub fn foo(_: OriginFor<T>) -> DispatchResult {
    |                ^^^
    |
    = note: `-D deprecated` implied by `-D warnings`
+
+error: use of deprecated constant `pallet::warnings::ImplicitCallIndex_1::_w`:
+               It is deprecated to use implicit call indices.
+               Please instead ensure that all calls have a `pallet::call_index` attribute or put the pallet into `dev` mode.
+
+               For more info see:
+                   <https://github.com/paritytech/substrate/pull/12891>
+                   <https://github.com/paritytech/substrate/pull/11381>
+  --> tests/pallet_ui/call_missing_index.rs:20:10
+   |
+20 |         pub fn bar(_: OriginFor<T>) -> DispatchResult {
+   |                ^^^
+
+error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
+               It is deprecated to use hard-coded constant as call weight.
+               Please instead benchmark all calls or put the pallet into `dev` mode.
+
+               For more info see:
+                   <https://github.com/paritytech/substrate/pull/13798>
+  --> tests/pallet_ui/call_missing_index.rs:14:20
+   |
+14 |         #[pallet::weight(0)]
+   |                          ^
+
+error: use of deprecated constant `pallet::warnings::ConstantWeight_1::_w`:
+               It is deprecated to use hard-coded constant as call weight.
+               Please instead benchmark all calls or put the pallet into `dev` mode.
+
+               For more info see:
+                   <https://github.com/paritytech/substrate/pull/13798>
+  --> tests/pallet_ui/call_missing_index.rs:19:20
+   |
+19 |         #[pallet::weight(0)]
+   |                          ^

--- a/frame/support/test/tests/pallet_ui/call_weight_argument_has_suffix.rs
+++ b/frame/support/test/tests/pallet_ui/call_weight_argument_has_suffix.rs
@@ -11,15 +11,9 @@ mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
-		#[pallet::weight(0)]
-		pub fn foo(_: OriginFor<T>) -> DispatchResult {
-			Ok(())
-		}
-
-		#[pallet::weight(0)]
-		pub fn bar(_: OriginFor<T>) -> DispatchResult {
-			Ok(())
-		}
+		#[pallet::call_index(0)]
+        #[pallet::weight(10_000something)]
+		pub fn foo(_: OriginFor<T>) -> DispatchResult { Ok(()) }
 	}
 }
 

--- a/frame/support/test/tests/pallet_ui/call_weight_argument_has_suffix.stderr
+++ b/frame/support/test/tests/pallet_ui/call_weight_argument_has_suffix.stderr
@@ -1,0 +1,20 @@
+error: invalid suffix `something` for number literal
+  --> tests/pallet_ui/call_weight_argument_has_suffix.rs:15:26
+   |
+15 |         #[pallet::weight(10_000something)]
+   |                          ^^^^^^^^^^^^^^^ invalid suffix `something`
+   |
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
+
+error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
+               It is deprecated to use hard-coded constant as call weight.
+               Please instead benchmark all calls or put the pallet into `dev` mode.
+
+               For more info see:
+                   <https://github.com/paritytech/substrate/pull/13798>
+  --> tests/pallet_ui/call_weight_argument_has_suffix.rs:15:26
+   |
+15 |         #[pallet::weight(10_000something)]
+   |                          ^^^^^^^^^^^^^^^
+   |
+   = note: `-D deprecated` implied by `-D warnings`

--- a/frame/support/test/tests/pallet_ui/call_weight_const_warning.rs
+++ b/frame/support/test/tests/pallet_ui/call_weight_const_warning.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::DispatchResultWithPostInfo;
+	use frame_support::pallet_prelude::DispatchResult;
 	use frame_system::pallet_prelude::OriginFor;
 
 	#[pallet::config]
@@ -12,8 +12,8 @@ mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		#[pallet::call_index(0)]
-        #[pallet::weight(10_000something)]
-		pub fn foo(origin: OriginFor<T>) -> DispatchResultWithPostInfo { Ok(().into()) }
+        #[pallet::weight(123_u64)]
+		pub fn foo(_: OriginFor<T>) -> DispatchResult { Ok(()) }
 	}
 }
 

--- a/frame/support/test/tests/pallet_ui/call_weight_const_warning.stderr
+++ b/frame/support/test/tests/pallet_ui/call_weight_const_warning.stderr
@@ -1,0 +1,12 @@
+error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
+               It is deprecated to use hard-coded constant as call weight.
+               Please instead benchmark all calls or put the pallet into `dev` mode.
+
+               For more info see:
+                   <https://github.com/paritytech/substrate/pull/13798>
+  --> tests/pallet_ui/call_weight_const_warning.rs:15:26
+   |
+15 |         #[pallet::weight(123_u64)]
+   |                          ^^^^^^^
+   |
+   = note: `-D deprecated` implied by `-D warnings`

--- a/frame/support/test/tests/pallet_ui/call_weight_const_warning_twice.rs
+++ b/frame/support/test/tests/pallet_ui/call_weight_const_warning_twice.rs
@@ -11,15 +11,13 @@ mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
-		#[pallet::weight(0)]
-		pub fn foo(_: OriginFor<T>) -> DispatchResult {
-			Ok(())
-		}
+		#[pallet::call_index(0)]
+        #[pallet::weight(123)]
+		pub fn foo(_: OriginFor<T>) -> DispatchResult { Ok(()) }
 
-		#[pallet::weight(0)]
-		pub fn bar(_: OriginFor<T>) -> DispatchResult {
-			Ok(())
-		}
+		#[pallet::call_index(1)]
+        #[pallet::weight(123_custom_prefix)]
+		pub fn bar(_: OriginFor<T>) -> DispatchResult { Ok(()) }
 	}
 }
 

--- a/frame/support/test/tests/pallet_ui/call_weight_const_warning_twice.stderr
+++ b/frame/support/test/tests/pallet_ui/call_weight_const_warning_twice.stderr
@@ -1,0 +1,31 @@
+error: invalid suffix `custom_prefix` for number literal
+  --> tests/pallet_ui/call_weight_const_warning_twice.rs:19:26
+   |
+19 |         #[pallet::weight(123_custom_prefix)]
+   |                          ^^^^^^^^^^^^^^^^^ invalid suffix `custom_prefix`
+   |
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
+
+error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
+               It is deprecated to use hard-coded constant as call weight.
+               Please instead benchmark all calls or put the pallet into `dev` mode.
+
+               For more info see:
+                   <https://github.com/paritytech/substrate/pull/13798>
+  --> tests/pallet_ui/call_weight_const_warning_twice.rs:15:26
+   |
+15 |         #[pallet::weight(123)]
+   |                          ^^^
+   |
+   = note: `-D deprecated` implied by `-D warnings`
+
+error: use of deprecated constant `pallet::warnings::ConstantWeight_1::_w`:
+               It is deprecated to use hard-coded constant as call weight.
+               Please instead benchmark all calls or put the pallet into `dev` mode.
+
+               For more info see:
+                   <https://github.com/paritytech/substrate/pull/13798>
+  --> tests/pallet_ui/call_weight_const_warning_twice.rs:19:26
+   |
+19 |         #[pallet::weight(123_custom_prefix)]
+   |                          ^^^^^^^^^^^^^^^^^

--- a/frame/support/test/tests/pallet_ui/dev_mode_without_arg_max_encoded_len.stderr
+++ b/frame/support/test/tests/pallet_ui/dev_mode_without_arg_max_encoded_len.stderr
@@ -1,15 +1,27 @@
-error: use of deprecated struct `pallet::warnings::my_call`:
-                   Implicit call indices are deprecated in favour of explicit ones.
-                   Please ensure that all calls have the `pallet::call_index` attribute or that the
-                   `dev-mode` of the pallet is enabled. For more info see:
-                   <https://github.com/paritytech/substrate/pull/12891> and
-                   <https://github.com/paritytech/substrate/pull/11381>.
+error: use of deprecated constant `pallet::warnings::ImplicitCallIndex_0::_w`:
+               It is deprecated to use implicit call indices.
+               Please instead ensure that all calls have a `pallet::call_index` attribute or put the pallet into `dev` mode.
+
+               For more info see:
+                   <https://github.com/paritytech/substrate/pull/12891>
+                   <https://github.com/paritytech/substrate/pull/11381>
   --> tests/pallet_ui/dev_mode_without_arg_max_encoded_len.rs:25:10
    |
 25 |         pub fn my_call(_origin: OriginFor<T>) -> DispatchResult {
    |                ^^^^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`
+
+error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
+               It is deprecated to use hard-coded constant as call weight.
+               Please instead benchmark all calls or put the pallet into `dev` mode.
+
+               For more info see:
+                   <https://github.com/paritytech/substrate/pull/13798>
+  --> tests/pallet_ui/dev_mode_without_arg_max_encoded_len.rs:24:20
+   |
+24 |         #[pallet::weight(0)]
+   |                          ^
 
 error[E0277]: the trait bound `Vec<u8>: MaxEncodedLen` is not satisfied
   --> tests/pallet_ui/dev_mode_without_arg_max_encoded_len.rs:11:12

--- a/frame/support/test/tests/pallet_ui/weight_argument_has_suffix.stderr
+++ b/frame/support/test/tests/pallet_ui/weight_argument_has_suffix.stderr
@@ -1,7 +1,0 @@
-error: invalid suffix `something` for number literal
-  --> tests/pallet_ui/weight_argument_has_suffix.rs:15:26
-   |
-15 |         #[pallet::weight(10_000something)]
-   |                          ^^^^^^^^^^^^^^^ invalid suffix `something`
-   |
-   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)

--- a/frame/support/test/tests/storage_layers.rs
+++ b/frame/support/test/tests/storage_layers.rs
@@ -22,7 +22,7 @@ use frame_support::{
 use pallet::*;
 use sp_io::TestExternalities;
 
-#[frame_support::pallet]
+#[frame_support::pallet(dev_mode)]
 pub mod pallet {
 	use frame_support::{ensure, pallet_prelude::*};
 	use frame_system::pallet_prelude::*;

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -41,7 +41,7 @@ use sp_runtime::{
 type BlockNumber = u64;
 
 // example module to test behaviors.
-#[frame_support::pallet]
+#[frame_support::pallet(dev_mode)]
 pub mod example {
 	use frame_support::{dispatch::WithPostDispatchInfo, pallet_prelude::*};
 	use frame_system::pallet_prelude::*;
@@ -91,7 +91,7 @@ pub mod example {
 
 mod mock_democracy {
 	pub use pallet::*;
-	#[frame_support::pallet]
+	#[frame_support::pallet(dev_mode)]
 	pub mod pallet {
 		use frame_support::pallet_prelude::*;
 		use frame_system::pallet_prelude::*;


### PR DESCRIPTION
Cleaning up the code a bit by using [proc-macro-warning](https://github.com/ggwpez/proc-macro-warning) and emitting a warning when using a hard-coded weight on a non-dev-mode pallet (https://github.com/paritytech/substrate/pull/13774).  
In cases where `dev` mode is not possible and you explicitly want to ignore this warning; wrap it in curly brackets like `{1}`.

This enforces consistent formatting and grammar across different warnings for enhanced developer experience.

```pre
warning: use of deprecated constant `pallet::warnings::ImplicitCallIndex::_w`: 
                 It is deprecated to use implicit call indices.
                 Please instead ensure that all calls have the `pallet::call_index` attribute or that the `dev-mode` of the pallet is enabled.
         
                 For more info see:
                     <https://github.com/paritytech/substrate/pull/12891>
                     <https://github.com/paritytech/substrate/pull/11381>
    --> frame/nomination-pools/src/lib.rs:2621:10
     |
2621 |         pub fn claim_commission(origin: OriginFor<T>, pool_id: PoolId) -> DispatchResult {
     |                ^^^^^^^^^^^^^^^^
     |
```
and
```pre
warning: use of deprecated constant `pallet::warnings::ConstantWeight::_w`: 
                 It is deprecated to use hard-coded constant as call weight.
                 Please instead benchmark all calls or put the pallet into `dev` mode.
         
                 For more info see:
                     <https://github.com/paritytech/substrate/pull/13798>
    --> frame/nomination-pools/src/lib.rs:2620:20
     |
2620 |         #[pallet::weight(0)]
     |                          
```

TODO:
- [x] Update and add UI tests

We could also think about a registry of known warnings / errors and have shortened links to them like `parity.link/frame-err-123` to explain how to resolve them.