### PR TITLE
remote-externalities: batch insert key/values

### DIFF
--- a/primitives/state-machine/src/testing.rs
+++ b/primitives/state-machine/src/testing.rs
@@ -135,7 +135,7 @@ where
 	/// Batch insert key/values into backend
 	pub fn batch_insert(&mut self, kvs: Vec<(StorageKey, StorageValue)>) {
 		self.backend.insert(
-			vec![(None, kvs.iter().map(|(k, v)| (k.clone(), Some(v.clone()))).collect())],
+			vec![(None, kvs.into_iter().map(|(k, v)| (k, Some(v))).collect())],
 			self.state_version,
 		);
 	}

--- a/primitives/state-machine/src/testing.rs
+++ b/primitives/state-machine/src/testing.rs
@@ -133,9 +133,12 @@ where
 	}
 
 	/// Batch insert key/values into backend
-	pub fn batch_insert(&mut self, kvs: Vec<(StorageKey, StorageValue)>) {
+	pub fn batch_insert<I>(&mut self, kvs: I)
+	where
+		I: IntoIterator<Item = (StorageKey, StorageValue)>,
+	{
 		self.backend.insert(
-			vec![(None, kvs.into_iter().map(|(k, v)| (k, Some(v))).collect())],
+			Some((None, kvs.into_iter().map(|(k, v)| (k, Some(v))).collect())),
 			self.state_version,
 		);
 	}

--- a/primitives/state-machine/src/testing.rs
+++ b/primitives/state-machine/src/testing.rs
@@ -132,6 +132,14 @@ where
 		self.offchain_db.clone()
 	}
 
