### PR TITLE
Remove superfluous Pair::verify_weak

### DIFF
--- a/primitives/application-crypto/src/lib.rs
+++ b/primitives/application-crypto/src/lib.rs
@@ -154,13 +154,6 @@ macro_rules! app_crypto_pair {
 			) -> bool {
 				<$pair>::verify(&sig.0, message, pubkey.as_ref())
 			}
-			fn verify_weak<P: AsRef<[u8]>, M: AsRef<[u8]>>(
-				sig: &[u8],
-				message: M,
-				pubkey: P,
-			) -> bool {
-				<$pair>::verify_weak(sig, message, pubkey)
-			}
 			fn public(&self) -> Self::Public {
 				Public(self.0.public())
 			}

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -716,10 +716,6 @@ mod dummy {
 			true
 		}
 
-		fn verify_weak<P: AsRef<[u8]>, M: AsRef<[u8]>>(_: &[u8], _: M, _: P) -> bool {
-			true
-		}
-
 		fn public(&self) -> Self::Public {
 			Self
 		}
@@ -916,9 +912,6 @@ pub trait Pair: CryptoType + Sized + Clone + Send + Sync + 'static {
 
 	/// Verify a signature on a message. Returns true if the signature is good.
 	fn verify<M: AsRef<[u8]>>(sig: &Self::Signature, message: M, pubkey: &Self::Public) -> bool;
-
-	/// Verify a signature on a message. Returns true if the signature is good.
-	fn verify_weak<P: AsRef<[u8]>, M: AsRef<[u8]>>(sig: &[u8], message: M, pubkey: P) -> bool;
 
 	/// Get the public key.
 	fn public(&self) -> Self::Public;
@@ -1269,14 +1262,6 @@ mod tests {
 		}
 
 		fn verify<M: AsRef<[u8]>>(_: &Self::Signature, _: M, _: &Self::Public) -> bool {
-			true
-		}
-
-		fn verify_weak<P: AsRef<[u8]>, M: AsRef<[u8]>>(
-			_sig: &[u8],
-			_message: M,
-			_pubkey: P,
-		) -> bool {
 			true
 		}
 

--- a/primitives/core/src/ecdsa.rs
+++ b/primitives/core/src/ecdsa.rs
@@ -407,22 +407,8 @@ impl TraitPair for Pair {
 	}
 
 	/// Verify a signature on a message. Returns true if the signature is good.
-	fn verify<M: AsRef<[u8]>>(sig: &Self::Signature, message: M, pubkey: &Self::Public) -> bool {
-		match sig.recover(message) {
-			Some(actual) => actual == *pubkey,
-			None => false,
-		}
-	}
-
-	/// Verify a signature on a message. Returns true if the signature is good.
-	///
-	/// This doesn't use the type system to ensure that `sig` and `pubkey` are the correct
-	/// size. Use it only if you're coming from byte buffers and need the speed.
-	fn verify_weak<P: AsRef<[u8]>, M: AsRef<[u8]>>(sig: &[u8], message: M, pubkey: P) -> bool {
-		match Signature::from_slice(sig).and_then(|sig| sig.recover(message)) {
-			Some(actual) => actual.as_ref() == pubkey.as_ref(),
-			None => false,
-		}
+	fn verify<M: AsRef<[u8]>>(sig: &Self::Signature, message: M, public: &Self::Public) -> bool {
+		sig.recover(message).map(|actual| actual == *public).unwrap_or_default()
 	}
 
 	/// Return a vec filled with raw data.

--- a/primitives/core/src/ed25519.rs
+++ b/primitives/core/src/ed25519.rs
@@ -406,27 +406,17 @@ impl TraitPair for Pair {
 		Signature::from_raw(self.secret.sign(message).into())
 	}
 
-	/// Verify a signature on a message. Returns true if the signature is good.
-	fn verify<M: AsRef<[u8]>>(sig: &Self::Signature, message: M, pubkey: &Self::Public) -> bool {
-		Self::verify_weak(&sig.0[..], message.as_ref(), pubkey)
-	}
-
-	/// Verify a signature on a message. Returns true if the signature is good.
+	/// Verify a signature on a message.
 	///
-	/// This doesn't use the type system to ensure that `sig` and `pubkey` are the correct
-	/// size. Use it only if you're coming from byte buffers and need the speed.
-	fn verify_weak<P: AsRef<[u8]>, M: AsRef<[u8]>>(sig: &[u8], message: M, pubkey: P) -> bool {
-		let public_key = match VerificationKey::try_from(pubkey.as_ref()) {
-			Ok(pk) => pk,
-			Err(_) => return false,
+	/// Returns true if the signature is good.
+	fn verify<M: AsRef<[u8]>>(sig: &Self::Signature, message: M, public: &Self::Public) -> bool {
+		let Ok(public) = VerificationKey::try_from(public.as_slice()) else {
+			return false
 		};
-
-		let sig = match ed25519_zebra::Signature::try_from(sig) {
-			Ok(s) => s,
-			Err(_) => return false,
+		let Ok(signature) = ed25519_zebra::Signature::try_from(sig.as_ref()) else {
+			return false
 		};
-
-		public_key.verify(&sig, message.as_ref()).is_ok()
+		public.verify(&signature, message.as_ref()).is_ok()
 	}
 
 	/// Return a vec filled with raw data.

--- a/primitives/core/src/sr25519.rs
+++ b/primitives/core/src/sr25519.rs
@@ -487,21 +487,13 @@ impl TraitPair for Pair {
 	}
 
 	fn verify<M: AsRef<[u8]>>(sig: &Self::Signature, message: M, pubkey: &Self::Public) -> bool {
-		Self::verify_weak(&sig.0[..], message, pubkey)
-	}
-
-	fn verify_weak<P: AsRef<[u8]>, M: AsRef<[u8]>>(sig: &[u8], message: M, pubkey: P) -> bool {
-		let signature = match schnorrkel::Signature::from_bytes(sig) {
-			Ok(signature) => signature,
-			Err(_) => return false,
+		let Ok(signature) = schnorrkel::Signature::from_bytes(sig.as_ref()) else {
+			return false
 		};
-
-		let pub_key = match PublicKey::from_bytes(pubkey.as_ref()) {
-			Ok(pub_key) => pub_key,
-			Err(_) => return false,
+		let Ok(public) = PublicKey::from_bytes(pubkey.as_ref()) else {
+			return false
 		};
-
-		pub_key.verify_simple(SIGNING_CTX, message.as_ref(), &signature).is_ok()
+		public.verify_simple(SIGNING_CTX, message.as_ref(), &signature).is_ok()
 	}
 
 	fn to_raw_vec(&self) -> Vec<u8> {


### PR DESCRIPTION
Just duplicated code

1. If passing raw bytes we need to construct proper backend types anyway to verify the signature (so no real added value)
2. Not used anywhere