### PR TITLE
refactor spawn API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5317,6 +5317,7 @@ dependencies = [
  "sp-timestamp",
  "substrate-test-client",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -10525,6 +10526,7 @@ dependencies = [
  "substrate-bip39",
  "thiserror",
  "tiny-bip39",
+ "tokio",
  "zeroize",
 ]
 

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -45,3 +45,4 @@ sp-keyring = { version = "7.0.0", path = "../../../primitives/keyring" }
 sp-runtime = { version = "7.0.0", path = "../../../primitives/runtime" }
 sp-timestamp = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/timestamp" }
 substrate-test-client = { version = "2.0.0", path = "../../../test-utils/client" }
+tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -40,6 +40,7 @@ dyn-clonable = { version = "0.9.0", optional = true }
 thiserror = { version = "1.0.30", optional = true }
 bitflags = "1.3"
 paste = "1.0.7"
+tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
 
 # full crypto
 array-bytes = { version = "4.1", optional = true }
@@ -111,6 +112,7 @@ std = [
 	"futures/thread-pool",
 	"libsecp256k1/std",
 	"dyn-clonable",
+	"tokio",
 ]
 
 # This feature enables all crypto primitives for `no_std` builds like microcontrollers

--- a/primitives/core/src/traits.rs
+++ b/primitives/core/src/traits.rs
@@ -179,6 +179,9 @@ impl ReadRuntimeVersionExt {
 	}
 }
 
+/// A handle for spawned task.
+pub type SpawnHandle = tokio::task::JoinHandle<()>;
+
 /// Something that can spawn tasks (blocking and non-blocking) with an assigned name
 /// and optional group.
 #[dyn_clonable::clonable]
@@ -191,7 +194,7 @@ pub trait SpawnNamed: Clone + Send + Sync {
 		name: &'static str,
 		group: Option<&'static str>,
 		future: futures::future::BoxFuture<'static, ()>,
-	);
+	) -> SpawnHandle;
 	/// Spawn the given non-blocking future.
 	///
 	/// The given `group` and `name` is used to identify the future in tracing.
@@ -200,7 +203,7 @@ pub trait SpawnNamed: Clone + Send + Sync {
 		name: &'static str,
 		group: Option<&'static str>,
 		future: futures::future::BoxFuture<'static, ()>,
-	);
+	) -> SpawnHandle;
 }
 
 impl SpawnNamed for Box<dyn SpawnNamed> {
@@ -209,7 +212,7 @@ impl SpawnNamed for Box<dyn SpawnNamed> {
 		name: &'static str,
 		group: Option<&'static str>,
 		future: futures::future::BoxFuture<'static, ()>,
-	) {
+	) -> SpawnHandle {
 		(**self).spawn_blocking(name, group, future)
 	}
 	fn spawn(
@@ -217,7 +220,7 @@ impl SpawnNamed for Box<dyn SpawnNamed> {
 		name: &'static str,
 		group: Option<&'static str>,
 		future: futures::future::BoxFuture<'static, ()>,
-	) {
+	) -> SpawnHandle {
 		(**self).spawn(name, group, future)
 	}
 }
@@ -236,7 +239,7 @@ pub trait SpawnEssentialNamed: Clone + Send + Sync {
 		name: &'static str,
 		group: Option<&'static str>,
 		future: futures::future::BoxFuture<'static, ()>,
-	);
+	) -> SpawnHandle;
 	/// Spawn the given non-blocking future.
 	///
 	/// The given `group` and `name` is used to identify the future in tracing.
@@ -245,7 +248,7 @@ pub trait SpawnEssentialNamed: Clone + Send + Sync {
 		name: &'static str,
 		group: Option<&'static str>,
 		future: futures::future::BoxFuture<'static, ()>,
-	);
+	) -> SpawnHandle;
 }
 
 impl SpawnEssentialNamed for Box<dyn SpawnEssentialNamed> {
@@ -254,7 +257,7 @@ impl SpawnEssentialNamed for Box<dyn SpawnEssentialNamed> {
 		name: &'static str,
 		group: Option<&'static str>,
 		future: futures::future::BoxFuture<'static, ()>,
-	) {
+	) -> SpawnHandle {
 		(**self).spawn_essential_blocking(name, group, future)
 	}
 
@@ -263,7 +266,7 @@ impl SpawnEssentialNamed for Box<dyn SpawnEssentialNamed> {
 		name: &'static str,
 		group: Option<&'static str>,
 		future: futures::future::BoxFuture<'static, ()>,
-	) {
+	) -> SpawnHandle {
 		(**self).spawn_essential(name, group, future)
 	}
 }


### PR DESCRIPTION
I would want the `spawn` and `spawn_blocking` to return a spawn handle or something equivalent and as substrate uses tokio quite extensively looks reasonable to return `tokio::task::JoinHandle` instead.

Needed by #13992 

No real code changes rather than tests and benchmarks