### PR TITLE
wasm-builder: Enforce `runtime_version` wasm section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5421,6 +5421,7 @@ name = "node-template"
 version = "4.0.0-dev"
 dependencies = [
  "clap 4.2.7",
+ "enum-as-inner",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "frame-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11860,6 +11860,7 @@ dependencies = [
  "build-helper",
  "cargo_metadata",
  "filetime",
+ "parity-wasm",
  "sp-maybe-compressed-blob",
  "strum",
  "tempfile",

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -66,6 +66,9 @@ node-template-runtime = { version = "4.0.0-dev", path = "../runtime" }
 # CLI-specific dependencies
 try-runtime-cli = { version = "0.10.0-dev", optional = true, path = "../../../utils/frame/try-runtime/cli" }
 
+# Workaround until https://github.com/bluejekyll/enum-as-inner/issues/98 is fixed.
+enum-as-inner = "=0.5.1"
+
 [build-dependencies]
 substrate-build-script-utils = { version = "3.0.0", path = "../../../utils/build-script-utils" }
 

--- a/client/executor/runtime-test/build.rs
+++ b/client/executor/runtime-test/build.rs
@@ -24,6 +24,7 @@ fn main() {
 			.with_current_project()
 			.export_heap_base()
 			.import_memory()
+			.disable_runtime_version_section_check()
 			.build();
 	}
 
@@ -36,6 +37,7 @@ fn main() {
 			.import_memory()
 			.set_file_name("wasm_binary_with_tracing.rs")
 			.append_to_rust_flags(r#"--cfg feature="with-tracing""#)
+			.disable_runtime_version_section_check()
 			.build();
 	}
 }

--- a/primitives/runtime-interface/test-wasm-deprecated/build.rs
+++ b/primitives/runtime-interface/test-wasm-deprecated/build.rs
@@ -22,6 +22,7 @@ fn main() {
 			.with_current_project()
 			.export_heap_base()
 			.import_memory()
+			.disable_runtime_version_section_check()
 			.build();
 	}
 }

--- a/primitives/runtime-interface/test-wasm/build.rs
+++ b/primitives/runtime-interface/test-wasm/build.rs
@@ -22,6 +22,7 @@ fn main() {
 			.with_current_project()
 			.export_heap_base()
 			.import_memory()
+			.disable_runtime_version_section_check()
 			.build();
 	}
 }

--- a/utils/wasm-builder/Cargo.toml
+++ b/utils/wasm-builder/Cargo.toml
@@ -23,3 +23,4 @@ walkdir = "2.3.2"
 sp-maybe-compressed-blob = { version = "4.1.0-dev", path = "../../primitives/maybe-compressed-blob" }
 filetime = "0.2.16"
 wasm-opt = "0.112"
+parity-wasm = "0.45"

--- a/utils/wasm-builder/src/builder.rs
+++ b/utils/wasm-builder/src/builder.rs
@@ -48,6 +48,7 @@ impl WasmBuilderSelectProject {
 			file_name: None,
 			project_cargo_toml: get_manifest_dir().join("Cargo.toml"),
 			features_to_enable: Vec::new(),
+			check_for_runtime_version_section: true,
 		}
 	}
 
