### PR TITLE
de-duplicate --help --sync docs

### DIFF
--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -132,11 +132,6 @@ pub struct NetworkParams {
 	pub ipfs_server: bool,
 
 	/// Blockchain syncing mode.
-	///
-	/// - `full`: Download and validate full blockchain history.
-	/// - `fast`: Download blocks and the latest state only.
-	/// - `fast-unsafe`: Same as `fast`, but skip downloading state proofs.
-	/// - `warp`: Download the latest state and proof.
 	#[arg(
 		long,
 		value_enum,


### PR DESCRIPTION
`./substrate --help` logs duplicate possible values for the `--sync` flag.

<img width="620" alt="Screenshot 2023-04-05 at 17 49 42" src="https://user-images.githubusercontent.com/16665596/230101834-9cf35645-3bfd-4cc5-97ff-69a03638df00.png">