### PR TITLE
Reimport `WeightInfo` in `pallet-contracts`

### DIFF
--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -102,7 +102,6 @@ use crate::{
 	gas::GasMeter,
 	storage::{meter::Meter as StorageMeter, ContractInfo, DeletionQueueManager},
 	wasm::{OwnerInfo, PrefabWasmModule, TryInstantiate},
-	weights::WeightInfo,
 };
 use codec::{Codec, Decode, Encode, HasCompact};
 use environmental::*;
@@ -130,6 +129,7 @@ use scale_info::TypeInfo;
 use smallvec::Array;
 use sp_runtime::traits::{Convert, Hash, Saturating, StaticLookup, Zero};
 use sp_std::{fmt::Debug, prelude::*};
+pub use weights::WeightInfo;
 
 pub use crate::{
 	address::{AddressGenerator, DefaultAddressGenerator},


### PR DESCRIPTION
When generating weights using benchmarks cli and default template here is the code that is generated:
```rust
impl<T: frame_system::Config> pallet_contracts::WeightInfo for WeightInfo<T>
```

in order for this to work `WeightInfo`, which is defined in `weights` module, should be re-imported (re-exported) from root.