### PR TITLE
Limit heap pages in state machine

### DIFF
--- a/primitives/state-machine/src/backend.rs
+++ b/primitives/state-machine/src/backend.rs
@@ -444,12 +444,15 @@ where
 			.flatten()
 			.ok_or("`:code` hash not found")?
 			.encode();
-		let heap_pages = self
+
+		let chain_heap_pages = self
 			.backend
 			.storage(sp_core::storage::well_known_keys::HEAP_PAGES)
 			.ok()
 			.flatten()
 			.and_then(|d| codec::Decode::decode(&mut &d[..]).ok());
+
+		let heap_pages = std::cmp::min(chain_heap_pages, Some(super::MAX_HEAP_PAGES));
 
 		Ok(RuntimeCode { code_fetcher: self, hash, heap_pages })
 	}

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -46,6 +46,8 @@ pub use log::{debug, error as log_error, warn};
 #[cfg(feature = "std")]
 pub use tracing::trace;
 
+const MAX_HEAP_PAGES: u64 = 2048u64;
+
 /// In no_std we skip logs for state_machine, this macro
 /// is a noops.
 #[cfg(not(feature = "std"))]


### PR DESCRIPTION
# Description

If the on-chain heap pages value is set to a really high value, the client will fail with an error similar to:
```
Error: Service(Application(Application(VersionInvalid("cannot create module: failed to parse WebAssembly module: Invalid input WebAssembly code at offset 9784: memory size must be at most 65536 pages (4GiB)"))))
```
This PR limits the heap pages requested by the state machine to a known good value, to avoid stalling the chain in case it's incorrectly set.
