### PR TITLE
asset-conversion pallet: Generalise integrity test

### DIFF
--- a/frame/asset-conversion/src/lib.rs
+++ b/frame/asset-conversion/src/lib.rs
@@ -361,7 +361,7 @@ pub mod pallet {
 					T::MultiAssetIdConverter::into_multiasset_id(&T::BenchmarkHelper::asset_id(1));
 				let asset_2 =
 					T::MultiAssetIdConverter::into_multiasset_id(&T::BenchmarkHelper::asset_id(2));
-				assert!(asset_1 != asset_2, "unfortunatly decoded to be the same asset.");
+				assert!(asset_1 != asset_2, "must return different assets for different ids.");
 				let pool_account_1 = Self::get_pool_account(&(native.clone(), asset_1));
 				let pool_account_2 = Self::get_pool_account(&(native, asset_2));
 				assert!(sp_std::mem::size_of::<T::AccountId>() >= sp_std::mem::size_of::<u128>());

--- a/frame/asset-conversion/src/lib.rs
+++ b/frame/asset-conversion/src/lib.rs
@@ -201,7 +201,7 @@ pub mod pallet {
 		type WeightInfo: WeightInfo;
 
 		/// The benchmarks need a way to create asset ids from u32s.
-		#[cfg(feature = "runtime-benchmarks")]
+		#[cfg(any(test, feature = "runtime-benchmarks"))]
 		type BenchmarkHelper: BenchmarkHelper<Self::AssetId>;
 	}
 
@@ -352,24 +352,22 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {
 		fn integrity_test() {
-			sp_std::if_std! {
-				sp_io::TestExternalities::new_empty().execute_with(|| {
-					// ensure that the `AccountId` is set properly and doesn't generate the same
-					// pool account for different pool ids.
-					let native = T::MultiAssetIdConverter::get_native();
-					// Decode the asset ids from bytes.
-					let asset_1 = T::MultiAssetIdConverter::into_multiasset_id(&T::AssetId::decode(&mut vec![0u8, 0, 0, 1].as_slice()).unwrap());
-					let asset_2 = T::MultiAssetIdConverter::into_multiasset_id(&T::AssetId::decode(&mut vec![255u8, 255, 255, 255].as_slice()).unwrap());
-					assert!(asset_1 != asset_2, "unfortunatly decoded to be the same asset.");
-					let pool_account_1 = Self::get_pool_account(&(native.clone(), asset_1));
-					let pool_account_2 = Self::get_pool_account(&(native, asset_2));
-					assert!(sp_std::mem::size_of::<T::AccountId>() >= sp_std::mem::size_of::<u128>());
-					assert!(
-						pool_account_1 != pool_account_2,
-						"AccountId should be set at least to u128"
-					);
-				});
-			}
+			#[cfg(test)]
+			sp_io::TestExternalities::new_empty().execute_with(|| {
+				// ensure that the `AccountId` is set properly and doesn't generate the same
+				// pool account for different pool ids.
+				let native = T::MultiAssetIdConverter::get_native();
+				let asset_1 = T::MultiAssetIdConverter::into_multiasset_id(&T::BenchmarkHelper::asset_id(1));
+				let asset_2 = T::MultiAssetIdConverter::into_multiasset_id(&T::BenchmarkHelper::asset_id(2));
+				assert!(asset_1 != asset_2, "unfortunatly decoded to be the same asset.");
+				let pool_account_1 = Self::get_pool_account(&(native.clone(), asset_1));
+				let pool_account_2 = Self::get_pool_account(&(native, asset_2));
+				assert!(sp_std::mem::size_of::<T::AccountId>() >= sp_std::mem::size_of::<u128>());
+				assert!(
+					pool_account_1 != pool_account_2,
+					"AccountId should be set at least to u128"
+				);
+			});
 		}
 	}
 

--- a/frame/asset-conversion/src/lib.rs
+++ b/frame/asset-conversion/src/lib.rs
@@ -357,8 +357,10 @@ pub mod pallet {
 				// ensure that the `AccountId` is set properly and doesn't generate the same
 				// pool account for different pool ids.
 				let native = T::MultiAssetIdConverter::get_native();
-				let asset_1 = T::MultiAssetIdConverter::into_multiasset_id(&T::BenchmarkHelper::asset_id(1));
-				let asset_2 = T::MultiAssetIdConverter::into_multiasset_id(&T::BenchmarkHelper::asset_id(2));
+				let asset_1 =
+					T::MultiAssetIdConverter::into_multiasset_id(&T::BenchmarkHelper::asset_id(1));
+				let asset_2 =
+					T::MultiAssetIdConverter::into_multiasset_id(&T::BenchmarkHelper::asset_id(2));
 				assert!(asset_1 != asset_2, "unfortunatly decoded to be the same asset.");
 				let pool_account_1 = Self::get_pool_account(&(native.clone(), asset_1));
 				let pool_account_2 = Self::get_pool_account(&(native, asset_2));

--- a/frame/asset-conversion/src/mock.rs
+++ b/frame/asset-conversion/src/mock.rs
@@ -178,7 +178,7 @@ impl Config for Test {
 	type MultiAssetId = NativeOrAssetId<u32>;
 	type MultiAssetIdConverter = NativeOrAssetIdConverter<u32>;
 
-	#[cfg(feature = "runtime-benchmarks")]
+	#[cfg(any(test, feature = "runtime-benchmarks"))]
 	type BenchmarkHelper = ();
 }
 

--- a/frame/asset-conversion/src/types.rs
+++ b/frame/asset-conversion/src/types.rs
@@ -50,13 +50,13 @@ pub trait MultiAssetIdConverter<MultiAssetId, AssetId> {
 }
 
 /// Benchmark Helper
-#[cfg(feature = "runtime-benchmarks")]
+#[cfg(any(test, feature = "runtime-benchmarks"))]
 pub trait BenchmarkHelper<AssetId> {
 	/// Returns an asset id from a given integer.
 	fn asset_id(asset_id: u32) -> AssetId;
 }
 
-#[cfg(feature = "runtime-benchmarks")]
+#[cfg(any(test, feature = "runtime-benchmarks"))]
 impl<AssetId> BenchmarkHelper<AssetId> for ()
 where
 	AssetId: From<u32>,


### PR DESCRIPTION
Integrity test was only working for u32 types. Switch to using the BenchmarkHelper that knows how to construct asset ids from integers.