### PR TITLE
sp-api: Set correct where bound in the generated code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10654,6 +10654,7 @@ dependencies = [
  "parity-scale-codec",
  "rustversion",
  "sc-block-builder",
+ "scale-info",
  "sp-api",
  "sp-consensus",
  "sp-core",

--- a/primitives/api/test/Cargo.toml
+++ b/primitives/api/test/Cargo.toml
@@ -23,6 +23,7 @@ codec = { package = "parity-scale-codec", version = "3.2.2" }
 sp-state-machine = { version = "0.13.0", path = "../../state-machine" }
 trybuild = "1.0.74"
 rustversion = "1.0.6"
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/primitives/api/test/tests/ui/positive_cases/custom_where_bound.rs
+++ b/primitives/api/test/tests/ui/positive_cases/custom_where_bound.rs
@@ -1,0 +1,46 @@
+use codec::{Decode, Encode};
+use scale_info::TypeInfo;
+use sp_runtime::traits::{Block as BlockT, GetNodeBlockType};
+use substrate_test_runtime_client::runtime::Block;
+
+struct Runtime {}
+impl GetNodeBlockType for Runtime {
+	type NodeBlock = Block;
+}
+
+pub trait CustomTrait: Encode + Decode + TypeInfo {}
+
+#[derive(Encode, Decode, TypeInfo)]
+pub struct SomeImpl;
+impl CustomTrait for SomeImpl {}
+
+#[derive(Encode, Decode, TypeInfo)]
+pub struct SomeOtherType<C: CustomTrait>(C);
+
+sp_api::decl_runtime_apis! {
+	pub trait Api<A> where A: CustomTrait {
+		fn test() -> A;
+		fn test2() -> SomeOtherType<A>;
+	}
+}
+
+sp_api::impl_runtime_apis! {
+	impl self::Api<Block, SomeImpl> for Runtime {
+		fn test() -> SomeImpl { SomeImpl }
+		fn test2() -> SomeOtherType<SomeImpl> { SomeOtherType(SomeImpl) }
+	}
+
+	impl sp_api::Core<Block> for Runtime {
+		fn version() -> sp_version::RuntimeVersion {
+			unimplemented!()
+		}
+		fn execute_block(_: Block) {
+			unimplemented!()
+		}
+		fn initialize_block(_: &<Block as BlockT>::Header) {
+			unimplemented!()
+		}
+	}
+}
+
+fn main() {}


### PR DESCRIPTION
The where bound for the `create_metadata` function wasn't correct. This pr fixes this by using the where bound declared at the type declaration augmented with the manual where bound.

Closes: https://github.com/paritytech/substrate/issues/14250