### PR TITLE
frame/support: Link call documentation only in prod-modes

### DIFF
--- a/frame/support/procedural/src/pallet/expand/call.rs
+++ b/frame/support/procedural/src/pallet/expand/call.rs
@@ -16,7 +16,10 @@
 // limitations under the License.
 
 use crate::{
-	pallet::{parse::call::CallWeightDef, Def},
+	pallet::{
+		parse::call::{CallVariantDef, CallWeightDef},
+		Def,
+	},
 	COUNTER,
 };
 use proc_macro2::TokenStream as TokenStream2;
@@ -113,13 +116,22 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 	}
 	debug_assert_eq!(fn_weight.len(), methods.len());
 
-	let fn_doc = methods
-		.iter()
-		.map(|method| {
+	let map_fn_docs = if !def.dev_mode {
+		// Emit the [`Pallet::method`] documentation only for non-dev modes.
+		|method: &CallVariantDef| {
 			let reference = format!("See [`Pallet::{}`].", method.name);
 			quote!(#reference)
-		})
-		.collect::<Vec<_>>();
+		}
+	} else {
+		// For the dev-mode do not provide a documenation link as it will break the
+		// `cargo doc` if the pallet is private inside a test.
+		|method: &CallVariantDef| {
+			let reference = format!("See `Pallet::{}`.", method.name);
+			quote!(#reference)
+		}
+	};
+
+	let fn_doc = methods.iter().map(map_fn_docs).collect::<Vec<_>>();
 
 	let args_name = methods
 		.iter()


### PR DESCRIPTION
After updating the `Cargo.lock` of Substrate in Cumulus, the doc CI step is failing with 

```bash
[2023-05-31 16:40:08] error: public documentation for `set_custom_validation_head_data` links to private item `Pallet::set_custom_validation_head_data`
[2023-05-31 16:40:08]   --> test/runtime/src/test_pallet.rs:34:12
[2023-05-31 16:40:08]    |
[2023-05-31 16:40:08] 34 |     #[pallet::call]
[2023-05-31 16:40:08]    |               ^^^^
[2023-05-31 16:40:08]    |
[2023-05-31 16:40:08]    = note: the link appears in this line:
[2023-05-31 16:40:08]            
[2023-05-31 16:40:08]            See [`Pallet::set_custom_validation_head_data`].
[2023-05-31 16:40:08]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2023-05-31 16:40:08]    = note: this link will resolve properly if you pass `--document-private-items`
[2023-05-31 16:40:08]    = note: `-D rustdoc::private-intra-doc-links` implied by `-D warnings`
[2023-05-31 16:40:08] 
[2023-05-31 16:40:08] error: could not document `cumulus-test-runtime`
```

This is related to a change done in the PR: https://github.com/paritytech/substrate/pull/14101/files.

This fixes the issue by removing the documentation link to private items, only for pallets started with `dev-mode`.


Extracted from: https://github.com/paritytech/cumulus/pull/2666.

// @paritytech/subxt-team 