### PR TITLE
contracts: stabilize `[seal0] call_runtime()`

### DIFF
--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -2404,8 +2404,6 @@ pub mod env {
 	/// - Provide functionality **exclusively** to contracts.
 	/// - Provide custom weights.
 	/// - Avoid the need to keep the `Call` data structure stable.
-	#[unstable]
-	#[prefixed_alias]
 	fn call_runtime(
 		ctx: _,
 		memory: _,


### PR DESCRIPTION
Stabilize `[seal0] call_runtime()` as it is covered by [e2e test](https://github.com/paritytech/ink/blob/6fb975d77c61bd08c662e2111c4f35b0e50a3d37/integration-tests/call-runtime/lib.rs).