### PR TITLE
Move back to ci-linux:production image after upgrade

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,7 +48,7 @@ variables:
   CARGO_INCREMENTAL: 0
   DOCKER_OS: "debian:bullseye"
   ARCH: "x86_64"
-  CI_IMAGE: "paritytech/ci-linux@sha256:f6cdc1e289e40f3eb1f93efb11f961d4f0e51f4c2adf80b31300ab5b35ef1386" # staging 2023-05-02
+  CI_IMAGE: "paritytech/ci-linux:production"
   BUILDAH_IMAGE: "quay.io/buildah/stable:v1.29"
   BUILDAH_COMMAND: "buildah --storage-driver overlay2"
   RELENG_SCRIPTS_BRANCH: "master"


### PR DESCRIPTION
There are still a bunch of open questions on how to handle image pinning; in the meantime, let's keep using the production tag.
