### PR TITLE
Add `try-state` hook to pallet aura 

### DIFF
--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -132,6 +132,11 @@ pub mod pallet {
 				T::DbWeight::get().reads(1)
 			}
 		}
+
+		#[cfg(feature = "try-runtime")]
+		fn try_state(_: T::BlockNumber) -> Result<(), sp_runtime::TryRuntimeError> {
+			Self::do_try_state()
+		}
 	}
 
 	/// The current authority set.
@@ -216,6 +221,55 @@ impl<T: Config> Pallet<T> {
 		// we double the minimum block-period so each author can always propose within
 		// the majority of its slot.
 		<T as pallet_timestamp::Config>::MinimumPeriod::get().saturating_mul(2u32.into())
+	}
+
+	/// Ensure the correctness of the state of this pallet.
+	///
+	/// This should be valid before or after each state transition of this pallet.
+	///
+	/// # Invariants
+	///
+	/// ## `CurrentSlot`
+	///
+	/// If we don't allow for multiple blocks per slot, then the current slot must be less than the
+	/// maximal slot number. Otherwise, it can be arbitrary.
+	///
+	/// ## `Authorities`
+	///
+	/// * The authorities must be non-empty.
+	/// * The current authority cannot be disabled.
+	/// * The number of authorities must be less than or equal to `T::MaxAuthorities`. This however,
+	///   is guarded by the type system.
+	#[cfg(feature = "try-runtime")]
+	pub fn do_try_state() -> Result<(), sp_runtime::TryRuntimeError> {
+		// We don't have any guarantee that we are already after `on_initialize` and thus we have to
+		// check the current slot from the digest or take the last known slot.
+		let current_slot =
+			Self::current_slot_from_digests().unwrap_or_else(|| CurrentSlot::<T>::get());
+
+		// Check that the current slot is less than the maximal slot number, unless we allow for
+		// multiple blocks per slot.
+		if !T::AllowMultipleBlocksPerSlot::get() {
+			frame_support::ensure!(
+				current_slot < u64::MAX,
+				"Current slot has reached maximum value and cannot be incremented further.",
+			);
+		}
+
+		let authorities_len =
+			<Authorities<T>>::decode_len().ok_or("Failed to decode authorities length")?;
+
+		// Check that the authorities are non-empty.
+		frame_support::ensure!(!authorities_len.is_zero(), "Authorities must be non-empty.");
+
+		// Check that the current authority is not disabled.
+		let authority_index = *current_slot % authorities_len as u64;
+		frame_support::ensure!(
+			!T::DisabledValidators::is_disabled(authority_index as u32),
+			"Current validator is disabled and should not be attempting to author blocks.",
+		);
+
+		Ok(())
 	}
 }
 

--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -240,7 +240,7 @@ impl<T: Config> Pallet<T> {
 	/// * The current authority cannot be disabled.
 	/// * The number of authorities must be less than or equal to `T::MaxAuthorities`. This however,
 	///   is guarded by the type system.
-	#[cfg(feature = "try-runtime")]
+	#[cfg(any(test, feature = "try-runtime"))]
 	pub fn do_try_state() -> Result<(), sp_runtime::TryRuntimeError> {
 		// We don't have any guarantee that we are already after `on_initialize` and thus we have to
 		// check the current slot from the digest or take the last known slot.

--- a/frame/aura/src/tests.rs
+++ b/frame/aura/src/tests.rs
@@ -19,7 +19,7 @@
 
 #![cfg(test)]
 
-use crate::mock::{new_test_ext, Aura, MockDisabledValidators, System};
+use crate::mock::{build_ext_and_execute_test, Aura, MockDisabledValidators, System};
 use codec::Encode;
 use frame_support::traits::OnInitialize;
 use sp_consensus_aura::{Slot, AURA_ENGINE_ID};
@@ -27,7 +27,7 @@ use sp_runtime::{Digest, DigestItem};
 
 #[test]
 fn initial_values() {
-	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
+	build_ext_and_execute_test(vec![0, 1, 2, 3], || {
 		assert_eq!(Aura::current_slot(), 0u64);
 		assert_eq!(Aura::authorities().len(), 4);
 	});
@@ -38,7 +38,7 @@ fn initial_values() {
 	expected = "Validator with index 1 is disabled and should not be attempting to author blocks."
 )]
 fn disabled_validators_cannot_author_blocks() {
-	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
+	build_ext_and_execute_test(vec![0, 1, 2, 3], || {
 		// slot 1 should be authored by validator at index 1
 		let slot = Slot::from(1);
 		let pre_digest =
@@ -58,7 +58,7 @@ fn disabled_validators_cannot_author_blocks() {
 #[test]
 #[should_panic(expected = "Slot must increase")]
 fn pallet_requires_slot_to_increase_unless_allowed() {
-	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
+	build_ext_and_execute_test(vec![0, 1, 2, 3], || {
 		crate::mock::AllowMultipleBlocksPerSlot::set(false);
 
 		let slot = Slot::from(1);
@@ -76,7 +76,7 @@ fn pallet_requires_slot_to_increase_unless_allowed() {
 
 #[test]
 fn pallet_can_allow_unchanged_slot() {
-	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
+	build_ext_and_execute_test(vec![0, 1, 2, 3], || {
 		let slot = Slot::from(1);
 		let pre_digest =
 			Digest { logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())] };
@@ -95,7 +95,7 @@ fn pallet_can_allow_unchanged_slot() {
 #[test]
 #[should_panic(expected = "Slot must not decrease")]
 fn pallet_always_rejects_decreasing_slot() {
-	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
+	build_ext_and_execute_test(vec![0, 1, 2, 3], || {
 		let slot = Slot::from(2);
 		let pre_digest =
 			Digest { logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())] };


### PR DESCRIPTION
# Description

This PR introduces storage invariants to pallet aura via `try-state` hook. Checks are also triggered after pallet unit tests. 

Completes one of the goals of https://github.com/paritytech/polkadot-sdk/issues/239.

## Notes

1. While I went for @kianenigma suggestion and triggered `do_try_state` after every unit test, I didn't add any tests that would actually trigger panic from these checks. IMHO this would be a bit misleading. For example, suppose that we craft a test that sets `CurrentSlot` to the maximal value and disallow multiple blocks per slot. Having such a test might give a wrong impression, that the pallet itself guards this and would panic, while in reality, only feature-gated check would do so.
2. I realized that `on_initialize` will panic if the previous block has cleared `Authorities` item (e.g. a malfunctioning pallet removed all validators). Is that okay?

# Checklist

- [x] My PR includes a detailed description as outlined in the "Description" section above
- [x] My PR follows the [labeling requirements](./CONTRIBUTING.adoc#merge-process) of this project (at minimum one label for each `A`, `B`, `C` and `D` required)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] If this PR alters any external APIs or interfaces used by Polkadot, the corresponding Polkadot PR is ready as well as the corresponding Cumulus PR (optional)
