### PR TITLE
pallet-beefy-mmr: fix when using custom hashing

### DIFF
--- a/frame/beefy-mmr/src/lib.rs
+++ b/frame/beefy-mmr/src/lib.rs
@@ -56,7 +56,7 @@ pub struct DepositBeefyDigest<T>(sp_std::marker::PhantomData<T>);
 
 impl<T> pallet_mmr::primitives::OnNewRoot<sp_consensus_beefy::MmrRootHash> for DepositBeefyDigest<T>
 where
-	T: pallet_mmr::Config<Hash = sp_consensus_beefy::MmrRootHash>,
+	T: pallet_mmr::Config<Hashing = sp_consensus_beefy::MmrHashing>,
 	T: pallet_beefy::Config,
 {
 	fn on_new_root(root: &sp_consensus_beefy::MmrRootHash) {

--- a/primitives/consensus/beefy/src/lib.rs
+++ b/primitives/consensus/beefy/src/lib.rs
@@ -47,7 +47,7 @@ use codec::{Codec, Decode, Encode};
 use scale_info::TypeInfo;
 use sp_application_crypto::RuntimeAppPublic;
 use sp_core::H256;
-use sp_runtime::traits::{Hash, NumberFor};
+use sp_runtime::traits::{Hash, Keccak256, NumberFor};
 use sp_std::prelude::*;
 
 /// Key type for BEEFY module.
@@ -156,6 +156,8 @@ impl<AuthorityId> ValidatorSet<AuthorityId> {
 /// The index of an authority.
 pub type AuthorityIndex = u32;
 
+/// The Hashing used within MMR.
+pub type MmrHashing = Keccak256;
 /// The type used to represent an MMR root hash.
 pub type MmrRootHash = H256;
 


### PR DESCRIPTION
Fix on top of https://github.com/paritytech/substrate/pull/14214:

`Hash` is no longer part of `pallet_mmr::Config`, but this code would still build because it assumes we're referring to underlying `<pallet_mmr::Config as frame_system::Config>::Hash` which is not what we want when using different hashing between `frame_system` and `pallet_mmr`.

Disambiguate by using correct `pallet_mmr::Config::Hashing` type.