### PR TITLE
[Fix] Remove redundant stash from Stake

### DIFF
--- a/frame/nomination-pools/src/mock.rs
+++ b/frame/nomination-pools/src/mock.rs
@@ -122,9 +122,9 @@ impl sp_staking::StakingInterface for StakingMock {
 			BondedBalanceMap::get().get(who).copied(),
 		) {
 			(None, None) => Err(DispatchError::Other("balance not found")),
-			(Some(v), None) => Ok(Stake { total: v, active: 0, stash: *who }),
-			(None, Some(v)) => Ok(Stake { total: v, active: v, stash: *who }),
-			(Some(a), Some(b)) => Ok(Stake { total: a + b, active: b, stash: *who }),
+			(Some(v), None) => Ok(Stake { total: v, active: 0 }),
+			(None, Some(v)) => Ok(Stake { total: v, active: v }),
+			(Some(a), Some(b)) => Ok(Stake { total: a + b, active: b }),
 		}
 	}
 

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -1611,7 +1611,7 @@ impl<T: Config> StakingInterface for Pallet<T> {
 	fn stake(who: &Self::AccountId) -> Result<Stake<Self>, DispatchError> {
 		Self::bonded(who)
 			.and_then(|c| Self::ledger(c))
-			.map(|l| Stake { stash: l.stash, total: l.total, active: l.active })
+			.map(|l| Stake { total: l.total, active: l.active })
 			.ok_or(Error::<T>::NotStash.into())
 	}
 

--- a/primitives/staking/src/lib.rs
+++ b/primitives/staking/src/lib.rs
@@ -58,8 +58,6 @@ impl<AccountId, Balance> OnStakerSlash<AccountId, Balance> for () {
 /// A struct that reflects stake that an account has in the staking system. Provides a set of
 /// methods to operate on it's properties. Aimed at making `StakingInterface` more concise.
 pub struct Stake<T: StakingInterface + ?Sized> {
-	/// The stash account whose balance is actually locked and at stake.
-	pub stash: T::AccountId,
 	/// The total stake that `stash` has in the staking system. This includes the
 	/// `active` stake, and any funds currently in the process of unbonding via
 	/// [`StakingInterface::unbond`].


### PR DESCRIPTION
We don't need to return `stash` as part of `Stake`, because we already need to know it in order to retrieve `Stake`.

This PR is a result of [that discussion](https://github.com/paritytech/substrate/pull/13079#discussion_r1155101515). 