### PR TITLE
`Pay` trait gets `Error` item

### DIFF
--- a/frame/salary/src/lib.rs
+++ b/frame/salary/src/lib.rs
@@ -436,8 +436,7 @@ pub mod pallet {
 
 			claimant.last_active = status.cycle_index;
 
-			let id = T::Paymaster::pay(&beneficiary, (), payout)
-				.map_err(|()| Error::<T, I>::PayError)?;
+			let id = T::Paymaster::pay(&beneficiary, (), payout).map_err(|_| Error::<T, I>::PayError)?;
 
 			claimant.status = Attempted { registered, id, amount: payout };
 

--- a/frame/salary/src/lib.rs
+++ b/frame/salary/src/lib.rs
@@ -436,7 +436,8 @@ pub mod pallet {
 
 			claimant.last_active = status.cycle_index;
 
-			let id = T::Paymaster::pay(&beneficiary, (), payout).map_err(|_| Error::<T, I>::PayError)?;
+			let id =
+				T::Paymaster::pay(&beneficiary, (), payout).map_err(|_| Error::<T, I>::PayError)?;
 
 			claimant.status = Attempted { registered, id, amount: payout };
 

--- a/frame/salary/src/tests.rs
+++ b/frame/salary/src/tests.rs
@@ -103,12 +103,13 @@ impl Pay for TestPay {
 	type Balance = u64;
 	type Id = u64;
 	type AssetKind = ();
+	type Error = ();
 
 	fn pay(
 		who: &Self::Beneficiary,
 		_: Self::AssetKind,
 		amount: Self::Balance,
-	) -> Result<Self::Id, ()> {
+	) -> Result<Self::Id, Self::Error> {
 		PAID.with(|paid| *paid.borrow_mut().entry(*who).or_default() += amount);
 		Ok(LAST_ID.with(|lid| {
 			let x = *lid.borrow();


### PR DESCRIPTION
Small trait alteration from https://github.com/paritytech/substrate/pull/13607, used in https://github.com/paritytech/polkadot/pull/6900 .