### PR TITLE
WASM executor: add `OutputExceedsBounds` variant to `Error`

### DIFF
--- a/client/executor/common/src/error.rs
+++ b/client/executor/common/src/error.rs
@@ -104,6 +104,9 @@ pub enum Error {
 
 	#[error("Execution aborted due to trap: {0}")]
 	AbortedDueToTrap(MessageWithBacktrace),
+
+	#[error("Output exceeds bounds of wasm memory")]
+	OutputExceedsBounds,
 }
 
 impl wasmi::HostError for Error {}
@@ -153,7 +156,7 @@ pub enum WasmError {
 	Instantiation(String),
 
 	/// Other error happenend.
-	#[error("{0}")]
+	#[error("Other error happened while constructing the runtime: {0}")]
 	Other(String),
 }
 

--- a/client/executor/src/integration_tests/mod.rs
+++ b/client/executor/src/integration_tests/mod.rs
@@ -819,9 +819,8 @@ fn return_huge_len(wasm_method: WasmExecutionMethod) {
 		Error::Runtime => {
 			assert_matches!(wasm_method, WasmExecutionMethod::Interpreted);
 		},
-		Error::RuntimeConstruction(WasmError::Other(error)) => {
+		Error::OutputExceedsBounds => {
 			assert_matches!(wasm_method, WasmExecutionMethod::Compiled { .. });
-			assert_eq!(error, "output exceeds bounds of wasm memory");
 		},
 		error => panic!("unexpected error: {:?}", error),
 	}
@@ -849,9 +848,8 @@ fn return_max_memory_offset_plus_one(wasm_method: WasmExecutionMethod) {
 		Error::Runtime => {
 			assert_matches!(wasm_method, WasmExecutionMethod::Interpreted);
 		},
-		Error::RuntimeConstruction(WasmError::Other(error)) => {
+		Error::OutputExceedsBounds => {
 			assert_matches!(wasm_method, WasmExecutionMethod::Compiled { .. });
-			assert_eq!(error, "output exceeds bounds of wasm memory");
 		},
 		error => panic!("unexpected error: {:?}", error),
 	}
@@ -866,9 +864,8 @@ fn return_overflow(wasm_method: WasmExecutionMethod) {
 		Error::Runtime => {
 			assert_matches!(wasm_method, WasmExecutionMethod::Interpreted);
 		},
-		Error::RuntimeConstruction(WasmError::Other(error)) => {
+		Error::OutputExceedsBounds => {
 			assert_matches!(wasm_method, WasmExecutionMethod::Compiled { .. });
-			assert_eq!(error, "output exceeds bounds of wasm memory");
 		},
 		error => panic!("unexpected error: {:?}", error),
 	}

--- a/client/executor/src/integration_tests/mod.rs
+++ b/client/executor/src/integration_tests/mod.rs
@@ -22,7 +22,7 @@ mod linux;
 use assert_matches::assert_matches;
 use codec::{Decode, Encode};
 use sc_executor_common::{
-	error::{Error, WasmError},
+	error::Error,
 	runtime_blob::RuntimeBlob,
 	wasm_runtime::{HeapAllocStrategy, WasmModule},
 };

--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -26,7 +26,7 @@ use crate::{
 
 use sc_allocator::{AllocationStats, FreeingBumpHeapAllocator};
 use sc_executor_common::{
-	error::{Result, WasmError},
+	error::{Error, Result, WasmError},
 	runtime_blob::{
 		self, DataSegmentsSnapshot, ExposedMutableGlobalsSet, GlobalsSnapshot, RuntimeBlob,
 	},
@@ -776,7 +776,7 @@ fn extract_output_data(
 	// Get the size of the WASM memory in bytes.
 	let memory_size = ctx.as_context().data().memory().data_size(ctx);
 	if checked_range(output_ptr as usize, output_len as usize, memory_size).is_none() {
-		Err(WasmError::Other("output exceeds bounds of wasm memory".into()))?
+		Err(Error::OutputExceedsBounds)?
 	}
 	let mut output = vec![0; output_len as usize];
 


### PR DESCRIPTION
# PULL REQUEST

## Overview

Previously this was a `WasmError`, which is intended for runtime construction errors. However this led to confusion as output-exceeds-bounds occurs due to execution of `validate_block`.

(Please review closely and correct me if I'm mistaken about something, the error story here is pretty confusing.)