### PR TITLE
Glutton pallet updates

### DIFF
--- a/frame/glutton/src/lib.rs
+++ b/frame/glutton/src/lib.rs
@@ -184,7 +184,7 @@ pub mod pallet {
 		/// `current_count` is the current number of elements in `TrashData`. This can be set to
 		/// `None` when the pallet is first initialized.
 		///
-		/// Only callable by Root or `Admintrash_countOrigin`. A good default for `new_count` is
+		/// Only callable by Root or `AdminOrigin`. A good default for `new_count` is
 		/// `5_000`.
 		#[pallet::call_index(0)]
 		#[pallet::weight(

--- a/frame/glutton/src/lib.rs
+++ b/frame/glutton/src/lib.rs
@@ -102,7 +102,7 @@ pub mod pallet {
 	pub(super) type TrashData<T: Config> = StorageMap<
 		Hasher = Twox64Concat,
 		Key = u32,
-		Value = [u8; 1024],
+		Value = [u8; VALUE_SIZE],
 		QueryKind = OptionQuery,
 		MaxValues = ConstU32<65_000>,
 	>;
@@ -297,7 +297,7 @@ pub mod pallet {
 			// compiler does not know that (hopefully).
 			debug_assert!(clobber.len() == 64);
 			if clobber.len() == 65 {
-				TrashData::<T>::insert(0, [clobber[0] as u8; 1024]);
+				TrashData::<T>::insert(0, [clobber[0] as u8; VALUE_SIZE]);
 			}
 		}
 

--- a/frame/glutton/src/mock.rs
+++ b/frame/glutton/src/mock.rs
@@ -68,6 +68,7 @@ impl frame_system::Config for Test {
 
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
+	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type WeightInfo = ();
 }
 

--- a/frame/glutton/src/tests.rs
+++ b/frame/glutton/src/tests.rs
@@ -43,8 +43,8 @@ fn initialize_pallet_works() {
 			Error::<Test>::AlreadyInitialized
 		);
 
-		assert_eq!(TrashData::<Test>::get(0), Some([0; 1024]));
-		assert_eq!(TrashData::<Test>::get(1), Some([1; 1024]));
+		assert_eq!(TrashData::<Test>::get(0), Some(Pallet::<Test>::gen_value(0)));
+		assert_eq!(TrashData::<Test>::get(1), Some(Pallet::<Test>::gen_value(1)));
 		assert_eq!(TrashData::<Test>::get(2), None);
 
 		assert_eq!(TrashDataCount::<Test>::get(), 2);
@@ -223,4 +223,15 @@ fn waste_at_most_proof_size_weight_close_enough() {
 			meter.consumed_ratio()
 		);
 	});
+}
+
+#[test]
+fn gen_value_works() {
+	let g0 = Pallet::<Test>::gen_value(0);
+	let g1 = Pallet::<Test>::gen_value(1);
+
+	assert_eq!(g0.len(), VALUE_SIZE);
+	assert_ne!(g0, g1, "Is distinct");
+	assert_ne!(g0, [0; VALUE_SIZE], "Is not zero");
+	assert_eq!(g0, Pallet::<Test>::gen_value(0), "Is deterministic");
 }


### PR DESCRIPTION
Changes:
- Add `AdminOrigin` to bypass the only-root requirement
- Extend docs
- Add `gen_value` to use pseudo-random values that should compress worse than just `[i; 1024]`.
- Add `VALUE_SIZE` const to get rid of the `1024` magic number

Note: Does not target master.