### PR TITLE
Easy PR: Allow missing docs for autogen weights

### DIFF
--- a/.maintain/frame-weight-template.hbs
+++ b/.maintain/frame-weight-template.hbs
@@ -15,6 +15,7 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(unused_parens)]
 #![allow(unused_imports)]
+#![allow(missing_docs)]
 
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
 use core::marker::PhantomData;

--- a/utils/frame/benchmarking-cli/src/pallet/template.hbs
+++ b/utils/frame/benchmarking-cli/src/pallet/template.hbs
@@ -15,6 +15,7 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(unused_parens)]
 #![allow(unused_imports)]
+#![allow(missing_docs)]
 
 use frame_support::{traits::Get, weights::Weight};
 use core::marker::PhantomData;


### PR DESCRIPTION
This change allows people to use `#![deny(missing_docs)]` for pallets should they wish to.