### PR TITLE
[NFTs] Improve offchain signature validation

### DIFF
--- a/frame/nfts/src/common_functions.rs
+++ b/frame/nfts/src/common_functions.rs
@@ -18,6 +18,7 @@
 //! Various pieces of common functionality.
 
 use crate::*;
+use frame_support::pallet_prelude::*;
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// Get the owner of the item, if the item exists.
@@ -28,6 +29,27 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// Get the owner of the collection, if the collection exists.
 	pub fn collection_owner(collection: T::CollectionId) -> Option<T::AccountId> {
 		Collection::<T, I>::get(collection).map(|i| i.owner)
+	}
+
+	/// Validate the `data` was signed by `signer` and the `signature` is correct.
+	pub fn validate_signature(
+		data: &Vec<u8>,
+		signature: &T::OffchainSignature,
+		signer: &T::AccountId,
+	) -> DispatchResult {
+		// NOTE: for security reasons modern UIs implicitly wrap the data requested to sign into
+		// <Bytes></Bytes>, that's why we support both wrapped and raw versions.
+		let mut wrapped: Vec<u8> = Vec::new();
+		wrapped.extend(b"<Bytes>");
+		wrapped.extend(data);
+		wrapped.extend(b"</Bytes>");
+
+		ensure!(
+			signature.verify(&**data, &signer) || signature.verify(&*wrapped, &signer),
+			Error::<T, I>::WrongSignature
+		);
+
+		Ok(())
 	}
 
 	#[cfg(any(test, feature = "runtime-benchmarks"))]

--- a/frame/nfts/src/lib.rs
+++ b/frame/nfts/src/lib.rs
@@ -50,7 +50,7 @@ use frame_support::traits::{
 };
 use frame_system::Config as SystemConfig;
 use sp_runtime::{
-	traits::{Saturating, StaticLookup, Zero},
+	traits::{IdentifyAccount, Saturating, StaticLookup, Verify, Zero},
 	RuntimeDebug,
 };
 use sp_std::prelude::*;
@@ -69,7 +69,6 @@ pub mod pallet {
 	use super::*;
 	use frame_support::{pallet_prelude::*, traits::ExistenceRequirement};
 	use frame_system::pallet_prelude::*;
-	use sp_runtime::traits::{IdentifyAccount, Verify};
 
 	/// The current storage version.
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
@@ -1841,8 +1840,7 @@ pub mod pallet {
 			signer: T::AccountId,
 		) -> DispatchResult {
 			let origin = ensure_signed(origin)?;
-			let msg = Encode::encode(&mint_data);
-			ensure!(signature.verify(&*msg, &signer), Error::<T, I>::WrongSignature);
+			Self::validate_signature(&Encode::encode(&mint_data), &signature, &signer)?;
 			Self::do_mint_pre_signed(origin, mint_data, signer)
 		}
 
@@ -1868,8 +1866,7 @@ pub mod pallet {
 			signer: T::AccountId,
 		) -> DispatchResult {
 			let origin = ensure_signed(origin)?;
-			let msg = Encode::encode(&data);
-			ensure!(signature.verify(&*msg, &signer), Error::<T, I>::WrongSignature);
+			Self::validate_signature(&Encode::encode(&data), &signature, &signer)?;
 			Self::do_set_attributes_pre_signed(origin, data, signer)
 		}
 	}


### PR DESCRIPTION
When we try to sign some data using the UIs like PolkadotJS apps, PolkadotJS extension + some others, all of them implicitly wrap the data value into the <Bytes> tag. That behaviour leads to different signatures generated, which look incorrect from the pallet's side.
This PR improves the offchain signature's validation by adding the support of wrapped into <Bytes> data values