### PR TITLE
Postpone public key creation in the test GenesisStorageBuilder

### DIFF
--- a/client/service/test/src/client/mod.rs
+++ b/client/service/test/src/client/mod.rs
@@ -173,7 +173,7 @@ fn construct_genesis_should_work_with_native() {
 		vec![AccountKeyring::One.into(), AccountKeyring::Two.into()],
 		1000 * DOLLARS,
 	)
-	.build_storage();
+	.build();
 	let genesis_hash = insert_genesis_block(&mut storage);
 
 	let backend = InMemoryBackend::from((storage, StateVersion::default()));
@@ -204,7 +204,7 @@ fn construct_genesis_should_work_with_wasm() {
 		vec![AccountKeyring::One.into(), AccountKeyring::Two.into()],
 		1000 * DOLLARS,
 	)
-	.build_storage();
+	.build();
 	let genesis_hash = insert_genesis_block(&mut storage);
 
 	let backend = InMemoryBackend::from((storage, StateVersion::default()));

--- a/test-utils/runtime/client/src/lib.rs
+++ b/test-utils/runtime/client/src/lib.rs
@@ -102,7 +102,7 @@ impl GenesisInit for GenesisParameters {
 			.with_heap_pages(self.heap_pages_override)
 			.with_wasm_code(&self.wasm_code)
 			.with_extra_storage(self.extra_storage.clone())
-			.build_storage()
+			.build()
 	}
 }
 

