### PR TITLE
pallet-uniques: remove #[transactional] macro for buy_item

### DIFF
--- a/frame/uniques/src/lib.rs
+++ b/frame/uniques/src/lib.rs
@@ -43,10 +43,8 @@ pub mod migration;
 pub mod weights;
 
 use codec::{Decode, Encode};
-use frame_support::{
-	traits::{
-		tokens::Locker, BalanceStatus::Reserved, Currency, EnsureOriginWithArg, ReservableCurrency,
-	}
+use frame_support::traits::{
+	tokens::Locker, BalanceStatus::Reserved, Currency, EnsureOriginWithArg, ReservableCurrency,
 };
 use frame_system::Config as SystemConfig;
 use sp_runtime::{

--- a/frame/uniques/src/lib.rs
+++ b/frame/uniques/src/lib.rs
@@ -46,8 +46,7 @@ use codec::{Decode, Encode};
 use frame_support::{
 	traits::{
 		tokens::Locker, BalanceStatus::Reserved, Currency, EnsureOriginWithArg, ReservableCurrency,
-	},
-	transactional,
+	}
 };
 use frame_system::Config as SystemConfig;
 use sp_runtime::{
@@ -1523,7 +1522,6 @@ pub mod pallet {
 		/// Emits `ItemBought` on success.
 		#[pallet::call_index(25)]
 		#[pallet::weight(T::WeightInfo::buy_item())]
-		#[transactional]
 		pub fn buy_item(
 			origin: OriginFor<T>,
 			collection: T::CollectionId,


### PR DESCRIPTION
Removed `#[transactional]` from `buy_item` of [`pallet-uniques`](https://github.com/paritytech/substrate/blob/7a64651e0ec6823cc2773f5b4823f56943d2d076/frame/uniques/src/lib.rs#L1524-L1536)

```rust
#[pallet::call_index(25)]
#[pallet::weight(T::WeightInfo::buy_item())]
#[transactional]
pub fn buy_item(
	origin: OriginFor<T>,
	collection: T::CollectionId,
	item: T::ItemId,
	bid_price: ItemPrice<T, I>,
) -> DispatchResult {
	let origin = ensure_signed(origin)?;
	Self::do_buy_item(collection, item, origin, bid_price)
}
```