### PR TITLE
cli: make `rpc_interface` re-useable

### DIFF
--- a/bin/node/cli/benches/block_production.rs
+++ b/bin/node/cli/benches/block_production.rs
@@ -92,6 +92,7 @@ fn new_node(tokio_handle: Handle) -> node_cli::service::NewFullBase {
 		rpc_max_response_size: Default::default(),
 		rpc_id_provider: Default::default(),
 		rpc_max_subs_per_conn: Default::default(),
+		rpc_port: 9944,
 		prometheus_config: None,
 		telemetry_endpoints: None,
 		default_heap_pages: None,

--- a/bin/node/cli/benches/transaction_pool.rs
+++ b/bin/node/cli/benches/transaction_pool.rs
@@ -86,6 +86,7 @@ fn new_node(tokio_handle: Handle) -> node_cli::service::NewFullBase {
 		rpc_max_response_size: Default::default(),
 		rpc_id_provider: Default::default(),
 		rpc_max_subs_per_conn: Default::default(),
+		rpc_port: 9944,
 		prometheus_config: None,
 		telemetry_endpoints: None,
 		default_heap_pages: None,

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -45,6 +45,17 @@ pub(crate) const DEFAULT_NETWORK_CONFIG_PATH: &str = "network";
 /// The recommended open file descriptor limit to be configured for the process.
 const RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT: u64 = 10_000;
 
+/// The default port.
+pub const RPC_DEFAULT_PORT: u16 = 9944;
+/// The default max number of subscriptions per connection.
+pub const RPC_DEFAULT_MAX_SUBS_PER_CONN: u32 = 1024;
+/// The default max request size in MB.
+pub const RPC_DEFAULT_MAX_REQUEST_SIZE_MB: u32 = 15;
+/// The default max response size in MB.
+pub const RPC_DEFAULT_MAX_RESPONSE_SIZE_MB: u32 = 15;
+/// The default number of connection..
+pub const RPC_DEFAULT_MAX_CONNECTIONS: u32 = 100;
+
 /// Default configuration values used by Substrate
 ///
 /// These values will be used by [`CliConfiguration`] to set
@@ -61,7 +72,7 @@ pub trait DefaultConfigurationValues {
 	///
 	/// By default this is `9944`.
 	fn rpc_listen_port() -> u16 {
-		9944
+		RPC_DEFAULT_PORT
 	}
 
 	/// The port Substrate should listen on for prometheus connections.
@@ -73,6 +84,20 @@ pub trait DefaultConfigurationValues {
 }
 
 impl DefaultConfigurationValues for () {}
+
+/// Configuration for RPC interface.
+pub struct RpcAddrConfig {
+	/// RPC interface exposed externally.
+	pub is_external: bool,
+	/// RPC interface exposed unsafe methods externally.
+	pub is_unsafe_external: bool,
+	/// Available RPC methods.
+	pub rpc_methods: RpcMethods,
+	/// Is running as validator.
+	pub is_validator: bool,
+	/// Port to run the RPC server on.
+	pub port: u16,
+}
 
 /// A trait that allows converting an object to a Configuration
 pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
@@ -296,6 +321,8 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 	}
 
 	/// Get the RPC address.
+	//
+	// NOTE: This is just a blanket impl and should replaced by implementors.
 	fn rpc_addr(&self, _default_listen_port: u16) -> Result<Option<SocketAddr>> {
 		Ok(None)
 	}
@@ -303,14 +330,14 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 	/// Returns the RPC method set to expose.
 	///
 	/// By default this is `RpcMethods::Auto` (unsafe RPCs are denied iff
-	/// `{rpc,ws}_external` returns true, respectively).
+	/// `rpc_external` returns true, respectively).
 	fn rpc_methods(&self) -> Result<RpcMethods> {
 		Ok(Default::default())
 	}
 
 	/// Get the maximum number of RPC server connections.
 	fn rpc_max_connections(&self) -> Result<u32> {
-		Ok(Default::default())
+		Ok(RPC_DEFAULT_MAX_CONNECTIONS)
 	}
 
 	/// Get the RPC cors (`None` if disabled)
@@ -322,17 +349,17 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 
 	/// Get maximum RPC request payload size.
 	fn rpc_max_request_size(&self) -> Result<u32> {
-		Ok(Default::default())
+		Ok(RPC_DEFAULT_MAX_REQUEST_SIZE_MB)
 	}
 
 	/// Get maximum RPC response payload size.
 	fn rpc_max_response_size(&self) -> Result<u32> {
-		Ok(Default::default())
+		Ok(RPC_DEFAULT_MAX_RESPONSE_SIZE_MB)
 	}
 
 	/// Get maximum number of subscriptions per connection.
 	fn rpc_max_subscriptions_per_connection(&self) -> Result<u32> {
-		Ok(Default::default())
+		Ok(RPC_DEFAULT_MAX_SUBS_PER_CONN)
 	}
 
 	/// Get the prometheus configuration (`None` if disabled)
@@ -506,6 +533,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 			rpc_max_response_size: self.rpc_max_response_size()?,
 			rpc_id_provider: None,
 			rpc_max_subs_per_conn: self.rpc_max_subscriptions_per_connection()?,
+			rpc_port: DCV::rpc_listen_port(),
 			prometheus_config: self
 				.prometheus_config(DCV::prometheus_listen_port(), &chain_spec)?,
 			telemetry_endpoints,
@@ -636,4 +664,36 @@ pub fn generate_node_name() -> String {
 			return node_name
 		}
 	}
+}
+
+/// Helper to construct a RPC interface.
+///
+/// It's possible to override the default port
+/// by passing a another port to this function.
+pub fn rpc_interface(cfg: RpcAddrConfig) -> Result<Option<SocketAddr>> {
+	let RpcAddrConfig { is_external, is_unsafe_external, rpc_methods, is_validator, port } = cfg;
+
+	if is_external && is_validator && rpc_methods != RpcMethods::Unsafe.into() {
+		return Err(crate::Error::Input(
+			"--rpc-external option shouldn't be used if the node is running as \
+			 a validator. Use `--unsafe-rpc-external` or `--rpc-methods=unsafe` if you understand \
+			 the risks. See the options description for more information."
+				.to_owned(),
+		))
+	}
+
+	let ip = if is_external || is_unsafe_external {
+		if rpc_methods == RpcMethods::Unsafe.into() {
+			log::warn!(
+				"It isn't safe to expose RPC publicly without a proxy server that filters \
+				 available set of RPC methods."
+			);
+		}
+
+		std::net::Ipv4Addr::UNSPECIFIED
+	} else {
+		std::net::Ipv4Addr::LOCALHOST
+	};
+
+	Ok(Some((ip, port).into()))
 }

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -672,7 +672,6 @@ pub fn generate_node_name() -> String {
 /// by passing a another port to this function.
 pub fn rpc_interface(cfg: RpcAddrConfig) -> Result<Option<SocketAddr>> {
 	let RpcAddrConfig { is_external, is_unsafe_external, rpc_methods, is_validator, port } = cfg;
-	let rpc_methods = rpc_methods.into();
 
 	if is_external && is_validator && rpc_methods != RpcMethods::Unsafe {
 		return Err(crate::Error::Input(

--- a/client/cli/src/runner.rs
+++ b/client/cli/src/runner.rs
@@ -296,6 +296,7 @@ mod tests {
 				rpc_max_response_size: Default::default(),
 				rpc_id_provider: Default::default(),
 				rpc_max_subs_per_conn: Default::default(),
+				rpc_port: 9944,
 				prometheus_config: None,
 				telemetry_endpoints: None,
 				default_heap_pages: None,

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -101,6 +101,8 @@ pub struct Configuration {
 	pub rpc_id_provider: Option<Box<dyn crate::RpcSubscriptionIdProvider>>,
 	/// Maximum allowed subscriptions per rpc connection
 	pub rpc_max_subs_per_conn: u32,
+	/// JSON-RPC server default port.
+	pub rpc_port: u16,
 	/// Prometheus endpoint configuration. `None` if disabled.
 	pub prometheus_config: Option<PrometheusConfig>,
 	/// Telemetry service URL. `None` if disabled.
@@ -247,7 +249,7 @@ impl Configuration {
 }
 
 /// Available RPC methods.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum RpcMethods {
 	/// Expose every RPC method only when RPC is listening on `localhost`,
 	/// otherwise serve only safe RPC methods.

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -386,7 +386,7 @@ where
 		addr
 	};
 
-	let addr = config.rpc_addr.unwrap_or(([127, 0, 0, 1], 9944).into());
+	let addr = config.rpc_addr.unwrap_or_else(|| ([127, 0, 0, 1], config.rpc_port).into());
 	let backup_addr = backup_port(addr);
 	let metrics = sc_rpc_server::RpcMetrics::new(config.prometheus_registry())?;
 

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -254,6 +254,7 @@ fn node_config<
 		rpc_max_response_size: Default::default(),
 		rpc_id_provider: Default::default(),
 		rpc_max_subs_per_conn: Default::default(),
+		rpc_port: 9944,
 		prometheus_config: None,
 		telemetry_endpoints: None,
 		default_heap_pages: None,


### PR DESCRIPTION
Follow-up on #13384 

It changed the `rpc_port` from a `Option<u16> -> u16` which broke overriding it in cumulus (see https://github.com/paritytech/cumulus/issues/2529) as the default value was used instead

So let's expose `rpc_interface` so others can override the default port besides using the CLI `--rpc-port` 

We could also revert port to be an option again but I would prefer to keep it port as u16 because it's simplifies the code in substrate but makes it a bit annoying to override (by comparing the port to the default sc_cli::RPC_DEFAULT_PORT)

polkadot companion: https://github.com/paritytech/polkadot/pull/7190
cumulus companion: https://github.com/paritytech/cumulus/pull/2538