### PR TITLE
frame-support-procedural: Fix detection of the tuples feature

### DIFF
--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -80,5 +80,5 @@ no-metadata-docs = ["frame-support-procedural/no-metadata-docs", "sp-api/no-meta
 full-metadata-docs = ["scale-info/docs"]
 # Generate impl-trait for tuples with the given number of tuples. Will be needed as the number of
 # pallets in a runtime grows. Does increase the compile time!
-tuples-96 = []
-tuples-128 = []
+tuples-96 = ["frame-support-procedural/tuples-96"]
+tuples-128 = ["frame-support-procedural/tuples-128"]

--- a/frame/support/procedural/Cargo.toml
+++ b/frame/support/procedural/Cargo.toml
@@ -29,3 +29,7 @@ proc-macro-warning = { version = "0.3.0", default-features = false }
 default = ["std"]
 std = []
 no-metadata-docs = []
+# Generate impl-trait for tuples with the given number of tuples. Will be needed as the number of
+# pallets in a runtime grows. Does increase the compile time!
+tuples-96 = []
+tuples-128 = []


### PR DESCRIPTION
We didn't had the tuples features declared for the `frame-support-procedural` crate and thus, it could not properly detect that the feature was already enabled.


