### PR TITLE
Don't run `check-crates-publishing` job on prs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -251,6 +251,18 @@ default:
 
 #### stage:                       .pre
 
+check-crates-publishing-pipeline:
+  stage: .pre
+  extends:
+    - .kubernetes-env
+    - .crates-publishing-pipeline
+  script:
+    - git clone
+      --depth 1
+      --branch "$RELENG_SCRIPTS_BRANCH"
+      https://github.com/paritytech/releng-scripts.git
+    - ONLY_CHECK_PIPELINE=true ./releng-scripts/publish-crates
+
 # By default our pipelines are interruptible, but some special pipelines shouldn't be interrupted:
 # * multi-project pipelines such as the ones triggered by the scripts repo
 # * the scheduled automatic-crate-publishing pipeline

--- a/scripts/ci/gitlab/pipeline/publish.yml
+++ b/scripts/ci/gitlab/pipeline/publish.yml
@@ -254,8 +254,8 @@ publish-crates-manual:
 check-crate-publishing:
   stage: publish
   extends:
-    - .test-refs
     - .crates-publishing-template
+    - .crates-publishing-pipeline
   # When lots of crates are taken into account (for example on master where all crates are tested)
   # the job might take a long time, as evidenced by:
   # https://gitlab.parity.io/parity/mirrors/substrate/-/jobs/2269364


### PR DESCRIPTION
Fixes a previous attempt in https://github.com/paritytech/substrate/pull/14044.