### PR TITLE
FRAME: Pay trait benchmark helper should use asset kind

### DIFF
--- a/frame/salary/src/benchmarking.rs
+++ b/frame/salary/src/benchmarking.rs
@@ -107,7 +107,7 @@ mod benchmarks {
 		System::<T>::set_block_number(System::<T>::block_number() + T::RegistrationPeriod::get());
 
 		let salary = T::Salary::get_salary(T::Members::rank_of(&caller).unwrap(), &caller);
-		T::Paymaster::ensure_successful(&caller, salary);
+		T::Paymaster::ensure_successful(&caller, (), salary);
 
 		#[extrinsic_call]
 		_(RawOrigin::Signed(caller.clone()));
@@ -134,7 +134,7 @@ mod benchmarks {
 
 		let salary = T::Salary::get_salary(T::Members::rank_of(&caller).unwrap(), &caller);
 		let recipient: T::AccountId = account("recipient", 0, SEED);
-		T::Paymaster::ensure_successful(&recipient, salary);
+		T::Paymaster::ensure_successful(&recipient, (), salary);
 
 		#[extrinsic_call]
 		_(RawOrigin::Signed(caller.clone()), recipient.clone());
@@ -161,7 +161,7 @@ mod benchmarks {
 
 		let salary = T::Salary::get_salary(T::Members::rank_of(&caller).unwrap(), &caller);
 		let recipient: T::AccountId = account("recipient", 0, SEED);
-		T::Paymaster::ensure_successful(&recipient, salary);
+		T::Paymaster::ensure_successful(&recipient, (), salary);
 		Salary::<T, I>::payout(RawOrigin::Signed(caller.clone()).into()).unwrap();
 		let id = match Claimant::<T, I>::get(&caller).unwrap().status {
 			Attempted { id, .. } => id,

--- a/frame/salary/src/tests.rs
+++ b/frame/salary/src/tests.rs
@@ -121,7 +121,7 @@ impl Pay for TestPay {
 		STATUS.with(|s| s.borrow().get(&id).cloned().unwrap_or(PaymentStatus::Unknown))
 	}
 	#[cfg(feature = "runtime-benchmarks")]
-	fn ensure_successful(_: &Self::Beneficiary, _: Self::Balance) {}
+	fn ensure_successful(_: &Self::Beneficiary, _: Self::AssetKind, _: Self::Balance) {}
 	#[cfg(feature = "runtime-benchmarks")]
 	fn ensure_concluded(id: Self::Id) {
 		set_status(id, PaymentStatus::Failure)

--- a/frame/support/src/traits/tokens/pay.rs
+++ b/frame/support/src/traits/tokens/pay.rs
@@ -56,7 +56,7 @@ pub trait Pay {
 	/// Ensure that a call to pay with the given parameters will be successful if done immediately
 	/// after this call. Used in benchmarking code.
 	#[cfg(feature = "runtime-benchmarks")]
-	fn ensure_successful(who: &Self::Beneficiary, amount: Self::Balance);
+	fn ensure_successful(who: &Self::Beneficiary, asset_kind: Self::AssetKind, amount: Self::Balance);
 	/// Ensure that a call to `check_payment` with the given parameters will return either `Success`
 	/// or `Failure`.
 	#[cfg(feature = "runtime-benchmarks")]
@@ -95,9 +95,9 @@ impl<A: TypedGet, F: fungible::Mutate<A::Type>> Pay for PayFromAccount<F, A> {
 	}
 	fn check_payment(_: ()) -> PaymentStatus {
 		PaymentStatus::Success
-	}
+	}         
 	#[cfg(feature = "runtime-benchmarks")]
-	fn ensure_successful(_: &Self::Beneficiary, amount: Self::Balance) {
+	fn ensure_successful(_: &Self::Beneficiary, _: Self::AssetKind, amount: Self::Balance) {
 		<F as fungible::Mutate<_>>::mint_into(&A::get(), amount).unwrap();
 	}
 	#[cfg(feature = "runtime-benchmarks")]

--- a/frame/support/src/traits/tokens/pay.rs
+++ b/frame/support/src/traits/tokens/pay.rs
@@ -56,7 +56,11 @@ pub trait Pay {
 	/// Ensure that a call to pay with the given parameters will be successful if done immediately
 	/// after this call. Used in benchmarking code.
 	#[cfg(feature = "runtime-benchmarks")]
-	fn ensure_successful(who: &Self::Beneficiary, asset_kind: Self::AssetKind, amount: Self::Balance);
+	fn ensure_successful(
+		who: &Self::Beneficiary,
+		asset_kind: Self::AssetKind,
+		amount: Self::Balance,
+	);
 	/// Ensure that a call to `check_payment` with the given parameters will return either `Success`
 	/// or `Failure`.
 	#[cfg(feature = "runtime-benchmarks")]
@@ -95,7 +99,7 @@ impl<A: TypedGet, F: fungible::Mutate<A::Type>> Pay for PayFromAccount<F, A> {
 	}
 	fn check_payment(_: ()) -> PaymentStatus {
 		PaymentStatus::Success
-	}         
+	}
 	#[cfg(feature = "runtime-benchmarks")]
 	fn ensure_successful(_: &Self::Beneficiary, _: Self::AssetKind, amount: Self::Balance) {
 		<F as fungible::Mutate<_>>::mint_into(&A::get(), amount).unwrap();


### PR DESCRIPTION
Pay trait benchmark helper `ensure_successful` did not get the argument of type `AssetKind` when it was introduced. This fixes it.