### PR TITLE
Emit events related to asset mutations

### DIFF
--- a/frame/assets/src/impl_fungibles.rs
+++ b/frame/assets/src/impl_fungibles.rs
@@ -81,7 +81,37 @@ impl<T: Config<I>, I: 'static> fungibles::Inspect<<T as SystemConfig>::AccountId
 	}
 }
 
-impl<T: Config<I>, I: 'static> fungibles::Mutate<<T as SystemConfig>::AccountId> for Pallet<T, I> {}
+impl<T: Config<I>, I: 'static> fungibles::Mutate<<T as SystemConfig>::AccountId> for Pallet<T, I> {
+	fn done_mint_into(
+		asset_id: Self::AssetId,
+		beneficiary: &<T as SystemConfig>::AccountId,
+		amount: Self::Balance,
+	) {
+		Self::deposit_event(Event::Issued { asset_id, owner: beneficiary.clone(), amount })
+	}
+
+	fn done_burn_from(
+		asset_id: Self::AssetId,
+		target: &<T as SystemConfig>::AccountId,
+		balance: Self::Balance,
+	) {
+		Self::deposit_event(Event::Burned { asset_id, owner: target.clone(), balance: actual });
+	}
+
+	fn done_transfer(
+		asset_id: Self::AssetId,
+		source: &<T as SystemConfig>::AccountId,
+		dest: &<T as SystemConfig>::AccountId,
+		amount: Self::Balance,
+	) {
+		Self::deposit_event(Event::Transferred {
+			asset_id,
+			from: source.clone(),
+			to: dest.clone(),
+			amount,
+		});
+	}
+}
 impl<T: Config<I>, I: 'static> fungibles::Balanced<<T as SystemConfig>::AccountId>
 	for Pallet<T, I>
 {

--- a/frame/assets/src/impl_fungibles.rs
+++ b/frame/assets/src/impl_fungibles.rs
@@ -95,7 +95,7 @@ impl<T: Config<I>, I: 'static> fungibles::Mutate<<T as SystemConfig>::AccountId>
 		target: &<T as SystemConfig>::AccountId,
 		balance: Self::Balance,
 	) {
-		Self::deposit_event(Event::Burned { asset_id, owner: target.clone(), balance: actual });
+		Self::deposit_event(Event::Burned { asset_id, owner: target.clone(), balance });
 	}
 
 	fn done_transfer(
@@ -112,6 +112,7 @@ impl<T: Config<I>, I: 'static> fungibles::Mutate<<T as SystemConfig>::AccountId>
 		});
 	}
 }
+
 impl<T: Config<I>, I: 'static> fungibles::Balanced<<T as SystemConfig>::AccountId>
 	for Pallet<T, I>
 {

--- a/frame/assets/src/tests.rs
+++ b/frame/assets/src/tests.rs
@@ -74,14 +74,26 @@ fn basic_minting_should_work() {
 		assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, true, 1));
 		assert_ok!(Assets::force_create(RuntimeOrigin::root(), 1, 1, true, 1));
 		assert_ok!(Assets::mint(RuntimeOrigin::signed(1), 0, 1, 100));
-		System::assert_last_event(RuntimeEvent::Assets(crate::Event::Issued { asset_id: 0, owner: 1, amount: 100 }));
+		System::assert_last_event(RuntimeEvent::Assets(crate::Event::Issued {
+			asset_id: 0,
+			owner: 1,
+			amount: 100,
+		}));
 		assert_eq!(Assets::balance(0, 1), 100);
 		assert_ok!(Assets::mint(RuntimeOrigin::signed(1), 0, 2, 100));
-		System::assert_last_event(RuntimeEvent::Assets(crate::Event::Issued { asset_id: 0, owner: 2, amount: 100 }));
+		System::assert_last_event(RuntimeEvent::Assets(crate::Event::Issued {
+			asset_id: 0,
+			owner: 2,
+			amount: 100,
+		}));
 		assert_eq!(Assets::balance(0, 2), 100);
 		assert_eq!(asset_ids(), vec![0, 1, 999]);
 		assert_ok!(Assets::mint(RuntimeOrigin::signed(1), 1, 1, 100));
