### PR TITLE
app_crypto: macro improvements

### DIFF
--- a/primitives/application-crypto/src/lib.rs
+++ b/primitives/application-crypto/src/lib.rs
@@ -328,6 +328,14 @@ macro_rules! app_crypto_public_common {
 	};
 }
 
+#[doc(hidden)]
+pub mod module_format_string_prelude {
+	#[cfg(all(not(feature = "std"), feature = "serde"))]
+	pub use super::{format, String};
+	#[cfg(feature = "std")]
+	pub use std::{format, string::String};
+}
+
 /// Implements traits for the public key type if `feature = "serde"` is enabled.
 #[cfg(feature = "serde")]
 #[doc(hidden)]
@@ -365,9 +373,7 @@ macro_rules! app_crypto_public_common_if_serde {
 			where
 				D: $crate::serde::Deserializer<'de>,
 			{
-				use $crate::Ss58Codec;
-				#[cfg(all(not(feature = "std"), feature = "serde"))]
-				use $crate::{format, String};
+				use $crate::{module_format_string_prelude::*, Ss58Codec};
 
 				Public::from_ss58check(&String::deserialize(deserializer)?)
 					.map_err(|e| $crate::serde::de::Error::custom(format!("{:?}", e)))


### PR DESCRIPTION
During `app_crypto`  macro expansion the `cfg` feature gate was injected
  into the macro client crate. This resulted in compilation error if
`serde` or `std` was not defined in client crate. This PR fixes this
problem.

For reference, the error was:

```
  error: cannot find macro `format` in this scope
    --> /home/miszka/parity/10-genesis-config/substrate-2/primitives/consensus/aura/src/lib.rs:32:3
     |
  32 |         app_crypto!(sr25519, AURA);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
...

  error[E0433]: failed to resolve: use of undeclared type `String`
    -->
/home/miszka/parity/10-genesis-config/substrate-2/primitives/consensus/aura/src/lib.rs:32:3
     |
  32 |         app_crypto!(sr25519, AURA);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `String`
```
