### PR TITLE
Remove `#[pallet::generate_storage_info]` from docs

### DIFF
--- a/frame/support/procedural/src/lib.rs
+++ b/frame/support/procedural/src/lib.rs
@@ -869,24 +869,6 @@ pub fn generate_store(_: TokenStream, _: TokenStream) -> TokenStream {
 	pallet_macro_stub()
 }
 
-/// To generate the full storage info (used for PoV calculation) use the attribute
-/// `#[pallet::generate_storage_info]`, e.g.:
-///
-/// ```ignore
-/// #[pallet::pallet]
-/// #[pallet::generate_storage_info]
-/// pub struct Pallet<T>(_);
-/// ```
-///
-/// This requires all storage items to implement the trait `StorageInfoTrait`, thus all keys
-/// and value types must be bound by `MaxEncodedLen`. Individual storages can opt-out from this
-/// constraint by using [`#[pallet::unbounded]`](`macro@unbounded`) (see
-/// [`#[pallet::storage]`](`macro@storage`) for more info).
-#[proc_macro_attribute]
-pub fn generate_storage_info(_: TokenStream, _: TokenStream) -> TokenStream {
-	pallet_macro_stub()
-}
-
 /// Because the `pallet::pallet` macro implements `GetStorageVersion`, the current storage
 /// version needs to be communicated to the macro. This can be done by using the
 /// `pallet::storage_version` attribute:

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -1597,7 +1597,6 @@ pub mod pallet_prelude {
 /// * [`pallet::constant`](#palletconstant)
 /// * [`pallet::disable_frame_system_supertrait_check`](#disable_supertrait_check)
 /// * [`pallet::generate_store($vis trait Store)`](#palletgenerate_storevis-trait-store)
-/// * [`pallet::generate_storage_info`](#palletgenerate_storage_info)
 /// * [`pallet::storage_version`](#palletstorage_version)
 /// * [`pallet::hooks`](#hooks-pallethooks-optional)
 /// * [`pallet::call`](#call-palletcall-optional)
@@ -1800,24 +1799,6 @@ pub mod pallet_prelude {
 /// definition.
 ///
 /// Also see [`pallet::generate_store`](`frame_support::pallet_macros::generate_store`).
-///
-/// # `pallet::generate_storage_info`
-///
-/// To generate the full storage info (used for PoV calculation) use the attribute
-/// `#[pallet::generate_storage_info]`, e.g.:
-///
-/// ```ignore
-/// #[pallet::pallet]
-/// #[pallet::generate_storage_info]
-/// pub struct Pallet<T>(_);
-/// ```
-///
-/// This requires all storage items to implement the trait [`traits::StorageInfoTrait`], thus
-/// all keys and value types must be bound by [`pallet_prelude::MaxEncodedLen`]. Individual
-/// storages can opt-out from this constraint by using `#[pallet::unbounded]` (see
-/// `#[pallet::storage]` for more info).
-///
-/// Also see [`pallet::generate_storage_info`](`frame_support::pallet_macros::generate_storage_info`)
 ///
 /// # `pallet::storage_version`
 ///
@@ -2903,9 +2884,9 @@ pub mod pallet_macros {
 	pub use frame_support_procedural::{
 		call_index, compact, composite_enum, config, constant,
 		disable_frame_system_supertrait_check, error, event, extra_constants, generate_deposit,
-		generate_storage_info, generate_store, genesis_build, genesis_config, getter, hooks,
-		inherent, origin, storage, storage_prefix, storage_version, type_value, unbounded,
-		validate_unsigned, weight, whitelist_storage,
+		generate_store, genesis_build, genesis_config, getter, hooks, inherent, origin, storage,
+		storage_prefix, storage_version, type_value, unbounded, validate_unsigned, weight,
+		whitelist_storage,
 	};
 }
 

--- a/frame/support/test/tests/pallet_ui/pallet_struct_invalid_attr.rs
+++ b/frame/support/test/tests/pallet_ui/pallet_struct_invalid_attr.rs
@@ -1,0 +1,15 @@
+#[frame_support::pallet]
+mod pallet {
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::pallet]
+	#[pallet::generate_storage_info] // invalid
+	pub struct Pallet<T>(_);
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
+}
+
+fn main() {
+}

--- a/frame/support/test/tests/pallet_ui/pallet_struct_invalid_attr.stderr
+++ b/frame/support/test/tests/pallet_ui/pallet_struct_invalid_attr.stderr
@@ -1,0 +1,5 @@
+error: expected one of: `generate_store`, `without_storage_info`, `storage_version`
+ --> tests/pallet_ui/pallet_struct_invalid_attr.rs:7:12
+  |
+7 |     #[pallet::generate_storage_info] // invalid
+  |               ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Closes https://github.com/paritytech/substrate/issues/14089

`#[pallet::generate_storage_info]` is not valid, and was probably added to the docs in error.  
It is only valid in the old `decl_*` pallet syntax.