### PR TITLE
Disable `sign-ext` WASM feature when building runtimes

### DIFF
--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -632,7 +632,7 @@ fn build_project(
 	let mut build_cmd = cargo_cmd.command();
 
 	let rustflags = format!(
-		"-C target-cpu=mvp -C link-arg=--export-table {} {}",
+		"-C target-cpu=mvp -C target-feature=-sign-ext -C link-arg=--export-table {} {}",
 		default_rustflags,
 		env::var(crate::WASM_BUILD_RUSTFLAGS_ENV).unwrap_or_default(),
 	);


### PR DESCRIPTION
Followup of https://github.com/paritytech/substrate/pull/13758

Looks like just setting `target-cpu=mvp` is not enough.

Fixes https://github.com/paritytech/substrate/issues/13636 (this time for real)