### PR TITLE
test-utils: Fix wait_for_blocks in presence of reorgs

### DIFF
--- a/test-utils/client/src/lib.rs
+++ b/test-utils/client/src/lib.rs
@@ -42,7 +42,11 @@ use sc_client_api::BlockchainEvents;
 use sc_service::client::{ClientConfig, LocalCallExecutor};
 use serde::Deserialize;
 use sp_core::{storage::ChildInfo, testing::TaskExecutor};
-use sp_runtime::{codec::Encode, traits::Block as BlockT, OpaqueExtrinsic};
+use sp_runtime::{
+	codec::Encode,
+	traits::{Block as BlockT, Header},
+	OpaqueExtrinsic,
+};
 use std::{
 	collections::{HashMap, HashSet},
 	pin::Pin,
@@ -410,7 +414,7 @@ where
 		Box::pin(async move {
 			while let Some(notification) = import_notification_stream.next().await {
 				if notification.is_new_best {
-					blocks.insert(notification.hash);
+					blocks.insert(*notification.header.number());
 					if blocks.len() == count {
 						break
 					}


### PR DESCRIPTION
In the cases where a reorg happens we might receive notifications for different blocks at the same level, so instead of the chain having `count` new blocks it has less and that will break the tests which use this function.

So, use the block number to identify that `count` blocks have been built in the chain.

Examples where this issue was hit:
  https://github.com/paritytech/polkadot/issues/7267
