### PR TITLE
Remove `enum-as-inner` pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5504,7 +5504,6 @@ name = "node-template"
 version = "4.0.0-dev"
 dependencies = [
  "clap 4.2.7",
- "enum-as-inner",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "frame-system",

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -66,9 +66,6 @@ node-template-runtime = { version = "4.0.0-dev", path = "../runtime" }
 # CLI-specific dependencies
 try-runtime-cli = { version = "0.10.0-dev", optional = true, path = "../../../utils/frame/try-runtime/cli" }
 
-# Workaround until https://github.com/bluejekyll/enum-as-inner/issues/98 is fixed.
-enum-as-inner = "=0.5.1"
-
 [build-dependencies]
 substrate-build-script-utils = { version = "3.0.0", path = "../../../utils/build-script-utils" }
 


### PR DESCRIPTION
The faulty version was yanked from crates.io.


