### PR TITLE
pallet Collective: fix genesis member sort order

### DIFF
--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -246,6 +246,10 @@ pub mod pallet {
 				self.members.len(),
 				"Members cannot contain duplicate accounts."
 			);
+			assert!(
+				self.members.len() <= T::MaxMembers::get() as usize,
+				"Members length cannot exceed MaxMembers.",
+			);
 
 			Pallet::<T, I>::initialize_members(&self.members)
 		}

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -1107,6 +1107,8 @@ impl<T: Config<I>, I: 'static> InitializeMembers<T::AccountId> for Pallet<T, I> 
 	fn initialize_members(members: &[T::AccountId]) {
 		if !members.is_empty() {
 			assert!(<Members<T, I>>::get().is_empty(), "Members are already initialized!");
+			let mut members = members.to_vec();
+			members.sort();
 			<Members<T, I>>::put(members);
 		}
 	}

--- a/frame/collective/src/tests.rs
+++ b/frame/collective/src/tests.rs
@@ -86,6 +86,7 @@ mod mock_democracy {
 }
 
 pub type MaxMembers = ConstU32<100>;
+type AccountId = u64;
 
 parameter_types! {
 	pub const MotionDuration: u64 = 3;
@@ -105,7 +106,7 @@ impl frame_system::Config for Test {
 	type RuntimeCall = RuntimeCall;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
-	type AccountId = u64;
+	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
 	type RuntimeEvent = RuntimeEvent;
@@ -161,19 +162,26 @@ impl Config for Test {
 	type MaxProposalWeight = MaxProposalWeight;
 }
 
-pub struct ExtBuilder {}
+pub struct ExtBuilder {
+	collective_members: Vec<AccountId>,
+}
 
 impl Default for ExtBuilder {
 	fn default() -> Self {
-		Self {}
+		Self { collective_members: vec![1, 2, 3] }
 	}
 }
 
 impl ExtBuilder {
+	fn set_collective_members(mut self, collective_members: Vec<AccountId>) -> Self {
+		self.collective_members = collective_members;
+		self
+	}
+
 	pub fn build(self) -> sp_io::TestExternalities {
 		let mut ext: sp_io::TestExternalities = GenesisConfig {
 			collective: pallet_collective::GenesisConfig {
-				members: vec![1, 2, 3],
+				members: self.collective_members,
 				phantom: Default::default(),
 			},
 			collective_majority: pallet_collective::GenesisConfig {
@@ -217,6 +225,17 @@ fn motions_basic_environment_works() {
 		assert_eq!(Collective::members(), vec![1, 2, 3]);
 		assert_eq!(*Collective::proposals(), Vec::<H256>::new());
 	});
+}
+
+#[test]
+fn initialize_members_sorts_members() {
+	let unsorted_accounts = vec![3, 2, 4, 1];
+	let expected_accounts = vec![1, 2, 3, 4];
+	ExtBuilder::default()
+		.set_collective_members(unsorted_accounts)
+		.build_and_execute(|| {
+			assert_eq!(Collective::members(), expected_accounts);
+		});
 }
 
 #[test]

--- a/frame/collective/src/tests.rs
+++ b/frame/collective/src/tests.rs
@@ -1443,6 +1443,19 @@ fn disapprove_proposal_works() {
 	})
 }
 
+#[should_panic(expected = "Members length cannot exceed MaxMembers.")]
+#[test]
+fn genesis_build_panics_with_too_many_members() {
+	let max_members: u32 = MaxMembers::get();
+	let too_many_members = (1..=max_members as u64 + 1).collect::<Vec<AccountId>>();
+	pallet_collective::GenesisConfig::<Test> {
+		members: too_many_members,
+		phantom: Default::default(),
+	}
+	.build_storage()
+	.unwrap();
+}
+
 #[test]
 #[should_panic(expected = "Members cannot contain duplicate accounts.")]
 fn genesis_build_panics_with_duplicate_members() {

--- a/frame/collective/src/tests.rs
+++ b/frame/collective/src/tests.rs
@@ -229,12 +229,12 @@ fn motions_basic_environment_works() {
 
 #[test]
 fn initialize_members_sorts_members() {
-	let unsorted_accounts = vec![3, 2, 4, 1];
-	let expected_accounts = vec![1, 2, 3, 4];
+	let unsorted_members = vec![3, 2, 4, 1];
+	let expected_members = vec![1, 2, 3, 4];
 	ExtBuilder::default()
-		.set_collective_members(unsorted_accounts)
+		.set_collective_members(unsorted_members)
 		.build_and_execute(|| {
-			assert_eq!(Collective::members(), expected_accounts);
+			assert_eq!(Collective::members(), expected_members);
 		});
 }
 


### PR DESCRIPTION
The Collective pallet currently does not check that genesis members are sorted or sort them before setting them as expected by the pallet:

https://github.com/paritytech/substrate/blob/9370f42ab35f7013f70b703884c9884888a3b153/frame/collective/src/lib.rs#L281-L285

`kitchen-sink-runtime` invariants are currently broken due to this bug.

This PR adds sorting logic into the `initialize_members`, ensuring genesis members are inserted in sorted order.

Props to @Szegoo for adding the Collective try-state hooks (https://github.com/paritytech/substrate/pull/13645) that caught this!

--- 

Open question: what's the likelihood there're other pallets that suffer from a similar bug? Should an issue need to be opened to investigate that? 