### PR TITLE
contracts fix store-call test path

### DIFF
--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -3585,7 +3585,7 @@ fn storage_deposit_works() {
 #[test]
 fn storage_deposit_callee_works() {
 	let (wasm_caller, _code_hash_caller) = compile_module::<Test>("call").unwrap();
-	let (wasm_callee, _code_hash_callee) = compile_module::<Test>("store").unwrap();
+	let (wasm_callee, _code_hash_callee) = compile_module::<Test>("store_call").unwrap();
 	const ED: u64 = 200;
 	ExtBuilder::default().existential_deposit(ED).build().execute_with(|| {
 		let _ = Balances::deposit_creating(&ALICE, 1_000_000);


### PR DESCRIPTION
missed file rename from https://github.com/paritytech/substrate/pull/13565/files#diff-6370b6056b1f65146c88f1b9f291c2d3a64bc5f59c93b1905bad95a09d959f7b