### PR TITLE
Fix keystore no std compilation

### DIFF
--- a/primitives/keystore/src/lib.rs
+++ b/primitives/keystore/src/lib.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 //! Keystore traits
-
+#[cfg(feature = "std")]
 pub mod testing;
 
 #[cfg(feature = "bls-experimental")]


### PR DESCRIPTION
This PR attaches the std to testing mod, makes the sp-keystore compilable in no-std.