### PR TITLE
CI: fix gha set-output command

### DIFF
--- a/.github/workflows/monthly-tag.yml
+++ b/.github/workflows/monthly-tag.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Get the tags by date
         id: tags
         run: |
-          echo "::set-output name=new::$(date +'monthly-%Y-%m')"
-          echo "::set-output name=old::$(date -d'1 month ago' +'monthly-%Y-%m')"
+          echo "new=$(date +'monthly-%Y-%m')" >> $GITHUB_OUTPUT
+          echo "old=$(date -d'1 month ago' +'monthly-%Y-%m')" >> $GITHUB_OUTPUT
       - name: Checkout branch "master"
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
GitHub is going to deprecate `save-state` and `set-output` commands. [More info](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

This PR adjusts GHA workflow to use new syntax.

Part of https://github.com/paritytech/ci_cd/issues/805