### PR TITLE
fix .test-refs-check-benches condition

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -179,7 +179,7 @@ variables:
 # exclude cargo-check-benches from such runs
 .test-refs-check-benches:
   rules:
-    - if: $CI_COMMIT_REF_NAME == "master" && $CI_PIPELINE_SOURCE == "parent_pipeline"  && $CI_IMAGE =~ /staging$/
+    - if: $CI_COMMIT_REF_NAME == "master" && $CI_PIPELINE_SOURCE == "pipeline"  && $CI_IMAGE =~ /staging$/
       when: never
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"


### PR DESCRIPTION
This check is meant to catch pipelines triggered by the scripts ci-linux staging tests. The correct CI_PIPELINE_SOURCE for multi-project pipelines such as this is "pipeline"; "parent_pipeline" is only set for child pipelines triggered /within the same repo/.

cf https://docs.gitlab.com/ee/ci/jobs/job_control.html#common-if-clauses-for-rules
