### PR TITLE
[sc-allocator] Handle some errors gracefully

### DIFF
--- a/client/allocator/src/lib.rs
+++ b/client/allocator/src/lib.rs
@@ -25,7 +25,7 @@
 mod error;
 mod freeing_bump;
 
-pub use error::Error;
+pub use error::PoisonedError;
 pub use freeing_bump::{AllocationStats, FreeingBumpHeapAllocator};
 
 /// The size of one wasm page in bytes.

--- a/client/executor/common/src/error.rs
+++ b/client/executor/common/src/error.rs
@@ -67,7 +67,7 @@ pub enum Error {
 	Other(String),
 
 	#[error(transparent)]
-	Allocator(#[from] sc_allocator::Error),
+	Allocator(#[from] sc_allocator::PoisonedError),
 
 	#[error("Host function {0} execution failed with: {1}")]
 	FunctionExecution(String, String),

--- a/client/executor/src/integration_tests/mod.rs
+++ b/client/executor/src/integration_tests/mod.rs
@@ -465,16 +465,10 @@ fn should_trap_when_heap_exhausted(wasm_method: WasmExecutionMethod) {
 		.unwrap_err();
 
 	match err {
-		Error::AbortedDueToTrap(error)
-			if matches!(wasm_method, WasmExecutionMethod::Compiled { .. }) =>
-		{
-			assert_eq!(
-				error.message,
-				r#"host code panicked while being called by the runtime: Failed to allocate memory: "Allocator ran out of space""#
-			);
-		},
-		Error::RuntimePanicked(error) if wasm_method == WasmExecutionMethod::Interpreted => {
-			assert_eq!(error, r#"Failed to allocate memory: "Allocator ran out of space""#);
+		Error::AbortedDueToPanic(error) => {
+			assert!(error
+				.message
+				.starts_with(r#"panicked at 'memory allocation of 16777216 bytes failed'"#),);
 		},
 		error => panic!("unexpected error: {:?}", error),
 	}


### PR DESCRIPTION
## High level ##

I was wondering if we could handle some allocator errors (for example OOM) gracefully or if there is a strong reason why we panic in all error case and mark the allocator as poisoned. I couldn't find any documentation on this, sorry if I missed it.

We could do this by simply returning a `NULL` pointer instead of an error when we encounter a non-critical problem.

## Context ##

The size of a structure in memory is different from its encoded size. It can happen at times that the difference between these 2 representations to be significant. Take for example the [XCM Instruction<Call>](https://github.com/paritytech/polkadot/blob/1d8ccbffd1235d4d1d3a0bf02132d8ea9105078f/xcm/src/v3/mod.rs#L369) structure which takes ~1400 bytes in memory but has some variants that can be encoded in just 1 byte (for example [`Instruction::ClearOrigin`](https://github.com/paritytech/polkadot/blob/1d8ccbffd1235d4d1d3a0bf02132d8ea9105078f/xcm/src/v3/mod.rs#L547))

In such cases we could store encoded structures in a relatively small space, compared to the real memory representation. If we end up in such a corner case (having for example a large encoded `Vec` of `Instruction<Call>`), when trying to decode it the execution will end up [here](https://github.com/paritytech/parity-scale-codec/blob/b0099e80b1f6f09ab5cffe27794a11e134403b49/src/codec.rs#L838), where `Vec::push` will eventually try to allocate too much memory and the wasm VM will panic [here](https://github.com/paritytech/substrate/blob/16b2e644487f7f767eeefd4debf11a7948bfa4db/primitives/io/src/lib.rs#L1451). 

I was wondering if we could avoid panicking on such errors (OOM) in order to give the wasm application the possibility to handle such corner cases gracefully. In the scenario above, for example we could adjust the decoding logic by replacing `r.push()` with:
```
		r.try_reserve(1)
			.map_err(|_| {
				parity_scale_codec::Error::from("Could not allocate enough memory")
			})?;
		r.push(T::decode(input)?);
```
and we would get a decoding error instead of a wasm trap, which could be better.

Related to: https://github.com/paritytech/parity-bridges-common/issues/2015