### PR TITLE
FRAME: Allow message ID to be mutated in `ProcessMessage`

### DIFF
--- a/frame/message-queue/src/benchmarking.rs
+++ b/frame/message-queue/src/benchmarking.rs
@@ -142,7 +142,7 @@ mod benchmarks {
 		// Check that it was processed.
 		assert_last_event::<T>(
 			Event::Processed {
-				hash: T::Hashing::hash(&msg),
+				id: sp_io::hashing::blake2_256(&msg),
 				origin: 0.into(),
 				weight_used: 1.into_weight(),
 				success: true,
@@ -227,7 +227,7 @@ mod benchmarks {
 
 		assert_last_event::<T>(
 			Event::Processed {
-				hash: T::Hashing::hash(&((msgs - 1) as u32).encode()),
+				id: sp_io::hashing::blake2_256(&((msgs - 1) as u32).encode()),
 				origin: 0.into(),
 				weight_used: Weight::from_parts(1, 1),
 				success: true,
@@ -264,7 +264,7 @@ mod benchmarks {
 
 		assert_last_event::<T>(
 			Event::Processed {
-				hash: T::Hashing::hash(&((msgs - 1) as u32).encode()),
+				id: sp_io::hashing::blake2_256(&((msgs - 1) as u32).encode()),
 				origin: 0.into(),
 				weight_used: Weight::from_parts(1, 1),
 				success: true,

--- a/frame/message-queue/src/mock.rs
+++ b/frame/message-queue/src/mock.rs
@@ -172,6 +172,7 @@ impl ProcessMessage for RecordingMessageProcessor {
 		message: &[u8],
 		origin: Self::Origin,
 		meter: &mut WeightMeter,
+		_id: &mut [u8; 32],
 	) -> Result<bool, ProcessMessageError> {
 		processing_message(message, &origin)?;
 
@@ -239,6 +240,7 @@ impl ProcessMessage for CountingMessageProcessor {
 		message: &[u8],
 		origin: Self::Origin,
 		meter: &mut WeightMeter,
+		_id: &mut [u8; 32],
 	) -> Result<bool, ProcessMessageError> {
 		if let Err(e) = processing_message(message, &origin) {
 			NumMessagesErrored::set(NumMessagesErrored::get() + 1);

--- a/frame/message-queue/src/mock_helpers.rs
+++ b/frame/message-queue/src/mock_helpers.rs
@@ -62,6 +62,7 @@ where
 		_message: &[u8],
 		_origin: Self::Origin,
 		meter: &mut WeightMeter,
+		_id: &mut [u8; 32],
 	) -> Result<bool, ProcessMessageError> {
 		let required = Weight::from_parts(REQUIRED_WEIGHT, REQUIRED_WEIGHT);
 

--- a/frame/message-queue/src/tests.rs
+++ b/frame/message-queue/src/tests.rs
@@ -23,6 +23,7 @@ use crate::{mock::*, *};
 
 use frame_support::{assert_noop, assert_ok, assert_storage_noop, StorageNoopGuard};
 use rand::{rngs::StdRng, Rng, SeedableRng};
+use sp_core::blake2_256;
 
 #[test]
 fn mocked_weight_works() {
@@ -178,7 +179,7 @@ fn service_queues_failing_messages_works() {
 		assert_eq!(MessageQueue::service_queues(1.into_weight()), 1.into_weight());
 		assert_last_event::<Test>(
 			Event::ProcessingFailed {
-				hash: <Test as frame_system::Config>::Hashing::hash(b"badformat"),
+				id: blake2_256(b"badformat"),
 				origin: MessageOrigin::Here,
 				error: ProcessMessageError::BadFormat,
 			}
@@ -187,7 +188,7 @@ fn service_queues_failing_messages_works() {
 		assert_eq!(MessageQueue::service_queues(1.into_weight()), 1.into_weight());
 		assert_last_event::<Test>(
 			Event::ProcessingFailed {
-				hash: <Test as frame_system::Config>::Hashing::hash(b"corrupt"),
+				id: blake2_256(b"corrupt"),
 				origin: MessageOrigin::Here,
 				error: ProcessMessageError::Corrupt,
 			}
@@ -196,7 +197,7 @@ fn service_queues_failing_messages_works() {
 		assert_eq!(MessageQueue::service_queues(1.into_weight()), 1.into_weight());
 		assert_last_event::<Test>(
 			Event::ProcessingFailed {
-				hash: <Test as frame_system::Config>::Hashing::hash(b"unsupported"),
+				id: blake2_256(b"unsupported"),
 				origin: MessageOrigin::Here,
 				error: ProcessMessageError::Unsupported,
 			}
@@ -677,7 +678,7 @@ fn service_page_item_skips_perm_overweight_message() {
 		assert_eq!(weight.consumed, 2.into_weight());
 		assert_last_event::<Test>(
 			Event::OverweightEnqueued {
-				hash: <Test as frame_system::Config>::Hashing::hash(b"TooMuch"),
+				id: blake2_256(b"TooMuch"),
 				origin: MessageOrigin::Here,
 				message_index: 0,
 				page_index: 0,
@@ -1050,7 +1051,7 @@ fn execute_overweight_works() {
 		assert_eq!(QueueChanges::take(), vec![(origin, 1, 8)]);
 		assert_last_event::<Test>(
 			Event::OverweightEnqueued {
-				hash: <Test as frame_system::Config>::Hashing::hash(b"weight=6"),
+				id: blake2_256(b"weight=6"),
 				origin: MessageOrigin::Here,
 				message_index: 0,
 				page_index: 0,
@@ -1105,7 +1106,7 @@ fn permanently_overweight_book_unknits() {
 		assert_eq!(MessageQueue::service_queues(8.into_weight()), 4.into_weight());
 		assert_last_event::<Test>(
 			Event::OverweightEnqueued {
-				hash: <Test as frame_system::Config>::Hashing::hash(b"weight=9"),
+				id: blake2_256(b"weight=9"),
 				origin: Here,
 				message_index: 0,
 				page_index: 0,

--- a/frame/support/src/traits/messages.rs
+++ b/frame/support/src/traits/messages.rs
@@ -59,6 +59,7 @@ pub trait ProcessMessage {
 		message: &[u8],
 		origin: Self::Origin,
 		meter: &mut WeightMeter,
+		id: &mut [u8; 32],
 	) -> Result<bool, ProcessMessageError>;
 }
 


### PR DESCRIPTION
Polkadot Companion: https://github.com/paritytech/polkadot/pull/7262

Minor API change to allow unique message IDs in Polkadot.