### PR TITLE
Move registration of `ReadRuntimeVersionExt` to `ExecutionExtension`

### DIFF
--- a/bin/node/testing/src/bench.rs
+++ b/bin/node/testing/src/bench.rs
@@ -411,11 +411,16 @@ impl BenchDb {
 
 		let client = sc_service::new_client(
 			backend.clone(),
-			executor,
+			executor.clone(),
 			genesis_block_builder,
 			None,
 			None,
-			ExecutionExtensions::new(profile.into_execution_strategies(), None, None),
+			ExecutionExtensions::new(
+				profile.into_execution_strategies(),
+				None,
+				None,
+				Arc::new(executor),
+			),
 			Box::new(task_executor.clone()),
 			None,
 			None,

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -181,6 +181,7 @@ where
 			config.execution_strategies.clone(),
 			Some(keystore_container.keystore()),
 			sc_offchain::OffchainDb::factory_from_backend(&*backend),
+			Arc::new(executor.clone()),
 		);
 
 		let wasm_runtime_substitutes = config

--- a/client/service/src/client/call_executor.rs
+++ b/client/service/src/client/call_executor.rs
@@ -427,6 +427,7 @@ mod tests {
 				Default::default(),
 				None,
 				None,
+				Arc::new(executor.clone()),
 			)),
 		};
 

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -243,6 +243,7 @@ where
 		Default::default(),
 		keystore,
 		sc_offchain::OffchainDb::factory_from_backend(&*backend),
+		Arc::new(executor.clone()),
 	);
 
 	let call_executor =

--- a/primitives/core/src/traits.rs
+++ b/primitives/core/src/traits.rs
@@ -157,6 +157,16 @@ pub trait ReadRuntimeVersion: Send + Sync {
 	) -> Result<Vec<u8>, String>;
 }
 
