### PR TITLE
WarpSync: Show number of required peers in informant

### DIFF
--- a/client/network/common/src/sync/warp.rs
+++ b/client/network/common/src/sync/warp.rs
@@ -72,7 +72,7 @@ pub trait WarpSyncProvider<Block: BlockT>: Send + Sync {
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum WarpSyncPhase<Block: BlockT> {
 	/// Waiting for peers to connect.
-	AwaitingPeers,
+	AwaitingPeers { required_peers: usize },
 	/// Waiting for target block to be received.
 	AwaitingTargetBlock,
 	/// Downloading and verifying grandpa warp proofs.
@@ -90,7 +90,8 @@ pub enum WarpSyncPhase<Block: BlockT> {
 impl<Block: BlockT> fmt::Display for WarpSyncPhase<Block> {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
-			Self::AwaitingPeers => write!(f, "Waiting for peers"),
+			Self::AwaitingPeers { required_peers } =>
+				write!(f, "Waiting for {required_peers} peers to be connected"),
 			Self::AwaitingTargetBlock => write!(f, "Waiting for target block to be received"),
 			Self::DownloadingWarpProofs => write!(f, "Downloading finality proofs"),
 			Self::DownloadingTargetBlock => write!(f, "Downloading target block"),

--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -515,8 +515,12 @@ where
 				phase: WarpSyncPhase::DownloadingBlocks(gap_sync.best_queued_number),
 				total_bytes: 0,
 			}),
-			(None, SyncMode::Warp, _) =>
-				Some(WarpSyncProgress { phase: WarpSyncPhase::AwaitingPeers, total_bytes: 0 }),
+			(None, SyncMode::Warp, _) => Some(WarpSyncProgress {
+				phase: WarpSyncPhase::AwaitingPeers {
+					required_peers: MIN_PEERS_TO_START_WARP_SYNC,
+				},
+				total_bytes: 0,
+			}),
 			(Some(sync), _, _) => Some(sync.progress()),
 			_ => None,
 		};


### PR DESCRIPTION
This makes it for the user more obvious on what we are waiting and not just "waiting for peers".

