### PR TITLE
benchmark pallet: Error if files are overwritten twice

### DIFF
--- a/utils/frame/benchmarking-cli/src/pallet/command.rs
+++ b/utils/frame/benchmarking-cli/src/pallet/command.rs
@@ -22,7 +22,6 @@ use frame_benchmarking::{
 	BenchmarkResult, BenchmarkSelector,
 };
 use frame_support::traits::StorageInfo;
-use itertools::Itertools;
 use linked_hash_map::LinkedHashMap;
 use sc_cli::{
 	execution_method_from_cli, CliConfiguration, ExecutionStrategy, Result, SharedParams,
@@ -509,10 +508,9 @@ impl PalletCmd {
 			self.print_summary(&batches, &storage_info, pov_modes.clone())
 		}
 
-		// Write all weight files and possibly error afterwards.
-		let mut soft_errors = Vec::new();
+		// Create the weights.rs file.
 		if let Some(output_path) = &self.output {
-			if let Err(err) = writer::write_results(
+			writer::write_results(
 				&batches,
 				&storage_info,
 				&component_ranges,
@@ -520,20 +518,10 @@ impl PalletCmd {
 				self.default_pov_mode,
 				output_path,
 				self,
-			)? {
-				soft_errors.push(err);
-			}
+			)?;
 		}
 
-		if !soft_errors.is_empty() {
-			Err(soft_errors
-				.into_iter()
-				.map(|e| format!("Error writing benchmark results: {}", e))
-				.join("\n")
-				.into())
-		} else {
-			Ok(())
-		}
+		Ok(())
 	}
 
 	/// Re-analyze a batch historic benchmark timing data. Will not take the PoV into account.

--- a/utils/frame/benchmarking-cli/src/pallet/mod.rs
+++ b/utils/frame/benchmarking-cli/src/pallet/mod.rs
@@ -195,4 +195,10 @@ pub struct PalletCmd {
 	/// the analysis is read from this file.
 	#[arg(long)]
 	pub json_input: Option<PathBuf>,
+
+	/// Allow overwriting a single file with multiple results.
+	///
+	/// This exists only to restore legacy behaviour. It should never actually be needed.
+	#[arg(long)]
+	pub unsafe_overwrite_results: bool,
 }

--- a/utils/frame/benchmarking-cli/src/pallet/writer.rs
+++ b/utils/frame/benchmarking-cli/src/pallet/writer.rs
@@ -376,9 +376,6 @@ fn get_benchmark_data(
 }
 
 /// Create weight file from benchmark data and Handlebars template.
-///
-/// The outer error is a hard error and must be treated as an immediate failure. An inner error case
-/// can be seen as success, since all results have been written in this case.
 pub(crate) fn write_results(
 	batches: &[BenchmarkBatchSplitResults],
 	storage_info: &[StorageInfo],
@@ -387,7 +384,7 @@ pub(crate) fn write_results(
 	default_pov_mode: PovEstimationMode,
 	path: &PathBuf,
 	cmd: &PalletCmd,
-) -> Result<Result<(), String>, std::io::Error> {
+) -> Result<(), sc_cli::Error> {
 	// Use custom template if provided.
 	let template: String = match &cmd.template {
 		Some(template_file) => fs::read_to_string(template_file)?,
@@ -508,10 +505,10 @@ pub(crate) fn write_results(
 		if cmd.unsafe_overwrite_results {
 			println!("{msg}");
 		} else {
-			return Ok(Err(msg))
+			return Err(msg.into())
 		}
 	}
-	Ok(Ok(()))
+	Ok(())
 }
 
 /// This function looks at the keys touched during the benchmark, and the storage info we collected

--- a/utils/frame/benchmarking-cli/src/pallet/writer.rs
+++ b/utils/frame/benchmarking-cli/src/pallet/writer.rs
@@ -497,7 +497,7 @@ pub(crate) fn write_results(
 		let msg = format!(
 			"Multiple results were written to the same file. This can happen when \
 		there are multiple instances of a pallet deployed and `--output` forces the output of all \
-		instances into the same file. Use `--unsafe_overwrite_results` to ignore this error. The \
+		instances into the same file. Use `--unsafe-overwrite-results` to ignore this error. The \
 		affected files are: {:?}",
 			overwritten_files
 		);


### PR DESCRIPTION
Currently we only print a warning if multiple instances of the same pallet overwrite each others results.  
Now this becomes an error since nobody seems to notice the warning. AFAIK Kusama is suffering from this - so if there is a failure on the next benchmark run; it just means that it was wrong before. cc @coderobe 

Changes:
- Add `--unsafe-overwrite-results` as legacy option.
- Error when one file was written multiple times and `--unsafe-overwrite-results` was not specified.

Note that the error is emitted *after* writing all files. This makes it less annoying to deal with. Otherwise it could disregard the results of possibly multiple hours runs.

Example output looks like:  
```pre
Created file: "output.rs"
Created file: "output.rs"
Error: Input("Multiple results were written to the same file. This can happen when there are multiple instances of a pallet deployed and `--output` forces the output of all instances into the same file. Use `--unsafe-overwrite-results` to ignore this error. The affected files are: [\"output.rs\"]")
> $?
1