### PR TITLE
expose the fields of Dust type to public

### DIFF
--- a/frame/support/src/traits/tokens/fungible/regular.rs
+++ b/frame/support/src/traits/tokens/fungible/regular.rs
@@ -109,7 +109,7 @@ pub trait Inspect<AccountId>: Sized {
 
 /// Special dust type which can be type-safely converted into a `Credit`.
 #[must_use]
-pub struct Dust<A, T: Inspect<A>>(pub(crate) T::Balance);
+pub struct Dust<A, T: Inspect<A>>(pub T::Balance);
 
 impl<A, T: Balanced<A>> Dust<A, T> {
 	/// Convert `Dust` into an instance of `Credit`.

--- a/frame/support/src/traits/tokens/fungibles/regular.rs
+++ b/frame/support/src/traits/tokens/fungibles/regular.rs
@@ -121,7 +121,7 @@ pub trait Inspect<AccountId>: Sized {
 
 /// Special dust type which can be type-safely converted into a `Credit`.
 #[must_use]
-pub struct Dust<A, T: Unbalanced<A>>(pub(crate) T::AssetId, pub(crate) T::Balance);
+pub struct Dust<A, T: Unbalanced<A>>(pub T::AssetId, pub T::Balance);
 
 impl<A, T: Balanced<A>> Dust<A, T> {
 	/// Convert `Dust` into an instance of `Credit`.


### PR DESCRIPTION
I'm using latest fungibles traits, for some reason I need to overwrite `Unbalanced::increase_balance` in my impl, but I found that the fielde of `Dust` type is invisible, and has no constructor and getter function.