### PR TITLE
sc-consensus-beefy: fix flaky test beefy_reports_equivocations

### DIFF
--- a/client/consensus/beefy/src/tests.rs
+++ b/client/consensus/beefy/src/tests.rs
@@ -1263,18 +1263,35 @@ async fn beefy_reports_equivocations() {
 
 	let peers = peers.into_iter().enumerate();
 	// finalize block #1 -> BEEFY should not finalize anything (each node votes on different MMR).
-	finalize_block_and_wait_for_beefy(&net, peers, &hashes[1], &[]).await;
+	let (best_blocks, versioned_finality_proof) = get_beefy_streams(&mut net.lock(), peers.clone());
+	peers.clone().for_each(|(index, _)| {
+		let client = net.lock().peer(index).client().as_client();
+		client.finalize_block(hashes[1], None).unwrap();
+	});
+
+	// run for up to 5 seconds waiting for Alice's report of Bob/Bob_Prime equivocation.
+	for wait_ms in [250, 500, 1250, 3000] {
+		run_for(Duration::from_millis(wait_ms), &net).await;
+		let alice_reported_equivocations =
+			api_alice.reported_equivocations.as_ref().unwrap().lock();
+		if alice_reported_equivocations.is_empty() {
+			continue
+		}
+		// Verify expected equivocation
+		assert_eq!(alice_reported_equivocations.len(), 1);
+		let equivocation_proof = alice_reported_equivocations.get(0).unwrap();
+		assert_eq!(equivocation_proof.first.id, BeefyKeyring::Bob.public());
+		assert_eq!(equivocation_proof.first.commitment.block_number, 1);
+		break
+	}
 
 	// Verify neither Bob or Bob_Prime report themselves as equivocating.
 	assert!(api_bob.reported_equivocations.as_ref().unwrap().lock().is_empty());
 	assert!(api_bob_prime.reported_equivocations.as_ref().unwrap().lock().is_empty());
 
-	// Verify Alice reports Bob/Bob_Prime equivocation.
-	let alice_reported_equivocations = api_alice.reported_equivocations.as_ref().unwrap().lock();
-	assert_eq!(alice_reported_equivocations.len(), 1);
-	let equivocation_proof = alice_reported_equivocations.get(0).unwrap();
-	assert_eq!(equivocation_proof.first.id, BeefyKeyring::Bob.public());
-	assert_eq!(equivocation_proof.first.commitment.block_number, 1);
+	// sanity verify no new blocks have been finalized by BEEFY
+	streams_empty_after_timeout(best_blocks, &net, None).await;
+	streams_empty_after_timeout(versioned_finality_proof, &net, None).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
Test was using too small a timeout of 250ms to verify equivocation is reported.

If the test machine is loaded with many async tasks running, the voters work and subsequent gossiping does not fit within the 250ms window.

Do multiple tries to verify equivocation reporting with exponential timeouts, most times it will be within 250ms, but the test will retry several times up to 5seconds total before giving up.

Part of https://github.com/paritytech/substrate/issues/11321
