### PR TITLE
Adds support for storage_pairs_paged

### DIFF
--- a/client/rpc-api/src/state/mod.rs
+++ b/client/rpc-api/src/state/mod.rs
@@ -62,6 +62,18 @@ pub trait StateApi<Hash> {
 		hash: Option<Hash>,
 	) -> RpcResult<Vec<StorageKey>>;
 
+	/// Returns the keys along with their values with prefix with pagination support.
+	/// Up to `count` items will be returned.
+	/// If `start_key` is passed, return next items in storage in lexicographic order.
+	#[method(name = "state_getPairsPaged", blocking)]
+	fn storage_pairs_paged(
+		&self,
+		prefix: Option<StorageKey>,
+		count: u32,
+		start_key: Option<StorageKey>,
+		hash: Option<Hash>,
+	) -> RpcResult<Vec<(StorageKey, StorageData)>>;
+
 	/// Returns a storage entry at a specific block's state.
 	#[method(name = "state_getStorage", aliases = ["state_getStorageAt"], blocking)]
 	fn storage(&self, key: StorageKey, hash: Option<Hash>) -> RpcResult<Option<StorageData>>;

--- a/client/rpc/src/state/mod.rs
+++ b/client/rpc/src/state/mod.rs
@@ -262,7 +262,6 @@ where
 		start_key: Option<StorageKey>,
 		block: Option<Block::Hash>,
 	) -> RpcResult<Vec<(StorageKey, StorageData)>> {
-        self.deny_unsafe.check_if_safe()?;
 		if count > STORAGE_KEYS_PAGED_MAX_COUNT {
 			return Err(JsonRpseeError::from(Error::InvalidCount {
 				value: count,

--- a/client/rpc/src/state/mod.rs
+++ b/client/rpc/src/state/mod.rs
@@ -262,6 +262,7 @@ where
 		start_key: Option<StorageKey>,
 		block: Option<Block::Hash>,
 	) -> RpcResult<Vec<(StorageKey, StorageData)>> {
+        self.deny_unsafe.check_if_safe()?;
 		if count > STORAGE_KEYS_PAGED_MAX_COUNT {
 			return Err(JsonRpseeError::from(Error::InvalidCount {
 				value: count,

--- a/client/rpc/src/state/mod.rs
+++ b/client/rpc/src/state/mod.rs
@@ -82,7 +82,7 @@ where
 		prefix: StorageKey,
 	) -> Result<Vec<(StorageKey, StorageData)>, Error>;
 
-	/// Returns the keys with prefix with pagination support.
+	/// Returns the keys with prefix along with their values, with pagination support.
 	fn storage_keys_paged(
 		&self,
 		block: Option<Block::Hash>,
@@ -90,6 +90,15 @@ where
 		count: u32,
 		start_key: Option<StorageKey>,
 	) -> Result<Vec<StorageKey>, Error>;
+
+	/// Returns the keys with prefix with pagination support.
+	fn storage_pairs_paged(
+		&self,
+		block: Option<Block::Hash>,
+		prefix: Option<StorageKey>,
+		count: u32,
+		start_key: Option<StorageKey>,
+	) -> Result<Vec<(StorageKey, StorageData)>, Error>;
 
 	/// Returns a storage entry at a specific block's state.
 	fn storage(
@@ -243,6 +252,24 @@ where
 		}
 		self.backend
 			.storage_keys_paged(block, prefix, count, start_key)
+			.map_err(Into::into)
+	}
+
+	fn storage_pairs_paged(
+		&self,
+		prefix: Option<StorageKey>,
+		count: u32,
+		start_key: Option<StorageKey>,
+		block: Option<Block::Hash>,
+	) -> RpcResult<Vec<(StorageKey, StorageData)>> {
+		if count > STORAGE_KEYS_PAGED_MAX_COUNT {
+			return Err(JsonRpseeError::from(Error::InvalidCount {
+				value: count,
+				max: STORAGE_KEYS_PAGED_MAX_COUNT,
+			}))
+		}
+		self.backend
+			.storage_pairs_paged(block, prefix, count, start_key)
 			.map_err(Into::into)
 	}
 

--- a/client/rpc/src/state/mod.rs
+++ b/client/rpc/src/state/mod.rs
@@ -82,7 +82,7 @@ where
 		prefix: StorageKey,
 	) -> Result<Vec<(StorageKey, StorageData)>, Error>;
 
-	/// Returns the keys with prefix along with their values, with pagination support.
+	/// Returns the keys with prefix with pagination support.
 	fn storage_keys_paged(
 		&self,
 		block: Option<Block::Hash>,
@@ -91,7 +91,7 @@ where
 		start_key: Option<StorageKey>,
 	) -> Result<Vec<StorageKey>, Error>;
 
-	/// Returns the keys with prefix with pagination support.
+	/// Returns the keys with prefix along with their values, with pagination support.
 	fn storage_pairs_paged(
 		&self,
 		block: Option<Block::Hash>,
@@ -248,7 +248,7 @@ where
 			return Err(JsonRpseeError::from(Error::InvalidCount {
 				value: count,
 				max: STORAGE_KEYS_PAGED_MAX_COUNT,
-			}))
+			}));
 		}
 		self.backend
 			.storage_keys_paged(block, prefix, count, start_key)
@@ -266,7 +266,7 @@ where
 			return Err(JsonRpseeError::from(Error::InvalidCount {
 				value: count,
 				max: STORAGE_KEYS_PAGED_MAX_COUNT,
-			}))
+			}));
 		}
 		self.backend
 			.storage_pairs_paged(block, prefix, count, start_key)
@@ -365,7 +365,7 @@ where
 		if keys.is_none() {
 			if let Err(err) = self.deny_unsafe.check_if_safe() {
 				let _ = sink.reject(JsonRpseeError::from(err));
-				return Ok(())
+				return Ok(());
 			}
 		}
 

--- a/client/rpc/src/state/state_full.rs
+++ b/client/rpc/src/state/state_full.rs
@@ -249,6 +249,19 @@ where
 			.map_err(client_err)
 	}
 
+	fn storage_pairs_paged(
+		&self,
+		block: Option<Block::Hash>,
+		prefix: Option<StorageKey>,
+		count: u32,
+		start_key: Option<StorageKey>,
+	) -> std::result::Result<Vec<(StorageKey, StorageData)>, Error> {
+		self.block_or_best(block)
+			.and_then(|block| self.client.storage_pairs(block, prefix.as_ref(), start_key.as_ref()))
+			.map(|iter| iter.take(count as usize).collect())
+			.map_err(client_err)
+	}
+
 	fn storage(
 		&self,
 		block: Option<Block::Hash>,


### PR DESCRIPTION
Adds the RPC methods to query the storage pairs (key, value) with pagination.
The goal is to provide a faster way to iterate through keys and their values. Previous method was to query the keys first and their values in additional queries.
