### PR TITLE
simplify some pattern matches to appease 1.68 clippy

### DIFF
--- a/client/consensus/grandpa/src/communication/mod.rs
+++ b/client/consensus/grandpa/src/communication/mod.rs
@@ -852,9 +852,7 @@ fn check_compact_commit<Block: BlockT>(
 
 	// check signatures on all contained precommits.
 	let mut buf = Vec::new();
-	for (i, (precommit, &(ref sig, ref id))) in
-		msg.precommits.iter().zip(&msg.auth_data).enumerate()
-	{
+	for (i, (precommit, (sig, id))) in msg.precommits.iter().zip(&msg.auth_data).enumerate() {
 		use crate::communication::gossip::Misbehavior;
 		use finality_grandpa::Message as GrandpaMessage;
 

--- a/client/network/common/src/sync.rs
+++ b/client/network/common/src/sync.rs
@@ -424,9 +424,9 @@ pub trait ChainSync<Block: BlockT>: Send {
 	///
 	/// If [`PollBlockAnnounceValidation::ImportHeader`] is returned, then the caller MUST try to
 	/// import passed header (call `on_block_data`). The network request isn't sent in this case.
-	fn poll_block_announce_validation<'a>(
+	fn poll_block_announce_validation(
 		&mut self,
-		cx: &mut std::task::Context<'a>,
+		cx: &mut std::task::Context<'_>,
 	) -> Poll<PollBlockAnnounceValidation<Block::Header>>;
 
 	/// Call when a peer has disconnected.

--- a/client/network/src/protocol/notifications/behaviour.rs
+++ b/client/network/src/protocol/notifications/behaviour.rs
@@ -2628,8 +2628,7 @@ mod tests {
 			conn,
 			NotifsHandlerOut::OpenDesiredByRemote { protocol_index: 0 },
 		);
-		if let Some(&PeerState::Incoming { ref connections, .. }) = notif.peers.get(&(peer, set_id))
-		{
+		if let Some(PeerState::Incoming { connections, .. }) = notif.peers.get(&(peer, set_id)) {
 			assert_eq!(connections.len(), 1);
 			assert_eq!(connections[0], (conn, ConnectionState::OpenDesiredByRemote));
 		} else {
@@ -2647,8 +2646,7 @@ mod tests {
 			},
 		));
 
-		if let Some(&PeerState::Incoming { ref connections, .. }) = notif.peers.get(&(peer, set_id))
-		{
+		if let Some(PeerState::Incoming { connections, .. }) = notif.peers.get(&(peer, set_id)) {
 			assert_eq!(connections.len(), 2);
 			assert_eq!(connections[0], (conn, ConnectionState::OpenDesiredByRemote));
 			assert_eq!(connections[1], (conn2, ConnectionState::Closed));
@@ -2797,8 +2795,7 @@ mod tests {
 			},
 		));
 
-		if let Some(&PeerState::Disabled { ref connections, .. }) = notif.peers.get(&(peer, set_id))
-		{
+		if let Some(PeerState::Disabled { connections, .. }) = notif.peers.get(&(peer, set_id)) {
 			assert_eq!(connections.len(), 1);
 			assert_eq!(connections[0], (conn1, ConnectionState::Closed));
 		} else {
@@ -2884,8 +2881,7 @@ mod tests {
 			));
 		}
 
-		if let Some(&PeerState::Disabled { ref connections, .. }) = notif.peers.get(&(peer, set_id))
-		{
+		if let Some(PeerState::Disabled { connections, .. }) = notif.peers.get(&(peer, set_id)) {
 			assert_eq!(connections[0], (conn1, ConnectionState::Closed));
 			assert_eq!(connections[1], (conn2, ConnectionState::Closed));
 		} else {
@@ -2900,8 +2896,7 @@ mod tests {
 			NotifsHandlerOut::OpenDesiredByRemote { protocol_index: 0 },
 		);
 
-		if let Some(&PeerState::Enabled { ref connections, .. }) = notif.peers.get(&(peer, set_id))
-		{
+		if let Some(PeerState::Enabled { connections, .. }) = notif.peers.get(&(peer, set_id)) {
 			assert_eq!(connections[0], (conn1, ConnectionState::Opening));
 			assert_eq!(connections[1], (conn2, ConnectionState::Opening));
 		} else {
@@ -3297,8 +3292,7 @@ mod tests {
 			));
 		}
 
-		if let Some(&PeerState::Disabled { ref connections, .. }) = notif.peers.get(&(peer, set_id))
-		{
+		if let Some(PeerState::Disabled { connections, .. }) = notif.peers.get(&(peer, set_id)) {
 			assert_eq!(connections[0], (conn1, ConnectionState::Closed));
 			assert_eq!(connections[1], (conn2, ConnectionState::Closed));
 		} else {
@@ -3356,8 +3350,7 @@ mod tests {
 			));
 		}
 
-		if let Some(&PeerState::Disabled { ref connections, .. }) = notif.peers.get(&(peer, set_id))
-		{
+		if let Some(PeerState::Disabled { connections, .. }) = notif.peers.get(&(peer, set_id)) {
 			assert_eq!(connections[0], (conn1, ConnectionState::Closed));
 			assert_eq!(connections[1], (conn2, ConnectionState::Closed));
 		} else {
@@ -3413,8 +3406,7 @@ mod tests {
 			));
 		}
 
-		if let Some(&PeerState::Disabled { ref connections, .. }) = notif.peers.get(&(peer, set_id))
-		{
+		if let Some(PeerState::Disabled { connections, .. }) = notif.peers.get(&(peer, set_id)) {
 			assert_eq!(connections[0], (conn1, ConnectionState::Closed));
 			assert_eq!(connections[1], (conn2, ConnectionState::Closed));
 		} else {
@@ -3424,8 +3416,7 @@ mod tests {
 		// open substreams on both active connections
 		notif.peerset_report_connect(peer, set_id);
 
-		if let Some(&PeerState::Enabled { ref connections, .. }) = notif.peers.get(&(peer, set_id))
-		{
+		if let Some(PeerState::Enabled { connections, .. }) = notif.peers.get(&(peer, set_id)) {
 			assert_eq!(connections[0], (conn1, ConnectionState::Opening));
 			assert_eq!(connections[1], (conn2, ConnectionState::Closed));
 		} else {

--- a/client/network/sync/src/blocks.rs
+++ b/client/network/sync/src/blocks.rs
@@ -89,7 +89,7 @@ impl<B: BlockT> BlockCollection<B> {
 			Some(&BlockRangeState::Downloading { .. }) => {
 				trace!(target: "sync", "Inserting block data still marked as being downloaded: {}", start);
 			},
-			Some(&BlockRangeState::Complete(ref existing)) if existing.len() >= blocks.len() => {
+			Some(BlockRangeState::Complete(existing)) if existing.len() >= blocks.len() => {
 				trace!(target: "sync", "Ignored block data already downloaded: {}", start);
 				return
 			},

--- a/client/network/transactions/src/lib.rs
+++ b/client/network/transactions/src/lib.rs
@@ -473,7 +473,7 @@ where
 
 			let (hashes, to_send): (Vec<_>, Vec<_>) = transactions
 				.iter()
-				.filter(|&(ref hash, _)| peer.known_transactions.insert(hash.clone()))
+				.filter(|(hash, _)| peer.known_transactions.insert(hash.clone()))
 				.cloned()
 				.unzip();
 

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -182,10 +182,7 @@ where
 			loop {
 				interval.tick().await;
 
-				if full_nodes
-					.iter()
-					.all(|&(ref id, ref service, _, _)| full_predicate(*id, service))
-				{
+				if full_nodes.iter().all(|(id, service, _, _)| full_predicate(*id, service)) {
 					break
 				}
 			}

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -502,10 +502,10 @@ where
 	fn eq(&self, other: &Self) -> bool {
 		use ElectionError::*;
 		match (self, other) {
-			(&Feasibility(ref x), &Feasibility(ref y)) if x == y => true,
-			(&Miner(ref x), &Miner(ref y)) if x == y => true,
-			(&DataProvider(ref x), &DataProvider(ref y)) if x == y => true,
-			(&Fallback(ref x), &Fallback(ref y)) if x == y => true,
+			(Feasibility(x), Feasibility(y)) if x == y => true,
+			(Miner(x), Miner(y)) if x == y => true,
+			(DataProvider(x), DataProvider(y)) if x == y => true,
+			(Fallback(x), Fallback(y)) if x == y => true,
 			_ => false,
 		}
 	}

--- a/frame/offences/src/lib.rs
+++ b/frame/offences/src/lib.rs
@@ -247,7 +247,7 @@ impl<T: Config, O: Offence<T::IdentificationTuple>> ReportIndexStorage<T, O> {
 	fn insert(&mut self, time_slot: &O::TimeSlot, report_id: ReportIdOf<T>) {
 		// Insert the report id into the list while maintaining the ordering by the time
 		// slot.
-		let pos = self.same_kind_reports.partition_point(|&(ref when, _)| when <= time_slot);
+		let pos = self.same_kind_reports.partition_point(|(when, _)| when <= time_slot);
 		self.same_kind_reports.insert(pos, (time_slot.clone(), report_id));
 
 		// Update the list of concurrent reports.

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -678,7 +678,7 @@ impl<T: Config> Pallet<T> {
 				// since a new validator set always leads to `changed` starting
 				// as true, we can ensure that `now_session_keys` and `next_validators`
 				// have the same length. this function is called once per iteration.
-				if let Some(&(_, ref old_keys)) = now_session_keys.next() {
+				if let Some((_, old_keys)) = now_session_keys.next() {
 					if old_keys != keys {
 						changed = true;
 					}

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -1299,8 +1299,8 @@ where
 			add_db_reads_writes(1, 0);
 
 			// Reverse because it's more likely to find reports from recent eras.
-			match eras.iter().rev().find(|&&(_, ref sesh)| sesh <= &slash_session) {
-				Some(&(ref slash_era, _)) => *slash_era,
+			match eras.iter().rev().find(|&(_, sesh)| sesh <= &slash_session) {
+				Some((slash_era, _)) => *slash_era,
 				// Before bonding period. defensive - should be filtered out.
 				None => return consumed_weight,
 			}


### PR DESCRIPTION
The rust 1.68 clippy will start throwing errors about these that'd fail our ci.