### PR TITLE
pallet-aura: Allow multiple blocks per slot

### DIFF
--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -27,7 +27,8 @@ use sp_version::RuntimeVersion;
 pub use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{
-		ConstU128, ConstU32, ConstU64, ConstU8, ConstBool, KeyOwnerProofSystem, Randomness, StorageInfo,
+		ConstBool, ConstU128, ConstU32, ConstU64, ConstU8, KeyOwnerProofSystem, Randomness,
+		StorageInfo,
 	},
 	weights::{
 		constants::{

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -203,10 +203,15 @@ impl frame_system::Config for Runtime {
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
+parameter_types! {
+	pub const AllowMultipleBlocksPerSlot: bool = false;
+}
+
 impl pallet_aura::Config for Runtime {
 	type AuthorityId = AuraId;
 	type DisabledValidators = ();
 	type MaxAuthorities = ConstU32<32>;
+	type AllowMultipleBlocksPerSlot = AllowMultipleBlocksPerSlot;
 }
 
 impl pallet_grandpa::Config for Runtime {

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -27,7 +27,7 @@ use sp_version::RuntimeVersion;
 pub use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{
-		ConstU128, ConstU32, ConstU64, ConstU8, KeyOwnerProofSystem, Randomness, StorageInfo,
+		ConstU128, ConstU32, ConstU64, ConstU8, ConstBool, KeyOwnerProofSystem, Randomness, StorageInfo,
 	},
 	weights::{
 		constants::{
@@ -203,15 +203,11 @@ impl frame_system::Config for Runtime {
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
-parameter_types! {
-	pub const AllowMultipleBlocksPerSlot: bool = false;
-}
-
 impl pallet_aura::Config for Runtime {
 	type AuthorityId = AuraId;
 	type DisabledValidators = ();
 	type MaxAuthorities = ConstU32<32>;
-	type AllowMultipleBlocksPerSlot = AllowMultipleBlocksPerSlot;
+	type AllowMultipleBlocksPerSlot = ConstBool<false>;
 }
 
 impl pallet_grandpa::Config for Runtime {

--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -139,8 +139,8 @@ pub mod pallet {
 	/// If this is `false`, the pallet will require that subsequent blocks always have higher slots
 	/// than previous ones.
 	///
-	/// Regardless of the setting of this storage value, the pallet will always enforce the invariant
-	/// that slots don't move backwards as the chain progresses.
+	/// Regardless of the setting of this storage value, the pallet will always enforce the
+	/// invariant that slots don't move backwards as the chain progresses.
 	///
 	/// The typical value for this should be 'false' unless this pallet is being augmented by
 	/// another pallet which enforces some limitation on the number of blocks authors can create

--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -92,7 +92,12 @@ pub mod pallet {
 			if let Some(new_slot) = Self::current_slot_from_digests() {
 				let current_slot = CurrentSlot::<T>::get();
 
-				assert!(current_slot < new_slot, "Slot must increase");
+				if AllowMultipleBlocksPerSlot::<T>::get() {
+					assert!(current_slot <= new_slot, "Slot must not decrease");
+				} else {
+					assert!(current_slot < new_slot, "Slot must increase");
+				}
+
 				CurrentSlot::<T>::put(new_slot);
 
 				if let Some(n_authorities) = <Authorities<T>>::decode_len() {
@@ -127,6 +132,22 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn current_slot)]
 	pub(super) type CurrentSlot<T: Config> = StorageValue<_, Slot, ValueQuery>;
+
+	/// Whether to allow authors to create multiple blocks per slot.
+	///
+	/// If this is `true`, the pallet will allow slots to stay the same across sequential blocks.
+	/// If this is `false`, the pallet will require that subsequent blocks always have higher slots
+	/// than previous ones.
+	///
+	/// Regardless of the setting of this storage value, the pallet will always enforce the invariant
+	/// that slots don't move backwards as the chain progresses.
+	///
+	/// The typical value for this should be 'false' unless this pallet is being augmented by
+	/// another pallet which enforces some limitation on the number of blocks authors can create
+	/// using the same slot.
+	#[pallet::storage]
+	#[pallet::getter(fn allow_multiple_blocks)]
+	pub(super) type AllowMultipleBlocksPerSlot<T: Config> = StorageValue<_, bool, ValueQuery>;
 
 	#[pallet::genesis_config]
 	#[derive(frame_support::DefaultNoBound)]

--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -81,6 +81,20 @@ pub mod pallet {
 		/// Blocks authored by a disabled validator will lead to a panic as part of this module's
 		/// initialization.
 		type DisabledValidators: DisabledValidators;
+
+		/// Whether to allow block authors to create multiple blocks per slot.
+		///
+		/// If this is `true`, the pallet will allow slots to stay the same across sequential blocks.
+		/// If this is `false`, the pallet will require that subsequent blocks always have higher slots
+		/// than previous ones.
+		///
+		/// Regardless of the setting of this storage value, the pallet will always enforce the
+		/// invariant that slots don't move backwards as the chain progresses.
+		///
+		/// The typical value for this should be 'false' unless this pallet is being augmented by
+		/// another pallet which enforces some limitation on the number of blocks authors can create
+		/// using the same slot.
+		type AllowMultipleBlocksPerSlot: Get<bool>;
 	}
 
 	#[pallet::pallet]
@@ -92,7 +106,7 @@ pub mod pallet {
 			if let Some(new_slot) = Self::current_slot_from_digests() {
 				let current_slot = CurrentSlot::<T>::get();
 
-				if AllowMultipleBlocksPerSlot::<T>::get() {
+				if T::AllowMultipleBlocksPerSlot::get() {
 					assert!(current_slot <= new_slot, "Slot must not decrease");
 				} else {
 					assert!(current_slot < new_slot, "Slot must increase");
@@ -132,22 +146,6 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn current_slot)]
 	pub(super) type CurrentSlot<T: Config> = StorageValue<_, Slot, ValueQuery>;
-
-	/// Whether to allow authors to create multiple blocks per slot.
-	///
-	/// If this is `true`, the pallet will allow slots to stay the same across sequential blocks.
-	/// If this is `false`, the pallet will require that subsequent blocks always have higher slots
-	/// than previous ones.
-	///
-	/// Regardless of the setting of this storage value, the pallet will always enforce the
-	/// invariant that slots don't move backwards as the chain progresses.
-	///
-	/// The typical value for this should be 'false' unless this pallet is being augmented by
-	/// another pallet which enforces some limitation on the number of blocks authors can create
-	/// using the same slot.
-	#[pallet::storage]
-	#[pallet::getter(fn allow_multiple_blocks)]
-	pub(super) type AllowMultipleBlocksPerSlot<T: Config> = StorageValue<_, bool, ValueQuery>;
 
 	#[pallet::genesis_config]
 	#[derive(frame_support::DefaultNoBound)]

--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -84,9 +84,9 @@ pub mod pallet {
 
 		/// Whether to allow block authors to create multiple blocks per slot.
 		///
-		/// If this is `true`, the pallet will allow slots to stay the same across sequential blocks.
-		/// If this is `false`, the pallet will require that subsequent blocks always have higher slots
-		/// than previous ones.
+		/// If this is `true`, the pallet will allow slots to stay the same across sequential
+		/// blocks. If this is `false`, the pallet will require that subsequent blocks always have
+		/// higher slots than previous ones.
 		///
 		/// Regardless of the setting of this storage value, the pallet will always enforce the
 		/// invariant that slots don't move backwards as the chain progresses.

--- a/frame/aura/src/mock.rs
+++ b/frame/aura/src/mock.rs
@@ -82,6 +82,7 @@ impl pallet_timestamp::Config for Test {
 
 parameter_types! {
 	static DisabledValidatorTestValue: Vec<AuthorityIndex> = Default::default();
+	pub static AllowMultipleBlocksPerSlot: bool = false;
 }
 
 pub struct MockDisabledValidators;
@@ -106,6 +107,7 @@ impl pallet_aura::Config for Test {
 	type AuthorityId = AuthorityId;
 	type DisabledValidators = MockDisabledValidators;
 	type MaxAuthorities = ConstU32<10>;
+	type AllowMultipleBlocksPerSlot = AllowMultipleBlocksPerSlot;
 }
 
 pub fn new_test_ext(authorities: Vec<u64>) -> sp_io::TestExternalities {

--- a/frame/aura/src/tests.rs
+++ b/frame/aura/src/tests.rs
@@ -19,7 +19,7 @@
 
 #![cfg(test)]
 
-use crate::mock::{new_test_ext, Aura, MockDisabledValidators, System};
+use crate::mock::{new_test_ext, Aura, MockDisabledValidators, System, Test};
 use codec::Encode;
 use frame_support::traits::OnInitialize;
 use sp_consensus_aura::{Slot, AURA_ENGINE_ID};
@@ -52,5 +52,68 @@ fn disabled_validators_cannot_author_blocks() {
 
 		// and we should not be able to initialize the block
 		Aura::on_initialize(42);
+	});
+}
+
+#[test]
+#[should_panic(
+	expected = "Slot must increase"
+)]
+fn pallet_requires_slot_to_increase_unless_allowed() {
+	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
+		let slot = Slot::from(1);
+		let pre_digest =
+			Digest { logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())] };
+
+		System::reset_events();
+		System::initialize(&42, &System::parent_hash(), &pre_digest);
+
+		// and we should not be able to initialize the block with the same slot a second time.
+		Aura::on_initialize(42);
+		Aura::on_initialize(42);
+	});
+}
+
+#[test]
+fn pallet_can_allow_unchanged_slot() {
+	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
+		let slot = Slot::from(1);
+		let pre_digest =
+			Digest { logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())] };
+
+		System::reset_events();
+		System::initialize(&42, &System::parent_hash(), &pre_digest);
+
+		crate::AllowMultipleBlocksPerSlot::<Test>::put(true);
+
+		// and we should be able to initialize the block with the same slot a second time.
+		Aura::on_initialize(42);
+		Aura::on_initialize(42);
+	});
+}
+
+#[test]
+#[should_panic(
+	expected = "Slot must not decrease"
+)]
+fn pallet_always_rejects_decreasing_slot() {
+	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
+		let slot = Slot::from(2);
+		let pre_digest =
+			Digest { logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())] };
+
+		System::reset_events();
+		System::initialize(&42, &System::parent_hash(), &pre_digest);
+
+		crate::AllowMultipleBlocksPerSlot::<Test>::put(true);
+
+		Aura::on_initialize(42);
+		System::finalize();
+
+		let earlier_slot = Slot::from(1);
+		let pre_digest =
+			Digest { logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, earlier_slot.encode())] };
+		System::initialize(&43, &System::parent_hash(), &pre_digest);
+		Aura::on_initialize(43);
 	});
 }

