### PR TITLE
Refactor the automatic-crate-publishing logic, make triggered pipelines uninterruptible as well

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,7 +58,7 @@ variables:
   NEXTEST_SUCCESS_OUTPUT: final
   ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.43"
 
-.shared-default: &shared-default
+default:
   retry:
     max: 2
     when:
@@ -66,21 +66,7 @@ variables:
       - unknown_failure
       - api_failure
   cache: {}
-
-.default-pipeline-definitions:
-  default:
-    <<: *shared-default
-    interruptible: true
-
-.crate-publishing-pipeline-definitions:
-  default:
-    <<: *shared-default
-    # The crate-publishing pipeline defaults to `interruptible: false` so that we'll be able to
-    # reach and run the publishing jobs despite the "Auto-cancel redundant pipelines" CI setting.
-    # The setting is relevant because the crate-publishing pipeline runs on `master`, thus future
-    # pipelines on `master` (e.g. created for new commits or other schedules) might unintendedly
-    # cancel the publishing jobs or its dependencies before we get to actually publish the crates.
-    interruptible: false
+  interruptible: true
 
 .collect-artifacts:
   artifacts:
@@ -288,6 +274,21 @@ check-crates-publishing-pipeline:
       https://github.com/paritytech/releng-scripts.git
     - ONLY_CHECK_PIPELINE=true ./releng-scripts/publish-crates
 
+# By default our pipelines are interruptible, but some special pipelines shouldn't be interrupted:
+# * the scheduled automatic-crate-publishing pipeline
+#
+# In those cases, we add an interruptible .pre job; once that one has started,
+# the entire pipeline becomes uninterruptible
+uninterruptible-pipeline:
+  extends: .kubernetes-env
+  variables:
+    CI_IMAGE: "paritytech/tools:latest"
+  stage: .pre
+  interruptible: false
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $PIPELINE == "automatic-crate-publishing"
+  script: "true"
+
 include:
   # check jobs
   - scripts/ci/gitlab/pipeline/check.yml
@@ -308,13 +309,6 @@ include:
   # pipeline is made uninterruptible to ensure that test jobs also get a chance to run to
   # completion, because the publishing jobs depends on them AS INTENDED: crates should not be
   # published before their source code is checked.
-  - local: scripts/ci/gitlab/crate-publishing-pipeline.yml
-    rules:
-      - if: $PIPELINE == "automatic-crate-publishing"
-  # For normal pipelines: run it with defaults + `interruptible: true`
-  - local: scripts/ci/gitlab/default-pipeline.yml
-    rules:
-      - if: $PIPELINE != "automatic-crate-publishing"
   - project: parity/infrastructure/ci_cd/shared
     ref: v0.2
     file: /common/timestamp.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -275,9 +275,10 @@ check-crates-publishing-pipeline:
     - ONLY_CHECK_PIPELINE=true ./releng-scripts/publish-crates
 
 # By default our pipelines are interruptible, but some special pipelines shouldn't be interrupted:
+# * multi-project pipelines such as the ones triggered by the scripts repo
 # * the scheduled automatic-crate-publishing pipeline
 #
-# In those cases, we add an interruptible .pre job; once that one has started,
+# In those cases, we add an uninterruptible .pre job; once that one has started,
 # the entire pipeline becomes uninterruptible
 uninterruptible-pipeline:
   extends: .kubernetes-env
@@ -286,6 +287,7 @@ uninterruptible-pipeline:
   stage: .pre
   interruptible: false
   rules:
+    - if: $CI_PIPELINE_SOURCE == "pipeline"
     - if: $CI_PIPELINE_SOURCE == "schedule" && $PIPELINE == "automatic-crate-publishing"
   script: "true"
 

--- a/scripts/ci/gitlab/crate-publishing-pipeline.yml
+++ b/scripts/ci/gitlab/crate-publishing-pipeline.yml
@@ -1,1 +1,0 @@
-default: !reference [.crate-publishing-pipeline-definitions, default]

--- a/scripts/ci/gitlab/default-pipeline.yml
+++ b/scripts/ci/gitlab/default-pipeline.yml
@@ -1,1 +1,0 @@
-default: !reference [.default-pipeline-definitions, default]


### PR DESCRIPTION
It's not neccessary to dynamically change the `interruptible` setting for *all* jobs as the old approach does; gitlab already considers a pipeline uninterruptible as soon as a single uninterruptible job has started (cf https://docs.gitlab.com/ee/ci/yaml/#interruptible).

IMO this approach is more readable, as it avoids dynamically loading the `.defaults` section from different files based on import conditions; the logic is now shorter and entirely contained in the main .gitlab-ci.yml.

In addition to the refactoring, this PR also adds a condition to make multi-project pipelines uninterruptible too. Currently, a substrate pipeline triggered e.g. by a ci-linux build in the scripts repo could be interrupted, thus unneccessarily preventing a `ci-linux:production` deployment.