### PR TITLE
expose `ExtensionsFactory` in sc-service

### DIFF
--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -75,6 +75,7 @@ pub fn new_partial(
 			config,
 			telemetry.as_ref().map(|(_, telemetry)| telemetry.handle()),
 			executor,
+			None
 		)?;
 	let client = Arc::new(client);
 

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -170,6 +170,7 @@ pub fn new_partial(
 			config,
 			telemetry.as_ref().map(|(_, telemetry)| telemetry.handle()),
 			executor,
+			None
 		)?;
 	let client = Arc::new(client);
 

--- a/bin/node/testing/src/bench.rs
+++ b/bin/node/testing/src/bench.rs
@@ -420,6 +420,7 @@ impl BenchDb {
 				None,
 				None,
 				Arc::new(executor),
+				None
 			),
 			Box::new(task_executor.clone()),
 			None,

--- a/client/api/src/execution_extensions.rs
+++ b/client/api/src/execution_extensions.rs
@@ -184,9 +184,11 @@ impl<Block: BlockT> ExecutionExtensions<Block> {
 		keystore: Option<KeystorePtr>,
 		offchain_db: Option<Box<dyn DbExternalitiesFactory>>,
 		read_runtime_version: Arc<dyn ReadRuntimeVersion>,
+		extensions_factory: Option<Box<dyn ExtensionsFactory<Block>>>,
 	) -> Self {
 		let transaction_pool = RwLock::new(None);
-		let extensions_factory = Box::new(());
+		let extensions_factory =
+			if let Some(factory) = extensions_factory { factory } else { Box::new(()) };
 		Self {
 			strategies,
 			keystore,

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -71,6 +71,7 @@ use sp_core::traits::{CodeExecutor, SpawnNamed};
 use sp_keystore::KeystorePtr;
 use sp_runtime::traits::{Block as BlockT, BlockIdTo, NumberFor, Zero};
 use std::{str::FromStr, sync::Arc, time::SystemTime};
+use sc_client_api::execution_extensions::ExtensionsFactory;
 
 /// Full client type.
 pub type TFullClient<TBl, TRtApi, TExec> =
@@ -129,6 +130,7 @@ pub fn new_full_parts<TBl, TRtApi, TExec>(
 	config: &Configuration,
 	telemetry: Option<TelemetryHandle>,
 	executor: TExec,
+	extensions_factory: Option<Box<dyn ExtensionsFactory<TBl>>>,
 ) -> Result<TFullParts<TBl, TRtApi, TExec>, Error>
 where
 	TBl: BlockT,
@@ -143,7 +145,7 @@ where
 		executor.clone(),
 	)?;
 
-	new_full_parts_with_genesis_builder(config, telemetry, executor, backend, genesis_block_builder)
+	new_full_parts_with_genesis_builder(config, telemetry, executor, backend, genesis_block_builder, extensions_factory)
 }
 
 /// Create the initial parts of a full node.
@@ -153,6 +155,7 @@ pub fn new_full_parts_with_genesis_builder<TBl, TRtApi, TExec, TBuildGenesisBloc
 	executor: TExec,
 	backend: Arc<TFullBackend<TBl>>,
 	genesis_block_builder: TBuildGenesisBlock,
+	extensions_factory: Option<Box<dyn ExtensionsFactory<TBl>>>,
 ) -> Result<TFullParts<TBl, TRtApi, TExec>, Error>
 where
 	TBl: BlockT,
@@ -184,6 +187,7 @@ where
 			Some(keystore_container.keystore()),
 			sc_offchain::OffchainDb::factory_from_backend(&*backend),
 			Arc::new(executor.clone()),
+			extensions_factory,
 		);
 
 		let wasm_runtime_substitutes = config

--- a/client/service/src/client/call_executor.rs
+++ b/client/service/src/client/call_executor.rs
@@ -432,6 +432,7 @@ mod tests {
 				None,
 				None,
 				Arc::new(executor.clone()),
+				None,
 			)),
 		};
 

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -88,6 +88,7 @@ use std::{
 	sync::Arc,
 };
 
+use sc_client_api::execution_extensions::ExtensionsFactory;
 #[cfg(feature = "test-helpers")]
 use {
 	super::call_executor::LocalCallExecutor, sc_client_api::in_mem, sp_core::traits::CodeExecutor,
@@ -186,6 +187,7 @@ where
 		prometheus_registry,
 		telemetry,
 		config,
+		None
 	)
 }
 
@@ -244,6 +246,7 @@ where
 		keystore,
 		sc_offchain::OffchainDb::factory_from_backend(&*backend),
 		Arc::new(executor.clone()),
+		None,
 	);
 
 	let call_executor =

--- a/test-utils/client/src/lib.rs
+++ b/test-utils/client/src/lib.rs
@@ -297,6 +297,7 @@ impl<Block: BlockT, D, Backend, G: GenesisInit>
 				self.keystore.clone(),
 				sc_offchain::OffchainDb::factory_from_backend(&*self.backend),
 				Arc::new(executor),
+				None
 			),
 		)
 		.expect("Creates LocalCallExecutor");


### PR DESCRIPTION
By exposing `ExtensionFactory` we allow for users to implement custom host functions by registering the neccessary execution `Extension` on the `ExtensionFactory` needed by this new host function.

