### PR TITLE
Request labels on issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -16,6 +16,14 @@ body:
       options:
         - label: This is not a support question.
           required: true
+  - type: checkboxes
+    id: labels
+    attributes:
+      label: Have you labeled this issue correctly?
+      description: Please label this issue correctly, specially with one of the **Tx** ones. Check <https://paritytech.github.io/labels/doc_substrate.html> for more info.
+      options:
+        - label: I have labeled this issue correctly.
+          required: true
   - type: textarea
     id: bug
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -18,6 +18,14 @@ body:
       options:
         - label: This is not a support question.
           required: true
+  - type: checkboxes
+    id: labels
+    attributes:
+      label: Have you labeled this issue correctly?
+      description: Please label this issue correctly, specially with one of the **Tx** ones. Check <https://paritytech.github.io/labels/doc_substrate.html> for more info.
+      options:
+        - label: I have labeled this issue correctly.
+          required: true
   - type: textarea
     id: motivation
     attributes:


### PR DESCRIPTION
Issues are poorly labeled, that makes it difficult to categorise them as the amount of them grow.
This is an attempt to alleviate the problem and not a radical solution, as people could just ignore the question, but at least those contributors that are not familiar would know about these labels.
Also, this could work as a test to see if we want to replicate this template with the new labels in the upcoming monorepo.