--- a/frame/aura/src/tests.rs
+++ b/frame/aura/src/tests.rs
@@ -56,9 +56,7 @@ fn disabled_validators_cannot_author_blocks() {
 }
 
 #[test]
-#[should_panic(
-	expected = "Slot must increase"
-)]
+#[should_panic(expected = "Slot must increase")]
 fn pallet_requires_slot_to_increase_unless_allowed() {
 	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
 		let slot = Slot::from(1);
@@ -93,9 +91,7 @@ fn pallet_can_allow_unchanged_slot() {
 }
 
 #[test]
-#[should_panic(
-	expected = "Slot must not decrease"
-)]
+#[should_panic(expected = "Slot must not decrease")]
 fn pallet_always_rejects_decreasing_slot() {
 	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
 		let slot = Slot::from(2);

--- a/frame/aura/src/tests.rs
+++ b/frame/aura/src/tests.rs
@@ -19,7 +19,7 @@
 
 #![cfg(test)]
 
-use crate::mock::{new_test_ext, Aura, MockDisabledValidators, System, Test};
+use crate::mock::{new_test_ext, Aura, MockDisabledValidators, System};
 use codec::Encode;
 use frame_support::traits::OnInitialize;
 use sp_consensus_aura::{Slot, AURA_ENGINE_ID};
@@ -59,6 +59,8 @@ fn disabled_validators_cannot_author_blocks() {
 #[should_panic(expected = "Slot must increase")]
 fn pallet_requires_slot_to_increase_unless_allowed() {
 	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
+		crate::mock::AllowMultipleBlocksPerSlot::set(false);
+
 		let slot = Slot::from(1);
 		let pre_digest =
 			Digest { logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())] };
@@ -82,7 +84,7 @@ fn pallet_can_allow_unchanged_slot() {
 		System::reset_events();
 		System::initialize(&42, &System::parent_hash(), &pre_digest);
 
-		crate::AllowMultipleBlocksPerSlot::<Test>::put(true);
+		crate::mock::AllowMultipleBlocksPerSlot::set(true);
 
 		// and we should be able to initialize the block with the same slot a second time.
 		Aura::on_initialize(42);
@@ -101,7 +103,7 @@ fn pallet_always_rejects_decreasing_slot() {
 		System::reset_events();
 		System::initialize(&42, &System::parent_hash(), &pre_digest);
 
-		crate::AllowMultipleBlocksPerSlot::<Test>::put(true);
+		crate::mock::AllowMultipleBlocksPerSlot::set(true);
 
 		Aura::on_initialize(42);
 		System::finalize();


### PR DESCRIPTION
This amends pallet-aura to optionally allow sequential blocks to be authored within the same slot. This is being done for https://github.com/paritytech/cumulus/issues/2476 , as we often need to create a 'backlog' of blocks to post to the relay chain, and therefore can temporarily require block production to speed up.

This will also be useful for further roadmap items like elastic scaling and parallel block production, where chains need to make multiple blocks per slot for longer periods of time as well.

## Update Guide

Set the new `AllowMultipleBlocksPerSlot` to `false` to maintain current behavior. Setting this value to `true` will be necessary for parachains looking to enable asynchronous backing later on, but this will require other changes alongside.

Example:
```rust
impl pallet_aura::Config for Runtime {
  // .. snip
  type AllowMultipleBlocksPerSlot = ConstBool<false>;
}
```

cumulus companion: https://github.com/paritytech/cumulus/pull/2707