### PR TITLE
TrieCache: Fine tune the size of the local and node cache

### DIFF
--- a/primitives/trie/src/cache/mod.rs
+++ b/primitives/trie/src/cache/mod.rs
@@ -91,9 +91,13 @@ const LOCAL_NODE_CACHE_MAX_INLINE_SIZE: usize = 512 * 1024;
 const LOCAL_VALUE_CACHE_MAX_INLINE_SIZE: usize = 512 * 1024;
 
 /// The maximum size of the memory allocated on the heap by the local cache, in bytes.
-const LOCAL_NODE_CACHE_MAX_HEAP_SIZE: usize = 2 * 1024 * 1024;
+///
+/// The size of the node cache should always be bigger than the value cache. The value
+/// cache is only holding weak references to the actual values found in the nodes and
+/// we account for the size of the node as part of the node cache.
+const LOCAL_NODE_CACHE_MAX_HEAP_SIZE: usize = 8 * 1024 * 1024;
 /// Same as [`LOCAL_NODE_CACHE_MAX_HEAP_SIZE`].
-const LOCAL_VALUE_CACHE_MAX_HEAP_SIZE: usize = 4 * 1024 * 1024;
+const LOCAL_VALUE_CACHE_MAX_HEAP_SIZE: usize = 2 * 1024 * 1024;
 
 /// The size of the shared cache.
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
First, we increase the size to 10MiB for the local cache. Second, we give the node cache a bigger max size than the value cache, see the changed comment on why.

In general this should ensure that we are able to cache the `:code` and not directly throw it out of the cache because it is too big (which currently happens when the size of the runtime > 2MiB). In the future this should be improved to ensure that certain values are not removed from the cache at all, like `:code`.


