### PR TITLE
asset-conversion pallet: No need for AssetBalanceOf

### DIFF
--- a/frame/asset-conversion/src/types.rs
+++ b/frame/asset-conversion/src/types.rs
@@ -20,11 +20,8 @@ use core::marker::PhantomData;
 use sp_std::cmp::Ordering;
 
 use codec::{Decode, Encode, MaxEncodedLen};
-use frame_support::traits::fungibles::Inspect;
 use scale_info::TypeInfo;
 
-pub(super) type AssetBalanceOf<T> =
-	<<T as Config>::Assets as Inspect<<T as frame_system::Config>::AccountId>>::Balance;
 pub(super) type PoolIdOf<T> = (<T as Config>::MultiAssetId, <T as Config>::MultiAssetId);
 
 /// Stores the lp_token asset id a particular pool has been assigned.


### PR DESCRIPTION
Instead of `AssetBalanceOf<T>` we can just reference `T::AssetBalance`. Less voodoo.

No other changes contained in this PR.