### PR TITLE
Soft deprecate GenesisConfig

### DIFF
--- a/bin/node-template/node/src/chain_spec.rs
+++ b/bin/node-template/node/src/chain_spec.rs
@@ -1,6 +1,6 @@
 use node_template_runtime::{
-	AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, Signature, SudoConfig,
-	SystemConfig, WASM_BINARY,
+	AccountId, AuraConfig, BalancesConfig, GrandpaConfig, RuntimeGenesisConfig, Signature,
+	SudoConfig, SystemConfig, WASM_BINARY,
 };
 use sc_service::ChainType;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -12,7 +12,7 @@ use sp_runtime::traits::{IdentifyAccount, Verify};
 // const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
-pub type ChainSpec = sc_service::GenericChainSpec<GenesisConfig>;
+pub type ChainSpec = sc_service::GenericChainSpec<RuntimeGenesisConfig>;
 
 /// Generate a crypto pair from seed.
 pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
@@ -131,8 +131,8 @@ fn testnet_genesis(
 	root_key: AccountId,
 	endowed_accounts: Vec<AccountId>,
 	_enable_println: bool,
-) -> GenesisConfig {
-	GenesisConfig {
+) -> RuntimeGenesisConfig {
+	RuntimeGenesisConfig {
 		system: SystemConfig {
 			// Add Wasm runtime to storage.
 			code: wasm_binary.to_vec(),

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -39,7 +39,7 @@ use sp_runtime::{
 	Perbill,
 };
 
-pub use kitchensink_runtime::GenesisConfig;
+pub use kitchensink_runtime::RuntimeGenesisConfig;
 pub use node_primitives::{AccountId, Balance, Signature};
 
 type AccountPublic = <Signature as Verify>::Signer;
@@ -62,7 +62,7 @@ pub struct Extensions {
 }
 
 /// Specialized `ChainSpec`.
-pub type ChainSpec = sc_service::GenericChainSpec<GenesisConfig, Extensions>;
+pub type ChainSpec = sc_service::GenericChainSpec<RuntimeGenesisConfig, Extensions>;
 /// Flaming Fir testnet generator
 pub fn flaming_fir_config() -> Result<ChainSpec, String> {
 	ChainSpec::from_json_bytes(&include_bytes!("../res/flaming-fir.json")[..])
@@ -77,7 +77,7 @@ fn session_keys(
 	SessionKeys { grandpa, babe, im_online, authority_discovery }
 }
 
-fn staging_testnet_config_genesis() -> GenesisConfig {
+fn staging_testnet_config_genesis() -> RuntimeGenesisConfig {
 	#[rustfmt::skip]
 	// stash, controller, session-key
 	// generated with secret:
@@ -229,7 +229,7 @@ pub fn authority_keys_from_seed(
 	)
 }
 
-/// Helper function to create GenesisConfig for testing
+/// Helper function to create RuntimeGenesisConfig for testing
 pub fn testnet_genesis(
 	initial_authorities: Vec<(
 		AccountId,
@@ -242,7 +242,7 @@ pub fn testnet_genesis(
 	initial_nominators: Vec<AccountId>,
 	root_key: AccountId,
 	endowed_accounts: Option<Vec<AccountId>>,
-) -> GenesisConfig {
+) -> RuntimeGenesisConfig {
 	let mut endowed_accounts: Vec<AccountId> = endowed_accounts.unwrap_or_else(|| {
 		vec![
 			get_account_id_from_seed::<sr25519::Public>("Alice"),
@@ -294,7 +294,7 @@ pub fn testnet_genesis(
 	const ENDOWMENT: Balance = 10_000_000 * DOLLARS;
 	const STASH: Balance = ENDOWMENT / 1000;
 
-	GenesisConfig {
+	RuntimeGenesisConfig {
 		system: SystemConfig { code: wasm_binary_unwrap().to_vec() },
 		balances: BalancesConfig {
 			balances: endowed_accounts.iter().cloned().map(|x| (x, ENDOWMENT)).collect(),
@@ -380,7 +380,7 @@ pub fn testnet_genesis(
 	}
 }
 
-fn development_config_genesis() -> GenesisConfig {
+fn development_config_genesis() -> RuntimeGenesisConfig {
 	testnet_genesis(
 		vec![authority_keys_from_seed("Alice")],
 		vec![],
@@ -405,7 +405,7 @@ pub fn development_config() -> ChainSpec {
 	)
 }
 
-fn local_testnet_genesis() -> GenesisConfig {
+fn local_testnet_genesis() -> RuntimeGenesisConfig {
 	testnet_genesis(
 		vec![authority_keys_from_seed("Alice"), authority_keys_from_seed("Bob")],
 		vec![],
@@ -437,7 +437,7 @@ pub(crate) mod tests {
 	use sc_service_test;
 	use sp_runtime::BuildStorage;
 
-	fn local_testnet_genesis_instant_single() -> GenesisConfig {
+	fn local_testnet_genesis_instant_single() -> RuntimeGenesisConfig {
 		testnet_genesis(
 			vec![authority_keys_from_seed("Alice")],
 			vec![],

--- a/bin/node/testing/src/bench.rs
+++ b/bin/node/testing/src/bench.rs
@@ -603,7 +603,7 @@ impl BenchKeyring {
 	}
 
 	/// Generate genesis with accounts from this keyring endowed with some balance.
-	pub fn generate_genesis(&self) -> kitchensink_runtime::GenesisConfig {
+	pub fn generate_genesis(&self) -> kitchensink_runtime::RuntimeGenesisConfig {
 		crate::genesis::config_endowed(
 			Some(kitchensink_runtime::wasm_binary_unwrap()),
 			self.collect_account_ids(),

--- a/bin/node/testing/src/genesis.rs
+++ b/bin/node/testing/src/genesis.rs
@@ -21,20 +21,21 @@
 use crate::keyring::*;
 use kitchensink_runtime::{
 	constants::currency::*, wasm_binary_unwrap, AccountId, AssetsConfig, BabeConfig,
-	BalancesConfig, GenesisConfig, GluttonConfig, GrandpaConfig, IndicesConfig, SessionConfig,
-	SocietyConfig, StakerStatus, StakingConfig, SystemConfig, BABE_GENESIS_EPOCH_CONFIG,
+	BalancesConfig, GluttonConfig, GrandpaConfig, IndicesConfig, RuntimeGenesisConfig,
+	SessionConfig, SocietyConfig, StakerStatus, StakingConfig, SystemConfig,
+	BABE_GENESIS_EPOCH_CONFIG,
 };
 use sp_keyring::{Ed25519Keyring, Sr25519Keyring};
 use sp_runtime::Perbill;
 
 /// Create genesis runtime configuration for tests.
-pub fn config(code: Option<&[u8]>) -> GenesisConfig {
+pub fn config(code: Option<&[u8]>) -> RuntimeGenesisConfig {
 	config_endowed(code, Default::default())
 }
 
 /// Create genesis runtime configuration for tests with some extra
 /// endowed accounts.
-pub fn config_endowed(code: Option<&[u8]>, extra_endowed: Vec<AccountId>) -> GenesisConfig {
+pub fn config_endowed(code: Option<&[u8]>, extra_endowed: Vec<AccountId>) -> RuntimeGenesisConfig {
 	let mut endowed = vec![
 		(alice(), 111 * DOLLARS),
 		(bob(), 100 * DOLLARS),
@@ -46,7 +47,7 @@ pub fn config_endowed(code: Option<&[u8]>, extra_endowed: Vec<AccountId>) -> Gen
 
 	endowed.extend(extra_endowed.into_iter().map(|endowed| (endowed, 100 * DOLLARS)));
 
-	GenesisConfig {
+	RuntimeGenesisConfig {
 		system: SystemConfig {
 			code: code.map(|x| x.to_vec()).unwrap_or_else(|| wasm_binary_unwrap().to_vec()),
 		},

--- a/bin/utils/chain-spec-builder/src/main.rs
+++ b/bin/utils/chain-spec-builder/src/main.rs
@@ -100,7 +100,7 @@ fn genesis_constructor(
 	nominator_accounts: &[AccountId],
 	endowed_accounts: &[AccountId],
 	sudo_account: &AccountId,
-) -> chain_spec::GenesisConfig {
+) -> chain_spec::RuntimeGenesisConfig {
 	let authorities = authority_seeds
 		.iter()
 		.map(AsRef::as_ref)

--- a/frame/alliance/src/mock.rs
+++ b/frame/alliance/src/mock.rs
@@ -372,7 +372,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
 #[cfg(feature = "runtime-benchmarks")]
 pub fn new_bench_ext() -> sp_io::TestExternalities {
-	GenesisConfig::default().build_storage().unwrap().into()
+	RuntimeGenesisConfig::default().build_storage().unwrap().into()
 }
 
 pub fn test_cid() -> Cid {

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -118,7 +118,7 @@ impl pallet_test::Config for Test {
 }
 
 fn new_test_ext() -> sp_io::TestExternalities {
-	GenesisConfig::default().build_storage().unwrap().into()
+	RuntimeGenesisConfig::default().build_storage().unwrap().into()
 }
 
 thread_local! {

--- a/frame/benchmarking/src/tests_instance.rs
+++ b/frame/benchmarking/src/tests_instance.rs
@@ -128,7 +128,7 @@ impl pallet_test::OtherConfig for Test {
 }
 
 fn new_test_ext() -> sp_io::TestExternalities {
-	GenesisConfig::default().build_storage().unwrap().into()
+	RuntimeGenesisConfig::default().build_storage().unwrap().into()
 }
 
 mod benchmarks {

--- a/frame/bounties/src/tests.rs
+++ b/frame/bounties/src/tests.rs
@@ -194,7 +194,7 @@ type TreasuryError = pallet_treasury::Error<Test>;
 type TreasuryError1 = pallet_treasury::Error<Test, Instance1>;
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let mut ext: sp_io::TestExternalities = GenesisConfig {
+	let mut ext: sp_io::TestExternalities = RuntimeGenesisConfig {
 		system: frame_system::GenesisConfig::default(),
 		balances: pallet_balances::GenesisConfig { balances: vec![(0, 100), (1, 98), (2, 1)] },
 		treasury: Default::default(),

--- a/frame/collective/src/tests.rs
+++ b/frame/collective/src/tests.rs
@@ -177,7 +177,7 @@ impl ExtBuilder {
 	}
 
 	pub fn build(self) -> sp_io::TestExternalities {
-		let mut ext: sp_io::TestExternalities = GenesisConfig {
+		let mut ext: sp_io::TestExternalities = RuntimeGenesisConfig {
 			collective: pallet_collective::GenesisConfig {
 				members: self.collective_members,
 				phantom: Default::default(),

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -1500,7 +1500,7 @@ mod tests {
 			MEMBERS.with(|m| {
 				*m.borrow_mut() = self.genesis_members.iter().map(|(m, _)| *m).collect::<Vec<_>>()
 			});
-			let mut ext: sp_io::TestExternalities = GenesisConfig {
+			let mut ext: sp_io::TestExternalities = RuntimeGenesisConfig {
 				balances: pallet_balances::GenesisConfig::<Test> {
 					balances: vec![
 						(1, 10 * self.balance_factor),

--- a/frame/examples/basic/src/tests.rs
+++ b/frame/examples/basic/src/tests.rs
@@ -102,7 +102,7 @@ impl Config for Test {
 // This function basically just builds a genesis storage key/value store according to
 // our desired mockup.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let t = GenesisConfig {
+	let t = RuntimeGenesisConfig {
 		// We use default for brevity, but you can configure as desired if needed.
 		system: Default::default(),
 		balances: Default::default(),

--- a/frame/examples/dev-mode/src/tests.rs
+++ b/frame/examples/dev-mode/src/tests.rs
@@ -94,7 +94,7 @@ impl Config for Test {
 // This function basically just builds a genesis storage key/value store according to
 // our desired mockup.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let t = GenesisConfig {
+	let t = RuntimeGenesisConfig {
 		// We use default for brevity, but you can configure as desired if needed.
 		system: Default::default(),
 		balances: Default::default(),

--- a/frame/remark/src/mock.rs
+++ b/frame/remark/src/mock.rs
@@ -74,6 +74,6 @@ impl pallet_remark::Config for Test {
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let t = GenesisConfig { system: Default::default() }.build_storage().unwrap();
+	let t = RuntimeGenesisConfig { system: Default::default() }.build_storage().unwrap();
 	t.into()
 }

--- a/frame/support/procedural/src/construct_runtime/expand/config.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/config.rs
@@ -78,9 +78,7 @@ pub fn expand_outer_config(
 			#fields
 		}
 
-		// TODO [#14065]
-		// - deprecate it
-		// - later, remove it
+		// GenesisConfig is in the process of being deprecated [https://github.com/paritytech/substrate/issues/14065]
 		#[cfg(any(feature = "std", test))]
 		pub type GenesisConfig = RuntimeGenesisConfig;
 

--- a/frame/support/procedural/src/construct_runtime/expand/config.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/config.rs
@@ -74,12 +74,18 @@ pub fn expand_outer_config(
 		#[serde(rename_all = "camelCase")]
 		#[serde(deny_unknown_fields)]
 		#[serde(crate = "__genesis_config_serde_import__")]
-		pub struct GenesisConfig {
+		pub struct RuntimeGenesisConfig {
 			#fields
 		}
 
+		// TODO [#14065]
+		// - deprecate it
+		// - later, remove it
 		#[cfg(any(feature = "std", test))]
-		impl #scrate::sp_runtime::BuildStorage for GenesisConfig {
+		pub type GenesisConfig = RuntimeGenesisConfig;
+
+		#[cfg(any(feature = "std", test))]
+		impl #scrate::sp_runtime::BuildStorage for RuntimeGenesisConfig {
 			fn assimilate_storage(
 				&self,
 				storage: &mut #scrate::sp_runtime::Storage,

--- a/frame/support/procedural/src/construct_runtime/expand/config.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/config.rs
@@ -79,9 +79,11 @@ pub fn expand_outer_config(
 		}
 
 		// TODO [#14065]
-		// - deprecate it
+		// - remove the deprecation attribute before merging the PR
+		// - deprecate it (for real)
 		// - later, remove it
 		#[cfg(any(feature = "std", test))]
+		#[deprecated(note = "Use `RuntimeGenesisConfig` instead")] // just to make sure CI passes before merging the PR
 		pub type GenesisConfig = RuntimeGenesisConfig;
 
 		#[cfg(any(feature = "std", test))]

--- a/frame/support/procedural/src/construct_runtime/expand/config.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/config.rs
@@ -79,11 +79,9 @@ pub fn expand_outer_config(
 		}
 
 		// TODO [#14065]
-		// - remove the deprecation attribute before merging the PR
-		// - deprecate it (for real)
+		// - deprecate it
 		// - later, remove it
 		#[cfg(any(feature = "std", test))]
-		#[deprecated(note = "Use `RuntimeGenesisConfig` instead")] // just to make sure CI passes before merging the PR
 		pub type GenesisConfig = RuntimeGenesisConfig;
 
 		#[cfg(any(feature = "std", test))]

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -980,7 +980,7 @@ pub mod tests {
 	}
 
 	fn new_test_ext() -> TestExternalities {
-		GenesisConfig::default().build_storage().unwrap().into()
+		RuntimeGenesisConfig::default().build_storage().unwrap().into()
 	}
 
 	trait Sorted {

--- a/frame/support/src/storage/generator/mod.rs
+++ b/frame/support/src/storage/generator/mod.rs
@@ -148,7 +148,7 @@ mod tests {
 
 	#[test]
 	fn value_translate_works() {
-		let t = GenesisConfig::default().build_storage().unwrap();
+		let t = RuntimeGenesisConfig::default().build_storage().unwrap();
 		TestExternalities::new(t).execute_with(|| {
 			type Value = self::frame_system::Value<Runtime>;
 
@@ -170,7 +170,7 @@ mod tests {
 
 	#[test]
 	fn map_translate_works() {
-		let t = GenesisConfig::default().build_storage().unwrap();
+		let t = RuntimeGenesisConfig::default().build_storage().unwrap();
 		TestExternalities::new(t).execute_with(|| {
 			type NumberMap = self::frame_system::NumberMap<Runtime>;
 
@@ -201,7 +201,7 @@ mod tests {
 
 	#[test]
 	fn try_mutate_works() {
-		let t = GenesisConfig::default().build_storage().unwrap();
+		let t = RuntimeGenesisConfig::default().build_storage().unwrap();
 		TestExternalities::new(t).execute_with(|| {
 			type Value = self::frame_system::Value<Runtime>;
 			type NumberMap = self::frame_system::NumberMap<Runtime>;

--- a/frame/support/test/tests/instance.rs
+++ b/frame/support/test/tests/instance.rs
@@ -352,7 +352,7 @@ impl module3::Config for Runtime {
 }
 
 fn new_test_ext() -> sp_io::TestExternalities {
-	GenesisConfig {
+	RuntimeGenesisConfig {
 		module_1_1: module1::GenesisConfig { value: 3, test: 2 },
 		module_1_2: module1::GenesisConfig { value: 4, test: 5 },
 		module_2: module2::GenesisConfig {

--- a/frame/support/test/tests/issue2219.rs
+++ b/frame/support/test/tests/issue2219.rs
@@ -186,7 +186,7 @@ frame_support::construct_runtime!(
 
 #[test]
 fn create_genesis_config() {
-	let config = GenesisConfig {
+	let config = RuntimeGenesisConfig {
 		module: module::GenesisConfig { request_life_time: 0, enable_storage_role: true },
 	};
 	assert_eq!(config.module.request_life_time, 0);

--- a/frame/system/src/mock.rs
+++ b/frame/system/src/mock.rs
@@ -126,7 +126,7 @@ pub const CALL: &<Test as Config>::RuntimeCall =
 /// Create new externalities for `System` module tests.
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut ext: sp_io::TestExternalities =
-		GenesisConfig::default().build_storage().unwrap().into();
+		RuntimeGenesisConfig::default().build_storage().unwrap().into();
 	// Add to each test the initial weight of a block
 	ext.execute_with(|| {
 		System::register_extra_weight_unchecked(

--- a/frame/tips/src/tests.rs
+++ b/frame/tips/src/tests.rs
@@ -196,7 +196,7 @@ impl Config<Instance1> for Test {
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let mut ext: sp_io::TestExternalities = GenesisConfig {
+	let mut ext: sp_io::TestExternalities = RuntimeGenesisConfig {
 		system: frame_system::GenesisConfig::default(),
 		balances: pallet_balances::GenesisConfig { balances: vec![(0, 100), (1, 98), (2, 1)] },
 		treasury: Default::default(),

--- a/frame/transaction-storage/src/mock.rs
+++ b/frame/transaction-storage/src/mock.rs
@@ -101,7 +101,7 @@ impl pallet_transaction_storage::Config for Test {
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let t = GenesisConfig {
+	let t = RuntimeGenesisConfig {
 		system: Default::default(),
 		balances: pallet_balances::GenesisConfig::<Test> {
 			balances: vec![(1, 1000000000), (2, 100), (3, 100), (4, 100)],

--- a/frame/whitelist/src/mock.rs
+++ b/frame/whitelist/src/mock.rs
@@ -111,7 +111,7 @@ impl pallet_whitelist::Config for Test {
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let t = GenesisConfig::default().build_storage().unwrap();
+	let t = RuntimeGenesisConfig::default().build_storage().unwrap();
 	let mut ext = sp_io::TestExternalities::new(t);
 	ext.execute_with(|| System::set_block_number(1));
 	ext

--- a/test-utils/runtime/src/genesismap.rs
+++ b/test-utils/runtime/src/genesismap.rs
@@ -18,7 +18,7 @@
 //! Tool for creating the genesis block.
 
 use super::{
-	currency, substrate_test_pallet, wasm_binary_unwrap, AccountId, Balance, GenesisConfig,
+	currency, substrate_test_pallet, wasm_binary_unwrap, AccountId, Balance, RuntimeGenesisConfig,
 };
 use codec::Encode;
 use sc_service::construct_genesis_block;
@@ -116,7 +116,7 @@ impl GenesisStorageBuilder {
 			.map(|id| sr25519::Public::from(id))
 			.collect();
 
-		let genesis_config = GenesisConfig {
+		let genesis_config = RuntimeGenesisConfig {
 			system: frame_system::GenesisConfig {
 				code: self.wasm_code.clone().unwrap_or(wasm_binary_unwrap().to_vec()),
 			},


### PR DESCRIPTION
Relates to paritytech/polkadot-sdk#175

This PR Soft deprecates the runtime level `GenesisConfig` by renaming it to `RuntimeGenesisConfig`.
An alias `GenesisConfig` is created to keep backwards compatibility. No deprecation warning has been added at this stage as that will happen later in a separate PR as indicated in paritytech/polkadot-sdk#175 