### PR TITLE
Get rid of some pointless pin_project stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9621,7 +9621,6 @@ dependencies = [
  "libp2p",
  "log",
  "parity-scale-codec",
- "pin-project",
  "sc-network",
  "sc-network-common",
  "sc-peerset",

--- a/client/network/transactions/Cargo.toml
+++ b/client/network/transactions/Cargo.toml
@@ -18,7 +18,6 @@ codec = { package = "parity-scale-codec", version = "3.2.2", features = ["derive
 futures = "0.3.21"
 libp2p = "0.51.3"
 log = "0.4.17"
-pin-project = "1.0.12"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", path = "../../../utils/prometheus" }
 sc-network = { version = "0.10.0-dev", path = "../" }
 sc-network-common = { version = "0.10.0-dev", path = "../common" }


### PR DESCRIPTION
The `validation` future is boxed, so the `PendingTransaction` struct can just be `Unpin`.