### PR TITLE
sc-executor-wasmtime: Do not use absolute path to `Cargo.toml` in test

### DIFF
--- a/client/executor/wasmtime/src/tests.rs
+++ b/client/executor/wasmtime/src/tests.rs
@@ -501,7 +501,6 @@ fn test_instances_without_reuse_are_not_leaked() {
 #[test]
 fn test_rustix_version_matches_with_wasmtime() {
 	let metadata = cargo_metadata::MetadataCommand::new()
-		.manifest_path("../../../Cargo.toml")
 		.exec()
 		.unwrap();
 

--- a/client/executor/wasmtime/src/tests.rs
+++ b/client/executor/wasmtime/src/tests.rs
@@ -500,9 +500,7 @@ fn test_instances_without_reuse_are_not_leaked() {
 
 #[test]
 fn test_rustix_version_matches_with_wasmtime() {
-	let metadata = cargo_metadata::MetadataCommand::new()
-		.exec()
-		.unwrap();
+	let metadata = cargo_metadata::MetadataCommand::new().exec().unwrap();
 
 	let wasmtime_rustix = metadata
 		.packages


### PR DESCRIPTION
As the test is executed inside the workspace, `cargo metadata` will automatically detect the correct `Cargo.toml`. This is required for the mono repo.


