### PR TITLE
Achimcc/arkworks integration remove affine hostcalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10549,7 +10549,7 @@ dependencies = [
 [[package]]
 name = "sp-ark-bls12-377"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/ark-substrate#9b4b012ce1a92fdc079ce85e3f70eef8ee924936"
+source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#c3e13456d51034753a78b281e8d661d096cf2d2b"
 dependencies = [
  "ark-bls12-377",
  "ark-ff",
@@ -10558,14 +10558,14 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "parity-scale-codec",
- "sp-ark-models 0.4.0 (git+https://github.com/paritytech/ark-substrate)",
+ "sp-ark-models 0.4.0 (git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls)",
  "sp-arkworks",
 ]
 
 [[package]]
 name = "sp-ark-bls12-381"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/ark-substrate#9b4b012ce1a92fdc079ce85e3f70eef8ee924936"
+source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#c3e13456d51034753a78b281e8d661d096cf2d2b"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -10574,14 +10574,14 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "parity-scale-codec",
- "sp-ark-models 0.4.0 (git+https://github.com/paritytech/ark-substrate)",
+ "sp-ark-models 0.4.0 (git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls)",
  "sp-arkworks",
 ]
 
 [[package]]
 name = "sp-ark-bw6-761"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/ark-substrate#9b4b012ce1a92fdc079ce85e3f70eef8ee924936"
+source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#c3e13456d51034753a78b281e8d661d096cf2d2b"
 dependencies = [
  "ark-bw6-761",
  "ark-ec",
@@ -10590,14 +10590,14 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "parity-scale-codec",
- "sp-ark-models 0.4.0 (git+https://github.com/paritytech/ark-substrate)",
+ "sp-ark-models 0.4.0 (git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls)",
  "sp-arkworks",
 ]
 
 [[package]]
 name = "sp-ark-ed-on-bls12-377"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/ark-substrate#9b4b012ce1a92fdc079ce85e3f70eef8ee924936"
+source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#c3e13456d51034753a78b281e8d661d096cf2d2b"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -10606,13 +10606,13 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "parity-scale-codec",
- "sp-ark-models 0.4.0 (git+https://github.com/paritytech/ark-substrate)",
+ "sp-ark-models 0.4.0 (git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls)",
 ]
 
 [[package]]
 name = "sp-ark-ed-on-bls12-381"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/ark-substrate#9b4b012ce1a92fdc079ce85e3f70eef8ee924936"
+source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#c3e13456d51034753a78b281e8d661d096cf2d2b"
 dependencies = [
  "ark-ed-on-bls12-381",
  "ark-ff",
@@ -10621,7 +10621,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "parity-scale-codec",
- "sp-ark-models 0.4.0 (git+https://github.com/paritytech/ark-substrate)",
+ "sp-ark-models 0.4.0 (git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls)",
 ]
 
 [[package]]
