### PR TITLE
Restructure macro-related exports into private mods for frame

### DIFF
--- a/frame/election-provider-support/solution-type/src/codec.rs
+++ b/frame/election-provider-support/solution-type/src/codec.rs
@@ -51,14 +51,14 @@ fn decode_impl(
 		quote! {
 			let #name =
 			<
-				_feps::sp_std::prelude::Vec<(_feps::codec::Compact<#voter_type>, _feps::codec::Compact<#target_type>)>
+				_fepsp::sp_std::prelude::Vec<(_fepsp::codec::Compact<#voter_type>, _fepsp::codec::Compact<#target_type>)>
 				as
-				_feps::codec::Decode
+				_fepsp::codec::Decode
 			>::decode(value)?;
 			let #name = #name
 				.into_iter()
 				.map(|(v, t)| (v.0, t.0))
-				.collect::<_feps::sp_std::prelude::Vec<_>>();
+				.collect::<_fepsp::sp_std::prelude::Vec<_>>();
 		}
 	};
 
@@ -73,12 +73,12 @@ fn decode_impl(
 			quote! {
 				let #name =
 				<
-					_feps::sp_std::prelude::Vec<(
-						_feps::codec::Compact<#voter_type>,
-						[(_feps::codec::Compact<#target_type>, _feps::codec::Compact<#weight_type>); #c-1],
-						_feps::codec::Compact<#target_type>,
+					_fepsp::sp_std::prelude::Vec<(
+						_fepsp::codec::Compact<#voter_type>,
+						[(_fepsp::codec::Compact<#target_type>, _fepsp::codec::Compact<#weight_type>); #c-1],
+						_fepsp::codec::Compact<#target_type>,
 					)>
-					as _feps::codec::Decode
+					as _fepsp::codec::Decode
 				>::decode(value)?;
 				let #name = #name
 					.into_iter()
@@ -87,7 +87,7 @@ fn decode_impl(
 						[ #inner_impl ],
 						t_last.0,
 					))
-					.collect::<_feps::sp_std::prelude::Vec<_>>();
+					.collect::<_fepsp::sp_std::prelude::Vec<_>>();
 			}
 		})
 		.collect::<TokenStream2>();
@@ -100,8 +100,8 @@ fn decode_impl(
 		.collect::<TokenStream2>();
 
 	quote!(
-		impl _feps::codec::Decode for #ident {
-			fn decode<I: _feps::codec::Input>(value: &mut I) -> Result<Self, _feps::codec::Error> {
+		impl _fepsp::codec::Decode for #ident {
+			fn decode<I: _fepsp::codec::Input>(value: &mut I) -> Result<Self, _fepsp::codec::Error> {
 				#decode_impl_single
 				#decode_impl_rest
 
@@ -123,10 +123,10 @@ fn encode_impl(ident: &syn::Ident, count: usize) -> TokenStream2 {
 			let #name = self.#name
 				.iter()
 				.map(|(v, t)| (
-					_feps::codec::Compact(v.clone()),
-					_feps::codec::Compact(t.clone()),
+					_fepsp::codec::Compact(v.clone()),
+					_fepsp::codec::Compact(t.clone()),
 				))
-				.collect::<_feps::sp_std::prelude::Vec<_>>();
+				.collect::<_fepsp::sp_std::prelude::Vec<_>>();
 			#name.encode_to(&mut r);
 		}
 	};
@@ -139,8 +139,8 @@ fn encode_impl(ident: &syn::Ident, count: usize) -> TokenStream2 {
 			let inners_solution_array = (0..c - 1)
 				.map(|i| {
 					quote! {(
-						_feps::codec::Compact(inner[#i].0.clone()),
-						_feps::codec::Compact(inner[#i].1.clone()),
+						_fepsp::codec::Compact(inner[#i].0.clone()),
+						_fepsp::codec::Compact(inner[#i].1.clone()),
 					),}
 				})
 				.collect::<TokenStream2>();
@@ -149,19 +149,19 @@ fn encode_impl(ident: &syn::Ident, count: usize) -> TokenStream2 {
 				let #name = self.#name
 					.iter()
 					.map(|(v, inner, t_last)| (
-						_feps::codec::Compact(v.clone()),
+						_fepsp::codec::Compact(v.clone()),
 						[ #inners_solution_array ],
-						_feps::codec::Compact(t_last.clone()),
+						_fepsp::codec::Compact(t_last.clone()),
 					))
-					.collect::<_feps::sp_std::prelude::Vec<_>>();
+					.collect::<_fepsp::sp_std::prelude::Vec<_>>();
 				#name.encode_to(&mut r);
 			}
 		})
 		.collect::<TokenStream2>();
 
 	quote!(
-		impl _feps::codec::Encode for #ident {
-			fn encode(&self) -> _feps::sp_std::prelude::Vec<u8> {
+		impl _fepsp::codec::Encode for #ident {
+			fn encode(&self) -> _fepsp::sp_std::prelude::Vec<u8> {
 				let mut r = vec![];
 				#encode_impl_single
 				#encode_impl_rest
@@ -182,8 +182,8 @@ fn scale_info_impl(
 		let name = format!("{}", vote_field(1));
 		quote! {
 			.field(|f|
-				f.ty::<_feps::sp_std::prelude::Vec<
-				   (_feps::codec::Compact<#voter_type>, _feps::codec::Compact<#target_type>)
+				f.ty::<_fepsp::sp_std::prelude::Vec<
+				   (_fepsp::codec::Compact<#voter_type>, _fepsp::codec::Compact<#target_type>)
 				>>()
 				.name(#name)
 			)
@@ -194,10 +194,10 @@ fn scale_info_impl(
 		let name = format!("{}", vote_field(2));
 		quote! {
 			.field(|f|
-				f.ty::<_feps::sp_std::prelude::Vec<(
-					_feps::codec::Compact<#voter_type>,
-					(_feps::codec::Compact<#target_type>, _feps::codec::Compact<#weight_type>),
-					_feps::codec::Compact<#target_type>
+				f.ty::<_fepsp::sp_std::prelude::Vec<(
+					_fepsp::codec::Compact<#voter_type>,
+					(_fepsp::codec::Compact<#target_type>, _fepsp::codec::Compact<#weight_type>),
+					_fepsp::codec::Compact<#target_type>
 				)>>()
 				.name(#name)
 			)
@@ -209,13 +209,13 @@ fn scale_info_impl(
 			let name = format!("{}", vote_field(c));
 			quote! {
 				.field(|f|
-					f.ty::<_feps::sp_std::prelude::Vec<(
-						_feps::codec::Compact<#voter_type>,
+					f.ty::<_fepsp::sp_std::prelude::Vec<(
+						_fepsp::codec::Compact<#voter_type>,
 						[
-							(_feps::codec::Compact<#target_type>, _feps::codec::Compact<#weight_type>);
+							(_fepsp::codec::Compact<#target_type>, _fepsp::codec::Compact<#weight_type>);
 							#c - 1
 						],
-						_feps::codec::Compact<#target_type>
+						_fepsp::codec::Compact<#target_type>
 					)>>()
 					.name(#name)
 				)
@@ -224,14 +224,14 @@ fn scale_info_impl(
 		.collect::<TokenStream2>();
 
 	quote!(
-		 impl _feps::scale_info::TypeInfo for #ident {
+		 impl _fepsp::scale_info::TypeInfo for #ident {
 			 type Identity = Self;
 
-			 fn type_info() -> _feps::scale_info::Type<_feps::scale_info::form::MetaForm> {
-				 _feps::scale_info::Type::builder()
-					 .path(_feps::scale_info::Path::new(stringify!(#ident), module_path!()))
+			 fn type_info() -> _fepsp::scale_info::Type<_fepsp::scale_info::form::MetaForm> {
+				 _fepsp::scale_info::Type::builder()
+					 .path(_fepsp::scale_info::Path::new(stringify!(#ident), module_path!()))
 					 .composite(
-						 _feps::scale_info::build::Fields::named()
+						 _fepsp::scale_info::build::Fields::named()
 						 #scale_info_impl_single
 						 #scale_info_impl_double
 						 #scale_info_impl_rest

--- a/frame/election-provider-support/solution-type/src/lib.rs
+++ b/frame/election-provider-support/solution-type/src/lib.rs
@@ -252,10 +252,16 @@ where
 
 fn imports() -> Result<TokenStream2> {
 	match crate_name("frame-election-provider-support") {
-		Ok(FoundCrate::Itself) => Ok(quote! { use crate as _feps; }),
+		Ok(FoundCrate::Itself) => Ok(quote! {
+			use crate as _feps;
+			use _feps::private as _fepsp;
+		}),
 		Ok(FoundCrate::Name(frame_election_provider_support)) => {
 			let ident = syn::Ident::new(&frame_election_provider_support, Span::call_site());
-			Ok(quote!( extern crate #ident as _feps; ))
+			Ok(quote!(
+					extern crate #ident as _feps;
+					use _feps::private as _fepsp;
+			))
 		},
 		Err(e) => Err(syn::Error::new(Span::call_site(), e)),
 	}

--- a/frame/election-provider-support/solution-type/src/lib.rs
+++ b/frame/election-provider-support/solution-type/src/lib.rs
@@ -259,7 +259,7 @@ fn imports() -> Result<TokenStream2> {
 		Ok(FoundCrate::Name(frame_election_provider_support)) => {
 			let ident = syn::Ident::new(&frame_election_provider_support, Span::call_site());
 			Ok(quote!(
-					extern crate #ident as _feps;
+					use #ident as _feps;
 					use _feps::private as _fepsp;
 			))
 		},

--- a/frame/election-provider-support/solution-type/src/single_page.rs
+++ b/frame/election-provider-support/solution-type/src/single_page.rs
@@ -40,7 +40,7 @@ pub(crate) fn generate(def: crate::SolutionDef) -> Result<TokenStream2> {
 		let name = vote_field(1);
 		// NOTE: we use the visibility of the struct for the fields as well.. could be made better.
 		quote!(
-			#vis #name: _feps::sp_std::prelude::Vec<(#voter_type, #target_type)>,
+			#vis #name: _fepsp::sp_std::prelude::Vec<(#voter_type, #target_type)>,
 		)
 	};
 
@@ -49,7 +49,7 @@ pub(crate) fn generate(def: crate::SolutionDef) -> Result<TokenStream2> {
 			let field_name = vote_field(c);
 			let array_len = c - 1;
 			quote!(
-				#vis #field_name: _feps::sp_std::prelude::Vec<(
+				#vis #field_name: _fepsp::sp_std::prelude::Vec<(
 					#voter_type,
 					[(#target_type, #weight_type); #array_len],
 					#target_type
@@ -84,9 +84,9 @@ pub(crate) fn generate(def: crate::SolutionDef) -> Result<TokenStream2> {
 			Eq,
 			Clone,
 			Debug,
-			_feps::codec::Encode,
-			_feps::codec::Decode,
-			_feps::scale_info::TypeInfo,
+			_fepsp::codec::Encode,
+			_fepsp::codec::Decode,
+			_fepsp::scale_info::TypeInfo,
 		)])
 	};
 
@@ -102,7 +102,7 @@ pub(crate) fn generate(def: crate::SolutionDef) -> Result<TokenStream2> {
 		#derives_and_maybe_compact_encoding
 		#vis struct #ident { #single #rest }
 
-		use _feps::__OrInvalidIndex;
+		use _fepsp::__OrInvalidIndex;
 		impl _feps::NposSolution for #ident {
 			const LIMIT: usize = #count;
 			type VoterIndex = #voter_type;
@@ -147,8 +147,8 @@ pub(crate) fn generate(def: crate::SolutionDef) -> Result<TokenStream2> {
 				self,
 				voter_at: impl Fn(Self::VoterIndex) -> Option<A>,
 				target_at: impl Fn(Self::TargetIndex) -> Option<A>,
-			) -> Result<_feps::sp_std::prelude::Vec<_feps::Assignment<A, #weight_type>>, _feps::Error> {
-				let mut #assignment_name: _feps::sp_std::prelude::Vec<_feps::Assignment<A, #weight_type>> = Default::default();
+			) -> Result<_fepsp::sp_std::prelude::Vec<_feps::Assignment<A, #weight_type>>, _feps::Error> {
+				let mut #assignment_name: _fepsp::sp_std::prelude::Vec<_feps::Assignment<A, #weight_type>> = Default::default();
 				#into_impl
 				Ok(#assignment_name)
 			}
@@ -165,10 +165,10 @@ pub(crate) fn generate(def: crate::SolutionDef) -> Result<TokenStream2> {
 				all_edges
 			}
 
-			fn unique_targets(&self) -> _feps::sp_std::prelude::Vec<Self::TargetIndex> {
+			fn unique_targets(&self) -> _fepsp::sp_std::prelude::Vec<Self::TargetIndex> {
 				// NOTE: this implementation returns the targets sorted, but we don't use it yet per
 				// se, nor is the API enforcing it.
-				use _feps::sp_std::collections::btree_set::BTreeSet;
+				use _fepsp::sp_std::collections::btree_set::BTreeSet;
 				let mut all_targets: BTreeSet<Self::TargetIndex> = BTreeSet::new();
 				let mut maybe_insert_target = |t: Self::TargetIndex| {
 					all_targets.insert(t);
@@ -185,10 +185,10 @@ pub(crate) fn generate(def: crate::SolutionDef) -> Result<TokenStream2> {
 			<#ident as _feps::NposSolution>::TargetIndex,
 			<#ident as _feps::NposSolution>::Accuracy,
 		>;
-		impl _feps::codec::MaxEncodedLen for #ident {
+		impl _fepsp::codec::MaxEncodedLen for #ident {
 			fn max_encoded_len() -> usize {
 				use frame_support::traits::Get;
-				use _feps::codec::Encode;
+				use _fepsp::codec::Encode;
 				let s: u32 = #max_voters::get();
 				let max_element_size =
 					// the first voter..
@@ -202,11 +202,11 @@ pub(crate) fn generate(def: crate::SolutionDef) -> Result<TokenStream2> {
 				// The assumption is that it contains #count-1 empty elements
 				// and then last element with full size
 				#count
-					.saturating_mul(_feps::codec::Compact(0u32).encoded_size())
+					.saturating_mul(_fepsp::codec::Compact(0u32).encoded_size())
 					.saturating_add((s as usize).saturating_mul(max_element_size))
 			}
 		}
-		impl<'a> _feps::sp_std::convert::TryFrom<&'a [__IndexAssignment]> for #ident {
+		impl<'a> _fepsp::sp_std::convert::TryFrom<&'a [__IndexAssignment]> for #ident {
 			type Error = _feps::Error;
 			fn try_from(index_assignments: &'a [__IndexAssignment]) -> Result<Self, Self::Error> {
 				let mut #struct_name =  #ident::default();
@@ -357,18 +357,18 @@ pub(crate) fn into_impl(
 					let mut inners_parsed = inners
 						.iter()
 						.map(|(ref t_idx, p)| {
-							sum = _feps::sp_arithmetic::traits::Saturating::saturating_add(sum, *p);
+							sum = _fepsp::sp_arithmetic::traits::Saturating::saturating_add(sum, *p);
 							let target = target_at(*t_idx).or_invalid_index()?;
 							Ok((target, *p))
 						})
-						.collect::<Result<_feps::sp_std::prelude::Vec<(A, #per_thing)>, _feps::Error>>()?;
+						.collect::<Result<_fepsp::sp_std::prelude::Vec<(A, #per_thing)>, _feps::Error>>()?;
 
 					if sum >= #per_thing::one() {
 						return Err(_feps::Error::SolutionWeightOverflow);
 					}
 
 					// defensive only. Since Percent doesn't have `Sub`.
-					let p_last = _feps::sp_arithmetic::traits::Saturating::saturating_sub(
+					let p_last = _fepsp::sp_arithmetic::traits::Saturating::saturating_sub(
 						#per_thing::one(),
 						sum,
 					);

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -192,7 +192,6 @@ pub use traits::NposSolution;
 #[cfg(feature = "try-runtime")]
 use sp_runtime::TryRuntimeError;
 
-
 // re-export for the solution macro, with the dependencies of the macro.
 #[doc(hidden)]
 pub mod private {

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -192,15 +192,30 @@ pub use traits::NposSolution;
 #[cfg(feature = "try-runtime")]
 use sp_runtime::TryRuntimeError;
 
+
 // re-export for the solution macro, with the dependencies of the macro.
 #[doc(hidden)]
-pub use codec;
-#[doc(hidden)]
-pub use scale_info;
-#[doc(hidden)]
-pub use sp_arithmetic;
-#[doc(hidden)]
-pub use sp_std;
+pub mod private {
+	pub use codec;
+	pub use scale_info;
+	pub use sp_arithmetic;
+	pub use sp_std;
+
+	// Simple Extension trait to easily convert `None` from index closures to `Err`.
+	//
+	// This is only generated and re-exported for the solution code to use.
+	pub trait __OrInvalidIndex<T> {
+		fn or_invalid_index(self) -> Result<T, crate::Error>;
+	}
+
+	impl<T> __OrInvalidIndex<T> for Option<T> {
+		fn or_invalid_index(self) -> Result<T, crate::Error> {
+			self.ok_or(crate::Error::SolutionInvalidIndex)
+		}
+	}
+}
+
+use private::__OrInvalidIndex;
 
 pub mod weights;
 pub use weights::WeightInfo;
@@ -209,19 +224,6 @@ pub use weights::WeightInfo;
 mod mock;
 #[cfg(test)]
 mod tests;
-// Simple Extension trait to easily convert `None` from index closures to `Err`.
-//
-// This is only generated and re-exported for the solution code to use.
-#[doc(hidden)]
-pub trait __OrInvalidIndex<T> {
-	fn or_invalid_index(self) -> Result<T, Error>;
-}
-
-impl<T> __OrInvalidIndex<T> for Option<T> {
-	fn or_invalid_index(self) -> Result<T, Error> {
-		self.ok_or(Error::SolutionInvalidIndex)
-	}
-}
 
 /// The [`IndexAssignment`] type is an intermediate between the assignments list
 /// ([`&[Assignment<T>]`][Assignment]) and `SolutionOf<T>`.

--- a/frame/support/procedural/src/construct_runtime/expand/inherent.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/inherent.rs
@@ -58,22 +58,22 @@ pub fn expand_outer_inherent(
 
 		trait InherentDataExt {
 			fn create_extrinsics(&self) ->
-				#scrate::inherent::Vec<<#block as #scrate::inherent::BlockT>::Extrinsic>;
+				#scrate::sp_std::vec::Vec<<#block as #scrate::sp_runtime::traits::Block>::Extrinsic>;
 			fn check_extrinsics(&self, block: &#block) -> #scrate::inherent::CheckInherentsResult;
 		}
 
 		impl InherentDataExt for #scrate::inherent::InherentData {
 			fn create_extrinsics(&self) ->
-				#scrate::inherent::Vec<<#block as #scrate::inherent::BlockT>::Extrinsic>
+				#scrate::sp_std::vec::Vec<<#block as #scrate::sp_runtime::traits::Block>::Extrinsic>
 			{
 				use #scrate::inherent::ProvideInherent;
 
-				let mut inherents = Vec::new();
+				let mut inherents = #scrate::sp_std::vec::Vec::new();
 
 				#(
 					#pallet_attrs
 					if let Some(inherent) = #pallet_names::create_inherent(self) {
-						let inherent = <#unchecked_extrinsic as #scrate::inherent::Extrinsic>::new(
+						let inherent = <#unchecked_extrinsic as #scrate::sp_runtime::traits::Extrinsic>::new(
 							inherent.into(),
 							None,
 						).expect("Runtime UncheckedExtrinsic is not Opaque, so it has to return \
@@ -96,7 +96,7 @@ pub fn expand_outer_inherent(
 				for xt in block.extrinsics() {
 					// Inherents are before any other extrinsics.
 					// And signed extrinsics are not inherents.
-					if #scrate::inherent::Extrinsic::is_signed(xt).unwrap_or(false) {
+					if #scrate::sp_runtime::traits::Extrinsic::is_signed(xt).unwrap_or(false) {
 						break
 					}
 
@@ -134,7 +134,7 @@ pub fn expand_outer_inherent(
 					match #pallet_names::is_inherent_required(self) {
 						Ok(Some(e)) => {
 							let found = block.extrinsics().iter().any(|xt| {
-								let is_signed = #scrate::inherent::Extrinsic::is_signed(xt)
+								let is_signed = #scrate::sp_runtime::traits::Extrinsic::is_signed(xt)
 									.unwrap_or(false);
 
 								if !is_signed {
@@ -186,7 +186,8 @@ pub fn expand_outer_inherent(
 				let mut first_signed_observed = false;
 
 				for (i, xt) in block.extrinsics().iter().enumerate() {
-					let is_signed = #scrate::inherent::Extrinsic::is_signed(xt).unwrap_or(false);
+					let is_signed = #scrate::sp_runtime::traits::Extrinsic::is_signed(xt)
+						.unwrap_or(false);
 
 					let is_inherent = if is_signed {
 						// Signed extrinsics are not inherents.

--- a/frame/support/src/inherent.rs
+++ b/frame/support/src/inherent.rs
@@ -15,11 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[doc(hidden)]
-pub use crate::sp_runtime::traits::{Block as BlockT, Extrinsic};
-#[doc(hidden)]
-pub use crate::sp_std::vec::Vec;
-
 pub use sp_inherents::{
 	CheckInherentsResult, InherentData, InherentIdentifier, IsFatalError, MakeFatalError,
 };

--- a/frame/support/src/traits/filter.rs
+++ b/frame/support/src/traits/filter.rs
@@ -96,15 +96,6 @@ impl<T> InstanceFilter<T> for () {
 	}
 }
 
-/// Re-expected for the macro.
-#[doc(hidden)]
-pub use sp_std::{
-	boxed::Box,
-	cell::RefCell,
-	mem::{swap, take},
-	vec::Vec,
-};
-
 #[macro_export]
 macro_rules! impl_filter_stack {
 	($target:ty, $base:ty, $call:ty, $module:ident) => {
@@ -112,7 +103,8 @@ macro_rules! impl_filter_stack {
 		mod $module {
 			#[allow(unused_imports)]
 			use super::*;
-			use $crate::traits::filter::{swap, take, RefCell, Vec, Box, Contains, FilterStack};
+			use $crate::sp_std::{boxed::Box, cell::RefCell, mem::{swap, take}, vec::Vec};
+			use $crate::traits::filter::{Contains, FilterStack};
 
 			thread_local! {
 				static FILTER: RefCell<Vec<Box<dyn Fn(&$call) -> bool + 'static>>> = RefCell::new(Vec::new());

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -815,12 +815,12 @@ fn instance_expand() {
 #[test]
 fn inherent_expand() {
 	use frame_support::{
-		inherent::{BlockT, InherentData},
+		inherent::InherentData,
 		traits::EnsureInherentsAreFirst,
 	};
 	use sp_core::Hasher;
 	use sp_runtime::{
-		traits::{BlakeTwo256, Header},
+		traits::{BlakeTwo256, Header, Block as _},
 		Digest,
 	};
 

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -814,13 +814,10 @@ fn instance_expand() {
 
 #[test]
 fn inherent_expand() {
-	use frame_support::{
-		inherent::InherentData,
-		traits::EnsureInherentsAreFirst,
-	};
+	use frame_support::{inherent::InherentData, traits::EnsureInherentsAreFirst};
 	use sp_core::Hasher;
 	use sp_runtime::{
-		traits::{BlakeTwo256, Header, Block as _},
+		traits::{BlakeTwo256, Block as _, Header},
 		Digest,
 	};
 


### PR DESCRIPTION
related issue: https://github.com/paritytech/polkadot-sdk/issues/172
cumulus companion: https://github.com/paritytech/cumulus/pull/2733

There is still some in the primitives but we can do in another PR
And there is some in `frame/support/src/lib.rs` but I think some people are using them like a `frame` umbrella crate (https://github.com/paritytech/substrate/pull/14137). So it is probably better to wait for `frame` crate to give them a smooth transition.


# breaking change

* `frame::support::inherent::BlockT` is removed and should be imported from `sp_runtime::traits::Block`.
* `frame::support::inherent::Extrinsic` is removed and should be imported from `sp-runtime::traits::Extrinsic`
* some other minor type re-export are removed and should be imported from their respective origins.