### PR TITLE
AccountTouch trait: deposit_required accepts asset id

### DIFF
--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -1654,7 +1654,7 @@ pub mod pallet {
 	impl<T: Config<I>, I: 'static> AccountTouch<T::AssetId, T::AccountId> for Pallet<T, I> {
 		type Balance = DepositBalanceOf<T, I>;
 
-		fn deposit_required() -> Self::Balance {
+		fn deposit_required(_: T::AssetId) -> Self::Balance {
 			T::AssetAccountDeposit::get()
 		}
 

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -1160,8 +1160,8 @@ pub trait AccountTouch<AssetId, AccountId> {
 	/// The type for currency units of the deposit.
 	type Balance;
 
-	/// The deposit amount of a native currency required for creating an asset account.
-	fn deposit_required() -> Self::Balance;
+	/// The deposit amount of a native currency required for creating an account of the `asset`.
+	fn deposit_required(asset: AssetId) -> Self::Balance;
 
 	/// Create an account for `who` of the `asset` with a deposit taken from the `depositor`.
 	fn touch(asset: AssetId, who: AccountId, depositor: AccountId) -> DispatchResult;


### PR DESCRIPTION
`deposit_required` accepts an asset id to determine a required deposit.