@@ -10644,7 +10644,7 @@ dependencies = [
 [[package]]
 name = "sp-ark-models"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/ark-substrate#9b4b012ce1a92fdc079ce85e3f70eef8ee924936"
+source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#c3e13456d51034753a78b281e8d661d096cf2d2b"
 dependencies = [
  "ark-ec",
  "ark-ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10549,7 +10549,7 @@ dependencies = [
 [[package]]
 name = "sp-ark-bls12-377"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#c3e13456d51034753a78b281e8d661d096cf2d2b"
+source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#3660a2686e932e39739f58ad7f90bc7123c08af6"
 dependencies = [
  "ark-bls12-377",
  "ark-ff",
@@ -10565,7 +10565,7 @@ dependencies = [
 [[package]]
 name = "sp-ark-bls12-381"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#c3e13456d51034753a78b281e8d661d096cf2d2b"
+source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#3660a2686e932e39739f58ad7f90bc7123c08af6"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -10581,7 +10581,7 @@ dependencies = [
 [[package]]
 name = "sp-ark-bw6-761"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#c3e13456d51034753a78b281e8d661d096cf2d2b"
+source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#3660a2686e932e39739f58ad7f90bc7123c08af6"
 dependencies = [
  "ark-bw6-761",
  "ark-ec",
@@ -10597,7 +10597,7 @@ dependencies = [
 [[package]]
 name = "sp-ark-ed-on-bls12-377"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#c3e13456d51034753a78b281e8d661d096cf2d2b"
+source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#3660a2686e932e39739f58ad7f90bc7123c08af6"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -10612,7 +10612,7 @@ dependencies = [
 [[package]]
 name = "sp-ark-ed-on-bls12-381"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#c3e13456d51034753a78b281e8d661d096cf2d2b"
+source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#3660a2686e932e39739f58ad7f90bc7123c08af6"
 dependencies = [
  "ark-ed-on-bls12-381",
  "ark-ff",
@@ -10644,7 +10644,7 @@ dependencies = [
 [[package]]
 name = "sp-ark-models"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#c3e13456d51034753a78b281e8d661d096cf2d2b"
+source = "git+https://github.com/paritytech/ark-substrate?branch=remove-affine-host-calls#3660a2686e932e39739f58ad7f90bc7123c08af6"
 dependencies = [
  "ark-ec",
  "ark-ff",

--- a/primitives/arkworks/src/bls12_377.rs
+++ b/primitives/arkworks/src/bls12_377.rs
@@ -55,13 +55,3 @@ pub fn mul_projective_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> 
 pub fn mul_projective_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
 	mul_projective_generic::<g2::Config>(base, scalar)
 }
-
-/// Compute a affine scalar multiplication for short_weierstrass through arkworks on G1
-pub fn mul_affine_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-	mul_affine_generic::<g1::Config>(base, scalar)
-}
-
-/// Compute a affine scalar multiplication for short_weierstrass through arkworks on G2
-pub fn mul_affine_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-	mul_affine_generic::<g2::Config>(base, scalar)
-}

--- a/primitives/arkworks/src/bls12_381.rs
+++ b/primitives/arkworks/src/bls12_381.rs
@@ -55,13 +55,3 @@ pub fn mul_projective_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> 
 pub fn mul_projective_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
 	mul_projective_generic::<g2::Config>(base, scalar)
 }
-
-/// Compute a affine scalar multiplication for short_weierstrass through arkworks on G1
-pub fn mul_affine_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-	mul_affine_generic::<g1::Config>(base, scalar)
-}
-
-/// Compute a affine scalar multiplication for short_weierstrass through arkworks on G2
-pub fn mul_affine_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-	mul_affine_generic::<g2::Config>(base, scalar)
-}

--- a/primitives/arkworks/src/bw6_761.rs
+++ b/primitives/arkworks/src/bw6_761.rs
@@ -55,13 +55,3 @@ pub fn mul_projective_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> 
 pub fn mul_projective_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
 	mul_projective_generic::<g2::Config>(base, scalar)
 }
-
-/// Compute a affine scalar multiplication for short_weierstrass through arkworks on G1
-pub fn mul_affine_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-	mul_affine_generic::<g1::Config>(base, scalar)
-}
-
-/// Compute a affine scalar multiplication for short_weierstrass through arkworks on G2
-pub fn mul_affine_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-	mul_affine_generic::<g2::Config>(base, scalar)
-}

--- a/primitives/arkworks/src/ed_on_bls12_377.rs
+++ b/primitives/arkworks/src/ed_on_bls12_377.rs
@@ -28,11 +28,6 @@ pub fn mul_projective(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
 	mul_projective_te_generic::<EdwardsConfig>(base, scalar)
 }
 
