### PR TITLE
Bump version of `pallet-contracts-primitives` for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6289,7 +6289,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-primitives"
-version = "7.0.0"
+version = "24.0.0"
 dependencies = [
  "bitflags",
  "parity-scale-codec",

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -69,7 +69,7 @@ pallet-bounties = { version = "4.0.0-dev", default-features = false, path = "../
 pallet-child-bounties = { version = "4.0.0-dev", default-features = false, path = "../../../frame/child-bounties" }
 pallet-collective = { version = "4.0.0-dev", default-features = false, path = "../../../frame/collective" }
 pallet-contracts = { version = "4.0.0-dev", default-features = false, path = "../../../frame/contracts" }
-pallet-contracts-primitives = { version = "7.0.0", default-features = false, path = "../../../frame/contracts/primitives/" }
+pallet-contracts-primitives = { version = "24.0.0", default-features = false, path = "../../../frame/contracts/primitives/" }
 pallet-conviction-voting = { version = "4.0.0-dev", default-features = false, path = "../../../frame/conviction-voting" }
 pallet-core-fellowship = { version = "4.0.0-dev", default-features = false, path = "../../../frame/core-fellowship" }
 pallet-democracy = { version = "4.0.0-dev", default-features = false, path = "../../../frame/democracy" }

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -39,7 +39,7 @@ environmental = { version = "1.1.4", default-features = false }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 frame-support = { version = "4.0.0-dev", default-features = false, path = "../support" }
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
-pallet-contracts-primitives = { version = "7.0.0", default-features = false, path = "primitives" }
+pallet-contracts-primitives = { version = "24.0.0", default-features = false, path = "primitives" }
 pallet-contracts-proc-macro = { version = "4.0.0-dev", path = "proc-macro" }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../primitives/api" }
 sp-core = { version = "21.0.0", default-features = false, path = "../../primitives/core" }

--- a/frame/contracts/primitives/Cargo.toml
+++ b/frame/contracts/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-contracts-primitives"
-version = "7.0.0"
+version = "24.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Following on from https://github.com/paritytech/substrate/pull/14265, this bumps `pallet-contracts-primitives` to version `0.24`, since the latest [version on crates.io is `0.23`]( https://crates.io/crates/pallet-contracts-primitives/23.0.0).

cumulus companion: https://github.com/paritytech/cumulus/pull/2679