-		System::assert_last_event(RuntimeEvent::Assets(crate::Event::Issued { asset_id: 1, owner: 1, amount: 100 }));
+		System::assert_last_event(RuntimeEvent::Assets(crate::Event::Issued {
+			asset_id: 1,
+			owner: 1,
+			amount: 100,
+		}));
 		assert_eq!(Assets::account_balances(1), vec![(0, 100), (999, 100), (1, 100)]);
 	});
 }
@@ -1145,7 +1157,11 @@ fn burning_asset_balance_with_positive_balance_should_work() {
 		assert_ok!(Assets::mint(RuntimeOrigin::signed(1), 0, 1, 100));
 		assert_eq!(Assets::balance(0, 1), 100);
 		assert_ok!(Assets::burn(RuntimeOrigin::signed(1), 0, 1, u64::MAX));
-		System::assert_last_event(RuntimeEvent::Assets(crate::Event::Burned { asset_id: 0, owner: 1, balance: 100 }));
+		System::assert_last_event(RuntimeEvent::Assets(crate::Event::Burned {
+			asset_id: 0,
+			owner: 1,
+			balance: 100,
+		}));
 		assert_eq!(Assets::balance(0, 1), 0);
 	});
 }

--- a/frame/assets/src/tests.rs
+++ b/frame/assets/src/tests.rs
@@ -52,9 +52,18 @@ fn transfer_should_never_burn() {
 
 		while System::inc_consumers(&2).is_ok() {}
 		let _ = System::dec_consumers(&2);
+		let _ = System::dec_consumers(&2);
 		// Exactly one consumer ref remaining.
+		assert_eq!(System::consumers(&2), 1);
 
 		let _ = <Assets as fungibles::Mutate<_>>::transfer(0, &1, &2, 50, Protect);
+		System::assert_has_event(RuntimeEvent::Assets(crate::Event::Transferred {
+			asset_id: 0,
+			from: 1,
+			to: 2,
+			amount: 50,
+		}));
+		assert_eq!(Assets::balance(0, 1), 50);
 		assert_eq!(Assets::balance(0, 1) + Assets::balance(0, 2), 100);
 	});
 }
@@ -65,11 +74,14 @@ fn basic_minting_should_work() {
 		assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, true, 1));
 		assert_ok!(Assets::force_create(RuntimeOrigin::root(), 1, 1, true, 1));
 		assert_ok!(Assets::mint(RuntimeOrigin::signed(1), 0, 1, 100));
+		System::assert_last_event(RuntimeEvent::Assets(crate::Event::Issued { asset_id: 0, owner: 1, amount: 100 }));
 		assert_eq!(Assets::balance(0, 1), 100);
 		assert_ok!(Assets::mint(RuntimeOrigin::signed(1), 0, 2, 100));
+		System::assert_last_event(RuntimeEvent::Assets(crate::Event::Issued { asset_id: 0, owner: 2, amount: 100 }));
 		assert_eq!(Assets::balance(0, 2), 100);
 		assert_eq!(asset_ids(), vec![0, 1, 999]);
 		assert_ok!(Assets::mint(RuntimeOrigin::signed(1), 1, 1, 100));
+		System::assert_last_event(RuntimeEvent::Assets(crate::Event::Issued { asset_id: 1, owner: 1, amount: 100 }));
 		assert_eq!(Assets::account_balances(1), vec![(0, 100), (999, 100), (1, 100)]);
 	});
 }
@@ -1133,6 +1145,7 @@ fn burning_asset_balance_with_positive_balance_should_work() {
 		assert_ok!(Assets::mint(RuntimeOrigin::signed(1), 0, 1, 100));
 		assert_eq!(Assets::balance(0, 1), 100);
 		assert_ok!(Assets::burn(RuntimeOrigin::signed(1), 0, 1, u64::MAX));
+		System::assert_last_event(RuntimeEvent::Assets(crate::Event::Burned { asset_id: 0, owner: 1, balance: 100 }));
 		assert_eq!(Assets::balance(0, 1), 0);
 	});
 }


### PR DESCRIPTION
In one of the XCM integration tests, it was discovered that the `fungibles::regular::Mutate::transfer` implementation of the Assets pallet didn't fire off any events, causing the test to fail, but the asset to actually be transferred. This PR aims to make sure that all asset mutation events properly fire off the associated events.