-/// Compute a scalar multiplication for twisted_edwards through arkworks
-pub fn mul_affine(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-	mul_affine_te_generic::<EdwardsConfig>(base, scalar)
-}
-
 /// Compute a multi scalar mulitplication for twisted_edwards through arkworks
 pub fn msm(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Vec<u8>, ()> {
 	msm_te_generic::<EdwardsConfig>(bases, scalars)

--- a/primitives/arkworks/src/ed_on_bls12_381.rs
+++ b/primitives/arkworks/src/ed_on_bls12_381.rs
@@ -31,19 +31,9 @@ pub fn sw_mul_projective(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> 
 	mul_projective_generic::<JubjubConfig>(base, scalar)
 }
 
-/// Compute a affine scalar multiplication for short_weierstrass through arkworks
-pub fn sw_mul_affine(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-	mul_affine_generic::<JubjubConfig>(base, scalar)
-}
-
 /// Compute a projective scalar multiplication for twisted_edwards through arkworks
 pub fn te_mul_projective(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
 	mul_projective_te_generic::<JubjubConfig>(base, scalar)
-}
-
-/// Compute a scalar multiplication for twisted_edwards through arkworks
-pub fn te_mul_affine(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-	mul_affine_te_generic::<JubjubConfig>(base, scalar)
 }
 
 /// Compute a multi scalar mulitplication for twisted_edwards through arkworks

--- a/primitives/arkworks/test/Cargo.toml
+++ b/primitives/arkworks/test/Cargo.toml
@@ -21,11 +21,11 @@ sp-io =  { version = "7.0.0", path = "../../io", default-features =  false }
 sp-arkworks = { path = "../" }
 ark-ec = { version = "0.4.0", default-features = false }
 ark-algebra-test-templates = { version = "0.4.0", default-features = false }
-sp-ark-bls12-377 = { version = "0.4.0", git = "https://github.com/paritytech/ark-substrate", default-features = false }
-sp-ark-bls12-381 = { version = "0.4.0", git = "https://github.com/paritytech/ark-substrate", defult-features = false }
-sp-ark-bw6-761 = { version = "0.4.0",git = "https://github.com/paritytech/ark-substrate", default-features = false }
-sp-ark-ed-on-bls12-377 = { version = "0.4.0", git = "https://github.com/paritytech/ark-substrate", default-features = false }
-sp-ark-ed-on-bls12-381 = { version = "0.4.0", git = "https://github.com/paritytech/ark-substrate", default-features = false }
+sp-ark-bls12-377 = { version = "0.4.0", git = "https://github.com/paritytech/ark-substrate", branch= "remove-affine-host-calls", default-features = false }
+sp-ark-bls12-381 = { version = "0.4.0", git = "https://github.com/paritytech/ark-substrate", branch= "remove-affine-host-calls", defult-features = false }
+sp-ark-bw6-761 = { version = "0.4.0",git = "https://github.com/paritytech/ark-substrate", branch= "remove-affine-host-calls", default-features = false }
+sp-ark-ed-on-bls12-377 = { version = "0.4.0", git = "https://github.com/paritytech/ark-substrate", branch= "remove-affine-host-calls", default-features = false }
+sp-ark-ed-on-bls12-381 = { version = "0.4.0", git = "https://github.com/paritytech/ark-substrate", branch= "remove-affine-host-calls", default-features = false }
 
 [features]
 default = [ "std" ]

--- a/primitives/arkworks/test/tests/bls12_377.rs
+++ b/primitives/arkworks/test/tests/bls12_377.rs
@@ -20,14 +20,8 @@ impl HostFunctions for Host {
 	fn bls12_377_mul_projective_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
 		sp_io::elliptic_curves::bls12_377_mul_projective_g1(base, scalar)
 	}
-	fn bls12_377_mul_affine_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_io::elliptic_curves::bls12_377_mul_affine_g1(base, scalar)
-	}
 	fn bls12_377_mul_projective_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
 		sp_io::elliptic_curves::bls12_377_mul_projective_g2(base, scalar)
-	}
-	fn bls12_377_mul_affine_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_io::elliptic_curves::bls12_377_mul_affine_g2(base, scalar)
 	}
 }
 

