### PR TITLE
Improve `try-runtime::on_runtime_upgrade` and fix some storage version issues

### DIFF
--- a/frame/bounties/src/lib.rs
+++ b/frame/bounties/src/lib.rs
@@ -187,7 +187,10 @@ pub trait ChildBountyManager<Balance> {
 pub mod pallet {
 	use super::*;
 
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(4);
+
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T, I = ()>(_);
 
 	#[pallet::config]

--- a/frame/support/procedural/src/pallet/expand/hooks.rs
+++ b/frame/support/procedural/src/pallet/expand/hooks.rs
@@ -121,7 +121,7 @@ pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 
 				#frame_support::log::error!(
 					target: #frame_support::LOG_TARGET,
-					"{}: On chain storage version {:?} is set to non zero,\
+					"{}: On chain storage version {:?} is set to non zero, \
 					 while the pallet is missing the `#[pallet::storage_version(VERSION)]` attribute.",
 					pallet_name,
 					on_chain_version,


### PR DESCRIPTION
We now run all `try_on_runtime_upgrade` and collect the errors, instead of bailing on the first error. This makes it easier to see directly all the things that are failing instead of fixing one, recompiling and then checking the next one.

Then this pr also sets the correct storage version for `pallet-bounties` that was already correctly set in the storage with the appropriate migration.

