### PR TITLE
test-runtime: Return hashed call as provides in unsigned validation

### DIFF
--- a/test-utils/runtime/src/substrate_test_pallet.rs
+++ b/test-utils/runtime/src/substrate_test_pallet.rs
@@ -23,8 +23,11 @@
 
 use frame_support::{pallet_prelude::*, storage};
 use sp_core::sr25519::Public;
-use sp_runtime::transaction_validity::{
-	InvalidTransaction, TransactionSource, TransactionValidity, ValidTransaction,
+use sp_runtime::{
+	traits::{BlakeTwo256, Hash},
+	transaction_validity::{
+		InvalidTransaction, TransactionSource, TransactionValidity, ValidTransaction,
+	},
 };
 use sp_std::prelude::*;
 
@@ -225,7 +228,10 @@ pub mod pallet {
 				Call::deposit_log_digest_item { .. } |
 				Call::storage_change { .. } |
 				Call::read { .. } |
-				Call::read_and_panic { .. } => Ok(Default::default()),
+				Call::read_and_panic { .. } => Ok(ValidTransaction {
+					provides: vec![BlakeTwo256::hash_of(&call).encode()],
+					..Default::default()
+				}),
 				_ => Err(TransactionValidityError::Invalid(InvalidTransaction::Call)),
 			}
 		}


### PR DESCRIPTION
This is required to make different unsigned extrinsics resolve to different transactions in the tx pool by having `provides` set to the hash of the call.

