### PR TITLE
sp-api: Remove requirement on `Get*BlockType`

### DIFF
--- a/primitives/api/proc-macro/src/decl_runtime_apis.rs
+++ b/primitives/api/proc-macro/src/decl_runtime_apis.rs
@@ -88,32 +88,6 @@ fn remove_supported_attributes(attrs: &mut Vec<Attribute>) -> HashMap<&'static s
 	result
 }
 
-/// Visits the ast and checks if `Block` ident is used somewhere.
-struct IsUsingBlock {
-	result: bool,
-}
-
-impl<'ast> Visit<'ast> for IsUsingBlock {
-	fn visit_ident(&mut self, i: &'ast Ident) {
-		if i == BLOCK_GENERIC_IDENT {
-			self.result = true;
-		}
-	}
-}
-
-/// Replace all occurrences of `Block` with `NodeBlock`
-struct ReplaceBlockWithNodeBlock {}
-
-impl Fold for ReplaceBlockWithNodeBlock {
-	fn fold_ident(&mut self, input: Ident) -> Ident {
-		if input == BLOCK_GENERIC_IDENT {
-			Ident::new("NodeBlock", Span::call_site())
-		} else {
-			input
-		}
-	}
-}
-
 /// Versioned API traits are used to catch missing methods when implementing a specific version of a
 /// versioned API. They contain all non-versioned methods (aka stable methods) from the main trait
 /// and all versioned methods for the specific version. This means that there is one trait for each

--- a/primitives/api/src/lib.rs
+++ b/primitives/api/src/lib.rs
@@ -91,10 +91,7 @@ pub use sp_runtime::StateVersion;
 #[doc(hidden)]
 pub use sp_runtime::{
 	generic::BlockId,
-	traits::{
-		Block as BlockT, GetNodeBlockType, GetRuntimeBlockType, Hash as HashT, HashFor,
-		Header as HeaderT, NumberFor,
-	},
+	traits::{Block as BlockT, Hash as HashT, HashFor, Header as HeaderT, NumberFor},
 	transaction_validity::TransactionValidity,
 	RuntimeString, TransactionOutcome,
 };
@@ -263,15 +260,12 @@ pub use sp_api_proc_macro::decl_runtime_apis;
 /// ```rust
 /// use sp_version::create_runtime_str;
 /// #
-/// # use sp_runtime::traits::{GetNodeBlockType, Block as BlockT};
+/// # use sp_runtime::traits::Block as BlockT;
 /// # use sp_test_primitives::Block;
 /// #
-/// # /// The declaration of the `Runtime` type and the implementation of the `GetNodeBlockType`
-/// # /// trait are done by the `construct_runtime!` macro in a real runtime.
+/// # /// The declaration of the `Runtime` type is done by the `construct_runtime!` macro
+/// # /// in a real runtime.
 /// # pub struct Runtime {}
-/// # impl GetNodeBlockType for Runtime {
-/// #     type NodeBlock = Block;
-/// # }
 /// #
 /// # sp_api::decl_runtime_apis! {
 /// #     /// Declare the api trait.

--- a/primitives/api/test/tests/decl_and_impl.rs
+++ b/primitives/api/test/tests/decl_and_impl.rs
@@ -18,16 +18,13 @@
 use sp_api::{
 	decl_runtime_apis, impl_runtime_apis, mock_impl_runtime_apis, ApiError, ApiExt, RuntimeApiInfo,
 };
-use sp_runtime::traits::{Block as BlockT, GetNodeBlockType};
+use sp_runtime::traits::Block as BlockT;
 
 use substrate_test_runtime_client::runtime::{Block, Hash};
 
-/// The declaration of the `Runtime` type and the implementation of the `GetNodeBlockType`
-/// trait are done by the `construct_runtime!` macro in a real runtime.
+/// The declaration of the `Runtime` type is done by the `construct_runtime!` macro in a real
+/// runtime.
 pub struct Runtime {}
