### PR TITLE
`balances` `impl_currency` WithdrawReasons note

### DIFF
--- a/frame/balances/src/impl_currency.rs
+++ b/frame/balances/src/impl_currency.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 //! Implementations for the `Currency` family of traits.
-//! Note that WithdrawReason is intentionally not used for anything in this implementation.
+//! Note that WithdrawReasons are intentionally not used for anything in this implementation.
 
 use super::*;
 use frame_support::{

--- a/frame/balances/src/impl_currency.rs
+++ b/frame/balances/src/impl_currency.rs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 //! Implementations for the `Currency` family of traits.
+//! Note that WithdrawReason is intentionally not used for anything in this implementation.
 
 use super::*;
 use frame_support::{

--- a/frame/balances/src/impl_currency.rs
+++ b/frame/balances/src/impl_currency.rs
@@ -16,7 +16,8 @@
 // limitations under the License.
 
 //! Implementations for the `Currency` family of traits.
-//! Note that WithdrawReasons are intentionally not used for anything in this implementation.
+//! 
+//! Note that `WithdrawReasons` are intentionally not used for anything in this implementation and are expected to be removed in the near future, once migration to `fungible::*` traits is done.
 
 use super::*;
 use frame_support::{

--- a/frame/balances/src/impl_currency.rs
+++ b/frame/balances/src/impl_currency.rs
@@ -16,8 +16,9 @@
 // limitations under the License.
 
 //! Implementations for the `Currency` family of traits.
-//! 
-//! Note that `WithdrawReasons` are intentionally not used for anything in this implementation and are expected to be removed in the near future, once migration to `fungible::*` traits is done.
+//!
+//! Note that `WithdrawReasons` are intentionally not used for anything in this implementation and
+//! are expected to be removed in the near future, once migration to `fungible::*` traits is done.
 
 use super::*;
 use frame_support::{


### PR DESCRIPTION
Per a suggestion from @kianenigma, adding a note to the `balances` `currency` implementation explaining that `WithdrawReasons` are intentionally ignored. 

This is to help prevent possible developer confusion as they read the implementation. 