### PR TITLE
Validate inbound substreams in `SyncingEngine`

### DIFF
--- a/client/network/src/event.rs
+++ b/client/network/src/event.rs
@@ -96,6 +96,16 @@ pub enum Event {
 /// Event sent to `SyncingEngine`
 // TODO: remove once `NotificationService` is implemented.
 pub enum SyncEvent<B: BlockT> {
+	/// Validate inbound substream before accepting it.
+	ValidateSubstream {
+		/// Node we opened the substream with.
+		remote: PeerId,
+		/// Received handshake.
+		received_handshake: BlockAnnouncesHandshake<B>,
+		/// Channel for reporting accept/reject of the substream.
+		tx: oneshot::Sender<bool>,
+	},
+
 	/// Opened a substream with the given node with the given notifications protocol.
 	///
 	/// The protocol is always one of the notification protocols that have been registered.
@@ -106,8 +116,6 @@ pub enum SyncEvent<B: BlockT> {
 		received_handshake: BlockAnnouncesHandshake<B>,
 		/// Notification sink.
 		sink: NotificationsSink,
-		/// Channel for reporting accept/reject of the substream.
-		tx: oneshot::Sender<bool>,
 	},
 
 	/// Closed a substream with the given node. Always matches a corresponding previous

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -474,7 +474,7 @@ impl<B: BlockT> NetworkBehaviour for Protocol<B> {
 						target: "sub-libp2p",
 						"`SyncingEngine` rejected stream"
 					);
-					self.behaviour.peerset_report_reject(index);
+					self.behaviour.reject_inbound_substream(index);
 				},
 			}
 		}
@@ -523,7 +523,7 @@ impl<B: BlockT> NetworkBehaviour for Protocol<B> {
 							target: "sub-libp2p",
 							"Failed to parse handshake ({received_handshake:?}) for {peer_id}",
 						);
-						self.behaviour.peerset_report_reject(index);
+						self.behaviour.reject_inbound_substream(index);
 					},
 				}
 

--- a/client/network/src/protocol/notifications/behaviour.rs
+++ b/client/network/src/protocol/notifications/behaviour.rs
@@ -17,8 +17,11 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-	protocol::notifications::handler::{
-		self, NotificationsSink, NotifsHandlerIn, NotifsHandlerOut, NotifsHandlerProto,
+	protocol::{
+		notifications::handler::{
+			self, NotificationsSink, NotifsHandlerIn, NotifsHandlerOut, NotifsHandlerProto,
+		},
+		HARDCODED_PEERSETS_SYNC,
 	},
 	types::ProtocolName,
 };
@@ -882,6 +885,11 @@ impl Notifications {
 		self.peerset.incoming(0.into(), peer_id, index);
 	}
 
