### PR TITLE
CI: Remove crate publish check

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -247,18 +247,6 @@ default:
 
 #### stage:                       .pre
 
-check-crates-publishing-pipeline:
-  stage: .pre
-  extends:
-    - .kubernetes-env
-    - .crates-publishing-pipeline
-  script:
-    - git clone
-      --depth 1
-      --branch "$RELENG_SCRIPTS_BRANCH"
-      https://github.com/paritytech/releng-scripts.git
-    - ONLY_CHECK_PIPELINE=true ./releng-scripts/publish-crates
-
 # By default our pipelines are interruptible, but some special pipelines shouldn't be interrupted:
 # * multi-project pipelines such as the ones triggered by the scripts repo
 # * the scheduled automatic-crate-publishing pipeline

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -70,7 +70,11 @@ std = [
 	"log/std",
 	"environmental/std",
 ]
-runtime-benchmarks = []
+runtime-benchmarks = [
+	"frame-system/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+	"sp-staking/runtime-benchmarks"
+]
 try-runtime = []
 # By default some types have documentation, `no-metadata-docs` allows to reduce the documentation
 # in the metadata.


### PR DESCRIPTION
There is another job with name `check-crate-publishing` in `scripts/ci/gitlab/pipeline/publish.yml`, so i hope to have removed the correct one :see_no_evil: 