@@ -63,6 +64,7 @@ impl WasmBuilderSelectProject {
 				file_name: None,
 				project_cargo_toml: path,
 				features_to_enable: Vec::new(),
+				check_for_runtime_version_section: true,
 			})
 		} else {
 			Err("Project path must point to the `Cargo.toml` of the project")
@@ -93,6 +95,8 @@ pub struct WasmBuilder {
 	project_cargo_toml: PathBuf,
 	/// Features that should be enabled when building the wasm binary.
 	features_to_enable: Vec<String>,
+	/// Should the builder check that the `runtime_version` section exists in the wasm binary?
+	check_for_runtime_version_section: bool,
 }
 
 impl WasmBuilder {
@@ -143,6 +147,17 @@ impl WasmBuilder {
 		self
 	}
 
+	/// Disable the check for the `runtime_version` wasm section.
+	///
+	/// By default the `wasm-builder` will ensure that the `runtime_version` section will
+	/// exists in the build wasm binary. This `runtime_version` section is used to get the
+	/// `RuntimeVersion` without needing to call into the wasm binary. However, for some
+	/// use cases (like tests) you may want to disable this check.
+	pub fn disable_runtime_version_section_check(mut self) -> Self {
+		self.check_for_runtime_version_section = false;
+		self
+	}
+
 	/// Build the WASM binary.
 	pub fn build(self) {
 		let out_dir = PathBuf::from(env::var("OUT_DIR").expect("`OUT_DIR` is set by cargo!"));
@@ -165,6 +180,7 @@ impl WasmBuilder {
 			self.rust_flags.into_iter().map(|f| format!("{} ", f)).collect(),
 			self.features_to_enable,
 			self.file_name,
+			self.check_for_runtime_version_section,
 		);
 
 		// As last step we need to generate our `rerun-if-changed` stuff. If a build fails, we don't
@@ -215,7 +231,7 @@ fn generate_rerun_if_changed_instructions() {
 /// The current project is determined by using the `CARGO_MANIFEST_DIR` environment variable.
 ///
 /// `file_name` - The name + path of the file being generated. The file contains the
-/// constant `WASM_BINARY`, which contains the built WASM binary.
+/// constant `WASM_BINARY`, which contains the built wasm binary.
 ///
 /// `project_cargo_toml` - The path to the `Cargo.toml` of the project that should be built.
 ///
@@ -224,14 +240,17 @@ fn generate_rerun_if_changed_instructions() {
 /// `features_to_enable` - Features that should be enabled for the project.
 ///
 /// `wasm_binary_name` - The optional wasm binary name that is extended with
-///
 /// `.compact.compressed.wasm`. If `None`, the project name will be used.
+///
+/// `check_for_runtime_version_section` - Should the wasm binary be checked for the
+/// `runtime_version` section?
 fn build_project(
 	file_name: PathBuf,
 	project_cargo_toml: PathBuf,
 	default_rustflags: String,
 	features_to_enable: Vec<String>,
 	wasm_binary_name: Option<String>,
+	check_for_runtime_version_section: bool,
 ) {
 	let cargo_cmd = match crate::prerequisites::check() {
 		Ok(cmd) => cmd,
@@ -247,6 +266,7 @@ fn build_project(
 		cargo_cmd,
 		features_to_enable,
 		wasm_binary_name,
+		check_for_runtime_version_section,
 	);
 
 	let (wasm_binary, wasm_binary_bloaty) = if let Some(wasm_binary) = wasm_binary {

--- a/utils/wasm-builder/src/builder.rs
+++ b/utils/wasm-builder/src/builder.rs
@@ -48,7 +48,7 @@ impl WasmBuilderSelectProject {
 			file_name: None,
 			project_cargo_toml: get_manifest_dir().join("Cargo.toml"),
 			features_to_enable: Vec::new(),
-			check_for_runtime_version_section: true,
+			disable_runtime_version_section_check: fale,
 		}
 	}
 
@@ -64,7 +64,7 @@ impl WasmBuilderSelectProject {
 				file_name: None,
 				project_cargo_toml: path,
 				features_to_enable: Vec::new(),
-				check_for_runtime_version_section: true,
+				disable_runtime_version_section_check: false,
 			})
 		} else {
 			Err("Project path must point to the `Cargo.toml` of the project")
@@ -95,8 +95,8 @@ pub struct WasmBuilder {
 	project_cargo_toml: PathBuf,
 	/// Features that should be enabled when building the wasm binary.
 	features_to_enable: Vec<String>,
-	/// Should the builder check that the `runtime_version` section exists in the wasm binary?
-	check_for_runtime_version_section: bool,
+	/// Should the builder not check that the `runtime_version` section exists in the wasm binary?
+	disable_runtime_version_section_check: bool,
 }
 
 impl WasmBuilder {
@@ -154,7 +154,7 @@ impl WasmBuilder {
 	/// `RuntimeVersion` without needing to call into the wasm binary. However, for some
 	/// use cases (like tests) you may want to disable this check.
 	pub fn disable_runtime_version_section_check(mut self) -> Self {
-		self.check_for_runtime_version_section = false;
+		self.disable_runtime_version_section_check = true;
 		self
 	}
 
@@ -180,7 +180,7 @@ impl WasmBuilder {
 			self.rust_flags.into_iter().map(|f| format!("{} ", f)).collect(),
 			self.features_to_enable,
 			self.file_name,
-			self.check_for_runtime_version_section,
+			!self.disable_runtime_version_section_check,
 		);
 
 		// As last step we need to generate our `rerun-if-changed` stuff. If a build fails, we don't

--- a/utils/wasm-builder/src/builder.rs
+++ b/utils/wasm-builder/src/builder.rs
@@ -48,7 +48,7 @@ impl WasmBuilderSelectProject {
 			file_name: None,
 			project_cargo_toml: get_manifest_dir().join("Cargo.toml"),
 			features_to_enable: Vec::new(),
-			disable_runtime_version_section_check: fale,
+			disable_runtime_version_section_check: false,
 		}
 	}
 


### PR DESCRIPTION
This pr changes the `wasm-builder` to enforce the `runtime_version` wasm section. This wasm section is being created by the `sp_version::runtime_version` attribute macro. This attribute macro now exists since quite some time and `runtime_version` also is the only way for parachains to support reading the `RuntimeVersion` from the runtime.

\# Disabling the check

By default the `WasmBuilder` will now check for this wasm section and if not found, exit with an error. However, there are situations where you may want to disable this check (like for tests). In this case there exists the `disable_runtime_version_section_check` function.

```
WasmBuilder::new()
   ...
   ...
   ...
   .disable_runtime_version_section_check()
   .build()
```

By using this method you get back the old behavior.

Should prevent issues like this: https://github.com/paritytech/substrate/issues/14223

polkadot companion: https://github.com/paritytech/polkadot/pull/7295