### PR TITLE
Remove unrequired check

### DIFF
--- a/frame/asset-conversion/src/benchmarking.rs
+++ b/frame/asset-conversion/src/benchmarking.rs
@@ -17,8 +17,6 @@
 
 //! Asset Conversion pallet benchmarking.
 
-#![cfg(feature = "runtime-benchmarks")]
-
 use super::*;
 use frame_benchmarking::{benchmarks, whitelisted_caller};
 use frame_support::{

--- a/frame/asset-conversion/src/lib.rs
+++ b/frame/asset-conversion/src/lib.rs
@@ -201,7 +201,7 @@ pub mod pallet {
 		type WeightInfo: WeightInfo;
 
 		/// The benchmarks need a way to create asset ids from u32s.
-		#[cfg(any(test, feature = "runtime-benchmarks"))]
+		#[cfg(feature = "runtime-benchmarks")]
 		type BenchmarkHelper: BenchmarkHelper<Self::AssetId>;
 	}
 
@@ -347,30 +347,6 @@ pub mod pallet {
 		PathError,
 		/// The provided path must consists of unique assets.
 		NonUniquePath,
-	}
-
-	#[pallet::hooks]
-	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {
-		fn integrity_test() {
-			#[cfg(test)]
-			sp_io::TestExternalities::new_empty().execute_with(|| {
-				// ensure that the `AccountId` is set properly and doesn't generate the same
-				// pool account for different pool ids.
-				let native = T::MultiAssetIdConverter::get_native();
-				let asset_1 =
-					T::MultiAssetIdConverter::into_multiasset_id(&T::BenchmarkHelper::asset_id(1));
-				let asset_2 =
-					T::MultiAssetIdConverter::into_multiasset_id(&T::BenchmarkHelper::asset_id(2));
-				assert!(asset_1 != asset_2, "must return different assets for different ids.");
-				let pool_account_1 = Self::get_pool_account(&(native.clone(), asset_1));
-				let pool_account_2 = Self::get_pool_account(&(native, asset_2));
-				assert!(sp_std::mem::size_of::<T::AccountId>() >= sp_std::mem::size_of::<u128>());
-				assert!(
-					pool_account_1 != pool_account_2,
-					"AccountId should be set at least to u128"
-				);
-			});
-		}
 	}
 
 	/// Pallet's callable functions.
@@ -1107,8 +1083,8 @@ pub mod pallet {
 			Ok(())
 		}
 
-		#[cfg(any(test, feature = "runtime-benchmarks"))]
 		/// Returns the next pool asset id for benchmark purposes only.
+		#[cfg(feature = "runtime-benchmarks")]
 		pub fn get_next_pool_asset_id() -> T::PoolAssetId {
 			NextPoolAssetId::<T>::get().unwrap_or(T::PoolAssetId::initial_value())
 		}

--- a/frame/asset-conversion/src/lib.rs
+++ b/frame/asset-conversion/src/lib.rs
@@ -1084,7 +1084,7 @@ pub mod pallet {
 		}
 
 		/// Returns the next pool asset id for benchmark purposes only.
-		#[cfg(feature = "runtime-benchmarks")]
+		#[cfg(any(test, feature = "runtime-benchmarks"))]
 		pub fn get_next_pool_asset_id() -> T::PoolAssetId {
 			NextPoolAssetId::<T>::get().unwrap_or(T::PoolAssetId::initial_value())
 		}

--- a/frame/asset-conversion/src/mock.rs
+++ b/frame/asset-conversion/src/mock.rs
@@ -178,7 +178,7 @@ impl Config for Test {
 	type MultiAssetId = NativeOrAssetId<u32>;
 	type MultiAssetIdConverter = NativeOrAssetIdConverter<u32>;
 
-	#[cfg(any(test, feature = "runtime-benchmarks"))]
+	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
 }
 

--- a/frame/asset-conversion/src/types.rs
+++ b/frame/asset-conversion/src/types.rs
@@ -50,13 +50,13 @@ pub trait MultiAssetIdConverter<MultiAssetId, AssetId> {
 }
 
 /// Benchmark Helper
-#[cfg(any(test, feature = "runtime-benchmarks"))]
+#[cfg(feature = "runtime-benchmarks")]
 pub trait BenchmarkHelper<AssetId> {
 	/// Returns an asset id from a given integer.
 	fn asset_id(asset_id: u32) -> AssetId;
 }
 
-#[cfg(any(test, feature = "runtime-benchmarks"))]
+#[cfg(feature = "runtime-benchmarks")]
 impl<AssetId> BenchmarkHelper<AssetId> for ()
 where
 	AssetId: From<u32>,


### PR DESCRIPTION
The `get_pool_account` function no longer relies on a `_truncating` function when creating the account (which could have lead to pool collisions), and there is a test in place
should someone alter the function in the future to something that created pool collisions.

I don't think this check is helpful any longer and it's now inaccurate as there's now no reason for the account type to be at least u128.

Fixes issues brought to attention in #14289.