### PR TITLE
`GenesisBuild` trait implemented for `RuntimeGenesisConfig`

### DIFF
--- a/frame/alliance/src/mock.rs
+++ b/frame/alliance/src/mock.rs
@@ -372,7 +372,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
 #[cfg(feature = "runtime-benchmarks")]
 pub fn new_bench_ext() -> sp_io::TestExternalities {
-	RuntimeGenesisConfig::default().build_storage().unwrap().into()
+	BuildStorage::build_storage(&RuntimeGenesisConfig::default()).unwrap().into()
 }
 
 pub fn test_cid() -> Cid {

--- a/frame/bounties/src/tests.rs
+++ b/frame/bounties/src/tests.rs
@@ -194,13 +194,12 @@ type TreasuryError = pallet_treasury::Error<Test>;
 type TreasuryError1 = pallet_treasury::Error<Test, Instance1>;
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let mut ext: sp_io::TestExternalities = RuntimeGenesisConfig {
+	let mut ext: sp_io::TestExternalities = BuildStorage::build_storage(&RuntimeGenesisConfig {
 		system: frame_system::GenesisConfig::default(),
 		balances: pallet_balances::GenesisConfig { balances: vec![(0, 100), (1, 98), (2, 1)] },
 		treasury: Default::default(),
 		treasury_1: Default::default(),
-	}
-	.build_storage()
+	})
 	.unwrap()
 	.into();
 	ext.execute_with(|| System::set_block_number(1));

--- a/frame/collective/src/tests.rs
+++ b/frame/collective/src/tests.rs
@@ -177,20 +177,20 @@ impl ExtBuilder {
 	}
 
 	pub fn build(self) -> sp_io::TestExternalities {
-		let mut ext: sp_io::TestExternalities = RuntimeGenesisConfig {
-			collective: pallet_collective::GenesisConfig {
-				members: self.collective_members,
-				phantom: Default::default(),
-			},
-			collective_majority: pallet_collective::GenesisConfig {
-				members: vec![1, 2, 3, 4, 5],
-				phantom: Default::default(),
-			},
-			default_collective: Default::default(),
-		}
-		.build_storage()
-		.unwrap()
-		.into();
+		let mut ext: sp_io::TestExternalities =
+			BuildStorage::build_storage(&RuntimeGenesisConfig {
+				collective: pallet_collective::GenesisConfig {
+					members: self.collective_members,
+					phantom: Default::default(),
+				},
+				collective_majority: pallet_collective::GenesisConfig {
+					members: vec![1, 2, 3, 4, 5],
+					phantom: Default::default(),
+				},
+				default_collective: Default::default(),
+			})
+			.unwrap()
+			.into();
 		ext.execute_with(|| System::set_block_number(1));
 		ext
 	}

--- a/frame/support/procedural/src/construct_runtime/expand/config.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/config.rs
@@ -30,6 +30,7 @@ pub fn expand_outer_config(
 	let mut types = TokenStream::new();
 	let mut fields = TokenStream::new();
 	let mut build_storage_calls = TokenStream::new();
+	let mut genesis_build_calls = TokenStream::new();
 	let mut query_genesis_config_part_macros = Vec::new();
 
 	for decl in pallet_decls {
@@ -54,6 +55,9 @@ pub fn expand_outer_config(
 			fields.extend(quote!(#attr pub #field_name: #config,));
 			build_storage_calls
 				.extend(expand_config_build_storage_call(scrate, attr, runtime, decl, field_name));
+			genesis_build_calls.extend(expand_config_genesis_build_call(
+				scrate, &config, attr, runtime, decl, field_name,
+			));
 			query_genesis_config_part_macros.push(quote! {
 				#path::__substrate_genesis_config_check::is_genesis_config_defined!(#pallet_name);
 				#[cfg(feature = "std")]
@@ -93,6 +97,12 @@ pub fn expand_outer_config(
 				});
 
 				Ok(())
+			}
+		}
+
+		impl<T> #scrate::traits::GenesisBuild<T> for RuntimeGenesisConfig {
+			fn build(&self) {
+				#genesis_build_calls
 			}
 		}
 	}
@@ -141,5 +151,26 @@ fn expand_config_build_storage_call(
 		#attr
 		#scrate::sp_runtime::BuildModuleGenesisStorage::
 			<#runtime, #instance>::build_module_genesis_storage(&self.#field_name, storage)?;
+	}
+}
+
+fn expand_config_genesis_build_call(
+	scrate: &TokenStream,
+	pallet_genesis_config: &Ident,
+	attr: &TokenStream,
+	runtime: &Ident,
+	decl: &Pallet,
+	field_name: &Ident,
+) -> TokenStream {
+	let path = &decl.path;
+	let instance = if let Some(inst) = decl.instance.as_ref() {
+		quote!(#path::#inst)
+	} else {
+		quote!(#path::__InherentHiddenInstance)
+	};
+
+	quote! {
+		#attr
+		<#pallet_genesis_config as #scrate::traits::GenesisBuild::<#runtime, #instance>>::build(&self.#field_name);
 	}
 }

--- a/frame/support/procedural/src/construct_runtime/expand/config.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/config.rs
@@ -100,9 +100,10 @@ pub fn expand_outer_config(
 			}
 		}
 
-		impl<T> #scrate::traits::GenesisBuild<T> for RuntimeGenesisConfig {
+		impl #scrate::traits::GenesisBuild<()> for RuntimeGenesisConfig {
 			fn build(&self) {
 				#genesis_build_calls
+				<AllPalletsWithSystem as #scrate::traits::OnGenesis>::on_genesis();
 			}
 		}
 	}

--- a/frame/support/procedural/src/construct_runtime/expand/config.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/config.rs
@@ -67,9 +67,7 @@ pub fn expand_outer_config(
 
 		#types
 
-		#[cfg(any(feature = "std", test))]
 		use #scrate::serde as __genesis_config_serde_import__;
-		#[cfg(any(feature = "std", test))]
 		#[derive(#scrate::serde::Serialize, #scrate::serde::Deserialize, Default)]
 		#[serde(rename_all = "camelCase")]
 		#[serde(deny_unknown_fields)]
@@ -112,17 +110,14 @@ fn expand_config_types(
 	match (decl.instance.as_ref(), part_is_generic) {
 		(Some(inst), true) => quote! {
 			#attr
-			#[cfg(any(feature = "std", test))]
 			pub type #config = #path::GenesisConfig<#runtime, #path::#inst>;
 		},
 		(None, true) => quote! {
 			#attr
-			#[cfg(any(feature = "std", test))]
 			pub type #config = #path::GenesisConfig<#runtime>;
 		},
 		(_, false) => quote! {
 			#attr
-			#[cfg(any(feature = "std", test))]
 			pub type #config = #path::GenesisConfig;
 		},
 	}

--- a/frame/system/src/mock.rs
+++ b/frame/system/src/mock.rs
@@ -126,7 +126,7 @@ pub const CALL: &<Test as Config>::RuntimeCall =
 /// Create new externalities for `System` module tests.
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut ext: sp_io::TestExternalities =
-		RuntimeGenesisConfig::default().build_storage().unwrap().into();
+		BuildStorage::build_storage(&RuntimeGenesisConfig::default()).unwrap().into();
 	// Add to each test the initial weight of a block
 	ext.execute_with(|| {
 		System::register_extra_weight_unchecked(

--- a/frame/tips/src/tests.rs
+++ b/frame/tips/src/tests.rs
@@ -196,13 +196,12 @@ impl Config<Instance1> for Test {
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let mut ext: sp_io::TestExternalities = RuntimeGenesisConfig {
+	let mut ext: sp_io::TestExternalities = BuildStorage::build_storage(&RuntimeGenesisConfig {
 		system: frame_system::GenesisConfig::default(),
 		balances: pallet_balances::GenesisConfig { balances: vec![(0, 100), (1, 98), (2, 1)] },
 		treasury: Default::default(),
 		treasury_1: Default::default(),
-	}
-	.build_storage()
+	})
 	.unwrap()
 	.into();
 	ext.execute_with(|| System::set_block_number(1));


### PR DESCRIPTION
`GenesisBuild<T,I>` was implemented for `RuntimGenesisConfig. This implementation provides a way to build (put all the required keys into the storage) the full GenesisConfig on the runtime side. (Till now it was possible via externalities).

GenesisBuild and BuildStorage (which is already implemented for RuntimeGenesisConfig) both have the same methods build_storage and assimilate_storage, so this PR fixes ambiguity.