### PR TITLE
Added serde feature to sp-consensus-aura

### DIFF
--- a/primitives/consensus/aura/Cargo.toml
+++ b/primitives/consensus/aura/Cargo.toml
@@ -40,3 +40,11 @@ std = [
 	"sp-std/std",
 	"sp-timestamp/std",
 ]
+
+# Serde support without relying on std features.
+serde = [
+	"scale-info/serde",
+	"sp-application-crypto/serde",
+	"sp-consensus-slots/serde",
+	"sp-runtime/serde",
+]


### PR DESCRIPTION
This is followup of #13027.

`sp-consensus-aura` need to enable `serde` feature in dependent crates, otherwise test-substrate-runtime compilation (or other environmet) fails with the following error if `serde` is enabled:

```
  error: cannot find macro `format` in this scope
    -->
/home/miszka/parity/10-genesis-config/substrate-master/primitives/consensus/aura/src/lib.rs:50:3
     |
  50 |         app_crypto!(ed25519, AURA);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: consider importing one of these items:
             scale_info::prelude::format
             sp_application_crypto::format
     = note: this error originates in the macro
`$crate::app_crypto_public_common_if_serde` which comes from the
expansion of the macro `app_crypto` (in Nightly builds, run with -Z
macro-backtrace for more info)
```