+	/// Reject inbound substream
+	pub fn reject_inbound_substream(&mut self, index: sc_peerset::IncomingIndex) {
+		self.peerset_report_reject(index);
+	}
+
 	/// Function that is called when the peerset wants us to accept a connection
 	/// request from a peer.
 	fn peerset_report_accept(&mut self, index: sc_peerset::IncomingIndex) {
@@ -953,7 +961,7 @@ impl Notifications {
 	}
 
 	/// Function that is called when the peerset wants us to reject an incoming peer.
-	pub fn peerset_report_reject(&mut self, index: sc_peerset::IncomingIndex) {
+	fn peerset_report_reject(&mut self, index: sc_peerset::IncomingIndex) {
 		let incoming = if let Some(pos) = self.incoming.iter().position(|i| i.incoming_id == index)
 		{
 			self.incoming.remove(pos)
@@ -1568,7 +1576,7 @@ impl NetworkBehaviour for Notifications {
 									incoming_id,
 								});
 
-								if set_id == 0.into() {
+								if set_id == HARDCODED_PEERSETS_SYNC {
 									let event = NotificationsOut::ValidateSubstream {
 										peer_id,
 										index: incoming_id,

--- a/client/network/src/protocol/notifications/handler.rs
+++ b/client/network/src/protocol/notifications/handler.rs
@@ -326,6 +326,8 @@ pub enum NotifsHandlerOut {
 	OpenDesiredByRemote {
 		/// Index of the protocol in the list of protocols passed at initialization.
 		protocol_index: usize,
+		/// Received handshake.
+		handshake: Vec<u8>,
 	},
 
 	/// The remote would like the substreams to be closed. Send a [`NotifsHandlerIn::Close`] in
@@ -511,7 +513,10 @@ impl ConnectionHandler for NotifsHandler {
 				match protocol_info.state {
 					State::Closed { pending_opening } => {
 						self.events_queue.push_back(ConnectionHandlerEvent::Custom(
-							NotifsHandlerOut::OpenDesiredByRemote { protocol_index },
+							NotifsHandlerOut::OpenDesiredByRemote {
+								protocol_index,
+								handshake: in_substream_open.handshake,
+							},
 						));
 
 						protocol_info.state = State::OpenDesiredByRemote {
@@ -1630,7 +1635,7 @@ pub mod tests {
 			assert!(std::matches!(
 				handler.poll(cx),
 				Poll::Ready(ConnectionHandlerEvent::Custom(
-					NotifsHandlerOut::OpenDesiredByRemote { protocol_index: 0 },
+					NotifsHandlerOut::OpenDesiredByRemote { protocol_index: 0, .. },
 				))
 			));
 			assert!(std::matches!(

--- a/client/network/src/protocol/notifications/tests.rs
+++ b/client/network/src/protocol/notifications/tests.rs
@@ -261,6 +261,16 @@ fn reconnect_after_disconnect() {
 					ServiceState::NotConnected |
 					ServiceState::Disconnected => panic!(),
 				},
+				future::Either::Left(SwarmEvent::Behaviour(
+					NotificationsOut::ValidateSubstream { peer_id, index, .. },
+				)) => {
+					service1.behaviour_mut().accept_inbound_substream(peer_id, index);
+				},
+				future::Either::Right(SwarmEvent::Behaviour(
+					NotificationsOut::ValidateSubstream { peer_id, index, .. },
+				)) => {
+					service2.behaviour_mut().accept_inbound_substream(peer_id, index);
+				},
 				_ => {},
 			}
 

--- a/client/network/sync/src/engine.rs
+++ b/client/network/sync/src/engine.rs
@@ -844,12 +844,15 @@ where
 	) -> Result<(), ()> {
 		log::trace!(target: "sync", "New peer {} {:?}", who, status);
 
-		// peer is not reported in `validate_inbound_substream()` as the peer might be
-		// in `Incoming` state and genesis mismatch would disconnect the peer which is
-		// an invalid state transition in `Notifications`.
-		if status.genesis_hash != self.genesis_hash {
-			self.network_service.report_peer(who, rep::GENESIS_MISMATCH);
-		}
+		// TODO: peer with invalid genesis hash must be reported but because
+		// `validate_inbound_substream()` is first called when `ValidateSubstream` is received,
+		// meaning the peer state is `Incoming`, the peer cannot be reported without causing an
+		// invalid state transition. Report the peer for invalid genesis hash when
+		// `ValidateSubstream` is removed/`Notifications` is fixed.
+		//
+		// if status.genesis_hash != self.genesis_hash {
+		// 	self.network_service.report_peer(who, rep::GENESIS_MISMATCH);
+		// }
 
 		if let Err(_) = self.validate_inbound_substream(who, status) {
 			return Err(())

--- a/client/network/sync/src/engine.rs
+++ b/client/network/sync/src/engine.rs
@@ -77,8 +77,8 @@ const MAX_KNOWN_BLOCKS: usize = 1024; // ~32kb per peer + LruHashSet overhead
 
 mod rep {
 	use sc_peerset::ReputationChange as Rep;
-	/// Peer has different genesis.
-	pub const GENESIS_MISMATCH: Rep = Rep::new_fatal("Genesis mismatch");
+	// /// Peer has different genesis.
+	// pub const GENESIS_MISMATCH: Rep = Rep::new_fatal("Genesis mismatch");
 	/// Peer send us a block announcement that failed at validation.
 	pub const BAD_BLOCK_ANNOUNCEMENT: Rep = Rep::new(-(1 << 12), "Bad block announcement");
 }


### PR DESCRIPTION
Validate inbound substreams before accepting them in `Notifications`. This is done to prevent the constant influx of substreams that are incorrectly being opened by remote nodes because they were first accepted and then rejected.

This is a temporary change but models the upcoming `NotificationService`. Before informing `Peerset` of the new inbound substream, pass it to `SyncingEngine` which first checks whether it can accept the peer. When the response is received from `SyncingEngine`, and if the substream was accepted, inform `Peerset` of the substream which allocates a slot for the connection. When `Peerset` is done with its validation, emit `NotificationStreamOpened` to inform all protocols that a new substream has been opened.

This done to prevent remote peers getting confused about outbound substream first getting accepted and then getting rejected right after.

---
This PR combined with peer eviction yields very promising results. I was running a validator yesterday all day and there was no stalling of any kind. Nevertheless, this is only a temporary change to keep `sc-network` on life support until we've finished the `Peerset`/`Notifications` refactoring.
