### PR TITLE
frame_system::remark: Allow any kind of origin

### DIFF
--- a/frame/alliance/src/tests.rs
+++ b/frame/alliance/src/tests.rs
@@ -299,7 +299,7 @@ fn close_works() {
 				})),
 				record(mock::RuntimeEvent::AllianceMotion(AllianceMotionEvent::Executed {
 					proposal_hash: hash,
-					result: Err(DispatchError::BadOrigin),
+					result: Ok(()),
 				}))
 			]
 		);

--- a/frame/collective/src/benchmarking.rs
+++ b/frame/collective/src/benchmarking.rs
@@ -131,7 +131,7 @@ benchmarks_instance_pallet! {
 		let proposal_hash = T::Hashing::hash_of(&proposal);
 		// Note that execution fails due to mis-matched origin
 		assert_last_event::<T, I>(
-			Event::MemberExecuted { proposal_hash, result: Err(DispatchError::BadOrigin) }.into()
+			Event::MemberExecuted { proposal_hash, result: Ok(()) }.into()
 		);
 	}
 
@@ -162,7 +162,7 @@ benchmarks_instance_pallet! {
 		let proposal_hash = T::Hashing::hash_of(&proposal);
 		// Note that execution fails due to mis-matched origin
 		assert_last_event::<T, I>(
-			Event::Executed { proposal_hash, result: Err(DispatchError::BadOrigin) }.into()
+			Event::Executed { proposal_hash, result: Ok(()) }.into()
 		);
 	}
 
@@ -441,7 +441,7 @@ benchmarks_instance_pallet! {
 	verify {
 		// The last proposal is removed.
 		assert_eq!(Collective::<T, I>::proposals().len(), (p - 1) as usize);
-		assert_last_event::<T, I>(Event::Executed { proposal_hash: last_hash, result: Err(DispatchError::BadOrigin) }.into());
+		assert_last_event::<T, I>(Event::Executed { proposal_hash: last_hash, result: Ok(()) }.into());
 	}
 
 	close_disapproved {
@@ -595,7 +595,7 @@ benchmarks_instance_pallet! {
 	}: close(SystemOrigin::Signed(caller), last_hash, p - 1, Weight::MAX, bytes_in_storage)
 	verify {
 		assert_eq!(Collective::<T, I>::proposals().len(), (p - 1) as usize);
-		assert_last_event::<T, I>(Event::Executed { proposal_hash: last_hash, result: Err(DispatchError::BadOrigin) }.into());
+		assert_last_event::<T, I>(Event::Executed { proposal_hash: last_hash, result: Ok(()) }.into());
 	}
 
 	disapprove_proposal {

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -374,11 +374,10 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Make some on-chain remark.
 		///
-		/// - `O(1)`
+		/// Can be executed by every `origin`.
 		#[pallet::call_index(0)]
 		#[pallet::weight(T::SystemWeightInfo::remark(_remark.len() as u32))]
-		pub fn remark(origin: OriginFor<T>, _remark: Vec<u8>) -> DispatchResultWithPostInfo {
-			ensure_signed_or_root(origin)?;
+		pub fn remark(_origin: OriginFor<T>, _remark: Vec<u8>) -> DispatchResultWithPostInfo {
 			Ok(().into())
 		}
 


### PR DESCRIPTION
There should be no downside in allowing any kind of origin for `remark`.


