### PR TITLE
Expose ExtraFlags struct

### DIFF
--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -193,7 +193,9 @@ use sp_runtime::{
 	ArithmeticError, DispatchError, FixedPointOperand, Perbill, RuntimeDebug, TokenError,
 };
 use sp_std::{cmp, fmt::Debug, mem, prelude::*, result};
-pub use types::{AccountData, BalanceLock, DustCleaner, IdAmount, Reasons, ReserveData};
+pub use types::{
+	AccountData, BalanceLock, DustCleaner, ExtraFlags, IdAmount, Reasons, ReserveData,
+};
 pub use weights::WeightInfo;
 
 pub use pallet::*;


### PR DESCRIPTION


# Description
This pr makes `ExtraFlags` visible outside the `pallet-balances`.  Since it is a public field of the `AccountData` struct this should also be made public otherwise, it's not possible to create a non-default value of this type

# Checklist

- [ x] My PR includes a detailed description as outlined in the "Description" section above
- [ ] My PR follows the [labeling requirements](./CONTRIBUTING.adoc#merge-process) of this project (at minimum one label for each `A`, `B`, `C` and `D` required)
- [ x] I have made corresponding changes to the documentation (if applicable)
- [ x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ x] If this PR alters any external APIs or interfaces used by Polkadot, the corresponding Polkadot PR is ready as well as the corresponding Cumulus PR (optional)
