### PR TITLE
Include `node-template-release` in workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,5 @@ rls*.log
 .cargo-remote.toml
 *.bin
 *.iml
-scripts/ci/node-template-release/Cargo.lock
 bin/node-template/Cargo.lock
 substrate.code-workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,6 +2996,8 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe",
+ "openssl-sys",
  "url",
 ]
 
@@ -3922,7 +3924,9 @@ checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
 ]
 
@@ -4472,6 +4476,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
 dependencies = [
  "libsecp256k1-core",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -5362,6 +5380,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "node-template-release"
+version = "3.0.0"
+dependencies = [
+ "clap 4.2.5",
+ "flate2",
+ "fs_extra",
+ "git2",
+ "glob",
+ "tar",
+ "tempfile",
+ "toml 0.7.3",
+]
+
+[[package]]
 name = "node-template-runtime"
 version = "4.0.0-dev"
 dependencies = [
@@ -5635,6 +5667,18 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -11802,6 +11846,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13682,6 +13737,15 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time 0.3.20",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,6 +236,7 @@ members = [
 	"primitives/version/proc-macro",
 	"primitives/wasm-interface",
 	"primitives/weights",
+	"scripts/ci/node-template-release",
 	"test-utils",
 	"test-utils/client",
 	"test-utils/derive",

--- a/scripts/ci/deny.toml
+++ b/scripts/ci/deny.toml
@@ -40,6 +40,7 @@ exceptions = [
     { allow = ["GPL-3.0 WITH Classpath-exception-2.0"], name = "node-bench" },
     { allow = ["GPL-3.0 WITH Classpath-exception-2.0"], name = "node-cli" },
     { allow = ["GPL-3.0 WITH Classpath-exception-2.0"], name = "node-inspect" },
+    { allow = ["GPL-3.0 WITH Classpath-exception-2.0"], name = "node-template-release" },
     { allow = ["GPL-3.0 WITH Classpath-exception-2.0"], name = "node-testing" },
     { allow = ["GPL-3.0 WITH Classpath-exception-2.0"], name = "sc-authority-discovery" },
     { allow = ["GPL-3.0 WITH Classpath-exception-2.0"], name = "sc-basic-authorship" },

--- a/scripts/ci/node-template-release/Cargo.toml
+++ b/scripts/ci/node-template-release/Cargo.toml
@@ -19,5 +19,3 @@ glob = "0.2"
 tar = "0.4"
 tempfile = "3"
 toml = "0.4"
-
-[workspace]

--- a/scripts/ci/node-template-release/Cargo.toml
+++ b/scripts/ci/node-template-release/Cargo.toml
@@ -11,11 +11,11 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-clap = { version = "4.0.9", features = ["derive"] }
+clap = { version = "4.2.5", features = ["derive"] }
 flate2 = "1.0"
-fs_extra = "1"
-git2 = "0.8"
-glob = "0.2"
+fs_extra = "1.3"
+git2 = "0.16"
+glob = "0.3"
 tar = "0.4"
 tempfile = "3"
-toml = "0.4"
+toml = "0.7"

--- a/scripts/ci/node-template-release/Cargo.toml
+++ b/scripts/ci/node-template-release/Cargo.toml
@@ -3,7 +3,7 @@ name = "node-template-release"
 version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-license = "GPL-3.0"
+license = "GPL-3.0 WITH Classpath-exception-2.0"
 homepage = "https://substrate.io"
 publish = false
 


### PR DESCRIPTION
(Preparation for the monorepo)

Including the `node-template-release` now in the workspace to have compatible dependencies.