--- a/test-utils/runtime/src/genesismap.rs
+++ b/test-utils/runtime/src/genesismap.rs
@@ -113,7 +113,7 @@ impl GenesisStorageBuilder {
 			.authorities
 			.clone()
 			.into_iter()
-			.map(|id| sr25519::Public::from(id).into())
+			.map(|id| sr25519::Public::from(id))
 			.collect();
 
 		let genesis_config = GenesisConfig {
@@ -121,7 +121,11 @@ impl GenesisStorageBuilder {
 				code: self.wasm_code.clone().unwrap_or(wasm_binary_unwrap().to_vec()),
 			},
 			babe: pallet_babe::GenesisConfig {
-				authorities: authorities_sr25519.clone().into_iter().map(|x| (x, 1)).collect(),
+				authorities: authorities_sr25519
+					.clone()
+					.into_iter()
+					.map(|x| (x.into(), 1))
+					.collect(),
 				epoch_config: Some(crate::TEST_RUNTIME_BABE_EPOCH_CONFIGURATION),
 			},
 			substrate_test: substrate_test_pallet::GenesisConfig {

--- a/test-utils/runtime/src/genesismap.rs
+++ b/test-utils/runtime/src/genesismap.rs
@@ -18,8 +18,7 @@
 //! Tool for creating the genesis block.
 
 use super::{
-	currency, substrate_test_pallet, wasm_binary_unwrap, AccountId, AuthorityId, Balance,
-	GenesisConfig,
+	currency, substrate_test_pallet, wasm_binary_unwrap, AccountId, Balance, GenesisConfig,
 };
 use codec::Encode;
 use sc_service::construct_genesis_block;
@@ -34,14 +33,19 @@ use sp_runtime::{
 	BuildStorage,
 };
 
-/// Builder for generating storage from substrate-test-runtime genesis config. Default storage can
-/// be extended with additional key-value pairs.
+/// Builder for generating storage from substrate-test-runtime genesis config.
+///
+/// Default storage can be extended with additional key-value pairs.
 pub struct GenesisStorageBuilder {
-	authorities: Vec<AuthorityId>,
+	/// Authorities accounts used by any component requiring an authority set (e.g. babe).
+	authorities: Vec<AccountId>,
+	/// Accounts to be endowed with some funds.
 	balances: Vec<(AccountId, u64)>,
+	/// Override default number of heap pages.
 	heap_pages_override: Option<u64>,
 	/// Additional storage key pairs that will be added to the genesis map.
 	extra_storage: Storage,
+	/// Optional wasm code override.
 	wasm_code: Option<Vec<u8>>,
 }
 
@@ -50,9 +54,9 @@ impl Default for GenesisStorageBuilder {
 	fn default() -> Self {
 		Self::new(
 			vec![
-				sr25519::Public::from(Sr25519Keyring::Alice).into(),
-				sr25519::Public::from(Sr25519Keyring::Bob).into(),
-				sr25519::Public::from(Sr25519Keyring::Charlie).into(),
+				Sr25519Keyring::Alice.into(),
+				Sr25519Keyring::Bob.into(),
+				Sr25519Keyring::Charlie.into(),
 			],
 			(0..16_usize)
 				.into_iter()
@@ -74,7 +78,7 @@ impl GenesisStorageBuilder {
 	/// from `extra_storage` will be injected into built storage. `HEAP_PAGES` key and value will
 	/// also be placed into storage.
 	pub fn new(
-		authorities: Vec<AuthorityId>,
+		authorities: Vec<AccountId>,
 		endowed_accounts: Vec<AccountId>,
 		balance: Balance,
 	) -> Self {
@@ -104,17 +108,24 @@ impl GenesisStorageBuilder {
 	}
 
 	/// Builds the `GenesisConfig` and returns its storage.
-	pub fn build_storage(&mut self) -> Storage {
+	pub fn build(self) -> Storage {
+		let authorities_sr25519: Vec<_> = self
+			.authorities
+			.clone()
+			.into_iter()
+			.map(|id| sr25519::Public::from(id).into())
+			.collect();
+
 		let genesis_config = GenesisConfig {
 			system: frame_system::GenesisConfig {
 				code: self.wasm_code.clone().unwrap_or(wasm_binary_unwrap().to_vec()),
 			},
 			babe: pallet_babe::GenesisConfig {
-				authorities: self.authorities.clone().into_iter().map(|x| (x, 1)).collect(),
+				authorities: authorities_sr25519.clone().into_iter().map(|x| (x, 1)).collect(),
 				epoch_config: Some(crate::TEST_RUNTIME_BABE_EPOCH_CONFIGURATION),
 			},
 			substrate_test: substrate_test_pallet::GenesisConfig {
-				authorities: self.authorities.clone(),
+				authorities: authorities_sr25519.clone(),
 			},
 			balances: pallet_balances::GenesisConfig { balances: self.balances.clone() },
 		};

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -1087,7 +1087,7 @@ mod tests {
 			vec![AccountKeyring::One.into(), AccountKeyring::Two.into()],
 			1000 * currency::DOLLARS,
 		)
-		.build_storage()
+		.build()
 		.into()
 	}
 
@@ -1095,7 +1095,7 @@ mod tests {
 	fn validate_storage_keys() {
 		assert_eq!(
 			genesismap::GenesisStorageBuilder::default()
-				.build_storage()
+				.build()
 				.top
 				.keys()
 				.cloned()

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -614,10 +614,7 @@ impl_runtime_apis! {
 		}
 
 		fn authorities() -> Vec<AuraId> {
-			SubstrateTest::authorities().into_iter().map(|a| {
-				let authority: sr25519::Public = a.into();
-				AuraId::from(authority)
-			}).collect()
+			SubstrateTest::authorities().into_iter().map(|auth| AuraId::from(auth)).collect()
 		}
 	}
 

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -64,13 +64,11 @@ use sp_runtime::{
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
-// Ensure Babe and Aura use the same crypto to simplify things a bit.
-pub use sp_consensus_babe::{AllowedSlots, AuthorityId, BabeEpochConfiguration, Slot};
+pub use sp_consensus_babe::{AllowedSlots, BabeEpochConfiguration, Slot};
 
 pub use pallet_balances::Call as BalancesCall;
 
 pub type AuraId = sp_consensus_aura::sr25519::AuthorityId;
-
 #[cfg(feature = "std")]
 pub use extrinsic::{ExtrinsicBuilder, Transfer};
 
@@ -630,10 +628,9 @@ impl_runtime_apis! {
 				slot_duration: Babe::slot_duration(),
 				epoch_length: EpochDuration::get(),
 				c: epoch_config.c,
-				authorities: SubstrateTest::authorities()
-					.into_iter().map(|x|(x, 1)).collect(),
-					randomness: Babe::randomness(),
-					allowed_slots: epoch_config.allowed_slots,
+				authorities: Babe::authorities().to_vec(),
+				randomness: Babe::randomness(),
+				allowed_slots: epoch_config.allowed_slots,
 			}
 		}
 

--- a/test-utils/runtime/src/substrate_test_pallet.rs
+++ b/test-utils/runtime/src/substrate_test_pallet.rs
@@ -21,8 +21,8 @@
 //! functioning runtime. Some calls are allowed to be submitted as unsigned extrinsics, however most
 //! of them requires signing. Refer to `pallet::Call` for further details.
 
-use crate::AuthorityId;
 use frame_support::{pallet_prelude::*, storage};
+use sp_core::sr25519::Public;
 use sp_runtime::transaction_validity::{
 	InvalidTransaction, TransactionSource, TransactionValidity, ValidTransaction,
 };
@@ -49,12 +49,12 @@ pub mod pallet {
 
 	#[pallet::storage]
 	#[pallet::getter(fn authorities)]
-	pub type Authorities<T> = StorageValue<_, Vec<AuthorityId>, ValueQuery>;
+	pub type Authorities<T> = StorageValue<_, Vec<Public>, ValueQuery>;
 
 	#[pallet::genesis_config]
 	#[cfg_attr(feature = "std", derive(Default))]
 	pub struct GenesisConfig {
-		pub authorities: Vec<AuthorityId>,
+		pub authorities: Vec<Public>,
 	}
 
 	#[pallet::genesis_build]


### PR DESCRIPTION
Lazy creation of public keys from AccountId in the `GenesisStorageBuilder::build()` method.

Reason: the new strategy better fits when we require to create keys using a different scheme.
Previous approach assumes that all the runtime pallets will require the same scheme (sr25519) but this is not always the case (sassafras uses bandersnatch vrf keys or grandpa).

Postponing the creation of the keys allows to maintain only the account ids list in the builder and then create all the key types we require (currently only sr25519) when we require them

---

Other trivial tweaks:
- `substrate-test-pallet`'s `Authorities` storage is used to store other protocols keys that doesn't instance the pallet within the test runtime (e.g. aura). Thus, is more appropriate to store a raw sr25519 key instead of the babe's `AuthorityId` newtype.
- (BabeApi impl) fetch babe's authorities from its pallet (should be the same list, but is formally more correct)
- rename `GenesisStorageBuilder::build_storage()` to `build` (inline with typical name used by [builder pattern](https://rust-unofficial.github.io/patterns/patterns/creational/builder.html))