### PR TITLE
Use Incrementable from frame_support::traits

### DIFF
--- a/frame/nfts/src/lib.rs
+++ b/frame/nfts/src/lib.rs
@@ -46,7 +46,8 @@ pub mod weights;
 
 use codec::{Decode, Encode};
 use frame_support::traits::{
-	tokens::Locker, BalanceStatus::Reserved, Currency, EnsureOriginWithArg, ReservableCurrency,
+	tokens::Locker, BalanceStatus::Reserved, Currency, EnsureOriginWithArg, Incrementable,
+	ReservableCurrency,
 };
 use frame_system::Config as SystemConfig;
 use sp_runtime::{
@@ -67,10 +68,7 @@ type AccountIdLookupOf<T> = <<T as SystemConfig>::Lookup as StaticLookup>::Sourc
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use frame_support::{
-		pallet_prelude::*,
-		traits::{ExistenceRequirement, Incrementable},
-	};
+	use frame_support::{pallet_prelude::*, traits::ExistenceRequirement};
 	use frame_system::pallet_prelude::*;
 
 	/// The current storage version.

--- a/frame/nfts/src/lib.rs
+++ b/frame/nfts/src/lib.rs
@@ -67,7 +67,10 @@ type AccountIdLookupOf<T> = <<T as SystemConfig>::Lookup as StaticLookup>::Sourc
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use frame_support::{pallet_prelude::*, traits::ExistenceRequirement};
+	use frame_support::{
+		pallet_prelude::*,
+		traits::{ExistenceRequirement, Incrementable},
+	};
 	use frame_system::pallet_prelude::*;
 
 	/// The current storage version.

--- a/frame/nfts/src/macros.rs
+++ b/frame/nfts/src/macros.rs
@@ -15,25 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-macro_rules! impl_incrementable {
-	($($type:ty),+) => {
-		$(
-			impl Incrementable for $type {
-				fn increment(&self) -> Self {
-					let mut val = self.clone();
-					val.saturating_inc();
-					val
-				}
-
-				fn initial_value() -> Self {
-					0
-				}
-			}
-		)+
-	};
-}
-pub(crate) use impl_incrementable;
-
 macro_rules! impl_codec_bitflags {
 	($wrapper:ty, $size:ty, $bitflag_enum:ty) => {
 		impl MaxEncodedLen for $wrapper {

--- a/frame/nfts/src/types.rs
+++ b/frame/nfts/src/types.rs
@@ -75,12 +75,6 @@ pub(super) type PreSignedAttributesOf<T, I = ()> = PreSignedAttributes<
 	<T as SystemConfig>::BlockNumber,
 >;
 
-pub trait Incrementable {
-	fn increment(&self) -> Self;
-	fn initial_value() -> Self;
-}
-impl_incrementable!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128);
-
 /// Information about a collection.
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub struct CollectionDetails<AccountId, DepositBalance> {


### PR DESCRIPTION
This switches the nfts pallet to use the Incrementable trait from the frame_support::traits instead of a local version of the same trait.

P. S. That is supposed to happen when adding the Asset Conversion pallet, but it probably got lost during the merge conflict resolution.