### PR TITLE
Timeout only if the referendum is not queued

### DIFF
--- a/frame/referenda/src/lib.rs
+++ b/frame/referenda/src/lib.rs
@@ -79,7 +79,7 @@ use frame_support::{
 };
 use scale_info::TypeInfo;
 use sp_runtime::{
-	traits::{AtLeast32BitUnsigned, Dispatchable, One, Saturating, Zero, Bounded},
+	traits::{AtLeast32BitUnsigned, Bounded, Dispatchable, One, Saturating, Zero},
 	DispatchError, Perbill,
 };
 use sp_std::{fmt::Debug, prelude::*};

--- a/frame/referenda/src/lib.rs
+++ b/frame/referenda/src/lib.rs
@@ -79,7 +79,7 @@ use frame_support::{
 };
 use scale_info::TypeInfo;
 use sp_runtime::{
-	traits::{AtLeast32BitUnsigned, Dispatchable, One, Saturating, Zero},
+	traits::{AtLeast32BitUnsigned, Dispatchable, One, Saturating, Zero, Bounded},
 	DispatchError, Perbill,
 };
 use sp_std::{fmt::Debug, prelude::*};
@@ -1054,9 +1054,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			Some(x) => x,
 			None => return (ReferendumInfo::Ongoing(status), false, ServiceBranch::Fail),
 		};
+		// Default the alarm to the end of the world.
 		let timeout = status.submitted + T::UndecidingTimeout::get();
-		// Default the alarm to the submission timeout.
-		let mut alarm = timeout;
+		let mut alarm = T::BlockNumber::max_value();
 		let branch;
 		match &mut status.deciding {
 			None => {
@@ -1097,11 +1097,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 							ServiceBranch::Preparing
 						}
 					} else {
+						alarm = timeout;
 						ServiceBranch::NoDeposit
 					}
 				}
 				// If we didn't move into being decided, then check the timeout.
-				if status.deciding.is_none() && now >= timeout {
+				if status.deciding.is_none() && now >= timeout && !status.in_queue {
 					// Too long without being decided - end it.
 					Self::ensure_no_alarm(&mut status);
 					Self::deposit_event(Event::<T, I>::TimedOut { index, tally: status.tally });
@@ -1186,7 +1187,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			},
 		}
 
-		let dirty_alarm = Self::ensure_alarm_at(&mut status, index, alarm);
+		let dirty_alarm = if alarm < T::BlockNumber::max_value() {
+			Self::ensure_alarm_at(&mut status, index, alarm)
+		} else {
+			Self::ensure_no_alarm(&mut status)
+		};
 		(ReferendumInfo::Ongoing(status), dirty_alarm || dirty, branch)
 	}
 
@@ -1210,10 +1215,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	}
 
 	/// Cancel the alarm in `status`, if one exists.
-	fn ensure_no_alarm(status: &mut ReferendumStatusOf<T, I>) {
+	fn ensure_no_alarm(status: &mut ReferendumStatusOf<T, I>) -> bool {
 		if let Some((_, last_alarm)) = status.alarm.take() {
 			// Incorrect alarm - cancel it.
 			let _ = T::Scheduler::cancel(last_alarm);
+			true
+		} else {
+			false
 		}
 	}
 

--- a/frame/referenda/src/tests.rs
+++ b/frame/referenda/src/tests.rs
@@ -190,6 +190,8 @@ fn queueing_works() {
 				set_balance_proposal_bounded(i),
 				DispatchTime::After(0),
 			));
+		}
+		for i in [1, 2, 4] {
 			assert_ok!(Referenda::place_decision_deposit(RuntimeOrigin::signed(i), i as u32));
 			// TODO: decision deposit after some initial votes with a non-highest voted coming
 			// first.


### PR DESCRIPTION
Right now a referendum is cancelled if the track is so busy that the deciding timeout elapses regardless of whether it is queued or not. This isn't especially sensible. We alter it so that it will only be cancelled if the timeout elapses and it is not queued (i.e. the deciding deposit is not paid).