### PR TITLE
Add genesis config to Glutton pallet

### DIFF
--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -21,10 +21,10 @@
 use grandpa_primitives::AuthorityId as GrandpaId;
 use kitchensink_runtime::{
 	constants::currency::*, wasm_binary_unwrap, AuthorityDiscoveryConfig, BabeConfig,
-	BalancesConfig, Block, CouncilConfig, DemocracyConfig, ElectionsConfig, GrandpaConfig,
-	ImOnlineConfig, IndicesConfig, MaxNominations, NominationPoolsConfig, SessionConfig,
-	SessionKeys, SocietyConfig, StakerStatus, StakingConfig, SudoConfig, SystemConfig,
-	TechnicalCommitteeConfig,
+	BalancesConfig, Block, CouncilConfig, DemocracyConfig, ElectionsConfig, GluttonConfig,
+	GrandpaConfig, ImOnlineConfig, IndicesConfig, MaxNominations, NominationPoolsConfig,
+	SessionConfig, SessionKeys, SocietyConfig, StakerStatus, StakingConfig, SudoConfig,
+	SystemConfig, TechnicalCommitteeConfig,
 };
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use sc_chain_spec::ChainSpecExtension;
@@ -371,6 +371,11 @@ pub fn testnet_genesis(
 			min_create_bond: 10 * DOLLARS,
 			min_join_bond: 1 * DOLLARS,
 			..Default::default()
+		},
+		glutton: GluttonConfig {
+			compute: Default::default(),
+			storage: Default::default(),
+			trash_data_count: Default::default(),
 		},
 	}
 }

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -377,6 +377,7 @@ impl pallet_scheduler::Config for Runtime {
 
 impl pallet_glutton::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
+	type AdminOrigin = EnsureRoot<AccountId>;
 	type WeightInfo = pallet_glutton::weights::SubstrateWeight<Runtime>;
 }
 

--- a/bin/node/testing/src/genesis.rs
+++ b/bin/node/testing/src/genesis.rs
@@ -21,8 +21,8 @@
 use crate::keyring::*;
 use kitchensink_runtime::{
 	constants::currency::*, wasm_binary_unwrap, AccountId, AssetsConfig, BabeConfig,
-	BalancesConfig, GenesisConfig, GrandpaConfig, IndicesConfig, SessionConfig, SocietyConfig,
-	StakerStatus, StakingConfig, SystemConfig, BABE_GENESIS_EPOCH_CONFIG,
+	BalancesConfig, GenesisConfig, GluttonConfig, GrandpaConfig, IndicesConfig, SessionConfig,
+	SocietyConfig, StakerStatus, StakingConfig, SystemConfig, BABE_GENESIS_EPOCH_CONFIG,
 };
 use sp_keyring::{Ed25519Keyring, Sr25519Keyring};
 use sp_runtime::Perbill;
@@ -94,5 +94,10 @@ pub fn config_endowed(code: Option<&[u8]>, extra_endowed: Vec<AccountId>) -> Gen
 		alliance: Default::default(),
 		alliance_motion: Default::default(),
 		nomination_pools: Default::default(),
+		glutton: GluttonConfig {
+			compute: Default::default(),
+			storage: Default::default(),
+			trash_data_count: Default::default(),
+		},
 	}
 }