-impl GetNodeBlockType for Runtime {
-	type NodeBlock = Block;
-}
 
 decl_runtime_apis! {
 	pub trait Api {

--- a/primitives/api/test/tests/ui/changed_in_no_default_method.rs
+++ b/primitives/api/test/tests/ui/changed_in_no_default_method.rs
@@ -1,12 +1,6 @@
-use sp_runtime::traits::GetNodeBlockType;
-use substrate_test_runtime_client::runtime::Block;
-
-/// The declaration of the `Runtime` type and the implementation of the `GetNodeBlockType`
-/// trait are done by the `construct_runtime!` macro in a real runtime.
+/// The declaration of the `Runtime` type is done by the `construct_runtime!` macro in a real
+/// runtime.
 struct Runtime {}
-impl GetNodeBlockType for Runtime {
-	type NodeBlock = Block;
-}
 
 sp_api::decl_runtime_apis! {
 	#[api_version(2)]

--- a/primitives/api/test/tests/ui/changed_in_no_default_method.stderr
+++ b/primitives/api/test/tests/ui/changed_in_no_default_method.stderr
@@ -1,6 +1,6 @@
 error: There is no 'default' method with this name (without `changed_in` attribute).
        The 'default' method is used to call into the latest implementation.
-  --> tests/ui/changed_in_no_default_method.rs:15:6
-   |
-15 |         fn test(data: u64);
-   |            ^^^^
+ --> tests/ui/changed_in_no_default_method.rs:9:6
+  |
+9 |         fn test(data: u64);
+  |            ^^^^

--- a/primitives/api/test/tests/ui/changed_in_unknown_version.rs
+++ b/primitives/api/test/tests/ui/changed_in_unknown_version.rs
@@ -1,12 +1,6 @@
-use sp_runtime::traits::GetNodeBlockType;
-use substrate_test_runtime_client::runtime::Block;
-
-/// The declaration of the `Runtime` type and the implementation of the `GetNodeBlockType`
-/// trait are done by the `construct_runtime!` macro in a real runtime.
+/// The declaration of the `Runtime` type is done by the `construct_runtime!` macro in a real
+/// runtime.
 struct Runtime {}
-impl GetNodeBlockType for Runtime {
-	type NodeBlock = Block;
-}
 
 sp_api::decl_runtime_apis! {
 	pub trait Api {

--- a/primitives/api/test/tests/ui/changed_in_unknown_version.stderr
+++ b/primitives/api/test/tests/ui/changed_in_unknown_version.stderr
@@ -1,5 +1,5 @@
 error: `changed_in` version can not be greater than the `api_version`
-  --> $DIR/changed_in_unknown_version.rs:14:3
-   |
-14 |         fn test(data: u64);
-   |         ^^
+ --> tests/ui/changed_in_unknown_version.rs:8:3
+  |
+8 |         fn test(data: u64);
+  |         ^^

--- a/primitives/api/test/tests/ui/empty_impl_runtime_apis_call.rs
+++ b/primitives/api/test/tests/ui/empty_impl_runtime_apis_call.rs
@@ -1,12 +1,6 @@
-use sp_runtime::traits::GetNodeBlockType;
-use substrate_test_runtime_client::runtime::Block;
-
-/// The declaration of the `Runtime` type and the implementation of the `GetNodeBlockType`
-/// trait are done by the `construct_runtime!` macro in a real runtime.
+/// The declaration of the `Runtime` type is done by the `construct_runtime!` macro in a real
+/// runtime.
 struct Runtime {}
-impl GetNodeBlockType for Runtime {
-	type NodeBlock = Block;
-}
 
 sp_api::decl_runtime_apis! {
 	pub trait Api {

--- a/primitives/api/test/tests/ui/empty_impl_runtime_apis_call.stderr
+++ b/primitives/api/test/tests/ui/empty_impl_runtime_apis_call.stderr
@@ -1,7 +1,7 @@
 error: No api implementation given!
-  --> $DIR/empty_impl_runtime_apis_call.rs:17:1
+  --> tests/ui/empty_impl_runtime_apis_call.rs:11:1
    |
-17 | sp_api::impl_runtime_apis! {}
+11 | sp_api::impl_runtime_apis! {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `sp_api::impl_runtime_apis` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/primitives/api/test/tests/ui/impl_incorrect_method_signature.rs
+++ b/primitives/api/test/tests/ui/impl_incorrect_method_signature.rs
@@ -1,12 +1,9 @@
-use sp_runtime::traits::{GetNodeBlockType, Block as BlockT};
+use sp_runtime::traits::Block as BlockT;
 use substrate_test_runtime_client::runtime::Block;
 
-/// The declaration of the `Runtime` type and the implementation of the `GetNodeBlockType`
-/// trait are done by the `construct_runtime!` macro in a real runtime.
+/// The declaration of the `Runtime` type is done by the `construct_runtime!` macro in a real
+/// runtime.
 struct Runtime {}
-impl GetNodeBlockType for Runtime {
-	type NodeBlock = Block;
-}
 
 sp_api::decl_runtime_apis! {
 	pub trait Api {

--- a/primitives/api/test/tests/ui/impl_incorrect_method_signature.stderr
+++ b/primitives/api/test/tests/ui/impl_incorrect_method_signature.stderr
@@ -1,35 +1,35 @@
 error[E0053]: method `test` has an incompatible type for trait
-  --> tests/ui/impl_incorrect_method_signature.rs:19:17
+  --> tests/ui/impl_incorrect_method_signature.rs:16:17
    |
-19 |         fn test(data: String) {}
+16 |         fn test(data: String) {}
    |                       ^^^^^^
    |                       |
    |                       expected `u64`, found `std::string::String`
    |                       help: change the parameter type to match the trait: `u64`
    |
 note: type in trait
-  --> tests/ui/impl_incorrect_method_signature.rs:13:17
+  --> tests/ui/impl_incorrect_method_signature.rs:10:17
    |
-13 |         fn test(data: u64);
+10 |         fn test(data: u64);
    |                       ^^^
    = note: expected signature `fn(u64)`
               found signature `fn(std::string::String)`
 
 error[E0308]: mismatched types
-  --> tests/ui/impl_incorrect_method_signature.rs:19:11
+  --> tests/ui/impl_incorrect_method_signature.rs:16:11
    |
-17 | / sp_api::impl_runtime_apis! {
-18 | |     impl self::Api<Block> for Runtime {
-19 | |         fn test(data: String) {}
+14 | / sp_api::impl_runtime_apis! {
+15 | |     impl self::Api<Block> for Runtime {
+16 | |         fn test(data: String) {}
    | |                 ^^^^ expected `u64`, found `String`
-20 | |     }
+17 | |     }
 ...  |
-32 | |     }
-33 | | }
+29 | |     }
+30 | | }
    | |_- arguments to this function are incorrect
    |
 note: associated function defined here
-  --> tests/ui/impl_incorrect_method_signature.rs:13:6
+  --> tests/ui/impl_incorrect_method_signature.rs:10:6
    |
-13 |         fn test(data: u64);
+10 |         fn test(data: u64);
    |            ^^^^

--- a/primitives/api/test/tests/ui/impl_missing_version.rs
+++ b/primitives/api/test/tests/ui/impl_missing_version.rs
@@ -1,10 +1,7 @@
-use sp_runtime::traits::{Block as BlockT, GetNodeBlockType};
+use sp_runtime::traits::Block as BlockT;
 use substrate_test_runtime_client::runtime::Block;
 
 struct Runtime {}
-impl GetNodeBlockType for Runtime {
-	type NodeBlock = Block;
-}
 
 sp_api::decl_runtime_apis! {
 	#[api_version(2)]

--- a/primitives/api/test/tests/ui/impl_missing_version.stderr
+++ b/primitives/api/test/tests/ui/impl_missing_version.stderr
@@ -1,14 +1,14 @@
 error[E0433]: failed to resolve: could not find `ApiV4` in `runtime_decl_for_api`
-  --> tests/ui/impl_missing_version.rs:21:13
+  --> tests/ui/impl_missing_version.rs:18:13
    |
-21 |     impl self::Api<Block> for Runtime {
+18 |     impl self::Api<Block> for Runtime {
    |                ^^^ could not find `ApiV4` in `runtime_decl_for_api`
 
 error[E0405]: cannot find trait `ApiV4` in module `self::runtime_decl_for_api`
-  --> tests/ui/impl_missing_version.rs:21:13
+  --> tests/ui/impl_missing_version.rs:18:13
    |
-11 |     pub trait Api {
+8  |     pub trait Api {
    |     ------------- similarly named trait `ApiV2` defined here
 ...
-21 |     impl self::Api<Block> for Runtime {
+18 |     impl self::Api<Block> for Runtime {
    |                ^^^ help: a trait with a similar name exists: `ApiV2`

--- a/primitives/api/test/tests/ui/impl_two_traits_with_same_name.rs
+++ b/primitives/api/test/tests/ui/impl_two_traits_with_same_name.rs
@@ -1,12 +1,6 @@
-use sp_runtime::traits::GetNodeBlockType;
-use substrate_test_runtime_client::runtime::Block;
-
-/// The declaration of the `Runtime` type and the implementation of the `GetNodeBlockType`
-/// trait are done by the `construct_runtime!` macro in a real runtime.
+/// The declaration of the `Runtime` type  is done by the `construct_runtime!` macro in a real
+/// runtime.
 struct Runtime {}
-impl GetNodeBlockType for Runtime {
-	type NodeBlock = Block;
-}
 
 sp_api::decl_runtime_apis! {
 	pub trait Api {

--- a/primitives/api/test/tests/ui/impl_two_traits_with_same_name.stderr
+++ b/primitives/api/test/tests/ui/impl_two_traits_with_same_name.stderr
@@ -1,5 +1,5 @@
 error: Two traits with the same name detected! The trait name is used to generate its ID. Please rename one trait at the declaration!
-  --> $DIR/impl_two_traits_with_same_name.rs:30:15
+  --> tests/ui/impl_two_traits_with_same_name.rs:24:15
    |
-30 |     impl second::Api<Block> for Runtime {
+24 |     impl second::Api<Block> for Runtime {
    |                  ^^^

--- a/primitives/api/test/tests/ui/missing_block_generic_parameter.rs
+++ b/primitives/api/test/tests/ui/missing_block_generic_parameter.rs
@@ -1,12 +1,6 @@
-use sp_runtime::traits::GetNodeBlockType;
-use substrate_test_runtime_client::runtime::Block;
-
-/// The declaration of the `Runtime` type and the implementation of the `GetNodeBlockType`
-/// trait are done by the `construct_runtime!` macro in a real runtime.
+/// The declaration of the `Runtime` type is done by the `construct_runtime!` macro in a real
+/// runtime.
 struct Runtime {}
-impl GetNodeBlockType for Runtime {
-	type NodeBlock = Block;
-}
 
 sp_api::decl_runtime_apis! {
 	pub trait Api {

--- a/primitives/api/test/tests/ui/missing_block_generic_parameter.stderr
+++ b/primitives/api/test/tests/ui/missing_block_generic_parameter.stderr
@@ -1,5 +1,5 @@
 error: Missing `Block` generic parameter.
-  --> $DIR/missing_block_generic_parameter.rs:18:13
+  --> tests/ui/missing_block_generic_parameter.rs:12:13
    |
-18 |     impl self::Api for Runtime {
+12 |     impl self::Api for Runtime {
    |                ^^^

--- a/primitives/api/test/tests/ui/missing_path_for_trait.rs
+++ b/primitives/api/test/tests/ui/missing_path_for_trait.rs
@@ -1,12 +1,6 @@
-use sp_runtime::traits::GetNodeBlockType;
-use substrate_test_runtime_client::runtime::Block;
-
-/// The declaration of the `Runtime` type and the implementation of the `GetNodeBlockType`
-/// trait are done by the `construct_runtime!` macro in a real runtime.
+/// The declaration of the `Runtime` type is done by the `construct_runtime!` macro in a real
+/// runtime.
 struct Runtime {}
-impl GetNodeBlockType for Runtime {
-	type NodeBlock = Block;
-}
 
 sp_api::decl_runtime_apis! {
 	pub trait Api {

--- a/primitives/api/test/tests/ui/missing_path_for_trait.stderr
+++ b/primitives/api/test/tests/ui/missing_path_for_trait.stderr
@@ -1,5 +1,5 @@
 error: The implemented trait has to be referenced with a path, e.g. `impl client::Core for Runtime`.
-  --> $DIR/missing_path_for_trait.rs:18:7
+  --> tests/ui/missing_path_for_trait.rs:12:7
    |
-18 |     impl Api<Block> for Runtime {
+12 |     impl Api<Block> for Runtime {
    |          ^^^

--- a/primitives/api/test/tests/ui/missing_versioned_method.rs
+++ b/primitives/api/test/tests/ui/missing_versioned_method.rs
@@ -1,10 +1,7 @@
-use sp_runtime::traits::{Block as BlockT, GetNodeBlockType};
+use sp_runtime::traits::Block as BlockT;
 use substrate_test_runtime_client::runtime::Block;
 
 struct Runtime {}
-impl GetNodeBlockType for Runtime {
-	type NodeBlock = Block;
-}
 
 sp_api::decl_runtime_apis! {
 	#[api_version(2)]

--- a/primitives/api/test/tests/ui/missing_versioned_method.stderr
+++ b/primitives/api/test/tests/ui/missing_versioned_method.stderr
@@ -1,8 +1,8 @@
 error[E0046]: not all trait items implemented, missing: `test3`
-  --> tests/ui/missing_versioned_method.rs:21:2
+  --> tests/ui/missing_versioned_method.rs:18:2
    |
-15 |         fn test3();
+12 |         fn test3();
    |         ----------- `test3` from trait
 ...
-21 |     impl self::Api<Block> for Runtime {
+18 |     impl self::Api<Block> for Runtime {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `test3` in implementation

--- a/primitives/api/test/tests/ui/missing_versioned_method_multiple_vers.rs
+++ b/primitives/api/test/tests/ui/missing_versioned_method_multiple_vers.rs
@@ -1,10 +1,7 @@
-use sp_runtime::traits::{Block as BlockT, GetNodeBlockType};
+use sp_runtime::traits::Block as BlockT;
 use substrate_test_runtime_client::runtime::Block;
 
 struct Runtime {}
-impl GetNodeBlockType for Runtime {
-	type NodeBlock = Block;
-}
 
 sp_api::decl_runtime_apis! {
 	#[api_version(2)]

--- a/primitives/api/test/tests/ui/missing_versioned_method_multiple_vers.stderr
+++ b/primitives/api/test/tests/ui/missing_versioned_method_multiple_vers.stderr
@@ -1,8 +1,8 @@
 error[E0046]: not all trait items implemented, missing: `test3`
-  --> tests/ui/missing_versioned_method_multiple_vers.rs:23:2
+  --> tests/ui/missing_versioned_method_multiple_vers.rs:20:2
    |
-15 |         fn test3();
+12 |         fn test3();
    |         ----------- `test3` from trait
 ...
-23 |     impl self::Api<Block> for Runtime {
+20 |     impl self::Api<Block> for Runtime {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `test3` in implementation

--- a/primitives/api/test/tests/ui/positive_cases/custom_where_bound.rs
+++ b/primitives/api/test/tests/ui/positive_cases/custom_where_bound.rs
@@ -1,12 +1,9 @@
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
-use sp_runtime::traits::{Block as BlockT, GetNodeBlockType};
+use sp_runtime::traits::Block as BlockT;
 use substrate_test_runtime_client::runtime::Block;
 
 struct Runtime {}
-impl GetNodeBlockType for Runtime {
-	type NodeBlock = Block;
-}
 
 pub trait CustomTrait: Encode + Decode + TypeInfo {}
 

--- a/primitives/api/test/tests/ui/positive_cases/default_impls.rs
+++ b/primitives/api/test/tests/ui/positive_cases/default_impls.rs
@@ -1,10 +1,7 @@
-use sp_runtime::traits::{Block as BlockT, GetNodeBlockType};
+use sp_runtime::traits::Block as BlockT;
 use substrate_test_runtime_client::runtime::Block;
 
 struct Runtime {}
-impl GetNodeBlockType for Runtime {
-	type NodeBlock = Block;
-}
 
 sp_api::decl_runtime_apis! {
 	#[api_version(2)]

--- a/primitives/api/test/tests/ui/type_reference_in_impl_runtime_apis_call.rs
+++ b/primitives/api/test/tests/ui/type_reference_in_impl_runtime_apis_call.rs
@@ -1,12 +1,9 @@
-use sp_runtime::traits::{GetNodeBlockType, Block as BlockT};
+use sp_runtime::traits::Block as BlockT;
 use substrate_test_runtime_client::runtime::Block;
 
-/// The declaration of the `Runtime` type and the implementation of the `GetNodeBlockType`
-/// trait are done by the `construct_runtime!` macro in a real runtime.
+/// The declaration of the `Runtime` type is done by the `construct_runtime!` macro in a real
+/// runtime.
 struct Runtime {}
-impl GetNodeBlockType for Runtime {
-	type NodeBlock = Block;
-}
 
 sp_api::decl_runtime_apis! {
 	pub trait Api {

--- a/primitives/api/test/tests/ui/type_reference_in_impl_runtime_apis_call.stderr
+++ b/primitives/api/test/tests/ui/type_reference_in_impl_runtime_apis_call.stderr
@@ -1,39 +1,39 @@
 error[E0053]: method `test` has an incompatible type for trait
-  --> tests/ui/type_reference_in_impl_runtime_apis_call.rs:19:17
+  --> tests/ui/type_reference_in_impl_runtime_apis_call.rs:16:17
    |
-19 |         fn test(data: &u64) {
+16 |         fn test(data: &u64) {
    |                       ^^^^
    |                       |
    |                       expected `u64`, found `&u64`
    |                       help: change the parameter type to match the trait: `u64`
    |
 note: type in trait
-  --> tests/ui/type_reference_in_impl_runtime_apis_call.rs:13:17
+  --> tests/ui/type_reference_in_impl_runtime_apis_call.rs:10:17
    |
-13 |         fn test(data: u64);
+10 |         fn test(data: u64);
    |                       ^^^
    = note: expected signature `fn(u64)`
               found signature `fn(&u64)`
 
 error[E0308]: mismatched types
-  --> tests/ui/type_reference_in_impl_runtime_apis_call.rs:19:11
+  --> tests/ui/type_reference_in_impl_runtime_apis_call.rs:16:11
    |
-17 | / sp_api::impl_runtime_apis! {
-18 | |     impl self::Api<Block> for Runtime {
-19 | |         fn test(data: &u64) {
+14 | / sp_api::impl_runtime_apis! {
+15 | |     impl self::Api<Block> for Runtime {
+16 | |         fn test(data: &u64) {
    | |                 ^^^^^^^ expected `u64`, found `&u64`
-20 | |             unimplemented!()
+17 | |             unimplemented!()
 ...  |
-34 | |     }
-35 | | }
+31 | |     }
+32 | | }
    | |_- arguments to this function are incorrect
    |
 note: associated function defined here
-  --> tests/ui/type_reference_in_impl_runtime_apis_call.rs:13:6
+  --> tests/ui/type_reference_in_impl_runtime_apis_call.rs:10:6
    |
-13 |         fn test(data: u64);
+10 |         fn test(data: u64);
    |            ^^^^
 help: consider removing the borrow
    |
-19 |         fn test(data: &u64) {
+16 |         fn test(data: &u64) {
    |


### PR DESCRIPTION
Remove the requirement on `GetNodeBlockType` and `GetRuntimeBlockType`. Actually this wasn't already used anymore and only referenced in tests.

cumulus companion: https://github.com/paritytech/cumulus/pull/2687
