### PR TITLE
Fix fungible and fungibles set_balance return value

### DIFF
--- a/frame/support/src/traits/tokens/fungible/regular.rs
+++ b/frame/support/src/traits/tokens/fungible/regular.rs
@@ -327,9 +327,9 @@ pub trait Mutate<AccountId>: Inspect<AccountId> + Unbalanced<AccountId> {
 	fn set_balance(who: &AccountId, amount: Self::Balance) -> Self::Balance {
 		let b = Self::balance(who);
 		if b > amount {
-			Self::burn_from(who, b - amount, BestEffort, Force).map(|d| amount.saturating_sub(d))
+			Self::burn_from(who, b - amount, BestEffort, Force).map(|d| b.saturating_sub(d))
 		} else {
-			Self::mint_into(who, amount - b).map(|d| amount.saturating_add(d))
+			Self::mint_into(who, amount - b).map(|d| b.saturating_add(d))
 		}
 		.unwrap_or(b)
 	}

--- a/frame/support/src/traits/tokens/fungibles/regular.rs
+++ b/frame/support/src/traits/tokens/fungibles/regular.rs
@@ -365,10 +365,9 @@ pub trait Mutate<AccountId>: Inspect<AccountId> + Unbalanced<AccountId> {
 	fn set_balance(asset: Self::AssetId, who: &AccountId, amount: Self::Balance) -> Self::Balance {
 		let b = Self::balance(asset, who);
 		if b > amount {
-			Self::burn_from(asset, who, b - amount, BestEffort, Force)
-				.map(|d| amount.saturating_sub(d))
+			Self::burn_from(asset, who, b - amount, BestEffort, Force).map(|d| b.saturating_sub(d))
 		} else {
-			Self::mint_into(asset, who, amount - b).map(|d| amount.saturating_add(d))
+			Self::mint_into(asset, who, amount - b).map(|d| b.saturating_add(d))
 		}
 		.unwrap_or(b)
 	}


### PR DESCRIPTION
There is a bug in the calculation of the return value of the `fungible` and `fungibles` `set_balance` default implementation.

The doc comment says it should return the new balance, but instead it returns `requested_balance +/- balance_change`. 

I have tests in [this PR](https://github.com/paritytech/substrate/pull/13852) that show the incorrect return value.

This test
```
cargo test --package pallet-balances -- tests::fungible_conformance_tests::set_balance_mint_success --nocapture
```

shows
```
initial_balance: 11
set_balance_amount: 16
expected_set_balance_return_value: 16
actual_set_balance_return_value: 21
```

and this test
```
cargo test --package pallet-balances -- tests::fungible_conformance_tests::set_balance_burn_success --nocapture
```

shows
```
initial_balance: 11
set_balance_amount: 6
expected_set_balance_return_value: 6
actual_set_balance_return_value: 1
```

Luckily (and I guess why this was not caught earlier), I couldn't find anywhere in Substrate or Polkadot that the return value for `set_balance` is used, so unless there is concern about ecosystem projects relying on the incorrect behavior I think this is safe to merge. 