### PR TITLE
`GenesisBuild` split

### DIFF
--- a/frame/alliance/src/mock.rs
+++ b/frame/alliance/src/mock.rs
@@ -28,7 +28,7 @@ use sp_std::convert::{TryFrom, TryInto};
 
 pub use frame_support::{
 	assert_noop, assert_ok, ord_parameter_types, parameter_types,
-	traits::{EitherOfDiverse, GenesisBuild, SortedMembers},
+	traits::{EitherOfDiverse, GenesisBuildStorage, SortedMembers},
 	BoundedVec,
 };
 use frame_system::{EnsureRoot, EnsureSignedBy};
@@ -274,7 +274,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	.assimilate_storage(&mut t)
 	.unwrap();
 
-	GenesisBuild::<Test>::assimilate_storage(
+	GenesisBuildStorage::<Test>::assimilate_storage(
 		&pallet_alliance::GenesisConfig {
 			fellows: vec![],
 			allies: vec![],

--- a/frame/assets/src/mock.rs
+++ b/frame/assets/src/mock.rs
@@ -23,7 +23,7 @@ use crate as pallet_assets;
 use codec::Encode;
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{AsEnsureOriginWithArg, ConstU32, ConstU64, GenesisBuild},
+	traits::{AsEnsureOriginWithArg, ConstU32, ConstU64, GenesisBuildStorage},
 };
 use sp_core::H256;
 use sp_io::storage;

--- a/frame/aura/src/mock.rs
+++ b/frame/aura/src/mock.rs
@@ -22,7 +22,7 @@
 use crate as pallet_aura;
 use frame_support::{
 	parameter_types,
-	traits::{ConstU32, ConstU64, DisabledValidators, GenesisBuild},
+	traits::{ConstU32, ConstU64, DisabledValidators, GenesisBuildStorage},
 };
 use sp_consensus_aura::{ed25519::AuthorityId, AuthorityIndex};
 use sp_core::H256;

--- a/frame/authority-discovery/src/lib.rs
+++ b/frame/authority-discovery/src/lib.rs
@@ -168,7 +168,7 @@ mod tests {
 	use crate as pallet_authority_discovery;
 	use frame_support::{
 		parameter_types,
-		traits::{ConstU32, ConstU64, GenesisBuild},
+		traits::{ConstU32, ConstU64, GenesisBuildStorage},
 	};
 	use sp_application_crypto::Pair;
 	use sp_authority_discovery::AuthorityPair;
@@ -310,7 +310,7 @@ mod tests {
 		// Build genesis.
 		let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
 
-		GenesisBuild::<Test>::assimilate_storage(
+		GenesisBuildStorage::<Test>::assimilate_storage(
 			&pallet_authority_discovery::GenesisConfig { keys: vec![] },
 			&mut t,
 		)

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -22,7 +22,9 @@ use codec::Encode;
 use frame_election_provider_support::{onchain, SequentialPhragmen};
 use frame_support::{
 	parameter_types,
-	traits::{ConstU128, ConstU32, ConstU64, GenesisBuild, KeyOwnerProofSystem, OnInitialize},
+	traits::{
+		ConstU128, ConstU32, ConstU64, GenesisBuildStorage, KeyOwnerProofSystem, OnInitialize,
+	},
 };
 use pallet_session::historical as pallet_session_historical;
 use sp_consensus_babe::{AuthorityId, AuthorityPair, Randomness, Slot, VrfSignature};

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -167,7 +167,7 @@ pub mod weights;
 
 use codec::{Codec, MaxEncodedLen};
 #[cfg(feature = "std")]
-use frame_support::traits::GenesisBuild;
+use frame_support::traits::GenesisBuildStorage;
 use frame_support::{
 	ensure,
 	pallet_prelude::DispatchResult,
@@ -499,18 +499,18 @@ pub mod pallet {
 
 	#[cfg(feature = "std")]
 	impl<T: Config<I>, I: 'static> GenesisConfig<T, I> {
-		/// Direct implementation of `GenesisBuild::build_storage`.
+		/// Direct implementation of `GenesisBuildStorage::build_storage`.
 		///
 		/// Kept in order not to break dependency.
 		pub fn build_storage(&self) -> Result<sp_runtime::Storage, String> {
-			<Self as GenesisBuild<T, I>>::build_storage(self)
+			<Self as GenesisBuildStorage<T, I>>::build_storage(self)
 		}
 
-		/// Direct implementation of `GenesisBuild::assimilate_storage`.
+		/// Direct implementation of `GenesisBuildStorage::assimilate_storage`.
 		///
 		/// Kept in order not to break dependency.
 		pub fn assimilate_storage(&self, storage: &mut sp_runtime::Storage) -> Result<(), String> {
-			<Self as GenesisBuild<T, I>>::assimilate_storage(self, storage)
+			<Self as GenesisBuildStorage<T, I>>::assimilate_storage(self, storage)
 		}
 	}
 

--- a/frame/beefy-mmr/src/mock.rs
+++ b/frame/beefy-mmr/src/mock.rs
@@ -21,7 +21,7 @@ use codec::Encode;
 use frame_support::{
 	construct_runtime, parameter_types,
 	sp_io::TestExternalities,
-	traits::{ConstU16, ConstU32, ConstU64, GenesisBuild},
+	traits::{ConstU16, ConstU32, ConstU64, GenesisBuildStorage},
 	BasicExternalities,
 };
 use sp_consensus_beefy::mmr::MmrLeafVersion;

--- a/frame/beefy/src/mock.rs
+++ b/frame/beefy/src/mock.rs
@@ -22,7 +22,8 @@ use frame_support::{
 	construct_runtime, parameter_types,
 	sp_io::TestExternalities,
 	traits::{
-		ConstU16, ConstU32, ConstU64, GenesisBuild, KeyOwnerProofSystem, OnFinalize, OnInitialize,
+		ConstU16, ConstU32, ConstU64, GenesisBuildStorage, KeyOwnerProofSystem, OnFinalize,
+		OnInitialize,
 	},
 	BasicExternalities,
 };

--- a/frame/bounties/src/tests.rs
+++ b/frame/bounties/src/tests.rs
@@ -23,10 +23,8 @@ use super::*;
 use crate as pallet_bounties;
 
 use frame_support::{
-	assert_noop, assert_ok,
-	pallet_prelude::GenesisBuild,
-	parameter_types,
-	traits::{ConstU32, ConstU64, OnInitialize},
+	assert_noop, assert_ok, parameter_types,
+	traits::{ConstU32, ConstU64, GenesisBuildStorage, OnInitialize},
 	PalletId,
 };
 
@@ -1081,7 +1079,8 @@ fn genesis_funding_works() {
 	}
 	.assimilate_storage(&mut t)
 	.unwrap();
-	GenesisBuild::<Test>::assimilate_storage(&pallet_treasury::GenesisConfig, &mut t).unwrap();
+	GenesisBuildStorage::<Test>::assimilate_storage(&pallet_treasury::GenesisConfig, &mut t)
+		.unwrap();
 	let mut t: sp_io::TestExternalities = t.into();
 
 	t.execute_with(|| {

--- a/frame/child-bounties/src/tests.rs
+++ b/frame/child-bounties/src/tests.rs
@@ -23,10 +23,8 @@ use super::*;
 use crate as pallet_child_bounties;
 
 use frame_support::{
-	assert_noop, assert_ok,
-	pallet_prelude::GenesisBuild,
-	parameter_types,
-	traits::{ConstU32, ConstU64, OnInitialize},
+	assert_noop, assert_ok, parameter_types,
+	traits::{ConstU32, ConstU64, GenesisBuildStorage, OnInitialize},
 	weights::Weight,
 	PalletId,
 };
@@ -169,7 +167,8 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	}
 	.assimilate_storage(&mut t)
 	.unwrap();
-	GenesisBuild::<Test>::assimilate_storage(&pallet_treasury::GenesisConfig, &mut t).unwrap();
+	GenesisBuildStorage::<Test>::assimilate_storage(&pallet_treasury::GenesisConfig, &mut t)
+		.unwrap();
 	t.into()
 }
 

--- a/frame/collective/src/tests.rs
+++ b/frame/collective/src/tests.rs
@@ -21,7 +21,7 @@ use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::Pays,
 	parameter_types,
-	traits::{ConstU32, ConstU64, GenesisBuild, StorageVersion},
+	traits::{ConstU32, ConstU64, GenesisBuildStorage, StorageVersion},
 	Hashable,
 };
 use frame_system::{EnsureRoot, EventRecord, Phase};

--- a/frame/democracy/src/tests.rs
+++ b/frame/democracy/src/tests.rs
@@ -22,7 +22,7 @@ use crate as pallet_democracy;
 use frame_support::{
 	assert_noop, assert_ok, ord_parameter_types, parameter_types,
 	traits::{
-		ConstU32, ConstU64, Contains, EqualPrivilegeOnly, GenesisBuild, OnInitialize,
+		ConstU32, ConstU64, Contains, EqualPrivilegeOnly, GenesisBuildStorage, OnInitialize,
 		SortedMembers, StorePreimage,
 	},
 	weights::Weight,

--- a/frame/election-provider-multi-phase/test-staking-e2e/src/mock.rs
+++ b/frame/election-provider-multi-phase/test-staking-e2e/src/mock.rs
@@ -20,7 +20,7 @@
 use _feps::ExtendedBalance;
 use frame_support::{
 	parameter_types, traits,
-	traits::{GenesisBuild, Hooks},
+	traits::{GenesisBuildStorage, Hooks},
 	weights::constants,
 };
 use frame_system::EnsureRoot;

--- a/frame/fast-unstake/src/mock.rs
+++ b/frame/fast-unstake/src/mock.rs
@@ -20,7 +20,7 @@ use frame_benchmarking::frame_support::assert_ok;
 use frame_support::{
 	pallet_prelude::*,
 	parameter_types,
-	traits::{ConstU64, Currency},
+	traits::{ConstU64, Currency, GenesisBuildStorage},
 	weights::constants::WEIGHT_REF_TIME_PER_SECOND,
 };
 use sp_runtime::traits::{Convert, IdentityLookup};

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -26,7 +26,8 @@ use frame_election_provider_support::{onchain, SequentialPhragmen};
 use frame_support::{
 	parameter_types,
 	traits::{
-		ConstU128, ConstU32, ConstU64, GenesisBuild, KeyOwnerProofSystem, OnFinalize, OnInitialize,
+		ConstU128, ConstU32, ConstU64, GenesisBuildStorage, KeyOwnerProofSystem, OnFinalize,
+		OnInitialize,
 	},
 };
 use pallet_session::historical as pallet_session_historical;

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -530,7 +530,7 @@ mod tests {
 
 	use frame_support::{
 		assert_noop, assert_ok, bounded_vec, ord_parameter_types, parameter_types,
-		traits::{ConstU32, ConstU64, GenesisBuild, StorageVersion},
+		traits::{ConstU32, ConstU64, GenesisBuildStorage, StorageVersion},
 	};
 	use frame_system::EnsureSignedBy;
 

--- a/frame/node-authorization/src/mock.rs
+++ b/frame/node-authorization/src/mock.rs
@@ -22,7 +22,7 @@ use crate as pallet_node_authorization;
 
 use frame_support::{
 	ord_parameter_types,
-	traits::{ConstU32, ConstU64, GenesisBuild},
+	traits::{ConstU32, ConstU64, GenesisBuildStorage},
 };
 use frame_system::EnsureSignedBy;
 use sp_core::H256;

--- a/frame/nomination-pools/benchmarking/src/mock.rs
+++ b/frame/nomination-pools/benchmarking/src/mock.rs
@@ -17,7 +17,12 @@
 
 use crate::VoterBagsListInstance;
 use frame_election_provider_support::VoteWeight;
-use frame_support::{pallet_prelude::*, parameter_types, traits::ConstU64, PalletId};
+use frame_support::{
+	pallet_prelude::*,
+	parameter_types,
+	traits::{ConstU64, GenesisBuildStorage},
+	PalletId,
+};
 use sp_runtime::{
 	traits::{Convert, IdentityLookup},
 	FixedU128, Perbill,

--- a/frame/nomination-pools/src/mock.rs
+++ b/frame/nomination-pools/src/mock.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{self as pools};
-use frame_support::{assert_ok, parameter_types, PalletId};
+use frame_support::{assert_ok, parameter_types, traits::GenesisBuildStorage, PalletId};
 use frame_system::RawOrigin;
 use sp_runtime::FixedU128;
 use sp_staking::Stake;

--- a/frame/nomination-pools/test-staking/src/mock.rs
+++ b/frame/nomination-pools/test-staking/src/mock.rs
@@ -20,7 +20,7 @@ use frame_support::{
 	assert_ok,
 	pallet_prelude::*,
 	parameter_types,
-	traits::{ConstU64, ConstU8},
+	traits::{ConstU64, ConstU8, GenesisBuildStorage},
 	PalletId,
 };
 use sp_runtime::{

--- a/frame/root-offences/src/mock.rs
+++ b/frame/root-offences/src/mock.rs
@@ -21,7 +21,7 @@ use crate as root_offences;
 use frame_election_provider_support::{onchain, SequentialPhragmen};
 use frame_support::{
 	parameter_types,
-	traits::{ConstU32, ConstU64, GenesisBuild, Hooks, OneSessionHandler},
+	traits::{ConstU32, ConstU64, GenesisBuildStorage, Hooks, OneSessionHandler},
 };
 use pallet_staking::StakerStatus;
 use sp_core::H256;

--- a/frame/scored-pool/src/mock.rs
+++ b/frame/scored-pool/src/mock.rs
@@ -22,7 +22,7 @@ use crate as pallet_scored_pool;
 
 use frame_support::{
 	bounded_vec, construct_runtime, ord_parameter_types, parameter_types,
-	traits::{ConstU32, ConstU64, GenesisBuild},
+	traits::{ConstU32, ConstU64, GenesisBuildStorage},
 };
 use frame_system::EnsureSignedBy;
 use sp_core::H256;

--- a/frame/session/src/historical/mod.rs
+++ b/frame/session/src/historical/mod.rs
@@ -380,7 +380,7 @@ pub(crate) mod tests {
 	use sp_runtime::{key_types::DUMMY, testing::UintAuthorityId};
 
 	use frame_support::{
-		traits::{GenesisBuild, KeyOwnerProofSystem, OnInitialize},
+		traits::{GenesisBuildStorage, KeyOwnerProofSystem, OnInitialize},
 		BasicExternalities,
 	};
 

--- a/frame/session/src/historical/offchain.rs
+++ b/frame/session/src/historical/offchain.rs
@@ -152,7 +152,7 @@ mod tests {
 	use sp_runtime::testing::UintAuthorityId;
 
 	use frame_support::{
-		traits::{GenesisBuild, KeyOwnerProofSystem, OnInitialize},
+		traits::{GenesisBuildStorage, KeyOwnerProofSystem, OnInitialize},
 		BasicExternalities,
 	};
 

--- a/frame/session/src/mock.rs
+++ b/frame/session/src/mock.rs
@@ -34,7 +34,7 @@ use sp_staking::SessionIndex;
 
 use frame_support::{
 	parameter_types,
-	traits::{ConstU32, ConstU64, GenesisBuild},
+	traits::{ConstU32, ConstU64, GenesisBuildStorage},
 	BasicExternalities,
 };
 

--- a/frame/society/src/mock.rs
+++ b/frame/society/src/mock.rs
@@ -22,7 +22,7 @@ use crate as pallet_society;
 
 use frame_support::{
 	ord_parameter_types, parameter_types,
-	traits::{ConstU32, ConstU64},
+	traits::{ConstU32, ConstU64, GenesisBuildStorage},
 };
 use frame_support_test::TestRandomness;
 use frame_system::EnsureSignedBy;

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -22,7 +22,7 @@ use frame_election_provider_support::{onchain, SequentialPhragmen, VoteWeight};
 use frame_support::{
 	assert_ok, ord_parameter_types, parameter_types,
 	traits::{
-		ConstU32, ConstU64, Currency, EitherOfDiverse, FindAuthor, GenesisBuild, Get, Hooks,
+		ConstU32, ConstU64, Currency, EitherOfDiverse, FindAuthor, GenesisBuildStorage, Get, Hooks,
 		Imbalance, OnUnbalanced, OneSessionHandler,
 	},
 	weights::constants::RocksDbWeight,

--- a/frame/sudo/src/mock.rs
+++ b/frame/sudo/src/mock.rs
@@ -19,7 +19,7 @@
 
 use super::*;
 use crate as sudo;
-use frame_support::traits::{ConstU32, ConstU64, Contains, GenesisBuild};
+use frame_support::traits::{ConstU32, ConstU64, Contains, GenesisBuildStorage};
 use sp_core::H256;
 use sp_io;
 use sp_runtime::{

--- a/frame/support/procedural/src/pallet/expand/genesis_build.rs
+++ b/frame/support/procedural/src/pallet/expand/genesis_build.rs
@@ -43,6 +43,9 @@ pub fn expand_genesis_build(def: &mut Def) -> proc_macro2::TokenStream {
 	let where_clause = &genesis_build.where_clause;
 
 	quote::quote_spanned!(genesis_build.attr_span =>
+		impl<#type_impl_gen> #frame_support::traits::PalletGenesisConfig<#trait_use_gen>
+			for #gen_cfg_ident<#gen_cfg_use_gen> #where_clause {}
+
 		#[cfg(feature = "std")]
 		impl<#type_impl_gen> #frame_support::sp_runtime::BuildModuleGenesisStorage<#trait_use_gen>
 			for #gen_cfg_ident<#gen_cfg_use_gen> #where_clause

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -80,9 +80,11 @@ pub use metadata::{
 };
 
 mod hooks;
+#[cfg(feature = "std")]
+pub use hooks::GenesisBuildStorage;
 pub use hooks::{
 	GenesisBuild, Hooks, IntegrityTest, OnFinalize, OnGenesis, OnIdle, OnInitialize,
-	OnRuntimeUpgrade, OnTimestampSet,
+	OnRuntimeUpgrade, OnTimestampSet, PalletGenesisConfig,
 };
 
 pub mod schedule;

--- a/frame/support/src/traits/hooks.rs
+++ b/frame/support/src/traits/hooks.rs
@@ -359,15 +359,22 @@ pub trait Hooks<BlockNumber> {
 	fn integrity_test() {}
 }
 
+/// Marker trait, indicating that something is the GenesisConfig for Pallet.
+pub trait PalletGenesisConfig<T, I = ()> {}
+
 /// A trait to define the build function of a genesis config, T and I are placeholder for pallet
 /// trait and pallet instance.
 pub trait GenesisBuild<T, I = ()>: Default + sp_runtime::traits::MaybeSerializeDeserialize {
 	/// The build function is called within an externalities allowing storage APIs.
 	/// Thus one can write to storage using regular pallet storages.
 	fn build(&self);
+}
 
+#[cfg(feature = "std")]
+/// A trait to define functions to build the  storage for a genesis config, T and I are placeholder
+/// for pallet trait and pallet instance.
+pub trait GenesisBuildStorage<T, I = ()>: GenesisBuild<T, I> {
 	/// Build the storage using `build` inside default storage.
-	#[cfg(feature = "std")]
 	fn build_storage(&self) -> Result<sp_runtime::Storage, String> {
 		let mut storage = Default::default();
 		self.assimilate_storage(&mut storage)?;
@@ -382,6 +389,12 @@ pub trait GenesisBuild<T, I = ()>: Default + sp_runtime::traits::MaybeSerializeD
 			Ok(())
 		})
 	}
+}
+
+#[cfg(feature = "std")]
+impl<GB, T, I> GenesisBuildStorage<T, I> for GB where
+	GB: GenesisBuild<T, I> + PalletGenesisConfig<T, I>
+{
 }
 
 /// A trait which is called when the timestamp is set in the runtime.

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -101,7 +101,7 @@ use sp_core::storage::well_known_keys;
 use sp_weights::{RuntimeDbWeight, Weight};
 
 #[cfg(feature = "std")]
-use frame_support::traits::GenesisBuild;
+use frame_support::traits::GenesisBuildStorage;
 #[cfg(any(feature = "std", test))]
 use sp_io::TestExternalities;
 
@@ -693,21 +693,21 @@ pub mod pallet {
 
 #[cfg(feature = "std")]
 impl GenesisConfig {
-	/// Direct implementation of `GenesisBuild::build_storage`.
+	/// Direct implementation of `GenesisBuildStorage::build_storage`.
 	///
 	/// Kept in order not to break dependency.
 	pub fn build_storage<T: Config>(&self) -> Result<sp_runtime::Storage, String> {
-		<Self as GenesisBuild<T>>::build_storage(self)
+		<Self as GenesisBuildStorage<T>>::build_storage(self)
 	}
 
-	/// Direct implementation of `GenesisBuild::assimilate_storage`.
+	/// Direct implementation of `GenesisBuildStorage::assimilate_storage`.
 	///
 	/// Kept in order not to break dependency.
 	pub fn assimilate_storage<T: Config>(
 		&self,
 		storage: &mut sp_runtime::Storage,
 	) -> Result<(), String> {
-		<Self as GenesisBuild<T>>::assimilate_storage(self, storage)
+		<Self as GenesisBuildStorage<T>>::assimilate_storage(self, storage)
 	}
 }
 

--- a/frame/tips/src/tests.rs
+++ b/frame/tips/src/tests.rs
@@ -28,11 +28,9 @@ use sp_runtime::{
 use sp_storage::Storage;
 
 use frame_support::{
-	assert_noop, assert_ok,
-	pallet_prelude::GenesisBuild,
-	parameter_types,
+	assert_noop, assert_ok, parameter_types,
 	storage::StoragePrefixedMap,
-	traits::{ConstU32, ConstU64, SortedMembers, StorageVersion},
+	traits::{ConstU32, ConstU64, GenesisBuildStorage, SortedMembers, StorageVersion},
 	PalletId,
 };
 
@@ -578,7 +576,8 @@ fn genesis_funding_works() {
 	}
 	.assimilate_storage(&mut t)
 	.unwrap();
-	GenesisBuild::<Test>::assimilate_storage(&pallet_treasury::GenesisConfig, &mut t).unwrap();
+	GenesisBuildStorage::<Test>::assimilate_storage(&pallet_treasury::GenesisConfig, &mut t)
+		.unwrap();
 	let mut t: sp_io::TestExternalities = t.into();
 
 	t.execute_with(|| {

--- a/frame/transaction-payment/src/tests.rs
+++ b/frame/transaction-payment/src/tests.rs
@@ -25,7 +25,7 @@ use sp_runtime::{testing::TestXt, traits::One, transaction_validity::InvalidTran
 use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::{DispatchClass, DispatchInfo, GetDispatchInfo, PostDispatchInfo},
-	traits::{Currency, GenesisBuild},
+	traits::{Currency, GenesisBuildStorage},
 	weights::Weight,
 };
 use frame_system as system;
@@ -100,7 +100,7 @@ impl ExtBuilder {
 
 		if let Some(multiplier) = self.initial_multiplier {
 			let genesis = pallet::GenesisConfig { multiplier };
-			GenesisBuild::<Runtime>::assimilate_storage(&genesis, &mut t).unwrap();
+			GenesisBuildStorage::<Runtime>::assimilate_storage(&genesis, &mut t).unwrap();
 		}
 
 		t.into()

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -72,6 +72,8 @@ use sp_runtime::{
 };
 use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
+#[cfg(feature = "std")]
+use frame_support::traits::GenesisBuildStorage;
 use frame_support::{
 	print,
 	traits::{
@@ -239,15 +241,15 @@ pub mod pallet {
 
 	#[cfg(feature = "std")]
 	impl GenesisConfig {
-		/// Direct implementation of `GenesisBuild::assimilate_storage`.
+		/// Direct implementation of `GenesisBuildStorage::assimilate_storage`.
 		#[deprecated(
-			note = "use `<GensisConfig<T, I> as GenesisBuild<T, I>>::assimilate_storage` instead"
+			note = "use `<GensisConfig<T, I> as GenesisBuildStorage<T, I>>::assimilate_storage` instead"
 		)]
 		pub fn assimilate_storage<T: Config<I>, I: 'static>(
 			&self,
 			storage: &mut sp_runtime::Storage,
 		) -> Result<(), String> {
-			<Self as GenesisBuild<T, I>>::assimilate_storage(self, storage)
+			<Self as GenesisBuildStorage<T, I>>::assimilate_storage(self, storage)
 		}
 	}
 

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -26,10 +26,8 @@ use sp_runtime::{
 };
 
 use frame_support::{
-	assert_err_ignore_postinfo, assert_noop, assert_ok,
-	pallet_prelude::GenesisBuild,
-	parameter_types,
-	traits::{ConstU32, ConstU64, OnInitialize},
+	assert_err_ignore_postinfo, assert_noop, assert_ok, parameter_types,
+	traits::{ConstU32, ConstU64, GenesisBuildStorage, OnInitialize},
 	PalletId,
 };
 
@@ -154,7 +152,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	}
 	.assimilate_storage(&mut t)
 	.unwrap();
-	GenesisBuild::<Test>::assimilate_storage(&crate::GenesisConfig, &mut t).unwrap();
+	GenesisBuildStorage::<Test>::assimilate_storage(&crate::GenesisConfig, &mut t).unwrap();
 	t.into()
 }
 
@@ -439,7 +437,7 @@ fn genesis_funding_works() {
 	}
 	.assimilate_storage(&mut t)
 	.unwrap();
-	GenesisBuild::<Test>::assimilate_storage(&crate::GenesisConfig, &mut t).unwrap();
+	GenesisBuildStorage::<Test>::assimilate_storage(&crate::GenesisConfig, &mut t).unwrap();
 	let mut t: sp_io::TestExternalities = t.into();
 
 	t.execute_with(|| {

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -27,7 +27,7 @@ use frame_support::{
 	dispatch::{DispatchError, DispatchErrorWithPostInfo, Dispatchable, Pays},
 	error::BadOrigin,
 	parameter_types, storage,
-	traits::{ConstU32, ConstU64, Contains, GenesisBuild},
+	traits::{ConstU32, ConstU64, Contains, GenesisBuildStorage},
 	weights::Weight,
 };
 use pallet_collective::{EnsureProportionAtLeast, Instance1};

--- a/frame/vesting/src/mock.rs
+++ b/frame/vesting/src/mock.rs
@@ -17,7 +17,7 @@
 
 use frame_support::{
 	parameter_types,
-	traits::{ConstU32, ConstU64, GenesisBuild, WithdrawReasons},
+	traits::{ConstU32, ConstU64, GenesisBuildStorage, WithdrawReasons},
 };
 use sp_core::H256;
 use sp_runtime::{


### PR DESCRIPTION
This PR removes the storage building part from the `GenesisBuild` trait.

`assimilate_storage` and `build_storage` methods were moved to new `GenesisBuildStorage` trait which is implemented only for pallets `GenesisConfig` (and not `RuntimeGenesisConfig`). `PalletGenesisConfig` marker trait was added to facilitate this.

The rationale behind this is as follows: since paritytech/substrate#14306 `GenesisBuild` is implemented for `RuntimeGenesisConfig`. As the `BuildStorage` is also implemented for `RuntimeGenesisConfig` there was is duality now - `RuntiemGenesisConfig` had two `bulid_storage` implementations.

Trait split is implemented in 13d66fd5d0, renaming in ad3b7df4ba.

Step towards: https://github.com/paritytech/polkadot-sdk/issues/25

cumulus companion: paritytech/cumulus#2720
