### PR TITLE
pallet-democracy: Do not request the proposal when scheduling

### DIFF
--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -1591,11 +1591,6 @@ impl<T: Config> Pallet<T> {
 
 		if approved {
 			Self::deposit_event(Event::<T>::Passed { ref_index: index });
-			// Actually `hold` the proposal now since we didn't hold it when it came in via the
-			// submit extrinsic and we now know that it will be needed. This will be reversed by
-			// Scheduler pallet once it is executed which assumes that we will already have placed
-			// a `hold` on it.
-			T::Preimages::hold(&status.proposal);
 
 			// Earliest it can be scheduled for is next block.
 			let when = now.saturating_add(status.delay.max(One::one()));

--- a/frame/democracy/src/tests/metadata.rs
+++ b/frame/democracy/src/tests/metadata.rs
@@ -33,7 +33,7 @@ fn set_external_metadata_works() {
 			Error::<Test>::NoProposal,
 		);
 		// create an external proposal.
-		assert_ok!(Democracy::external_propose(RuntimeOrigin::signed(2), set_balance_proposal(2),));
+		assert_ok!(Democracy::external_propose(RuntimeOrigin::signed(2), set_balance_proposal(2)));
 		assert!(<NextExternal<Test>>::exists());
 		// fails to set metadata with non external origin.
 		assert_noop!(
@@ -47,7 +47,7 @@ fn set_external_metadata_works() {
 		);
 		// set metadata successful.
 		let hash = note_preimage(1);
-		assert_ok!(Democracy::set_metadata(RuntimeOrigin::signed(2), owner.clone(), Some(hash),),);
+		assert_ok!(Democracy::set_metadata(RuntimeOrigin::signed(2), owner.clone(), Some(hash)));
 		System::assert_last_event(RuntimeEvent::Democracy(crate::Event::MetadataSet {
 			owner,
 			hash,
@@ -61,11 +61,11 @@ fn clear_metadata_works() {
 		// metadata owner is an external proposal.
 		let owner = MetadataOwner::External;
 		// create an external proposal.
-		assert_ok!(Democracy::external_propose(RuntimeOrigin::signed(2), set_balance_proposal(2),));
+		assert_ok!(Democracy::external_propose(RuntimeOrigin::signed(2), set_balance_proposal(2)));
 		assert!(<NextExternal<Test>>::exists());
 		// set metadata.
 		let hash = note_preimage(1);
-		assert_ok!(Democracy::set_metadata(RuntimeOrigin::signed(2), owner.clone(), Some(hash),));
+		assert_ok!(Democracy::set_metadata(RuntimeOrigin::signed(2), owner.clone(), Some(hash)));
 		// fails to clear metadata with a wrong origin.
 		assert_noop!(
 			Democracy::set_metadata(RuntimeOrigin::signed(1), owner.clone(), None),
@@ -92,18 +92,18 @@ fn set_proposal_metadata_works() {
 		let owner = MetadataOwner::Proposal(Democracy::public_prop_count() - 1);
 		// fails to set non-existing preimage.
 		assert_noop!(
-			Democracy::set_metadata(RuntimeOrigin::signed(1), owner.clone(), Some(invalid_hash),),
+			Democracy::set_metadata(RuntimeOrigin::signed(1), owner.clone(), Some(invalid_hash)),
 			Error::<Test>::PreimageNotExist,
 		);
 		// note preimage.
 		let hash = note_preimage(1);
 		// fails to set a preimage if an origin is not a proposer.
 		assert_noop!(
-			Democracy::set_metadata(RuntimeOrigin::signed(3), owner.clone(), Some(hash),),
+			Democracy::set_metadata(RuntimeOrigin::signed(3), owner.clone(), Some(hash)),
 			Error::<Test>::NoPermission,
 		);
 		// set metadata successful.
-		assert_ok!(Democracy::set_metadata(RuntimeOrigin::signed(1), owner.clone(), Some(hash),),);
+		assert_ok!(Democracy::set_metadata(RuntimeOrigin::signed(1), owner.clone(), Some(hash)));
 		System::assert_last_event(RuntimeEvent::Democracy(crate::Event::MetadataSet {
 			owner,
 			hash,
@@ -120,7 +120,7 @@ fn clear_proposal_metadata_works() {
 		let owner = MetadataOwner::Proposal(Democracy::public_prop_count() - 1);
 		// set metadata.
 		let hash = note_preimage(1);
-		assert_ok!(Democracy::set_metadata(RuntimeOrigin::signed(1), owner.clone(), Some(hash),));
+		assert_ok!(Democracy::set_metadata(RuntimeOrigin::signed(1), owner.clone(), Some(hash)));
 		// fails to clear metadata with a wrong origin.
 		assert_noop!(
 			Democracy::set_metadata(RuntimeOrigin::signed(3), owner.clone(), None),
@@ -150,16 +150,16 @@ fn set_referendum_metadata_by_root() {
 		let hash = note_preimage(1);
 		// fails to set if not a root.
 		assert_noop!(
-			Democracy::set_metadata(RuntimeOrigin::signed(3), owner.clone(), Some(hash),),
+			Democracy::set_metadata(RuntimeOrigin::signed(3), owner.clone(), Some(hash)),
 			Error::<Test>::NoPermission,
 		);
 		// fails to clear if not a root.
 		assert_noop!(
-			Democracy::set_metadata(RuntimeOrigin::signed(3), owner.clone(), None,),
+			Democracy::set_metadata(RuntimeOrigin::signed(3), owner.clone(), None),
 			Error::<Test>::NoPermission,
 		);
 		// succeed to set metadata by a root for an ongoing referendum.
-		assert_ok!(Democracy::set_metadata(RuntimeOrigin::root(), owner.clone(), Some(hash),));
+		assert_ok!(Democracy::set_metadata(RuntimeOrigin::root(), owner.clone(), Some(hash)));
 		System::assert_last_event(RuntimeEvent::Democracy(crate::Event::MetadataSet {
 			owner: owner.clone(),
 			hash,

--- a/frame/support/src/traits/schedule.rs
+++ b/frame/support/src/traits/schedule.rs
@@ -438,6 +438,8 @@ pub mod v3 {
 		/// Schedule a dispatch to happen at the beginning of some block in the future.
 		///
 		/// - `id`: The identity of the task. This must be unique and will return an error if not.
+		///
+		/// NOTE: This will request `call` to be made available.
 		fn schedule_named(
 			id: TaskName,
 			when: DispatchTime<BlockNumber>,


### PR DESCRIPTION
The requesting of the proposal is actually done now in `pallet-scheduler`.

Fixes: https://github.com/paritytech/substrate/issues/13534

