### PR TITLE
Remove unused import from bench.rs

### DIFF
--- a/client/executor/benches/bench.rs
+++ b/client/executor/benches/bench.rs
@@ -21,7 +21,7 @@ use codec::Encode;
 
 use sc_executor_common::{
 	runtime_blob::RuntimeBlob,
-	wasm_runtime::{HeapAllocStrategy, WasmInstance, WasmModule, DEFAULT_HEAP_ALLOC_STRATEGY},
+	wasm_runtime::{WasmInstance, WasmModule, DEFAULT_HEAP_ALLOC_STRATEGY},
 };
 use sc_executor_wasmtime::InstantiationStrategy;
 use sc_runtime_test::wasm_binary_unwrap as test_runtime;


### PR DESCRIPTION
`cargo +nightly check --benches --all` outputs an unused import warning

<img width="942" alt="Screenshot 2023-04-10 at 18 37 33" src="https://user-images.githubusercontent.com/16665596/230925362-e545fb33-1bd1-4d67-95e0-479651bde96b.png">
