### PR TITLE
fix(in_mem): fix the clone logic

### DIFF
--- a/client/api/src/in_mem.rs
+++ b/client/api/src/in_mem.rs
@@ -114,6 +114,7 @@ struct BlockchainStorage<Block: BlockT> {
 }
 
 /// In-memory blockchain. Supports concurrent reads.
+#[derive(Clone)]
 pub struct Blockchain<Block: BlockT> {
 	storage: Arc<RwLock<BlockchainStorage<Block>>>,
 }
@@ -121,13 +122,6 @@ pub struct Blockchain<Block: BlockT> {
 impl<Block: BlockT> Default for Blockchain<Block> {
 	fn default() -> Self {
 		Self::new()
-	}
-}
-
-impl<Block: BlockT + Clone> Clone for Blockchain<Block> {
-	fn clone(&self) -> Self {
-		let storage = Arc::new(RwLock::new(self.storage.read().clone()));
-		Blockchain { storage }
 	}
 }
 


### PR DESCRIPTION
The `clone` logic is wrong. Should clone `Arc` rather than clone inner `BlockchainStorage`