### PR TITLE
[pallet_collective] Enforce prime is a valid member of collective in set_members extrinsic

### DIFF
--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -345,6 +345,8 @@ pub mod pallet {
 		WrongProposalWeight,
 		/// The given length bound for the proposal was too low.
 		WrongProposalLength,
+		/// Prime account is not a member
+		PrimeAccountNotMember,
 	}
 
 	#[pallet::hooks]
@@ -415,6 +417,9 @@ pub mod pallet {
 					old_count,
 					old.len(),
 				);
+			}
+			if let Some(p) = prime.clone() {
+				ensure!(new_members.contains(&p), Error::<T, I>::PrimeAccountNotMember);
 			}
 			let mut new_members = new_members;
 			new_members.sort();

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -418,8 +418,8 @@ pub mod pallet {
 					old.len(),
 				);
 			}
-			if let Some(p) = prime.clone() {
-				ensure!(new_members.contains(&p), Error::<T, I>::PrimeAccountNotMember);
+			if let Some(p) = &prime {
+				ensure!(new_members.contains(p), Error::<T, I>::PrimeAccountNotMember);
 			}
 			let mut new_members = new_members;
 			new_members.sort();

--- a/frame/collective/src/tests.rs
+++ b/frame/collective/src/tests.rs
@@ -237,6 +237,25 @@ fn initialize_members_sorts_members() {
 }
 
 #[test]
+fn set_members_with_prime_works() {
+	ExtBuilder::default().build_and_execute(|| {
+		let members = vec![1, 2, 3];
+		assert_ok!(Collective::set_members(
+			RuntimeOrigin::root(),
+			members.clone(),
+			Some(3),
+			MaxMembers::get()
+		));
+		assert_eq!(Collective::members(), members.clone());
+		assert_eq!(Collective::prime(), Some(3));
+		assert_noop!(
+			Collective::set_members(RuntimeOrigin::root(), members, Some(4), MaxMembers::get()),
+			Error::<Test, Instance1>::PrimeAccountNotMember
+		);
+	});
+}
+
+#[test]
 fn proposal_weight_limit_works() {
 	ExtBuilder::default().build_and_execute(|| {
 		let proposal = make_proposal(42);


### PR DESCRIPTION
This fixes #14353

Polkadot address: 1WSnZDtb4FEufmwdQh2emEXdDCmwZ5pSoPfsgStQb3kQa9M

