### PR TITLE
Expose WASM extensions in executor semantics

### DIFF
--- a/client/executor/benches/bench.rs
+++ b/client/executor/benches/bench.rs
@@ -76,9 +76,6 @@ fn initialize(
 					wasm_bulk_memory: false,
 					wasm_reference_types: false,
 					wasm_simd: false,
-					wasm_threads: false,
-					wasm_multi_memory: false,
-					wasm_memory64: false,
 				},
 			};
 

--- a/client/executor/benches/bench.rs
+++ b/client/executor/benches/bench.rs
@@ -72,6 +72,13 @@ fn initialize(
 					deterministic_stack_limit: None,
 					canonicalize_nans: false,
 					parallel_compilation: true,
+					wasm_multi_value: false,
+					wasm_bulk_memory: false,
+					wasm_reference_types: false,
+					wasm_simd: false,
+					wasm_threads: false,
+					wasm_multi_memory: false,
+					wasm_memory64: false,
 				},
 			};
 

--- a/client/executor/src/wasm_runtime.rs
+++ b/client/executor/src/wasm_runtime.rs
@@ -330,9 +330,6 @@ where
 						wasm_bulk_memory: false,
 						wasm_reference_types: false,
 						wasm_simd: false,
-						wasm_threads: false,
-						wasm_multi_memory: false,
-						wasm_memory64: false,
 					},
 				},
 			)

--- a/client/executor/src/wasm_runtime.rs
+++ b/client/executor/src/wasm_runtime.rs
@@ -326,6 +326,13 @@ where
 						deterministic_stack_limit: None,
 						canonicalize_nans: false,
 						parallel_compilation: true,
+						wasm_multi_value: false,
+						wasm_bulk_memory: false,
+						wasm_reference_types: false,
+						wasm_simd: false,
+						wasm_threads: false,
+						wasm_multi_memory: false,
+						wasm_memory64: false,
 					},
 				},
 			)

--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -325,13 +325,13 @@ fn common_config(semantics: &Semantics) -> std::result::Result<wasmtime::Config,
 
 	// Be clear and specific about the extensions we support. If an update brings new features
 	// they should be introduced here as well.
