### PR TITLE
Fix bags-list tests execution

### DIFF
--- a/frame/bags-list/src/lib.rs
+++ b/frame/bags-list/src/lib.rs
@@ -397,7 +397,7 @@ impl<T: Config<I>, I: 'static> ScoreProvider<T::AccountId> for Pallet<T, I> {
 		Node::<T, I>::get(id).map(|node| node.score()).unwrap_or_default()
 	}
 
-	frame_election_provider_support::runtime_benchmarks_or_fuzz_enabled! {
+	frame_election_provider_support::runtime_benchmarks_fuzz_or_std_enabled! {
 		fn set_score_of(id: &T::AccountId, new_score: T::Score) {
 			ListNodes::<T, I>::mutate(id, |maybe_node| {
 				if let Some(node) = maybe_node.as_mut() {

--- a/frame/bags-list/src/mock.rs
+++ b/frame/bags-list/src/mock.rs
@@ -40,9 +40,10 @@ impl frame_election_provider_support::ScoreProvider<AccountId> for StakingMock {
 		*NextVoteWeightMap::get().get(id).unwrap_or(&NextVoteWeight::get())
 	}
 
-	#[cfg(any(feature = "runtime-benchmarks", feature = "fuzz", test))]
-	fn set_score_of(id: &AccountId, weight: Self::Score) {
-		NEXT_VOTE_WEIGHT_MAP.with(|m| m.borrow_mut().insert(*id, weight));
+	frame_election_provider_support::runtime_benchmarks_fuzz_or_std_enabled! {
+		fn set_score_of(id: &AccountId, weight: Self::Score) {
+			NEXT_VOTE_WEIGHT_MAP.with(|m| m.borrow_mut().insert(*id, weight));
+		}
 	}
 }
 

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -582,7 +582,7 @@ pub trait ScoreProvider<AccountId> {
 	fn score(who: &AccountId) -> Self::Score;
 
 	/// For tests, benchmarks and fuzzing, set the `score`.
-	#[cfg(any(feature = "runtime-benchmarks", feature = "fuzz", test))]
+	#[cfg(any(feature = "runtime-benchmarks", feature = "fuzz", feature = "std"))]
 	fn set_score_of(_: &AccountId, _: Self::Score) {}
 }
 
@@ -673,5 +673,14 @@ pub type BoundedSupportsOf<E> = BoundedSupports<
 	<E as ElectionProviderBase>::MaxWinners,
 >;
 
-sp_core::generate_feature_enabled_macro!(runtime_benchmarks_enabled, feature = "runtime-benchmarks", $);
-sp_core::generate_feature_enabled_macro!(runtime_benchmarks_or_fuzz_enabled, any(feature = "runtime-benchmarks", feature = "fuzzing"), $);
+sp_core::generate_feature_enabled_macro!(
+	runtime_benchmarks_enabled,
+	feature = "runtime-benchmarks",
+	$
+);
+
+sp_core::generate_feature_enabled_macro!(
+	runtime_benchmarks_fuzz_or_std_enabled,
+	any(feature = "runtime-benchmarks", feature = "fuzzing", feature = "std"),
+	$
+);


### PR DESCRIPTION
The `test` feature isn't propagated to dependencies in Rust, so we should just enable the method as well for `std`.


Closes: https://github.com/paritytech/substrate/issues/14033