### PR TITLE
Reduce logging verbosity when disconnecting an unknown peer

### DIFF
--- a/client/network/src/protocol_controller.rs
+++ b/client/network/src/protocol_controller.rs
@@ -530,7 +530,7 @@ impl ProtocolController {
 				self.drop_connection(peer_id);
 			},
 			None => {
-				warn!(
+				trace!(
 					target: LOG_TARGET,
 					"Trying to disconnect unknown peer {} from {:?}.", peer_id, self.set_id,
 				);


### PR DESCRIPTION
This fixes spamming in Cumulus with messages like
```
[Parachain] Trying to disconnect unknown peer XZ from SetId(0).
```

We try to disconnect a peer from `PeerStore` when its reputation drops below the `BANNED_THRESHOLD`, and in case it was already disconnected by the syncing code this message is generated. The operation itself is a no-op in this case, so nothing to worry about.