### PR TITLE
Reserved word function rename

### DIFF
--- a/frame/core-fellowship/src/benchmarking.rs
+++ b/frame/core-fellowship/src/benchmarking.rs
@@ -49,7 +49,7 @@ mod benchmarks {
 		for _ in 0..rank {
 			T::Members::promote(&member)?;
 		}
-		CoreFellowship::<T, I>::import(RawOrigin::Signed(member.clone()).into())?;
+		CoreFellowship::<T, I>::import_member(RawOrigin::Signed(member.clone()).into())?;
 		Ok(member)
 	}
 
@@ -162,7 +162,7 @@ mod benchmarks {
 	}
 
 	#[benchmark]
-	fn import() -> Result<(), BenchmarkError> {
+	fn import_member() -> Result<(), BenchmarkError> {
 		let member = account("member", 0, SEED);
 		T::Members::induct(&member)?;
 		T::Members::promote(&member)?;

--- a/frame/core-fellowship/src/lib.rs
+++ b/frame/core-fellowship/src/lib.rs
@@ -36,7 +36,7 @@
 //!   `bump` to demote the candidate by one rank.
 //! - If a candidate fails to be promoted to a member within the `offboard_timeout` period, then
 //!   anyone may call `bump` to remove the account's candidacy.
-//! - Pre-existing members may call `import` to have their rank recognised and be inducted into this
+//! - Pre-existing members may call `import_member` to have their rank recognised and be inducted into this
 //!   pallet (to gain a salary and allow for eventual promotion).
 //! - If, externally to this pallet, a member or candidate has their rank removed completely, then
 //!   `offboard` may be called to remove them entirely from this pallet.
@@ -507,7 +507,7 @@ pub mod pallet {
 		/// - `origin`: A signed origin of a ranked, but not tracked, account.
 		#[pallet::weight(T::WeightInfo::import())]
 		#[pallet::call_index(8)]
-		pub fn import(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+		pub fn import_member(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 			ensure!(!Member::<T, I>::contains_key(&who), Error::<T, I>::AlreadyInducted);
 			let rank = T::Members::rank_of(&who).ok_or(Error::<T, I>::Unranked)?;

--- a/frame/core-fellowship/src/lib.rs
+++ b/frame/core-fellowship/src/lib.rs
@@ -505,7 +505,7 @@ pub mod pallet {
 		/// thereby delaying any automatic demotion but allowing immediate promotion.
 		///
 		/// - `origin`: A signed origin of a ranked, but not tracked, account.
-		#[pallet::weight(T::WeightInfo::import())]
+		#[pallet::weight(T::WeightInfo::import_member())]
 		#[pallet::call_index(8)]
 		pub fn import_member(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;

--- a/frame/core-fellowship/src/tests.rs
+++ b/frame/core-fellowship/src/tests.rs
@@ -218,9 +218,9 @@ fn set_params_works() {
 fn induct_works() {
 	new_test_ext().execute_with(|| {
 		set_rank(0, 0);
-		assert_ok!(CoreFellowship::import(signed(0)));
+		assert_ok!(CoreFellowship::import_member(signed(0)));
 		set_rank(1, 1);
-		assert_ok!(CoreFellowship::import(signed(1)));
+		assert_ok!(CoreFellowship::import_member(signed(1)));
 
 		assert_noop!(CoreFellowship::induct(signed(10), 10), DispatchError::BadOrigin);
 		assert_noop!(CoreFellowship::induct(signed(0), 10), DispatchError::BadOrigin);
@@ -233,7 +233,7 @@ fn induct_works() {
 fn promote_works() {
 	new_test_ext().execute_with(|| {
 		set_rank(1, 1);
-		assert_ok!(CoreFellowship::import(signed(1)));
+		assert_ok!(CoreFellowship::import_member(signed(1)));
 		assert_noop!(CoreFellowship::promote(signed(1), 10, 1), Error::<Test>::Unranked);
 
 		assert_ok!(CoreFellowship::induct(signed(1), 10));
@@ -255,7 +255,7 @@ fn sync_works() {
 		set_rank(10, 5);
 		assert_noop!(CoreFellowship::approve(signed(4), 10, 5), Error::<Test>::NoPermission);
 		assert_noop!(CoreFellowship::approve(signed(6), 10, 6), Error::<Test>::UnexpectedRank);
-		assert_ok!(CoreFellowship::import(signed(10)));
+		assert_ok!(CoreFellowship::import_member(signed(10)));
 		assert!(Member::<Test>::contains_key(10));
 		assert_eq!(next_demotion(10), 11);
 	});
@@ -265,7 +265,7 @@ fn sync_works() {
 fn auto_demote_works() {
 	new_test_ext().execute_with(|| {
 		set_rank(10, 5);
-		assert_ok!(CoreFellowship::import(signed(10)));
+		assert_ok!(CoreFellowship::import_member(signed(10)));
 
 		run_to(10);
 		assert_noop!(CoreFellowship::bump(signed(0), 10), Error::<Test>::NothingDoing);
@@ -281,7 +281,7 @@ fn auto_demote_works() {
 fn auto_demote_offboard_works() {
 	new_test_ext().execute_with(|| {
 		set_rank(10, 1);
-		assert_ok!(CoreFellowship::import(signed(10)));
+		assert_ok!(CoreFellowship::import_member(signed(10)));
 
 		run_to(3);
 		assert_ok!(CoreFellowship::bump(signed(0), 10));
@@ -300,7 +300,7 @@ fn offboard_works() {
 		set_rank(10, 0);
 		assert_noop!(CoreFellowship::offboard(signed(0), 10), Error::<Test>::Ranked);
 
-		assert_ok!(CoreFellowship::import(signed(10)));
+		assert_ok!(CoreFellowship::import_member(signed(10)));
 		assert_noop!(CoreFellowship::offboard(signed(0), 10), Error::<Test>::Ranked);
 
 		unrank(10);
@@ -314,7 +314,7 @@ fn offboard_works() {
 fn proof_postpones_auto_demote() {
 	new_test_ext().execute_with(|| {
 		set_rank(10, 5);
-		assert_ok!(CoreFellowship::import(signed(10)));
+		assert_ok!(CoreFellowship::import_member(signed(10)));
 
 		run_to(11);
 		assert_ok!(CoreFellowship::approve(signed(5), 10, 5));
@@ -327,7 +327,7 @@ fn proof_postpones_auto_demote() {
 fn promote_postpones_auto_demote() {
 	new_test_ext().execute_with(|| {
 		set_rank(10, 5);
-		assert_ok!(CoreFellowship::import(signed(10)));
+		assert_ok!(CoreFellowship::import_member(signed(10)));
 
 		run_to(19);
 		assert_ok!(CoreFellowship::promote(signed(6), 10, 6));
@@ -341,7 +341,7 @@ fn get_salary_works() {
 	new_test_ext().execute_with(|| {
 		for i in 1..=9u64 {
 			set_rank(10 + i, i as u16);
-			assert_ok!(CoreFellowship::import(signed(10 + i)));
+			assert_ok!(CoreFellowship::import_member(signed(10 + i)));
 			assert_eq!(CoreFellowship::get_salary(i as u16, &(10 + i)), i * 10);
 		}
 	});
@@ -352,7 +352,7 @@ fn active_changing_get_salary_works() {
 	new_test_ext().execute_with(|| {
 		for i in 1..=9u64 {
 			set_rank(10 + i, i as u16);
-			assert_ok!(CoreFellowship::import(signed(10 + i)));
+			assert_ok!(CoreFellowship::import_member(signed(10 + i)));
 			assert_ok!(CoreFellowship::set_active(signed(10 + i), false));
 			assert_eq!(CoreFellowship::get_salary(i as u16, &(10 + i)), i);
 			assert_ok!(CoreFellowship::set_active(signed(10 + i), true));

--- a/frame/core-fellowship/src/weights.rs
+++ b/frame/core-fellowship/src/weights.rs
@@ -55,7 +55,7 @@ pub trait WeightInfo {
 	fn induct() -> Weight;
 	fn promote() -> Weight;
 	fn offboard() -> Weight;
-	fn import() -> Weight;
+	fn import_member() -> Weight;
 	fn approve() -> Weight;
 	fn submit_evidence() -> Weight;
 }
@@ -189,7 +189,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: CoreFellowship Member (max_values: None, max_size: Some(49), added: 2524, mode: MaxEncodedLen)
 	/// Storage: RankedCollective Members (r:1 w:0)
 	/// Proof: RankedCollective Members (max_values: None, max_size: Some(42), added: 2517, mode: MaxEncodedLen)
-	fn import() -> Weight {
+	fn import_member() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `280`
 		//  Estimated: `3514`
@@ -356,7 +356,7 @@ impl WeightInfo for () {
 	/// Proof: CoreFellowship Member (max_values: None, max_size: Some(49), added: 2524, mode: MaxEncodedLen)
 	/// Storage: RankedCollective Members (r:1 w:0)
 	/// Proof: RankedCollective Members (max_values: None, max_size: Some(42), added: 2517, mode: MaxEncodedLen)
-	fn import() -> Weight {
+	fn import_member() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `280`
 		//  Estimated: `3514`


### PR DESCRIPTION
I'm trying to use capi with a local substrate node running
and when I sync it with the node, there is an issue with codegen
it points to CoreFellowship's usage of an fn import
the issue is with the name itself

`'import' is a reserved word that cannot be used`

more on the issue itself here: https://github.com/paritytech/capi/issues/1033

therefore I've changed the name, tried sync, everything works fine with capi now