### PR TITLE
Introduce `entropy` function into frame System

### DIFF
--- a/frame/system/src/tests.rs
+++ b/frame/system/src/tests.rs
@@ -35,6 +35,27 @@ fn origin_works() {
 }
 
 #[test]
+fn unique_datum_works() {
+	new_test_ext().execute_with(|| {
+		System::initialize(&1, &[0u8; 32].into(), &Default::default());
+		assert!(sp_io::storage::exists(well_known_keys::INTRABLOCK_ENTROPY));
+
+		let h1 = unique(b"");
+		let h2 = unique(b"");
+		assert_ne!(h1, h2);
+
+		let h3 = unique(b"Hello");
+		assert_ne!(h2, h3);
+
+		let h4 = unique(b"Hello");
+		assert_ne!(h3, h4);
+
+		System::finalize();
+		assert!(!sp_io::storage::exists(well_known_keys::INTRABLOCK_ENTROPY));
+	});
+}
+
+#[test]
 fn stored_map_works() {
 	new_test_ext().execute_with(|| {
 		assert_eq!(System::inc_providers(&0), IncRefStatus::Created);

--- a/primitives/storage/src/lib.rs
+++ b/primitives/storage/src/lib.rs
@@ -204,6 +204,9 @@ pub mod well_known_keys {
 	/// Encodes to `0x3a65787472696e7369635f696e646578`.
 	pub const EXTRINSIC_INDEX: &[u8] = b":extrinsic_index";
 
+	/// Current intra-block entropy (a universally unique `[u8; 32]` value) is stored here.
+	pub const INTRABLOCK_ENTROPY: &[u8] = b":intrablock_entropy";
+
 	/// Prefix of child storage keys.
 	pub const CHILD_STORAGE_KEY_PREFIX: &[u8] = b":child_storage:";
 


### PR DESCRIPTION
This is a stateless function which provides a universally unique datum, suitable for use in XCM to provide each message with an unpredictable-but-unique identifier across the consensus universe. It may have other uses across the ecosystem.