### PR TITLE
fix `try-runtime fast-forward` when run from the substrate cli and add test

### DIFF
--- a/bin/node/cli/src/command.rs
+++ b/bin/node/cli/src/command.rs
@@ -33,6 +33,9 @@ use sp_keyring::Sr25519Keyring;
 use std::sync::Arc;
 
 #[cfg(feature = "try-runtime")]
+use try_runtime_cli::block_building_info::timestamp_with_aura_info;
+
+#[cfg(feature = "try-runtime")]
 use {
 	kitchensink_runtime::constants::time::SLOT_DURATION,
 	try_runtime_cli::block_building_info::substrate_info,
@@ -242,7 +245,7 @@ pub fn run() -> Result<()> {
 					sc_service::TaskManager::new(config.tokio_handle.clone(), registry)
 						.map_err(|e| sc_cli::Error::Service(sc_service::Error::Prometheus(e)))?;
 
-				let info_provider = substrate_info(SLOT_DURATION);
+				let info_provider = timestamp_with_aura_info(6000);
 
 				Ok((
 					cmd.run::<Block, ExtendedHostFunctions<

--- a/test-utils/cli/src/lib.rs
+++ b/test-utils/cli/src/lib.rs
@@ -61,10 +61,10 @@ use tokio::io::{AsyncBufReadExt, AsyncRead};
 ///
 /// [`Child`]: std::process::Child
 pub fn start_node() -> Child {
-	Command::new(cargo_bin("substrate"))
+	Command::new(cargo_bin("node-template"))
 		.stdout(process::Stdio::piped())
 		.stderr(process::Stdio::piped())
-		.args(&["--dev", "--tmp", "--ws-port=45789", "--no-hardware-benchmarks"])
+		.args(&["--dev", "--ws-port=45789"])
 		.spawn()
 		.unwrap()
 }

--- a/utils/frame/try-runtime/cli/tests/fast_forward.rs
+++ b/utils/frame/try-runtime/cli/tests/fast_forward.rs
@@ -36,7 +36,7 @@ mod tests {
 		common::build_substrate(&["--features=try-runtime"]);
 
 		let n_blocks = 10;
-		common::run_with_timeout(Duration::from_secs(60), async move {
+		common::run_with_timeout(Duration::from_secs(10 * 60), async move {
 			let run_fast_forward = |ws_url: String| async move {
 				Command::new(cargo_bin("substrate"))
 					.stdout(process::Stdio::piped())

--- a/utils/frame/try-runtime/cli/tests/fast_forward.rs
+++ b/utils/frame/try-runtime/cli/tests/fast_forward.rs
@@ -23,7 +23,7 @@ mod tests {
 	use assert_cmd::cargo::cargo_bin;
 	use regex::Regex;
 	use std::{
-		process::{self},
+		process,
 		str::from_utf8,
 		time::Duration,
 	};

--- a/utils/frame/try-runtime/cli/tests/fast_forward.rs
+++ b/utils/frame/try-runtime/cli/tests/fast_forward.rs
@@ -1,0 +1,74 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#![cfg(unix)]
+
+#[cfg(feature = "try-runtime")]
+mod tests {
+	use assert_cmd::cargo::cargo_bin;
+	use regex::Regex;
+	use std::{
+		process::{self},
+		str::from_utf8,
+		time::Duration,
+	};
+	use substrate_cli_test_utils as common;
+	use tokio::process::Command;
+
+	#[tokio::test]
+	async fn follow_chain_works() {
+		// Build substrate so binaries used in the test use the latest code.
+		common::build_substrate(&["--features=try-runtime"]);
+
+		let n_blocks = 10;
+		common::run_with_timeout(Duration::from_secs(60), async move {
+			let run_fast_forward = |ws_url: String| async move {
+				Command::new(cargo_bin("substrate"))
+					.stdout(process::Stdio::piped())
+					.stderr(process::Stdio::piped())
+					.args(&["try-runtime", "--runtime=existing"])
+					.args(&[
+						"fast-forward",
+						format!("--n-blocks={}", n_blocks).as_str(),
+						"live",
+						format!("--uri={}", ws_url).as_str(),
+					])
+					.kill_on_drop(true)
+					.output()
+					.await
+					.unwrap()
+			};
+
+			// Start a node and wait for it to begin finalizing blocks
+			let mut node = common::KillChildOnDrop(common::start_node());
+			let ws_url = common::extract_info_from_output(node.stderr.take().unwrap()).0.ws_url;
+			common::wait_n_finalized_blocks(1, &ws_url).await;
+
+			// Make sure fast_forward logged "Executed the new block" the expected number of times
+			// and exited successfully
+			let fast_forward = run_fast_forward(ws_url).await;
+			let re = Regex::new(
+				format!(r#"(?:(?s).*Executed the new block.*\s*){}"#, n_blocks).as_str(),
+			)
+			.unwrap();
+			assert!(re.is_match(from_utf8(&fast_forward.stderr).unwrap()));
+			assert!(fast_forward.status.success());
+		})
+		.await;
+	}
+}

--- a/utils/frame/try-runtime/cli/tests/follow_chain.rs
+++ b/utils/frame/try-runtime/cli/tests/follow_chain.rs
@@ -34,7 +34,7 @@ mod tests {
 		// Build substrate so binaries used in the test use the latest code.
 		common::build_substrate(&["--features=try-runtime"]);
 
-		common::run_with_timeout(Duration::from_secs(60), async move {
+		common::run_with_timeout(Duration::from_secs(10 * 60), async move {
 			fn start_follow(ws_url: &str) -> Child {
 				Command::new(cargo_bin("substrate"))
 					.stdout(process::Stdio::piped())


### PR DESCRIPTION
Closes: https://github.com/paritytech/substrate/issues/13831

## Description

`fast-forward` requires a custom `BlockBuildingInfoProvider` with the blocktime set (see discussion here https://github.com/paritytech/substrate/pull/12896).

The custom provider had been set for the `node-template` cli, but not the `substrate` cli.

- [x] Use a custom `BlockBuildingInfoProvider` with the `substrate` cli
- [ ] Add clearly labelled block building info providers for `node-template`, `substrate`, `polkadot`, `kusama`
- [ ] Allow the block building info provider to be configured by cli args
- [x] Test that `follow-chain` exits with a success status code, and perform a basic check on the output 