### PR TITLE
expose transport, peer_info and discovery in sc-network

### DIFF
--- a/client/network/src/lib.rs
+++ b/client/network/src/lib.rs
@@ -243,8 +243,8 @@
 //! More precise usage details are still being worked on and will likely change in the future.
 
 mod behaviour;
-mod service;
 mod protocol;
+mod service;
 
 pub mod config;
 pub mod discovery;

--- a/client/network/src/lib.rs
+++ b/client/network/src/lib.rs
@@ -243,17 +243,17 @@
 //! More precise usage details are still being worked on and will likely change in the future.
 
 mod behaviour;
-mod discovery;
-mod peer_info;
-mod protocol;
 mod service;
-mod transport;
+mod protocol;
 
 pub mod config;
+pub mod discovery;
 pub mod error;
 pub mod event;
 pub mod network_state;
+pub mod peer_info;
 pub mod request_responses;
+pub mod transport;
 pub mod types;
 pub mod utils;
 

--- a/client/network/src/peer_info.rs
+++ b/client/network/src/peer_info.rs
@@ -16,6 +16,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+//! [`PeerInfoBehaviour`] is implementation of `NetworkBehaviour` that holds information about peers
+//! in cache.
+
 use crate::utils::interval;
 use either::Either;
 

--- a/client/network/src/transport.rs
+++ b/client/network/src/transport.rs
@@ -16,6 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+//! Transport that serves as a common ground for all connections.
+
 use either::Either;
 use libp2p::{
 	core::{


### PR DESCRIPTION
## What does it do?

Makes `discovery`, `peer_info` and `transport` mods public in `sc-network`.

## Why?

Makes it easy to develop lightweight binaries that want to become of libp2p swarm and use libp2p's `NetworkBehaviour`s.