--- a/primitives/arkworks/test/tests/bls12_381/mod.rs
+++ b/primitives/arkworks/test/tests/bls12_381/mod.rs
@@ -27,14 +27,8 @@ impl HostFunctions for Host {
 	fn bls12_381_mul_projective_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
 		sp_io::elliptic_curves::bls12_381_mul_projective_g1(base, scalar)
 	}
-	fn bls12_381_mul_affine_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_io::elliptic_curves::bls12_381_mul_affine_g1(base, scalar)
-	}
 	fn bls12_381_mul_projective_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
 		sp_io::elliptic_curves::bls12_381_mul_projective_g2(base, scalar)
-	}
-	fn bls12_381_mul_affine_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_io::elliptic_curves::bls12_381_mul_affine_g2(base, scalar)
 	}
 }
 

--- a/primitives/arkworks/test/tests/bw6_761.rs
+++ b/primitives/arkworks/test/tests/bw6_761.rs
@@ -24,12 +24,6 @@ impl HostFunctions for Host {
 	fn bw6_761_mul_projective_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
 		sp_io::elliptic_curves::bw6_761_mul_projective_g2(base, scalar)
 	}
-	fn bw6_761_mul_affine_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_io::elliptic_curves::bw6_761_mul_affine_g1(base, scalar)
-	}
-	fn bw6_761_mul_affine_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_io::elliptic_curves::bw6_761_mul_affine_g2(base, scalar)
-	}
 }
 
 test_group!(g1; sp_ark_bw6_761::g1::G1Projective<super::Host>; sw);

--- a/primitives/arkworks/test/tests/ed_on_bls12_377.rs
+++ b/primitives/arkworks/test/tests/ed_on_bls12_377.rs
@@ -8,9 +8,6 @@ impl HostFunctions for Host {
 	fn ed_on_bls12_377_msm(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Vec<u8>, ()> {
 		sp_io::elliptic_curves::ed_on_bls12_377_msm(bases, scalars)
 	}
-	fn ed_on_bls12_377_mul_affine(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_io::elliptic_curves::ed_on_bls12_377_mul_affine(base, scalar)
-	}
 	fn ed_on_bls12_377_mul_projective(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
 		sp_io::elliptic_curves::ed_on_bls12_377_mul_projective(base, scalar)
 	}

--- a/primitives/arkworks/test/tests/ed_on_bls12_381.rs
+++ b/primitives/arkworks/test/tests/ed_on_bls12_381.rs
@@ -11,14 +11,8 @@ impl HostFunctions for Host {
 	fn ed_on_bls12_381_sw_msm(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Vec<u8>, ()> {
 		sp_io::elliptic_curves::ed_on_bls12_381_sw_msm(bases, scalars)
 	}
-	fn ed_on_bls12_381_sw_mul_affine(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_io::elliptic_curves::ed_on_bls12_381_sw_mul_affine(base, scalar)
-	}
 	fn ed_on_bls12_381_te_mul_projective(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
 		sp_io::elliptic_curves::ed_on_bls12_381_te_mul_projective(base, scalar)
-	}
-	fn ed_on_bls12_381_te_mul_affine(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_io::elliptic_curves::ed_on_bls12_381_te_mul_affine(base, scalar)
 	}
 	fn ed_on_bls12_381_sw_mul_projective(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
 		sp_io::elliptic_curves::ed_on_bls12_381_sw_mul_projective(base, scalar)

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -1160,19 +1160,9 @@ pub trait EllipticCurves {
 		sp_arkworks::bls12_381::mul_projective_g1(base, scalar)
 	}
 
-	/// Compute a projective multiplication on G1 for bls12_381
-	fn bls12_381_mul_affine_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_arkworks::bls12_381::mul_affine_g1(base, scalar)
-	}
-
 	/// Compute a projective multiplication on G2 for bls12_381
 	fn bls12_381_mul_projective_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
 		sp_arkworks::bls12_381::mul_projective_g2(base, scalar)
-	}
-
-	/// Compute a affine multiplication on G2 for bls12_381
-	fn bls12_381_mul_affine_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_arkworks::bls12_381::mul_affine_g2(base, scalar)
 	}
 
 	/// Compute a msm on G1 for bls12_381
@@ -1200,19 +1190,9 @@ pub trait EllipticCurves {
 		sp_arkworks::bls12_377::mul_projective_g1(base, scalar)
 	}
 
-	/// Compute a affine multiplication on G1 for bls12_377
-	fn bls12_377_mul_affine_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_arkworks::bls12_377::mul_affine_g1(base, scalar)
-	}
-
 	/// Compute a projective multiplication on G2 for bls12_377
 	fn bls12_377_mul_projective_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
 		sp_arkworks::bls12_377::mul_projective_g2(base, scalar)
-	}
-
-	/// Compute a affine multiplication on G2 for bls12_377
-	fn bls12_377_mul_affine_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_arkworks::bls12_377::mul_affine_g2(base, scalar)
 	}
 
 	/// Compute a msm on G1 for bls12_377
