### PR TITLE
Add HoldReason to the NIS pallet

### DIFF
--- a/frame/nis/src/lib.rs
+++ b/frame/nis/src/lib.rs
@@ -482,6 +482,14 @@ pub mod pallet {
 		AlreadyPrivate,
 	}
 
+	/// A reason for the NIS pallet placing a hold on funds.
+	#[pallet::composable_enum]
+	pub enum HoldReason {
+		/// The NIS Pallet has reserved it for a non-fungible receipt.
+		#[codec(index = 0)]
+		NftReceipt,
+	}
+
 	pub(crate) struct WeightCounter {
 		pub(crate) used: Weight,
 		pub(crate) limit: Weight,

--- a/frame/nis/src/lib.rs
+++ b/frame/nis/src/lib.rs
@@ -483,7 +483,7 @@ pub mod pallet {
 	}
 
 	/// A reason for the NIS pallet placing a hold on funds.
-	#[pallet::composable_enum]
+	#[pallet::composite_enum]
 	pub enum HoldReason {
 		/// The NIS Pallet has reserved it for a non-fungible receipt.
 		#[codec(index = 0)]

--- a/frame/support/procedural/src/construct_runtime/expand/freeze_reason.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/freeze_reason.rs
@@ -35,6 +35,7 @@ pub fn expand_outer_freeze_reason(pallet_decls: &[Pallet], scrate: &TokenStream)
 	}
 
 	quote! {
+		/// A reason for placing a freeze on funds.
 		#[derive(
 			Copy, Clone, Eq, PartialEq, Ord, PartialOrd,
 			#scrate::codec::Encode, #scrate::codec::Decode, #scrate::codec::MaxEncodedLen,

--- a/frame/support/procedural/src/construct_runtime/expand/hold_reason.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/hold_reason.rs
@@ -35,6 +35,7 @@ pub fn expand_outer_hold_reason(pallet_decls: &[Pallet], scrate: &TokenStream) -
 	}
 
 	quote! {
+		/// A reason for placing a hold on funds.
 		#[derive(
 			Copy, Clone, Eq, PartialEq, Ord, PartialOrd,
 			#scrate::codec::Encode, #scrate::codec::Decode, #scrate::codec::MaxEncodedLen,

--- a/frame/support/procedural/src/construct_runtime/expand/lock_id.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/lock_id.rs
@@ -35,6 +35,7 @@ pub fn expand_outer_lock_id(pallet_decls: &[Pallet], scrate: &TokenStream) -> To
 	}
 
 	quote! {
+		/// An identifier for each lock placed on funds.
 		#[derive(
 			Copy, Clone, Eq, PartialEq, Ord, PartialOrd,
 			#scrate::codec::Encode, #scrate::codec::Decode, #scrate::codec::MaxEncodedLen,

--- a/frame/support/procedural/src/construct_runtime/expand/slash_reason.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/slash_reason.rs
@@ -35,6 +35,7 @@ pub fn expand_outer_slash_reason(pallet_decls: &[Pallet], scrate: &TokenStream) 
 	}
 
 	quote! {
+		/// A reason for slashing funds.
 		#[derive(
 			Copy, Clone, Eq, PartialEq, Ord, PartialOrd,
 			#scrate::codec::Encode, #scrate::codec::Decode, #scrate::codec::MaxEncodedLen,

--- a/frame/support/procedural/src/lib.rs
+++ b/frame/support/procedural/src/lib.rs
@@ -1412,7 +1412,7 @@ pub fn origin(_: TokenStream, _: TokenStream) -> TokenStream {
 	pallet_macro_stub()
 }
 
-/// The `#[pallet::composable_enum]` attribute allows you to define an enum that gets composed as an
+/// The `#[pallet::composite_enum]` attribute allows you to define an enum that gets composed as an
 /// aggregate enum by `construct_runtime`. This is similar in principle with `#[pallet::event]` and
 /// `#[pallet::error]`.
 ///
@@ -1431,10 +1431,10 @@ pub fn origin(_: TokenStream, _: TokenStream) -> TokenStream {
 /// ```
 ///
 /// For ease of usage, when no `#[derive]` attributes are found for the enum under
-/// `#[pallet::composable_enum]`, the aforementioned traits are automatically derived for it. The
+/// `#[pallet::composite_enum]`, the aforementioned traits are automatically derived for it. The
 /// inverse is also true: if there are any `#[derive]` attributes found for the enum, then no traits
 /// will automatically be derived for it.
 #[proc_macro_attribute]
-pub fn composable_enum(_: TokenStream, _: TokenStream) -> TokenStream {
+pub fn composite_enum(_: TokenStream, _: TokenStream) -> TokenStream {
 	pallet_macro_stub()
 }

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -1552,7 +1552,7 @@ pub mod pallet_prelude {
 /// * [`pallet::inherent`](#inherent-palletinherent-optional)
 /// * [`pallet::validate_unsigned`](#validate-unsigned-palletvalidate_unsigned-optional)
 /// * [`pallet::origin`](#origin-palletorigin-optional)
-/// * [`pallet::composable_enum`](#composable-enum-palletcomposable_enum-optional)
+/// * [`pallet::composite_enum`](#composite-enum-palletcomposite_enum-optional)
 ///
 /// Note that at compile-time, the `#[pallet]` macro will analyze and expand all of these
 /// attributes, ultimately removing their AST nodes before they can be parsed as real
@@ -2278,19 +2278,19 @@ pub mod pallet_prelude {
 ///
 /// Also see [`pallet::origin`](`frame_support::pallet_macros::origin`)
 ///
-/// # Composable enum `#[pallet::composable_enum]` (optional)
+/// # Composite enum `#[pallet::composite_enum]` (optional)
 ///
-/// The `#[pallet::composable_enum]` attribute allows you to define an enum on the pallet which
+/// The `#[pallet::composite_enum]` attribute allows you to define an enum on the pallet which
 /// will then instruct `construct_runtime` to amalgamate all similarly-named enums from other
 /// pallets into an aggregate enum. This is similar in principle with how the aggregate enum is
 /// generated for `#[pallet::event]` or `#[pallet::error]`.
 ///
-/// The item tagged with `#[pallet::composable_enum]` MUST be an enum declaration, and can ONLY
+/// The item tagged with `#[pallet::composite_enum]` MUST be an enum declaration, and can ONLY
 /// be the following identifiers: `FreezeReason`, `HoldReason`, `LockId` or `SlashReason`.
 /// Custom identifiers are not supported.
 ///
 /// NOTE: For ease of usage, when no `#[derive]` attributes are detected, the
-/// `#[pallet::composable_enum]` attribute will automatically derive the following traits for
+/// `#[pallet::composite_enum]` attribute will automatically derive the following traits for
 /// the enum:
 ///
 /// ```ignore
@@ -2832,7 +2832,7 @@ pub use frame_support_procedural::pallet;
 /// Contains macro stubs for all of the pallet:: macros
 pub mod pallet_macros {
 	pub use frame_support_procedural::{
-		call_index, compact, composable_enum, config, constant,
+		call_index, compact, composite_enum, config, constant,
 		disable_frame_system_supertrait_check, error, event, extra_constants, generate_deposit,
 		generate_storage_info, generate_store, genesis_build, genesis_config, getter, hooks,
 		inherent, origin, storage, storage_prefix, storage_version, type_value, unbounded,

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -991,6 +991,8 @@ fn validate_unsigned_expand() {
 
 #[test]
 fn composite_expand() {
+	use codec::Encode;
+
 	let hold_reason: RuntimeHoldReason = pallet::HoldReason::Staking.into();
 	let hold_reason2: RuntimeHoldReason = pallet2::HoldReason::Governance.into();
 	let slash_reason: RuntimeSlashReason = pallet2::SlashReason::Equivocation.into();
@@ -998,6 +1000,10 @@ fn composite_expand() {
 	assert_eq!(hold_reason, RuntimeHoldReason::Example(pallet::HoldReason::Staking));
 	assert_eq!(hold_reason2, RuntimeHoldReason::Example2(pallet2::HoldReason::Governance));
 	assert_eq!(slash_reason, RuntimeSlashReason::Example2(pallet2::SlashReason::Equivocation));
+
+	assert_eq!(hold_reason.encode(), [1, 0]);
+	assert_eq!(hold_reason2.encode(), [2, 0]);
+	assert_eq!(slash_reason.encode(), [2, 0]);
 }
 
 #[test]


### PR DESCRIPTION
Partial #12918.

Adds the `HoldReason` as a `composite_enum` to the NIS pallet. Also fixes a couple of naming bugs and adds more tests.