### PR TITLE
Move `type Migrations` to `Config`

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1983,7 +1983,7 @@ pub type Executive = frame_executive::Executive<
 type Migrations = (
 	pallet_nomination_pools::migration::v2::MigrateToV2<Runtime>,
 	pallet_alliance::migration::Migration<Runtime>,
-	pallet_contracts::Migration<Runtime, <Runtime as pallet_contracts::Config>::Migrations>,
+	pallet_contracts::Migration<Runtime>,
 );
 
 type EventRecord = frame_system::EventRecord<

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -55,6 +55,7 @@ use frame_system::{
 pub use node_primitives::{AccountId, Signature};
 use node_primitives::{AccountIndex, Balance, BlockNumber, Hash, Index, Moment};
 use pallet_asset_conversion::{NativeOrAssetId, NativeOrAssetIdConverter};
+#[cfg(feature = "runtime-benchmarks")]
 use pallet_contracts::NoopMigration;
 use pallet_election_provider_multi_phase::SolutionAccuracyOf;
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
@@ -1241,9 +1242,9 @@ impl pallet_contracts::Config for Runtime {
 	type MaxStorageKeyLen = ConstU32<128>;
 	type UnsafeUnstableInterface = ConstBool<false>;
 	type MaxDebugBufferLen = ConstU32<{ 2 * 1024 * 1024 }>;
-    #[cfg(not(feature = "runtime-benchmarks"))]
+	#[cfg(not(feature = "runtime-benchmarks"))]
 	type Migrations = ();
-    #[cfg(feature = "runtime-benchmarks")]
+	#[cfg(feature = "runtime-benchmarks")]
 	type Migrations = (NoopMigration<1>, NoopMigration<2>);
 }
 

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -55,6 +55,7 @@ use frame_system::{
 pub use node_primitives::{AccountId, Signature};
 use node_primitives::{AccountIndex, Balance, BlockNumber, Hash, Index, Moment};
 use pallet_asset_conversion::{NativeOrAssetId, NativeOrAssetIdConverter};
+use pallet_contracts::migration::{v10, v11, v9};
 use pallet_election_provider_multi_phase::SolutionAccuracyOf;
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_nfts::PalletFeatures;
@@ -1240,6 +1241,7 @@ impl pallet_contracts::Config for Runtime {
 	type MaxStorageKeyLen = ConstU32<128>;
 	type UnsafeUnstableInterface = ConstBool<false>;
 	type MaxDebugBufferLen = ConstU32<{ 2 * 1024 * 1024 }>;
+	type Migrations = (v9::Migration<Runtime>, v10::Migration<Runtime>, v11::Migration<Runtime>);
 }
 
 impl pallet_sudo::Config for Runtime {
@@ -1981,7 +1983,7 @@ pub type Executive = frame_executive::Executive<
 type Migrations = (
 	pallet_nomination_pools::migration::v2::MigrateToV2<Runtime>,
 	pallet_alliance::migration::Migration<Runtime>,
-	pallet_contracts::Migration<Runtime>,
+	pallet_contracts::Migration<Runtime, <Runtime as pallet_contracts::Config>::Migrations>,
 );
 
 type EventRecord = frame_system::EventRecord<

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -55,7 +55,7 @@ use frame_system::{
 pub use node_primitives::{AccountId, Signature};
 use node_primitives::{AccountIndex, Balance, BlockNumber, Hash, Index, Moment};
 use pallet_asset_conversion::{NativeOrAssetId, NativeOrAssetIdConverter};
-use pallet_contracts::migration::{v10, v11, v9};
+use pallet_contracts::NoopMigration;
 use pallet_election_provider_multi_phase::SolutionAccuracyOf;
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_nfts::PalletFeatures;
@@ -1241,7 +1241,7 @@ impl pallet_contracts::Config for Runtime {
 	type MaxStorageKeyLen = ConstU32<128>;
 	type UnsafeUnstableInterface = ConstBool<false>;
 	type MaxDebugBufferLen = ConstU32<{ 2 * 1024 * 1024 }>;
-	type Migrations = (v9::Migration<Runtime>, v10::Migration<Runtime>, v11::Migration<Runtime>);
+	type Migrations = (NoopMigration<1>, NoopMigration<2>);
 }
 
 impl pallet_sudo::Config for Runtime {

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1241,6 +1241,9 @@ impl pallet_contracts::Config for Runtime {
 	type MaxStorageKeyLen = ConstU32<128>;
 	type UnsafeUnstableInterface = ConstBool<false>;
 	type MaxDebugBufferLen = ConstU32<{ 2 * 1024 * 1024 }>;
+    #[cfg(not(feature = "runtime-benchmarks"))]
+	type Migrations = ();
+    #[cfg(feature = "runtime-benchmarks")]
 	type Migrations = (NoopMigration<1>, NoopMigration<2>);
 }
 

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -272,7 +272,7 @@ benchmarks! {
 	migration_noop {
 		assert_eq!(StorageVersion::get::<Pallet<T>>(), 2);
 	}:  {
-		Migration::<T, T::Migrations>::migrate(Weight::MAX)
+		Migration::<T>::migrate(Weight::MAX)
 	} verify {
 		assert_eq!(StorageVersion::get::<Pallet<T>>(), 2);
 	}
@@ -281,7 +281,7 @@ benchmarks! {
 	#[pov_mode = Measured]
 	migrate {
 		StorageVersion::new(0).put::<Pallet<T>>();
-		<Migration::<T, T::Migrations> as frame_support::traits::OnRuntimeUpgrade>::on_runtime_upgrade();
+		<Migration::<T> as frame_support::traits::OnRuntimeUpgrade>::on_runtime_upgrade();
 		let origin: RawOrigin<<T as frame_system::Config>::AccountId> = RawOrigin::Signed(whitelisted_caller());
 	}: {
 		<Contracts<T>>::migrate(origin.into(), Weight::MAX).unwrap()
@@ -294,7 +294,7 @@ benchmarks! {
 	on_runtime_upgrade_noop {
 		assert_eq!(StorageVersion::get::<Pallet<T>>(), 2);
 	}:  {
-		<Migration::<T, T::Migrations> as frame_support::traits::OnRuntimeUpgrade>::on_runtime_upgrade()
+		<Migration::<T> as frame_support::traits::OnRuntimeUpgrade>::on_runtime_upgrade()
 	} verify {
 		assert!(MigrationInProgress::<T>::get().is_none());
 	}
@@ -306,7 +306,7 @@ benchmarks! {
 		let v = vec![42u8].try_into().ok();
 		MigrationInProgress::<T>::set(v.clone());
 	}:  {
-		<Migration::<T, T::Migrations> as frame_support::traits::OnRuntimeUpgrade>::on_runtime_upgrade()
+		<Migration::<T> as frame_support::traits::OnRuntimeUpgrade>::on_runtime_upgrade()
 	} verify {
 		assert!(MigrationInProgress::<T>::get().is_some());
 		assert_eq!(MigrationInProgress::<T>::get(), v);
@@ -317,7 +317,7 @@ benchmarks! {
 	on_runtime_upgrade {
 		StorageVersion::new(0).put::<Pallet<T>>();
 	}:  {
-		<Migration::<T, T::Migrations> as frame_support::traits::OnRuntimeUpgrade>::on_runtime_upgrade()
+		<Migration::<T> as frame_support::traits::OnRuntimeUpgrade>::on_runtime_upgrade()
 	} verify {
 		assert!(MigrationInProgress::<T>::get().is_some());
 	}

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -272,7 +272,7 @@ benchmarks! {
 	migration_noop {
 		assert_eq!(StorageVersion::get::<Pallet<T>>(), 2);
 	}:  {
-		Migration::<T>::migrate(Weight::MAX)
+		Migration::<T, T::Migrations>::migrate(Weight::MAX)
 	} verify {
 		assert_eq!(StorageVersion::get::<Pallet<T>>(), 2);
 	}
@@ -281,7 +281,7 @@ benchmarks! {
 	#[pov_mode = Measured]
 	migrate {
 		StorageVersion::new(0).put::<Pallet<T>>();
-		<Migration::<T> as frame_support::traits::OnRuntimeUpgrade>::on_runtime_upgrade();
+		<Migration::<T, T::Migrations> as frame_support::traits::OnRuntimeUpgrade>::on_runtime_upgrade();
 		let origin: RawOrigin<<T as frame_system::Config>::AccountId> = RawOrigin::Signed(whitelisted_caller());
 	}: {
 		<Contracts<T>>::migrate(origin.into(), Weight::MAX).unwrap()
@@ -294,7 +294,7 @@ benchmarks! {
 	on_runtime_upgrade_noop {
 		assert_eq!(StorageVersion::get::<Pallet<T>>(), 2);
 	}:  {
-		<Migration::<T> as frame_support::traits::OnRuntimeUpgrade>::on_runtime_upgrade()
+		<Migration::<T, T::Migrations> as frame_support::traits::OnRuntimeUpgrade>::on_runtime_upgrade()
 	} verify {
 		assert!(MigrationInProgress::<T>::get().is_none());
 	}
@@ -306,7 +306,7 @@ benchmarks! {
 		let v = vec![42u8].try_into().ok();
 		MigrationInProgress::<T>::set(v.clone());
 	}:  {
-		<Migration::<T> as frame_support::traits::OnRuntimeUpgrade>::on_runtime_upgrade()
+		<Migration::<T, T::Migrations> as frame_support::traits::OnRuntimeUpgrade>::on_runtime_upgrade()
 	} verify {
 		assert!(MigrationInProgress::<T>::get().is_some());
 		assert_eq!(MigrationInProgress::<T>::get(), v);
@@ -317,7 +317,7 @@ benchmarks! {
 	on_runtime_upgrade {
 		StorageVersion::new(0).put::<Pallet<T>>();
 	}:  {
-		<Migration::<T> as frame_support::traits::OnRuntimeUpgrade>::on_runtime_upgrade()
+		<Migration::<T, T::Migrations> as frame_support::traits::OnRuntimeUpgrade>::on_runtime_upgrade()
 	} verify {
 		assert!(MigrationInProgress::<T>::get().is_some());
 	}

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -327,6 +327,8 @@ pub mod pallet {
 		/// impl pallet_contracts::Config for Runtime {
 		/// 	// ...
 		/// 	type Migrations = (v9::Migration<Runtime>, v10::Migration<Runtime>, v11::Migration<Runtime>);
+		/// 	// ...
+		/// }
 		/// ```
 		type Migrations: MigrateSequence;
 	}

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -323,12 +323,10 @@ pub mod pallet {
 		/// The sequence of migration steps that will be applied during a migration.
 		///
 		/// # Examples
-		/// ```ignore
-		/// impl pallet_contracts::Config for Runtime {
-		/// 	// ...
-		/// 	type Migrations = (v9::Migration<Runtime>, v10::Migration<Runtime>, v11::Migration<Runtime>);
-		/// 	// ...
-		/// }
+		/// ```
+		/// use pallet_contracts::migration::{v9, v10, v11};
+		/// # struct Runtime {};
+		/// type Migrations = (v9::Migration<Runtime>, v10::Migration<Runtime>, v11::Migration<Runtime>);
 		/// ```
 		type Migrations: MigrateSequence;
 	}

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -87,12 +87,12 @@ mod address;
 mod benchmarking;
 mod exec;
 mod gas;
-mod migration;
 mod schedule;
 mod storage;
 mod wasm;
 
 pub mod chain_extension;
+pub mod migration;
 pub mod weights;
 
 #[cfg(test)]
@@ -319,6 +319,9 @@ pub mod pallet {
 		/// The maximum length of the debug buffer in bytes.
 		#[pallet::constant]
 		type MaxDebugBufferLen: Get<u32>;
+
+		/// The sequence of migrations applied.
+		type Migrations: MigrateSequence;
 	}
 
 	#[pallet::hooks]
@@ -326,7 +329,7 @@ pub mod pallet {
 		fn on_idle(_block: T::BlockNumber, remaining_weight: Weight) -> Weight {
 			use migration::MigrateResult::*;
 
-			let (result, weight) = Migration::<T>::migrate(remaining_weight);
+			let (result, weight) = Migration::<T, T::Migrations>::migrate(remaining_weight);
 			let remaining_weight = remaining_weight.saturating_sub(weight);
 
 			if !matches!(result, Completed | NoMigrationInProgress) {
@@ -338,7 +341,7 @@ pub mod pallet {
 		}
 
 		fn integrity_test() {
-			Migration::<T>::integrity_test();
+			Migration::<T, T::Migrations>::integrity_test();
 
 			// Total runtime memory limit
 			let max_runtime_mem: u32 = T::Schedule::get().limits.runtime_memory;
@@ -518,7 +521,7 @@ pub mod pallet {
 			storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>,
 			determinism: Determinism,
 		) -> DispatchResult {
-			Migration::<T>::ensure_migrated()?;
+			Migration::<T, T::Migrations>::ensure_migrated()?;
 			let origin = ensure_signed(origin)?;
 			Self::bare_upload_code(origin, code, storage_deposit_limit.map(Into::into), determinism)
 				.map(|_| ())
@@ -534,7 +537,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			code_hash: CodeHash<T>,
 		) -> DispatchResultWithPostInfo {
-			Migration::<T>::ensure_migrated()?;
+			Migration::<T, T::Migrations>::ensure_migrated()?;
 			let origin = ensure_signed(origin)?;
 			<PrefabWasmModule<T>>::remove(&origin, code_hash)?;
 			// we waive the fee because removing unused code is beneficial
@@ -558,7 +561,7 @@ pub mod pallet {
 			dest: AccountIdLookupOf<T>,
 			code_hash: CodeHash<T>,
 		) -> DispatchResult {
-			Migration::<T>::ensure_migrated()?;
+			Migration::<T, T::Migrations>::ensure_migrated()?;
 			ensure_root(origin)?;
 			let dest = T::Lookup::lookup(dest)?;
 			<ContractInfoOf<T>>::try_mutate(&dest, |contract| {
@@ -608,7 +611,7 @@ pub mod pallet {
 			storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>,
 			data: Vec<u8>,
 		) -> DispatchResultWithPostInfo {
-			Migration::<T>::ensure_migrated()?;
+			Migration::<T, T::Migrations>::ensure_migrated()?;
 			let common = CommonInput {
 				origin: Origin::from_runtime_origin(origin)?,
 				value,
@@ -668,7 +671,7 @@ pub mod pallet {
 			data: Vec<u8>,
 			salt: Vec<u8>,
 		) -> DispatchResultWithPostInfo {
-			Migration::<T>::ensure_migrated()?;
+			Migration::<T, T::Migrations>::ensure_migrated()?;
 			let code_len = code.len() as u32;
 			let data_len = data.len() as u32;
 			let salt_len = salt.len() as u32;
@@ -711,7 +714,7 @@ pub mod pallet {
 			data: Vec<u8>,
 			salt: Vec<u8>,
 		) -> DispatchResultWithPostInfo {
-			Migration::<T>::ensure_migrated()?;
+			Migration::<T, T::Migrations>::ensure_migrated()?;
 			let data_len = data.len() as u32;
 			let salt_len = salt.len() as u32;
 			let common = CommonInput {
@@ -746,7 +749,7 @@ pub mod pallet {
 			ensure_signed(origin)?;
 
 			let weight_limit = weight_limit.saturating_add(T::WeightInfo::migrate());
-			let (result, weight) = Migration::<T>::migrate(weight_limit);
+			let (result, weight) = Migration::<T, T::Migrations>::migrate(weight_limit);
 
 			match result {
 				Completed =>
@@ -1272,7 +1275,7 @@ impl<T: Config> Invokable<T> for InstantiateInput<T> {
 
 macro_rules! ensure_no_migration_in_progress {
 	() => {
-		if Migration::<T>::in_progress() {
+		if Migration::<T, T::Migrations>::in_progress() {
 			return ContractResult {
 				gas_consumed: Zero::zero(),
 				gas_required: Zero::zero(),
@@ -1412,7 +1415,7 @@ impl<T: Config> Pallet<T> {
 		storage_deposit_limit: Option<BalanceOf<T>>,
 		determinism: Determinism,
 	) -> CodeUploadResult<CodeHash<T>, BalanceOf<T>> {
-		Migration::<T>::ensure_migrated()?;
+		Migration::<T, T::Migrations>::ensure_migrated()?;
 		let schedule = T::Schedule::get();
 		let module = PrefabWasmModule::from_code(
 			code,
@@ -1433,7 +1436,7 @@ impl<T: Config> Pallet<T> {
 
 	/// Query storage of a specified contract under a specified key.
 	pub fn get_storage(address: T::AccountId, key: Vec<u8>) -> GetStorageResult {
-		if Migration::<T>::in_progress() {
+		if Migration::<T, T::Migrations>::in_progress() {
 			return Err(ContractAccessError::MigrationInProgress)
 		}
 		let contract_info =

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -321,6 +321,13 @@ pub mod pallet {
 		type MaxDebugBufferLen: Get<u32>;
 
 		/// The sequence of migration steps that will be applied during a migration.
+		///
+		/// # Examples
+		/// ```ignore
+		/// impl pallet_contracts::Config for Runtime {
+		/// 	// ...
+		/// 	type Migrations = (v9::Migration<Runtime>, v10::Migration<Runtime>, v11::Migration<Runtime>);
+		/// ```
 		type Migrations: MigrateSequence;
 	}
 

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -320,7 +320,7 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxDebugBufferLen: Get<u32>;
 
-		/// The sequence of migrations applied.
+		/// The sequence of migration steps that will be applied during a migration.
 		type Migrations: MigrateSequence;
 	}
 

--- a/frame/contracts/src/migration.rs
+++ b/frame/contracts/src/migration.rs
@@ -186,7 +186,7 @@ pub trait MigrateSequence: private::Sealed {
 			return false
 		};
 
-		in_storage == first_supported && target == high
+		in_storage >= first_supported && target == high
 	}
 }
 
@@ -513,7 +513,7 @@ mod test {
 	fn is_upgrade_supported_works() {
 		type Migrations = (MockMigration<9>, MockMigration<10>, MockMigration<11>);
 
-		[(1, 1), (8, 11)].into_iter().for_each(|(from, to)| {
+		[(1, 1), (8, 11), (9, 11)].into_iter().for_each(|(from, to)| {
 			assert!(
 				Migrations::is_upgrade_supported(
 					StorageVersion::new(from),
@@ -525,7 +525,7 @@ mod test {
 			)
 		});
 
-		[(1, 0), (0, 3), (7, 11), (8, 10), (9, 11)].into_iter().for_each(|(from, to)| {
+		[(1, 0), (0, 3), (7, 11), (8, 10)].into_iter().for_each(|(from, to)| {
 			assert!(
 				!Migrations::is_upgrade_supported(
 					StorageVersion::new(from),

--- a/frame/contracts/src/migration.rs
+++ b/frame/contracts/src/migration.rs
@@ -197,14 +197,7 @@ pub trait MigrateSequence: private::Sealed {
 }
 
 /// Performs all necessary migrations based on `StorageVersion`.
-// #[cfg(not(any(feature = "runtime-benchmarks", test)))]
 pub struct Migration<T: Config, M: MigrateSequence>(PhantomData<(T, M)>);
-
-// /// Custom migration for running runtime-benchmarks and tests.
-// #[cfg(any(feature = "runtime-benchmarks", test))]
-// pub struct Migration<T: Config, M: MigrateSequence = (NoopMigration<1>, NoopMigration<2>)>(
-// 	PhantomData<(T, M)>,
-// );
 
 #[cfg(feature = "try-runtime")]
 impl<T: Config, M: MigrateSequence> Migration<T, M> {

--- a/frame/contracts/src/migration.rs
+++ b/frame/contracts/src/migration.rs
@@ -17,16 +17,10 @@
 
 //! Migration framework for pallets.
 
-/// Macro to include all migration modules.
-macro_rules! use_modules {
-    ($($module:ident),*) => {
-        $(
-            pub mod $module;
-        )*
-    };
-}
+pub mod v10;
+pub mod v11;
+pub mod v9;
 
-use_modules!(v9, v10, v11);
 use crate::{weights::WeightInfo, Config, Error, MigrationInProgress, Pallet, Weight, LOG_TARGET};
 use codec::{Codec, Decode};
 use frame_support::{
@@ -197,16 +191,16 @@ pub trait MigrateSequence: private::Sealed {
 }
 
 /// Performs all necessary migrations based on `StorageVersion`.
-pub struct Migration<T: Config, M: MigrateSequence>(PhantomData<(T, M)>);
+pub struct Migration<T: Config>(PhantomData<T>);
 
 #[cfg(feature = "try-runtime")]
-impl<T: Config, M: MigrateSequence> Migration<T, M> {
+impl<T: Config> Migration<T> {
 	fn run_all_steps() -> Result<(), TryRuntimeError> {
 		let mut weight = Weight::zero();
 		let name = <Pallet<T>>::name();
 		loop {
 			let in_progress_version = <Pallet<T>>::on_chain_storage_version() + 1;
-			let state = M::pre_upgrade_step(in_progress_version)?;
+			let state = T::Migrations::pre_upgrade_step(in_progress_version)?;
 			let (status, w) = Self::migrate(Weight::MAX);
 			weight.saturating_accrue(w);
 			log::info!(
@@ -215,7 +209,7 @@ impl<T: Config, M: MigrateSequence> Migration<T, M> {
 				in_progress_version,
 				weight
 			);
-			M::post_upgrade_step(in_progress_version, state)?;
+			T::Migrations::post_upgrade_step(in_progress_version, state)?;
 			if matches!(status, MigrateResult::Completed) {
 				break
 			}
@@ -227,7 +221,7 @@ impl<T: Config, M: MigrateSequence> Migration<T, M> {
 	}
 }
 
-impl<T: Config, M: MigrateSequence> OnRuntimeUpgrade for Migration<T, M> {
+impl<T: Config> OnRuntimeUpgrade for Migration<T> {
 	fn on_runtime_upgrade() -> Weight {
 		let name = <Pallet<T>>::name();
 		let latest_version = <Pallet<T>>::current_storage_version();
@@ -258,7 +252,7 @@ impl<T: Config, M: MigrateSequence> OnRuntimeUpgrade for Migration<T, M> {
 			"{name}: Upgrading storage from {storage_version:?} to {latest_version:?}.",
 		);
 
-		let cursor = M::new(storage_version + 1);
+		let cursor = T::Migrations::new(storage_version + 1);
 		MigrationInProgress::<T>::set(Some(cursor));
 
 		#[cfg(feature = "try-runtime")]
@@ -279,11 +273,14 @@ impl<T: Config, M: MigrateSequence> OnRuntimeUpgrade for Migration<T, M> {
 			target: LOG_TARGET,
 			"{}: Range supported {:?}, range requested {:?}",
 			<Pallet<T>>::name(),
-			M::VERSION_RANGE,
+			T::Migrations::VERSION_RANGE,
 			(storage_version, target_version)
 		);
 
-		ensure!(M::is_upgrade_supported(storage_version, target_version), "Unsupported upgrade");
+		ensure!(
+			T::Migrations::is_upgrade_supported(storage_version, target_version),
+			"Unsupported upgrade"
+		);
 		Ok(Default::default())
 	}
 }
@@ -308,11 +305,11 @@ pub enum StepResult {
 	Completed { steps_done: u32 },
 }
 
-impl<T: Config, M: MigrateSequence> Migration<T, M> {
-	/// Verify that each migration's step of the MigrateSequence fits into `Cursor`.
+impl<T: Config> Migration<T> {
+	/// Verify that each migration's step of the [`T::Migrations`] sequence fits into `Cursor`.
 	pub(crate) fn integrity_test() {
 		let max_weight = <T as frame_system::Config>::BlockWeights::get().max_block;
-		M::integrity_test(max_weight)
+		T::Migrations::integrity_test(max_weight)
 	}
 
 	/// Migrate
@@ -341,33 +338,36 @@ impl<T: Config, M: MigrateSequence> Migration<T, M> {
 				in_progress_version,
 			);
 
-			let result =
-				match M::steps(in_progress_version, cursor_before.as_ref(), &mut weight_left) {
-					StepResult::InProgress { cursor, steps_done } => {
-						*progress = Some(cursor);
+			let result = match T::Migrations::steps(
+				in_progress_version,
+				cursor_before.as_ref(),
+				&mut weight_left,
+			) {
+				StepResult::InProgress { cursor, steps_done } => {
+					*progress = Some(cursor);
+					MigrateResult::InProgress { steps_done }
+				},
+				StepResult::Completed { steps_done } => {
+					in_progress_version.put::<Pallet<T>>();
+					if <Pallet<T>>::current_storage_version() != in_progress_version {
+						log::info!(
+							target: LOG_TARGET,
+							"{name}: Next migration is {:?},",
+							in_progress_version + 1
+						);
+						*progress = Some(T::Migrations::new(in_progress_version + 1));
 						MigrateResult::InProgress { steps_done }
-					},
-					StepResult::Completed { steps_done } => {
-						in_progress_version.put::<Pallet<T>>();
-						if <Pallet<T>>::current_storage_version() != in_progress_version {
-							log::info!(
-								target: LOG_TARGET,
-								"{name}: Next migration is {:?},",
-								in_progress_version + 1
-							);
-							*progress = Some(M::new(in_progress_version + 1));
-							MigrateResult::InProgress { steps_done }
-						} else {
-							log::info!(
-								target: LOG_TARGET,
-								"{name}: All migrations done. At version {:?},",
-								in_progress_version
-							);
-							*progress = None;
-							MigrateResult::Completed
-						}
-					},
-				};
+					} else {
+						log::info!(
+							target: LOG_TARGET,
+							"{name}: All migrations done. At version {:?},",
+							in_progress_version
+						);
+						*progress = None;
+						MigrateResult::Completed
+					}
+				},
+			};
 
 			(result, weight_limit.saturating_sub(weight_left))
 		})
@@ -511,11 +511,14 @@ mod test {
 
 	#[test]
 	fn is_upgrade_supported_works() {
-		type M = (MockMigration<9>, MockMigration<10>, MockMigration<11>);
+		type Migrations = (MockMigration<9>, MockMigration<10>, MockMigration<11>);
 
 		[(1, 1), (8, 11), (9, 11)].into_iter().for_each(|(from, to)| {
 			assert!(
-				M::is_upgrade_supported(StorageVersion::new(from), StorageVersion::new(to)),
+				Migrations::is_upgrade_supported(
+					StorageVersion::new(from),
+					StorageVersion::new(to)
+				),
 				"{} -> {} is supported",
 				from,
 				to
@@ -524,7 +527,10 @@ mod test {
 
 		[(1, 0), (0, 3), (7, 11), (8, 10)].into_iter().for_each(|(from, to)| {
 			assert!(
-				!M::is_upgrade_supported(StorageVersion::new(from), StorageVersion::new(to)),
+				!Migrations::is_upgrade_supported(
+					StorageVersion::new(from),
+					StorageVersion::new(to)
+				),
 				"{} -> {} is not supported",
 				from,
 				to
@@ -534,27 +540,26 @@ mod test {
 
 	#[test]
 	fn steps_works() {
-		type M = (MockMigration<2>, MockMigration<3>);
+		type Migrations = (MockMigration<2>, MockMigration<3>);
 		let version = StorageVersion::new(2);
-		let mut cursor = M::new(version);
+		let mut cursor = Migrations::new(version);
 
 		let mut weight = Weight::from_all(2);
-		let result = M::steps(version, &cursor, &mut weight);
+		let result = Migrations::steps(version, &cursor, &mut weight);
 		cursor = vec![1u8, 0].try_into().unwrap();
 		assert_eq!(result, StepResult::InProgress { cursor: cursor.clone(), steps_done: 1 });
 		assert_eq!(weight, Weight::from_all(1));
 
 		let mut weight = Weight::from_all(2);
 		assert_eq!(
-			M::steps(version, &cursor, &mut weight),
+			Migrations::steps(version, &cursor, &mut weight),
 			StepResult::Completed { steps_done: 1 }
 		);
 	}
 
 	#[test]
 	fn no_migration_in_progress_works() {
-		type M = (MockMigration<1>, MockMigration<2>);
-		type TestMigration = Migration<Test, M>;
+		type TestMigration = Migration<Test>;
 
 		ExtBuilder::default().build().execute_with(|| {
 			assert_eq!(StorageVersion::get::<Pallet<Test>>(), 2);
@@ -564,8 +569,7 @@ mod test {
 
 	#[test]
 	fn migration_works() {
-		type M = (MockMigration<1>, MockMigration<2>);
-		type TestMigration = Migration<Test, M>;
+		type TestMigration = Migration<Test>;
 
 		ExtBuilder::default().set_storage_version(0).build().execute_with(|| {
 			assert_eq!(StorageVersion::get::<Pallet<Test>>(), 0);

--- a/frame/contracts/src/migration.rs
+++ b/frame/contracts/src/migration.rs
@@ -18,15 +18,10 @@
 //! Migration framework for pallets.
 
 /// Macro to include all migration modules.
-/// We only want to make these modules public when `runtime-benchmarks` is
-/// enabled, so we can access migration code in benchmarks.
 macro_rules! use_modules {
     ($($module:ident),*) => {
         $(
-            #[cfg(feature = "runtime-benchmarks")]
             pub mod $module;
-            #[cfg(not(feature = "runtime-benchmarks"))]
-            mod $module;
         )*
     };
 }
@@ -57,10 +52,6 @@ fn invalid_version(version: StorageVersion) -> ! {
 
 /// The cursor used to store the state of the current migration step.
 pub type Cursor = BoundedVec<u8, ConstU32<1024>>;
-
-// In benchmark and tests we use noop migrations, to test and bench the migration framework itself.
-#[cfg(not(any(feature = "runtime-benchmarks", test)))]
-type Migrations<T> = (v9::Migration<T>, v10::Migration<T>, v11::Migration<T>);
 
 /// IsFinished describes whether a migration is finished or not.
 pub enum IsFinished {
@@ -206,14 +197,14 @@ pub trait MigrateSequence: private::Sealed {
 }
 
 /// Performs all necessary migrations based on `StorageVersion`.
-#[cfg(not(any(feature = "runtime-benchmarks", test)))]
-pub struct Migration<T: Config, M: MigrateSequence = Migrations<T>>(PhantomData<(T, M)>);
+// #[cfg(not(any(feature = "runtime-benchmarks", test)))]
+pub struct Migration<T: Config, M: MigrateSequence>(PhantomData<(T, M)>);
 
-/// Custom migration for running runtime-benchmarks and tests.
-#[cfg(any(feature = "runtime-benchmarks", test))]
-pub struct Migration<T: Config, M: MigrateSequence = (NoopMigration<1>, NoopMigration<2>)>(
-	PhantomData<(T, M)>,
-);
+// /// Custom migration for running runtime-benchmarks and tests.
+// #[cfg(any(feature = "runtime-benchmarks", test))]
+// pub struct Migration<T: Config, M: MigrateSequence = (NoopMigration<1>, NoopMigration<2>)>(
+// 	PhantomData<(T, M)>,
+// );
 
 #[cfg(feature = "try-runtime")]
 impl<T: Config, M: MigrateSequence> Migration<T, M> {

--- a/frame/contracts/src/migration.rs
+++ b/frame/contracts/src/migration.rs
@@ -186,7 +186,7 @@ pub trait MigrateSequence: private::Sealed {
 			return false
 		};
 
-		in_storage >= first_supported && target == high
+		in_storage == first_supported && target == high
 	}
 }
 
@@ -513,7 +513,7 @@ mod test {
 	fn is_upgrade_supported_works() {
 		type Migrations = (MockMigration<9>, MockMigration<10>, MockMigration<11>);
 
-		[(1, 1), (8, 11), (9, 11)].into_iter().for_each(|(from, to)| {
+		[(1, 1), (8, 11)].into_iter().for_each(|(from, to)| {
 			assert!(
 				Migrations::is_upgrade_supported(
 					StorageVersion::new(from),
@@ -525,7 +525,7 @@ mod test {
 			)
 		});
 
-		[(1, 0), (0, 3), (7, 11), (8, 10)].into_iter().for_each(|(from, to)| {
+		[(1, 0), (0, 3), (7, 11), (8, 10), (9, 11)].into_iter().for_each(|(from, to)| {
 			assert!(
 				!Migrations::is_upgrade_supported(
 					StorageVersion::new(from),

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -28,8 +28,8 @@ use crate::{
 	wasm::{Determinism, PrefabWasmModule, ReturnCode as RuntimeReturnCode},
 	weights::WeightInfo,
 	BalanceOf, Code, CodeStorage, CollectEvents, Config, ContractInfo, ContractInfoOf, DebugInfo,
-	DefaultAddressGenerator, DeletionQueueCounter, Error, MigrationInProgress, Origin, Pallet,
-	Schedule,
+	DefaultAddressGenerator, DeletionQueueCounter, Error, MigrationInProgress, NoopMigration,
+	Origin, Pallet, Schedule,
 };
 use assert_matches::assert_matches;
 use codec::Encode;
@@ -428,6 +428,7 @@ impl Config for Test {
 	type MaxStorageKeyLen = ConstU32<128>;
 	type UnsafeUnstableInterface = UnstableInterface;
 	type MaxDebugBufferLen = ConstU32<{ 2 * 1024 * 1024 }>;
+	type Migrations = (NoopMigration<1>, NoopMigration<2>);
 }
 
 pub const ALICE: AccountId32 = AccountId32::new([1u8; 32]);


### PR DESCRIPTION
This PR removes the hardcoded migration sequence from `migrations.rs` and places it within `Config` so it can be configured in the runtime.

### How to update the code
Developers need to update their runtime configuration with their pending migrations (or `()` if none). For example:
```rust
use pallet_contracts::migration::{v10, v11, v9};

// ...

impl pallet_contracts::Config for Runtime {

// ...

   type Migrations = (v9::Migration<Runtime>, v10::Migration<Runtime>, v11::Migration<Runtime>);
```

---

_This is a breaking change as it adds a new type to the `Config`, there's another breaking PR https://github.com/paritytech/substrate/pull/14020 that changes it, so it would be a good idea to have them in the same release._

---

cumulus companion: https://github.com/paritytech/cumulus/pull/2701