### PR TITLE
fix broken gensis state doc link

### DIFF
--- a/frame/support/procedural/src/pallet/expand/genesis_config.rs
+++ b/frame/support/procedural/src/pallet/expand/genesis_config.rs
@@ -89,7 +89,7 @@ pub fn expand_genesis_config(def: &mut Def) -> proc_macro2::TokenStream {
 				attrs.push(syn::parse_quote!(
 					#[doc = r"
 					Can be used to configure the
-					[genesis state](https://docs.substrate.io/v3/runtime/chain-specs#the-genesis-state)
+					[genesis state](https://docs.substrate.io/build/genesis-configuration/)
 					of this pallet.
 					"]
 				));


### PR DESCRIPTION
Was going through basic example pallet and noticed this.

Proc macro was expanding to a (now broken) doc link to https://docs.substrate.io/v3/runtime/chain-specs#the-genesis-state

This PR updates it to https://docs.substrate.io/build/genesis-configuration/. Please correct me if this is not the right updated link!

P.S. @kianenigma this might be a good opportunity to use a shortener if that has had any movement ;)