### PR TITLE
`construct_runtime`: support for expanding the macro code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,19 +2427,6 @@ dependencies = [
 
 [[package]]
 name = "expander"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f360349150728553f92e4c997a16af8915f418d3a0f21b440d34c5632f16ed84"
-dependencies = [
- "blake2",
- "fs-err",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "expander"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f86a749cf851891866c10515ef6c299b5c69661465e9c3bbe7e07a2b77fb0f7"
@@ -2861,7 +2848,7 @@ dependencies = [
  "Inflector",
  "cfg-expr",
  "derive-syn-parse",
- "expander 1.0.0",
+ "expander",
  "frame-support-procedural-tools",
  "itertools",
  "macro_magic",
@@ -10819,7 +10806,7 @@ dependencies = [
  "Inflector",
  "assert_matches",
  "blake2",
- "expander 2.0.0",
+ "expander",
  "proc-macro-crate",
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,6 +2427,19 @@ dependencies = [
 
 [[package]]
 name = "expander"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f360349150728553f92e4c997a16af8915f418d3a0f21b440d34c5632f16ed84"
+dependencies = [
+ "blake2",
+ "fs-err",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "expander"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f86a749cf851891866c10515ef6c299b5c69661465e9c3bbe7e07a2b77fb0f7"
@@ -2848,6 +2861,7 @@ dependencies = [
  "Inflector",
  "cfg-expr",
  "derive-syn-parse",
+ "expander 1.0.0",
  "frame-support-procedural-tools",
  "itertools",
  "macro_magic",
@@ -10805,7 +10819,7 @@ dependencies = [
  "Inflector",
  "assert_matches",
  "blake2",
- "expander",
+ "expander 2.0.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",

--- a/frame/support/procedural/Cargo.toml
+++ b/frame/support/procedural/Cargo.toml
@@ -25,6 +25,7 @@ syn = { version = "2.0.16", features = ["full"] }
 frame-support-procedural-tools = { version = "4.0.0-dev", path = "./tools" }
 proc-macro-warning = { version = "0.4.1", default-features = false }
 macro_magic = { version = "0.3.5", features = ["proc_support"] }
+expander = "1.0.0"
 
 [features]
 default = ["std"]

--- a/frame/support/procedural/Cargo.toml
+++ b/frame/support/procedural/Cargo.toml
@@ -25,7 +25,7 @@ syn = { version = "2.0.16", features = ["full"] }
 frame-support-procedural-tools = { version = "4.0.0-dev", path = "./tools" }
 proc-macro-warning = { version = "0.4.1", default-features = false }
 macro_magic = { version = "0.3.5", features = ["proc_support"] }
-expander = "1.0.0"
+expander = "2.0.0"
 
 [features]
 default = ["std"]

--- a/frame/support/procedural/src/construct_runtime/mod.rs
+++ b/frame/support/procedural/src/construct_runtime/mod.rs
@@ -183,7 +183,6 @@ pub fn construct_runtime(input: TokenStream) -> TokenStream {
 	let res = expander::Expander::new("construct_runtime")
 		.dry(std::env::var("FRAME_EXPAND").is_err())
 		.verbose(true)
-		.fmt(expander::Edition::_2021)
 		.write_to_out_dir(res)
 		.expect("Does not fail because of IO in OUT_DIR; qed");
 

--- a/frame/support/procedural/src/construct_runtime/mod.rs
+++ b/frame/support/procedural/src/construct_runtime/mod.rs
@@ -183,6 +183,7 @@ pub fn construct_runtime(input: TokenStream) -> TokenStream {
 	let res = expander::Expander::new("construct_runtime")
 		.dry(std::env::var("FRAME_EXPAND").is_err())
 		.verbose(true)
+		.fmt(expander::Edition::_2021)
 		.write_to_out_dir(res)
 		.expect("Does not fail because of IO in OUT_DIR; qed");
 

--- a/frame/support/procedural/src/construct_runtime/mod.rs
+++ b/frame/support/procedural/src/construct_runtime/mod.rs
@@ -181,7 +181,7 @@ pub fn construct_runtime(input: TokenStream) -> TokenStream {
 	let res = res.unwrap_or_else(|e| e.to_compile_error());
 
 	let res = expander::Expander::new("construct_runtime")
-		.dry(std::env::var("SP_API_EXPAND").is_err())
+		.dry(std::env::var("FRAME_EXPAND").is_err())
 		.verbose(true)
 		.write_to_out_dir(res)
 		.expect("Does not fail because of IO in OUT_DIR; qed");

--- a/frame/support/procedural/src/construct_runtime/mod.rs
+++ b/frame/support/procedural/src/construct_runtime/mod.rs
@@ -178,7 +178,15 @@ pub fn construct_runtime(input: TokenStream) -> TokenStream {
 				.and_then(|_| construct_runtime_final_expansion(explicit_decl)),
 	};
 
-	res.unwrap_or_else(|e| e.to_compile_error()).into()
+	let res = res.unwrap_or_else(|e| e.to_compile_error());
+
+	let res = expander::Expander::new("construct_runtime")
+		.dry(std::env::var("SP_API_EXPAND").is_err())
+		.verbose(true)
+		.write_to_out_dir(res)
+		.expect("Does not fail because of IO in OUT_DIR; qed");
+
+	res.into()
 }
 
 /// When some pallet have implicit parts definition then the macro will expand into a macro call to


### PR DESCRIPTION
Support for expanding the generated code from `construct_runtime`  macro into the source file which is included. Allows for better macro debugging (error points to the particular line in expanded source files).

Based on: https://github.com/paritytech/substrate/pull/13573

Setting `FRAME_EXPAND` environment variable enables feature.
