### PR TITLE
Deprecates the `chill_other` extrinsic in staking

### DIFF
--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -459,7 +459,7 @@ benchmarks! {
 		assert!(T::VoterList::contains(&stash));
 
 		whitelist_account!(controller);
-	}: _(RawOrigin::Signed(controller))
+	}: _(RawOrigin::Signed(controller), None)
 	verify {
 		assert!(!T::VoterList::contains(&stash));
 	}
@@ -897,7 +897,7 @@ benchmarks! {
 		)?;
 
 		let caller = whitelisted_caller();
-	}: _(RawOrigin::Signed(caller), controller)
+	}: chill(RawOrigin::Signed(caller), Some(controller))
 	verify {
 		assert!(!T::VoterList::contains(&stash));
 	}

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -1631,7 +1631,9 @@ impl<T: Config> StakingInterface for Pallet<T> {
 		// defensive-only: any account bonded via this interface has the stash set as the
 		// controller, but we have to be sure. Same comment anywhere else that we read this.
 		let ctrl = Self::bonded(who).ok_or(Error::<T>::NotStash)?;
-		Self::chill(RawOrigin::Signed(ctrl).into())
+		Self::chill(RawOrigin::Signed(ctrl).into(), None)
+			.map_err(|with_post| with_post.error)
+			.map(|_| ())
 	}
 
 	fn withdraw_unbonded(


### PR DESCRIPTION
This PR refactors the `chill` and `chill_other` extrinsics in staking. The current logic of the `chill` extrinsic can be deprecated in lieu of `chill_other`, since the logic of `chill` is a subset of `chill_other`. With these changes, all the chilling can be performed by calling the `chill` extrinsic.

**Changes**:
1. Removes `chill_other` extrinsic
2. Refactors `chill` so that callers can chill own or third-party controller.  The caller can pass a optional controller account ID, which has the same logic as the current `fn chill_other`

```rust
pub fn chill(
  origin: OriginFor<T>,
  controller: Option<T::AccountId>,
) -> DispatchResultWithPostInfo
``` 

### To finish
- [ ] Polkadot companion
- [ ] Cumulus companion

Closes https://github.com/paritytech/polkadot-sdk/issues/314