### PR TITLE
Drain all the pending messages in the channel when `TracingUnboundedReceiver` is dropped

### DIFF
--- a/client/utils/src/mpsc.rs
+++ b/client/utils/src/mpsc.rs
@@ -141,6 +141,7 @@ impl<T> TracingUnboundedReceiver<T> {
 
 impl<T> Drop for TracingUnboundedReceiver<T> {
 	fn drop(&mut self) {
+		// Close the channel to prevent any further messages to be sent into the channel
 		self.close();
 		// the number of messages about to be dropped
 		let count = self.inner.len();
@@ -150,6 +151,10 @@ impl<T> Drop for TracingUnboundedReceiver<T> {
 				.with_label_values(&[self.name, "dropped"])
 				.inc_by(count.saturated_into());
 		}
+		// Drain all the pending messages in the channel since they can never be accessed,
+		// this can be removed once https://github.com/smol-rs/async-channel/issues/23 is
+		// resolved
+		while let Ok(_) = self.inner.try_recv() {}
 	}
 }
 
@@ -175,5 +180,24 @@ impl<T> Stream for TracingUnboundedReceiver<T> {
 impl<T> FusedStream for TracingUnboundedReceiver<T> {
 	fn is_terminated(&self) -> bool {
 		self.inner.is_terminated()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::tracing_unbounded;
+	use async_channel::{self, RecvError, TryRecvError};
+
+	#[test]
+	fn test_tracing_unbounded_receiver_drop() {
+		let (tracing_unbounded_sender, tracing_unbounded_receiver) =
+			tracing_unbounded("test-receiver-drop", 10);
+		let (tx, rx) = async_channel::unbounded::<usize>();
+
+		tracing_unbounded_sender.unbounded_send(tx).unwrap();
+		drop(tracing_unbounded_receiver);
+
+		assert_eq!(rx.try_recv(), Err(TryRecvError::Closed));
+		assert_eq!(rx.recv_blocking(), Err(RecvError));
 	}
 }


### PR DESCRIPTION
Fix #13849 

`tracing_unbounded` uses `async_channel` internally, in which, the pending messages of the channel will not be dropped even if all the receivers have been dropped and these messages can never be accessed.

This may cause blocking issues when using `tracing_unbounded` to send `Sender<T>` and there is quite a lot of such usage within substrate as #13849 mentioned.

This PR fixes the issue by manually draining all the pending messages in the channel when `TracingUnboundedReceiver` is dropped and a test is added to cover the abovementioned case.

cc @bkchr 