### PR TITLE
macros: Add non_camel_case_types for storage_alias

### DIFF
--- a/frame/support/procedural/src/storage_alias.rs
+++ b/frame/support/procedural/src/storage_alias.rs
@@ -626,6 +626,7 @@ fn generate_storage_instance(
 
 	// Implement `StorageInstance` trait.
 	let code = quote! {
+		#[allow(non_camel_case_types)]
 		#visibility struct #name< #impl_generics >(
 			#crate_::sp_std::marker::PhantomData<(#type_generics)>
 		) #where_clause;


### PR DESCRIPTION
![Screenshot 2023-05-09 at 16 22 27](https://github.com/paritytech/substrate/assets/521091/4200be5e-cb4e-4f0e-9a63-8b2852e40bf0)
getting rid of these warnings