+impl ReadRuntimeVersion for std::sync::Arc<dyn ReadRuntimeVersion> {
+	fn read_runtime_version(
+		&self,
+		wasm_code: &[u8],
+		ext: &mut dyn Externalities,
+	) -> Result<Vec<u8>, String> {
+		(**self).read_runtime_version(wasm_code, ext)
+	}
+}
+
 sp_externalities::decl_extension! {
 	/// An extension that provides functionality to read version information from a given wasm blob.
 	pub struct ReadRuntimeVersionExt(Box<dyn ReadRuntimeVersion>);

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -163,7 +163,7 @@ mod execution {
 	use sp_core::{
 		hexdisplay::HexDisplay,
 		storage::{ChildInfo, ChildType, PrefixedStorageKey},
-		traits::{CallContext, CodeExecutor, ReadRuntimeVersionExt, RuntimeCode},
+		traits::{CallContext, CodeExecutor, RuntimeCode},
 	};
 	use sp_externalities::Extensions;
 	use std::{
@@ -322,12 +322,10 @@ mod execution {
 			exec: &'a Exec,
 			method: &'a str,
 			call_data: &'a [u8],
-			mut extensions: Extensions,
+			extensions: Extensions,
 			runtime_code: &'a RuntimeCode,
 			context: CallContext,
 		) -> Self {
-			extensions.register(ReadRuntimeVersionExt::new(exec.clone()));
-
 			Self {
 				backend,
 				exec,

--- a/test-utils/client/src/lib.rs
+++ b/test-utils/client/src/lib.rs
@@ -290,12 +290,13 @@ impl<Block: BlockT, D, Backend, G: GenesisInit>
 		});
 		let executor = LocalCallExecutor::new(
 			self.backend.clone(),
-			executor,
+			executor.clone(),
 			Default::default(),
 			ExecutionExtensions::new(
 				self.execution_strategies.clone(),
 				self.keystore.clone(),
 				sc_offchain::OffchainDb::factory_from_backend(&*self.backend),
+				Arc::new(executor),
 			),
 		)
 		.expect("Creates LocalCallExecutor");

--- a/utils/frame/benchmarking-cli/src/pallet/command.rs
+++ b/utils/frame/benchmarking-cli/src/pallet/command.rs
@@ -35,7 +35,7 @@ use sp_core::{
 		testing::{TestOffchainExt, TestTransactionPoolExt},
 		OffchainDbExt, OffchainWorkerExt, TransactionPoolExt,
 	},
-	traits::CallContext,
+	traits::{CallContext, ReadRuntimeVersionExt},
 };
 use sp_externalities::Extensions;
 use sp_keystore::{testing::MemoryKeystore, KeystoreExt};
@@ -225,6 +225,7 @@ impl PalletCmd {
 			extensions.register(OffchainWorkerExt::new(offchain.clone()));
 			extensions.register(OffchainDbExt::new(offchain));
 			extensions.register(TransactionPoolExt::new(pool));
+			extensions.register(ReadRuntimeVersionExt::new(executor.clone()));
 			extensions
 		};
 

--- a/utils/frame/try-runtime/cli/src/commands/execute_block.rs
+++ b/utils/frame/try-runtime/cli/src/commands/execute_block.rs
@@ -133,7 +133,7 @@ where
 		&executor,
 		"TryRuntime_execute_block",
 		&payload,
-		full_extensions(),
+		full_extensions(executor.clone()),
 		shared.export_proof,
 	)?;
 

--- a/utils/frame/try-runtime/cli/src/commands/fast_forward.rs
+++ b/utils/frame/try-runtime/cli/src/commands/fast_forward.rs
@@ -103,7 +103,7 @@ async fn dry_run<T: Decode, Block: BlockT, HostFns: HostFunctions>(
 		executor,
 		method,
 		data,
-		full_extensions(),
+		full_extensions(executor.clone()),
 	)?;
 
 	Ok(<T>::decode(&mut &*result)?)
@@ -121,7 +121,7 @@ async fn run<Block: BlockT, HostFns: HostFunctions>(
 		executor,
 		method,
 		data,
-		full_extensions(),
+		full_extensions(executor.clone()),
 	)?;
 
 	let storage_changes = changes.drain_storage_changes(

--- a/utils/frame/try-runtime/cli/src/commands/follow_chain.rs
+++ b/utils/frame/try-runtime/cli/src/commands/follow_chain.rs
@@ -149,7 +149,7 @@ where
 			&executor,
 			"TryRuntime_execute_block",
 			(block, command.state_root_check, command.try_state.clone()).encode().as_ref(),
-			full_extensions(),
+			full_extensions(executor.clone()),
 			shared
 				.export_proof
 				.as_ref()

--- a/utils/frame/try-runtime/cli/src/commands/offchain_worker.rs
+++ b/utils/frame/try-runtime/cli/src/commands/offchain_worker.rs
@@ -97,7 +97,7 @@ where
 		&executor,
 		"OffchainWorkerApi_offchain_worker",
 		&payload,
-		full_extensions(),
+		full_extensions(executor.clone()),
 	)?;
 
 	Ok(())

--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -377,7 +377,7 @@ use sp_core::{
 		OffchainDbExt, OffchainWorkerExt, TransactionPoolExt,
 	},
 	storage::well_known_keys,
-	traits::{CallContext, ReadRuntimeVersion},
+	traits::{CallContext, ReadRuntimeVersion, ReadRuntimeVersionExt},
 	twox_128, H256,
 };
 use sp_externalities::Extensions;
@@ -810,7 +810,7 @@ where
 }
 
 /// Build all extensions that we typically use.
-pub(crate) fn full_extensions() -> Extensions {
+pub(crate) fn full_extensions<H: HostFunctions>(wasm_executor: WasmExecutor<H>) -> Extensions {
 	let mut extensions = Extensions::default();
 	let (offchain, _offchain_state) = TestOffchainExt::new();
 	let (pool, _pool_state) = TestTransactionPoolExt::new();
@@ -819,6 +819,7 @@ pub(crate) fn full_extensions() -> Extensions {
 	extensions.register(OffchainWorkerExt::new(offchain));
 	extensions.register(KeystoreExt::new(keystore));
 	extensions.register(TransactionPoolExt::new(pool));
+	extensions.register(ReadRuntimeVersionExt::new(wasm_executor));
 
 	extensions
 }


### PR DESCRIPTION
Instead of registering `ReadRuntimeVersionExt` in `sp-state-machine` it is moved to `ExecutionExtension` which provides the default extensions.