-	config.wasm_reference_types(false);
-	config.wasm_simd(false);
-	config.wasm_bulk_memory(false);
-	config.wasm_multi_value(false);
-	config.wasm_multi_memory(false);
-	config.wasm_threads(false);
-	config.wasm_memory64(false);
+	config.wasm_reference_types(semantics.wasm_reference_types);
+	config.wasm_simd(semantics.wasm_simd);
+	config.wasm_bulk_memory(semantics.wasm_bulk_memory);
+	config.wasm_multi_value(semantics.wasm_multi_value);
+	config.wasm_multi_memory(semantics.wasm_multi_memory);
+	config.wasm_threads(semantics.wasm_threads);
+	config.wasm_memory64(semantics.wasm_memory64);
 
 	let (use_pooling, use_cow) = match semantics.instantiation_strategy {
 		InstantiationStrategy::PoolingCopyOnWrite => (true, true),
@@ -504,6 +504,27 @@ pub struct Semantics {
 
 	/// The heap allocation strategy to use.
 	pub heap_alloc_strategy: HeapAllocStrategy,
+
+	/// Enables WASM Multi-Value proposal
+	pub wasm_multi_value: bool,
+
+	/// Enables WASM Bulk Memory Operations proposal
+	pub wasm_bulk_memory: bool,
+
+	/// Enables WASM Reference Types proposal
+	pub wasm_reference_types: bool,
+
+	/// Enables WASM Fixed-Width SIMD proposal
+	pub wasm_simd: bool,
+
+	/// Enables WASM Threads and Atomics proposal
+	pub wasm_threads: bool,
+
+	/// Enables WASM Multi-Memory proposal
+	pub wasm_multi_memory: bool,
+
+	/// Enables WASM Memory64 proposal
+	pub wasm_memory64: bool,
 }
 
 #[derive(Clone)]

--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -329,9 +329,9 @@ fn common_config(semantics: &Semantics) -> std::result::Result<wasmtime::Config,
 	config.wasm_simd(semantics.wasm_simd);
 	config.wasm_bulk_memory(semantics.wasm_bulk_memory);
 	config.wasm_multi_value(semantics.wasm_multi_value);
-	config.wasm_multi_memory(semantics.wasm_multi_memory);
-	config.wasm_threads(semantics.wasm_threads);
-	config.wasm_memory64(semantics.wasm_memory64);
+	config.wasm_multi_memory(false);
+	config.wasm_threads(false);
+	config.wasm_memory64(false);
 
 	let (use_pooling, use_cow) = match semantics.instantiation_strategy {
 		InstantiationStrategy::PoolingCopyOnWrite => (true, true),
@@ -516,15 +516,6 @@ pub struct Semantics {
 
 	/// Enables WASM Fixed-Width SIMD proposal
 	pub wasm_simd: bool,
-
-	/// Enables WASM Threads and Atomics proposal
-	pub wasm_threads: bool,
-
-	/// Enables WASM Multi-Memory proposal
-	pub wasm_multi_memory: bool,
-
-	/// Enables WASM Memory64 proposal
-	pub wasm_memory64: bool,
 }
 
 #[derive(Clone)]

--- a/client/executor/wasmtime/src/tests.rs
+++ b/client/executor/wasmtime/src/tests.rs
@@ -159,9 +159,6 @@ impl RuntimeBuilder {
 				wasm_bulk_memory: false,
 				wasm_reference_types: false,
 				wasm_simd: false,
-				wasm_threads: false,
-				wasm_multi_memory: false,
-				wasm_memory64: false,
 			},
 		};
 
@@ -485,9 +482,6 @@ fn test_instances_without_reuse_are_not_leaked() {
 				wasm_bulk_memory: false,
 				wasm_reference_types: false,
 				wasm_simd: false,
-				wasm_threads: false,
-				wasm_multi_memory: false,
-				wasm_memory64: false,
 			},
 		},
 	)

--- a/client/executor/wasmtime/src/tests.rs
+++ b/client/executor/wasmtime/src/tests.rs
@@ -155,6 +155,13 @@ impl RuntimeBuilder {
 				canonicalize_nans: self.canonicalize_nans,
 				parallel_compilation: true,
 				heap_alloc_strategy: self.heap_pages,
+				wasm_multi_value: false,
+				wasm_bulk_memory: false,
+				wasm_reference_types: false,
+				wasm_simd: false,
+				wasm_threads: false,
+				wasm_multi_memory: false,
+				wasm_memory64: false,
 			},
 		};
 
@@ -474,6 +481,13 @@ fn test_instances_without_reuse_are_not_leaked() {
 				canonicalize_nans: false,
 				parallel_compilation: true,
 				heap_alloc_strategy: HeapAllocStrategy::Static { extra_pages: 2048 },
+				wasm_multi_value: false,
+				wasm_bulk_memory: false,
+				wasm_reference_types: false,
+				wasm_simd: false,
+				wasm_threads: false,
+				wasm_multi_memory: false,
+				wasm_memory64: false,
 			},
 		},
 	)


### PR DESCRIPTION
# Description

During a recent [LLVM incident](https://github.com/paritytech/substrate/issues/13636), we discovered that enabling and disabling WASM extensions is not only a matter of our will. Teams working on compilers and WASM runtimes stabilize things independently, and we need a mechanism to enable those extensions deterministically on a per-session basis.

Thus, paritytech/polkadot#6918 was raised. To enable the underlying execution logic to control the extensions, the Substrate has to expose corresponding handles through Wasmtime executor semantics. This PR solves that. The controlling logic will be implemented in a separate PR in the Polkadot repo.

# Related issues

Closes #13809 
Unblocks paritytech/polkadot#6918

# Companion PRs

Polkadot companion: paritytech/polkadot#6998