+	/// Batch insert key/values into backend
+	pub fn batch_insert(&mut self, kvs: Vec<(StorageKey, StorageValue)>) {
+		self.backend.insert(
+			vec![(None, kvs.iter().map(|(k, v)| (k.clone(), Some(v.clone()))).collect())],
+			self.state_version,
+		);
+	}
+
 	/// Insert key/value into backend
 	pub fn insert(&mut self, k: StorageKey, v: StorageValue) {
 		self.backend.insert(vec![(None, vec![(k, Some(v))])], self.state_version);

--- a/utils/frame/remote-externalities/src/lib.rs
+++ b/utils/frame/remote-externalities/src/lib.rs
@@ -638,24 +638,20 @@ where
 		let mut processed = 0usize;
 		loop {
 			match rx.next().await.unwrap() {
-				Message::Batch(kv) => {
-					for (k, v) in kv {
-						processed += 1;
-						if processed % 50_000 == 0 || processed == keys.len() || processed == 1 {
-							log::info!(
-								target: LOG_TARGET,
-								"inserting keys progress = {:.0}% [{} / {}]",
-								(processed as f32 / keys.len() as f32) * 100f32,
-								processed,
-								keys.len(),
-							);
-						}
-						// skip writing the child root data.
-						if is_default_child_storage_key(k.as_ref()) {
-							continue
-						}
-						pending_ext.insert(k, v);
-					}
+				Message::Batch(kvs) => {
+					let kvs = kvs
+						.into_iter()
+						.filter(|(k, _)| !is_default_child_storage_key(k))
+						.collect::<Vec<_>>();
+					processed += kvs.len();
+					pending_ext.batch_insert(kvs);
+					log::info!(
+						target: LOG_TARGET,
+						"inserting keys progress = {:.0}% [{} / {}]",
+						(processed as f32 / keys.len() as f32) * 100f32,
+						processed,
+						keys.len(),
+					);
 				},
 				Message::BatchFailed(error) => {
 					log::error!(target: LOG_TARGET, "Batch processing failed: {:?}", error);
@@ -876,7 +872,7 @@ where
 			);
 			match self.rpc_get_storage(key.clone(), Some(at)).await? {
 				Some(value) => {
-					pending_ext.insert(key.clone().0, value.clone().0);
+					pending_ext.batch_insert(vec![(key.clone().0, value.clone().0)]);
 					keys_and_values.push((key, value));
 				},
 				None => {
@@ -1010,13 +1006,15 @@ where
 		);
 
 		info!(target: LOG_TARGET, "injecting a total of {} top keys", top.len());
-		for (k, v) in top {
-			// skip writing the child root data.
-			if is_default_child_storage_key(k.as_ref()) {
-				continue
-			}
-			inner_ext.insert(k.0, v.0);
-		}
+		let top = top
+			.into_iter()
+			.filter(|(k, _)| {
+				// skip writing the child root data.
+				!is_default_child_storage_key(k.as_ref())
+			})
+			.map(|(k, v)| (k.0, v.0))
+			.collect::<Vec<_>>();
+		inner_ext.batch_insert(top);
 
 		info!(
 			target: LOG_TARGET,
@@ -1052,9 +1050,7 @@ where
 				"extending externalities with {} manually injected key-values",
 				self.hashed_key_values.len()
 			);
-			for (k, v) in self.hashed_key_values {
-				ext.insert(k.0, v.0);
-			}
+			ext.batch_insert(self.hashed_key_values.into_iter().map(|(k, v)| (k.0, v.0)).collect());
 		}
 
 		// exclude manual key values.

--- a/utils/frame/remote-externalities/src/lib.rs
+++ b/utils/frame/remote-externalities/src/lib.rs
@@ -1047,7 +1047,7 @@ where
 				"extending externalities with {} manually injected key-values",
 				self.hashed_key_values.len()
 			);
-			ext.batch_insert(self.hashed_key_values.into_iter().map(|(k, v)| (k.0, v.0)).collect());
+			ext.batch_insert(self.hashed_key_values.into_iter().map(|(k, v)| (k.0, v.0)));
 		}
 
 		// exclude manual key values.

--- a/utils/frame/remote-externalities/src/lib.rs
+++ b/utils/frame/remote-externalities/src/lib.rs
@@ -1008,10 +1008,7 @@ where
 		info!(target: LOG_TARGET, "injecting a total of {} top keys", top.len());
 		let top = top
 			.into_iter()
-			.filter(|(k, _)| {
-				// skip writing the child root data.
-				!is_default_child_storage_key(k.as_ref())
-			})
+			.filter(|(k, _)| !is_default_child_storage_key(k.as_ref()))
 			.map(|(k, v)| (k.0, v.0))
 			.collect::<Vec<_>>();
 		inner_ext.batch_insert(top);

--- a/utils/frame/remote-externalities/src/lib.rs
+++ b/utils/frame/remote-externalities/src/lib.rs
@@ -872,7 +872,7 @@ where
 			);
 			match self.rpc_get_storage(key.clone(), Some(at)).await? {
 				Some(value) => {
-					pending_ext.batch_insert(vec![(key.clone().0, value.clone().0)]);
+					pending_ext.insert(key.clone().0, value.clone().0);
 					keys_and_values.push((key, value));
 				},
 				None => {


### PR DESCRIPTION
As suggested by @arkpar (https://github.com/paritytech/substrate/issues/13562#issuecomment-1520853103), adds batch inserting of key/value pairs to remote-externalities so the trie root doesn't need to be re-computed after every insertion.

## some (totally unscientific) try-runtime benchmarks

at `ws://localhost:9944` is an (optimised build) kusama node

| Task | Build | Before | After | Improvement |
|---------|-------|--------|-------|-----|
| `on-runtime-upgrade` (live) | release | 72s | 59s | 18% |
| `on-runtime-upgrade` (live) | debug | 174s | 73s | 58% |
| `create-snapshot` | release | 70s | 58s | 17% |
| `create-snapshot` | debug | 173s | 57s | 67% |
| `on-runtime-upgrade` (snap) | release | 21s | 5s | 76% |
| `on-runtime-upgrade` (snap) | debug | 125s | 19s | 84% |
