### PR TITLE
Allow to wrap or overwrite low-level tcp-transport.

### DIFF
--- a/client/network/src/lib.rs
+++ b/client/network/src/lib.rs
@@ -260,8 +260,14 @@ pub mod types;
 pub mod utils;
 
 pub use event::{DhtEvent, Event, SyncEvent};
+pub use futures::{AsyncRead, AsyncWrite};
 #[doc(inline)]
-pub use libp2p::{multiaddr, Multiaddr, PeerId};
+pub use libp2p::{
+	core::transport::{ListenerId, Transport, TransportError, TransportEvent},
+	multiaddr,
+	tcp::tokio::Transport as TcpTransport,
+	Multiaddr, PeerId,
+};
 pub use request_responses::{IfDisconnected, RequestFailure, RequestResponseConfig};
 pub use sc_network_common::{
 	role::ObservedRole,

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -147,7 +147,7 @@ where
 	/// Returns a `NetworkWorker` that implements `Future` and must be regularly polled in order
 	/// for the network processing to advance. From it, you can extract a `NetworkService` using
 	/// `worker.service()`. The `NetworkService` can be shared through the codebase.
-	pub fn new(params: Params<B, Client>) -> Result<Self, Error> {
+	pub fn new(params: Params<B>) -> Result<Self, Error> {
 		Self::new_with_transport_wrapper(params, std::convert::identity)
 	}
 
@@ -157,7 +157,7 @@ where
 	/// for the network processing to advance. From it, you can extract a `NetworkService` using
 	/// `worker.service()`. The `NetworkService` can be shared through the codebase.
 	pub fn new_with_transport_wrapper<T, TBuild>(
-		mut params: Params<B, Client>,
+		mut params: Params<B>,
 		transport: TBuild,
 	) -> Result<Self, Error>
 	where

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -780,6 +780,7 @@ pub fn build_network_with_transport_wrapper<
 		TracingUnboundedSender<sc_rpc::system::Request<TBl>>,
 		sc_network_transactions::TransactionsHandlerController<<TBl as BlockT>::Hash>,
 		NetworkStarter,
+		Arc<SyncingService<TBl>>,
 	),
 	Error,
 >
@@ -794,7 +795,7 @@ where
 		+ HeaderBackend<TBl>
 		+ BlockchainEvents<TBl>
 		+ 'static,
-	TExPool: MaintainedTransactionPool<Block = TBl, Hash = <TBl as BlockT>::Hash> + 'static,
+	TExPool: TransactionPool<Block = TBl, Hash = <TBl as BlockT>::Hash> + 'static,
 	TImpQu: ImportQueue<TBl> + 'static,
 	TransportBuilder: Fn(sc_network::TcpTransport) -> Transport,
 	Transport: sc_network::Transport + Send + Unpin + 'static,

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -55,10 +55,10 @@ use sp_runtime::{
 
 pub use self::{
 	builder::{
-		build_network, build_offchain_workers, new_client, new_db_backend, new_full_client,
-		new_full_parts, new_full_parts_with_genesis_builder, new_native_or_wasm_executor,
-		spawn_tasks, BuildNetworkParams, KeystoreContainer, NetworkStarter, SpawnTasksParams,
-		TFullBackend, TFullCallExecutor, TFullClient,
+		build_network, build_network_with_transport_wrapper, build_offchain_workers, new_client,
+		new_db_backend, new_full_client, new_full_parts, new_full_parts_with_genesis_builder,
+		new_native_or_wasm_executor, spawn_tasks, BuildNetworkParams, KeystoreContainer,
+		NetworkStarter, SpawnTasksParams, TFullBackend, TFullCallExecutor, TFullClient,
 	},
 	client::{ClientConfig, LocalCallExecutor},
 	error::Error,


### PR DESCRIPTION
Extension of the api of the `sc-service` package that allows to wrap or even overwrite the default tcp-transport that is used by the `sc-network`. It should allow one to add some custom functionality to low-level networking layer, e.g. manual back-pressure on the network layer, additional logging/sniffing, etc.