--- a/frame/glutton/src/lib.rs
+++ b/frame/glutton/src/lib.rs
@@ -105,6 +105,37 @@ pub mod pallet {
 	#[pallet::storage]
 	pub(crate) type TrashDataCount<T: Config> = StorageValue<_, u32, ValueQuery>;
 
+	#[pallet::genesis_config]
+	pub struct GenesisConfig {
+		pub compute: Perbill,
+		pub storage: Perbill,
+		pub trash_data_count: u32,
+	}
+
+	impl Default for GenesisConfig {
+		fn default() -> Self {
+			Self {
+				compute: Default::default(),
+				storage: Default::default(),
+				trash_data_count: Default::default(),
+			}
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig {
+		fn build(&self) {
+			<Compute<T>>::put(self.compute);
+			<Storage<T>>::put(self.storage);
+
+			if self.trash_data_count <= 65_000 {
+				(0..self.trash_data_count).for_each(|i| TrashData::<T>::insert(i, [i as u8; 1024]));
+			}
+
+			TrashDataCount::<T>::set(self.trash_data_count);
+		}
+	}
+
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn integrity_test() {

--- a/frame/glutton/src/lib.rs
+++ b/frame/glutton/src/lib.rs
@@ -238,8 +238,10 @@ pub mod pallet {
 
 		/// Set how much of the remaining `proof_size` weight should be consumed by `on_idle`.
 		//
-		/// 100% means that all remaining `proof_size` will be consumed. The PoV metering will
-		/// likely be an
+		/// 100% means that all remaining `proof_size` will be consumed. The PoV benchmarking
+		/// results that are used here are likely an over-estimation. 100% intended consumption will
+		/// therefore translate to less than 100% actual consumption. In the future, this could be
+		/// counter-acted by allowing the glutton to specify over-unity consumption ratios.
 		///
 		/// Only callable by Root or `AdminOrigin`.
 		#[pallet::call_index(2)]

--- a/frame/glutton/src/lib.rs
+++ b/frame/glutton/src/lib.rs
@@ -349,7 +349,7 @@ pub mod pallet {
 			let mut ret = [0u8; VALUE_SIZE];
 
 			for i in 0u32..(VALUE_SIZE as u32 / 32) {
-				let hash = (seed, i).using_encoded(|p| twox_256(p));
+				let hash = (seed, i).using_encoded(twox_256);
 				ret[i as usize * 32..(i + 1) as usize * 32].copy_from_slice(&hash);
 			}
 

--- a/frame/glutton/src/lib.rs
+++ b/frame/glutton/src/lib.rs
@@ -136,7 +136,7 @@ pub mod pallet {
 		fn build(&self) {
 			assert!(
 				self.trash_data_count <= MAX_TRASH_DATA_ENTRIES,
-				"number of TrashData entries can not be bigger than {:?}",
+				"number of TrashData entries cannot be bigger than {:?}",
 				MAX_TRASH_DATA_ENTRIES
 			);
 

--- a/frame/glutton/src/lib.rs
+++ b/frame/glutton/src/lib.rs
@@ -36,6 +36,7 @@ use frame_support::{pallet_prelude::*, weights::WeightMeter};
 use frame_system::pallet_prelude::*;
 use sp_runtime::{traits::Zero, Perbill};
 use sp_std::{vec, vec::Vec};
+use sp_io::hashing::twox_256;
 
 pub use pallet::*;
 pub use weights::WeightInfo;
@@ -348,7 +349,7 @@ pub mod pallet {
 			let mut ret = [0u8; VALUE_SIZE];
 
 			for i in 0u32..(VALUE_SIZE as u32 / 32) {
-				let hash = (seed, i).using_encoded(sp_core::twox_256);
+				let hash = (seed, i).using_encoded(|p| twox_256(p));
 				ret[i as usize * 32..(i + 1) as usize * 32].copy_from_slice(&hash);
 			}
 

--- a/frame/glutton/src/lib.rs
+++ b/frame/glutton/src/lib.rs
@@ -40,6 +40,9 @@ use sp_std::{vec, vec::Vec};
 pub use pallet::*;
 pub use weights::WeightInfo;
 
+/// The size of each value in the `TrashData` storage in bytes.
+pub const VALUE_SIZE: usize = 1024;
+
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
@@ -47,6 +50,9 @@ pub mod pallet {
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
 		type RuntimeEvent: From<Event> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		/// The admin origin that can set computational limits and initialize the pallet.
+		type AdminOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
 		/// Weight information for this pallet.
 		type WeightInfo: WeightInfo;
@@ -58,11 +64,11 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event {
-		/// The pallet has been (re)initialized by root.
+		/// The pallet has been (re)initialized.
 		PalletInitialized { reinit: bool },
-		/// The computation limit has been updated by root.
+		/// The computation limit has been updated.
 		ComputationLimitSet { compute: Perbill },
-		/// The storage limit has been updated by root.
+		/// The storage limit has been updated.
 		StorageLimitSet { storage: Perbill },
 	}
 
@@ -96,7 +102,7 @@ pub mod pallet {
 	pub(super) type TrashData<T: Config> = StorageMap<
 		Hasher = Twox64Concat,
 		Key = u32,
-		Value = [u8; 1024],
+		Value = [u8; VALUE_SIZE],
 		QueryKind = OptionQuery,
 		MaxValues = ConstU32<65_000>,
 	>;
@@ -129,7 +135,8 @@ pub mod pallet {
 			<Storage<T>>::put(self.storage);
 
 			if self.trash_data_count <= 65_000 {
-				(0..self.trash_data_count).for_each(|i| TrashData::<T>::insert(i, [i as u8; 1024]));
+				(0..self.trash_data_count)
+					.for_each(|i| TrashData::<T>::insert(i, Pallet::<T>::gen_value(i)));
 			}
 
 			TrashDataCount::<T>::set(self.trash_data_count);
@@ -174,7 +181,11 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Initializes the pallet by writing into `TrashData`.
 		///
-		/// Only callable by Root. A good default for `trash_count` is `5_000`.
+		/// `current_count` is the current number of elements in `TrashData`. This can be set to
+		/// `None` when the pallet is first initialized.
+		///
+		/// Only callable by Root or `AdminOrigin`. A good default for `new_count` is
+		/// `5_000`.
 		#[pallet::call_index(0)]
 		#[pallet::weight(
 			T::WeightInfo::initialize_pallet_grow(witness_count.unwrap_or_default())
@@ -185,7 +196,7 @@ pub mod pallet {
 			new_count: u32,
 			witness_count: Option<u32>,
 		) -> DispatchResult {
-			ensure_root(origin)?;
+			T::AdminOrigin::try_origin(origin).map(|_| ()).or_else(|o| ensure_root(o))?;
 
 			let current_count = TrashDataCount::<T>::get();
 			ensure!(
@@ -194,7 +205,8 @@ pub mod pallet {
 			);
 
 			if new_count > current_count {
-				(current_count..new_count).for_each(|i| TrashData::<T>::insert(i, [i as u8; 1024]));
+				(current_count..new_count)
+					.for_each(|i| TrashData::<T>::insert(i, Self::gen_value(i)));
 			} else {
 				(new_count..current_count).for_each(TrashData::<T>::remove);
 			}
@@ -204,28 +216,31 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Set the `Compute` storage value that determines how much of the
-		/// block's weight `ref_time` to use during `on_idle`.
+		/// Set how much of the remaining `ref_time` weight should be consumed by `on_idle`.
 		///
-		/// Only callable by Root.
+		/// Only callable by Root or `AdminOrigin`.
 		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::set_compute())]
 		pub fn set_compute(origin: OriginFor<T>, compute: Perbill) -> DispatchResult {
-			ensure_root(origin)?;
+			T::AdminOrigin::try_origin(origin).map(|_| ()).or_else(|o| ensure_root(o))?;
+
 			Compute::<T>::set(compute);
 
 			Self::deposit_event(Event::ComputationLimitSet { compute });
 			Ok(())
 		}
 
-		/// Set the `Storage` storage value that determines the PoV size usage
-		/// for each block.
+		/// Set how much of the remaining `proof_size` weight should be consumed by `on_idle`.
+		//
+		/// 100% means that all remaining `proof_size` will be consumed. The PoV metering will
+		/// likely be an
 		///
-		/// Only callable by Root.
+		/// Only callable by Root or `AdminOrigin`.
 		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::set_storage())]
 		pub fn set_storage(origin: OriginFor<T>, storage: Perbill) -> DispatchResult {
-			ensure_root(origin)?;
+			T::AdminOrigin::try_origin(origin).map(|_| ()).or_else(|o| ensure_root(o))?;
+
 			Storage::<T>::set(storage);
 
 			Self::deposit_event(Event::StorageLimitSet { storage });
@@ -282,7 +297,7 @@ pub mod pallet {
 			// compiler does not know that (hopefully).
 			debug_assert!(clobber.len() == 64);
 			if clobber.len() == 65 {
-				TrashData::<T>::insert(0, [clobber[0] as u8; 1024]);
+				TrashData::<T>::insert(0, [clobber[0] as u8; VALUE_SIZE]);
 			}
 		}
 
@@ -318,6 +333,18 @@ pub mod pallet {
 				Some(0) | None => Err(()),
 				Some(i) => Ok(i as u32),
 			}
+		}
+
+		/// Generate a pseudo-random deterministic value from a `seed`.
+		pub(crate) fn gen_value(seed: u32) -> [u8; VALUE_SIZE] {
+			let mut ret = [0u8; VALUE_SIZE];
+
+			for i in 0u32..(VALUE_SIZE as u32 / 32) {
+				let hash = (seed, i).using_encoded(sp_core::twox_256);
+				ret[i as usize * 32..(i + 1) as usize * 32].copy_from_slice(&hash);
+			}
+
+			ret
 		}
 	}
 }

--- a/frame/glutton/src/lib.rs
+++ b/frame/glutton/src/lib.rs
@@ -34,9 +34,9 @@ pub mod weights;
 use blake2::{Blake2b512, Digest};
 use frame_support::{pallet_prelude::*, weights::WeightMeter};
 use frame_system::pallet_prelude::*;
+use sp_io::hashing::twox_256;
 use sp_runtime::{traits::Zero, Perbill};
 use sp_std::{vec, vec::Vec};
-use sp_io::hashing::twox_256;
 
 pub use pallet::*;
 pub use weights::WeightInfo;

--- a/frame/glutton/src/mock.rs
+++ b/frame/glutton/src/mock.rs
@@ -68,6 +68,7 @@ impl frame_system::Config for Test {
 
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
+	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type WeightInfo = ();
 }
 

--- a/frame/glutton/src/tests.rs
+++ b/frame/glutton/src/tests.rs
@@ -43,8 +43,8 @@ fn initialize_pallet_works() {
 			Error::<Test>::AlreadyInitialized
 		);
 
-		assert_eq!(TrashData::<Test>::get(0), Some([0; 1024]));
-		assert_eq!(TrashData::<Test>::get(1), Some([1; 1024]));
+		assert_eq!(TrashData::<Test>::get(0), Some(Pallet::<Test>::gen_value(0)));
+		assert_eq!(TrashData::<Test>::get(1), Some(Pallet::<Test>::gen_value(1)));
 		assert_eq!(TrashData::<Test>::get(2), None);
 
 		assert_eq!(TrashDataCount::<Test>::get(), 2);
@@ -223,4 +223,15 @@ fn waste_at_most_proof_size_weight_close_enough() {
 			meter.consumed_ratio()
 		);
 	});
+}
+
+#[test]
+fn gen_value_works() {
+	let g0 = Pallet::<Test>::gen_value(0);
+	let g1 = Pallet::<Test>::gen_value(1);
+
+	assert_eq!(g0.len(), VALUE_SIZE);
+	assert_ne!(g0, g1, "Is distinct");
+	assert_ne!(g0, [0; VALUE_SIZE], "Is not zero");
+	assert_eq!(g0, Pallet::<Test>::gen_value(0), "Is deterministic");
 }


### PR DESCRIPTION
Adding genesis config to Glutton pallet to avoid extra call to initialise Glutton Parachains.