@@ -1245,16 +1225,6 @@ pub trait EllipticCurves {
 		sp_arkworks::bw6_761::mul_projective_g2(base, scalar)
 	}
 
-	/// Compute a affine multiplication on G1 for bw6_761
-	fn bw6_761_mul_affine_g1(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_arkworks::bw6_761::mul_affine_g1(base, scalar)
-	}
-
-	/// Compute a affine multiplication on G2 for bw6_761
-	fn bw6_761_mul_affine_g2(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_arkworks::bw6_761::mul_affine_g2(base, scalar)
-	}
-
 	/// Compute a msm on G1 for bw6_761
 	fn bw6_761_msm_g1(bases: Vec<u8>, bigints: Vec<u8>) -> Result<Vec<u8>, ()> {
 		sp_arkworks::bw6_761::msm_g1(bases, bigints)
@@ -1265,19 +1235,9 @@ pub trait EllipticCurves {
 		sp_arkworks::bw6_761::msm_g2(bases, bigints)
 	}
 
-	/// Compute a short weierstrass affine multiplication on ed_on_bls12_381
-	fn ed_on_bls12_381_sw_mul_affine(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_arkworks::ed_on_bls12_381::sw_mul_affine(base, scalar)
-	}
-
 	/// Compute twisted edwards projective multiplication on ed_on_bls12_381
 	fn ed_on_bls12_381_te_mul_projective(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
 		sp_arkworks::ed_on_bls12_381::te_mul_projective(base, scalar)
-	}
-
-	/// Compute twisted edwards affine multiplication on ed_on_bls12_381
-	fn ed_on_bls12_381_te_mul_affine(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_arkworks::ed_on_bls12_381::te_mul_affine(base, scalar)
 	}
 
 	/// Compute short weierstrass projective multiplication on ed_on_bls12_381
@@ -1293,11 +1253,6 @@ pub trait EllipticCurves {
 	/// Compute short weierstrass msm on ed_on_bls12_381
 	fn ed_on_bls12_381_sw_msm(bases: Vec<u8>, scalars: Vec<u8>) -> Result<Vec<u8>, ()> {
 		sp_arkworks::ed_on_bls12_381::sw_msm(bases, scalars)
-	}
-
-	/// Compute affine multiplication on ed_on_bls12_377
-	fn ed_on_bls12_377_mul_affine(base: Vec<u8>, scalar: Vec<u8>) -> Result<Vec<u8>, ()> {
-		sp_arkworks::ed_on_bls12_377::mul_affine(base, scalar)
 	}
 
 	/// Compute projective multiplication on ed_on_bls12_377


### PR DESCRIPTION
We remove the host calls for `Affine` mul's. Instead, we convert `Affine` mul's to `Projective` points first in [ark-subtrate](https://github.com/paritytech/ark-substrate) and call then into the host call's for `Projective` mul's.