### PR TITLE
Only calculate tree route during finalization when there are multiple leaves

### DIFF
--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -936,19 +936,24 @@ where
 			return Err(sp_blockchain::Error::NotInFinalizedChain)
 		}
 
-		let route_from_best =
-			sp_blockchain::tree_route(self.backend.blockchain(), best_block, block)?;
+		// If there is only one leaf, best block is guaranteed to be
+		// a descendant of the new finalized block. If not,
+		// we need to check.
+		if self.backend.blockchain().leaves()?.len() != 1 {
+			let route_from_best =
+				sp_blockchain::tree_route(self.backend.blockchain(), best_block, block)?;
 
-		// if the block is not a direct ancestor of the current best chain,
-		// then some other block is the common ancestor.
-		if route_from_best.common_block().hash != block {
-			// NOTE: we're setting the finalized block as best block, this might
-			// be slightly inaccurate since we might have a "better" block
-			// further along this chain, but since best chain selection logic is
-			// plugable we cannot make a better choice here. usages that need
-			// an accurate "best" block need to go through `SelectChain`
-			// instead.
-			operation.op.mark_head(block)?;
+			// if the block is not a direct ancestor of the current best chain,
+			// then some other block is the common ancestor.
+			if route_from_best.common_block().hash != block {
+				// NOTE: we're setting the finalized block as best block, this might
+				// be slightly inaccurate since we might have a "better" block
+				// further along this chain, but since best chain selection logic is
+				// plugable we cannot make a better choice here. usages that need
+				// an accurate "best" block need to go through `SelectChain`
+				// instead.
+				operation.op.mark_head(block)?;
+			}
 		}
 
 		let enacted = route_from_finalized.enacted();

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -939,7 +939,7 @@ where
 		// If there is only one leaf, best block is guaranteed to be
 		// a descendant of the new finalized block. If not,
 		// we need to check.
-		if self.backend.blockchain().leaves()?.len() != 1 {
+		if self.backend.blockchain().leaves()?.len() > 1 {
 			let route_from_best =
 				sp_blockchain::tree_route(self.backend.blockchain(), best_block, block)?;
 


### PR DESCRIPTION
Calculation of these tree routes is very expensive. When the finalized block is very far from the best block, it can take multiple seconds to calculate this tree route, blocking the import lock.

If there is only one leave, we can skip this calculation since the best block is guaranteed to be a descendant of the new finalized one.

Closes https://github.com/paritytech/cumulus/issues/2494, https://github.com/paritytech/substrate/issues/13947, 

Could impact the parachain part of https://github.com/paritytech/substrate/issues/14049

~Edit: Do not close the above issues for now, freshly syncing node still has issues.~