### PR TITLE
Poll the substream validation before polling `Notifications`

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -40,7 +40,7 @@ use sc_utils::mpsc::TracingUnboundedSender;
 use sp_runtime::traits::Block as BlockT;
 
 use std::{
-	collections::{HashMap, HashSet, VecDeque},
+	collections::{HashMap, HashSet},
 	future::Future,
 	iter,
 	pin::Pin,


### PR DESCRIPTION
In tests, it can happen that `Notifications` doesn't produce any events which causes `poll()` to return `Poll::Pending` and the substream validation futures won't get polled.

Poll the futures before calling `Notifications` so results for substream validations are received even if `Notifications` is not producing any events.