### PR TITLE
Runtime: Add common morph utility types

### DIFF
--- a/frame/core-fellowship/src/lib.rs
+++ b/frame/core-fellowship/src/lib.rs
@@ -321,7 +321,7 @@ pub mod pallet {
 
 		/// Set the parameters.
 		///
-		/// - `origin`: A origin complying with `ParamsOrigin` or root.
+		/// - `origin`: An origin complying with `ParamsOrigin` or root.
 		/// - `params`: The new parameters for the pallet.
 		#[pallet::weight(T::WeightInfo::set_params())]
 		#[pallet::call_index(1)]


### PR DESCRIPTION
Just adds two utility types which were used across multiple crates for governance config.