### PR TITLE
expose setting kademlia replication factor through node CLI

### DIFF
--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -240,7 +240,7 @@ impl NetworkParams {
 			enable_dht_random_walk: !self.reserved_only,
 			allow_non_globals_in_dht,
 			kademlia_disjoint_query_paths: self.kademlia_disjoint_query_paths,
-			kademlia_replication_factor: self.kademlia_replication_factor,
+			kademlia_replication_factor: Some(self.kademlia_replication_factor),
 			yamux_window_size: None,
 			ipfs_server: self.ipfs_server,
 			sync_mode: self.sync.into(),

--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -28,7 +28,7 @@ use sc_service::{
 	config::{Multiaddr, MultiaddrWithPeerId},
 	ChainSpec, ChainType,
 };
-use std::{borrow::Cow, path::PathBuf};
+use std::{borrow::Cow, num::NonZeroUsize, path::PathBuf};
 
 /// Parameters used to create the network configuration.
 #[derive(Debug, Clone, Args)]
@@ -120,6 +120,12 @@ pub struct NetworkParams {
 	/// security improvements.
 	#[arg(long)]
 	pub kademlia_disjoint_query_paths: bool,
+
+	/// Kademlia replication factor determines to how many closest peers a record is replicated to.
+	/// Default value is 20. Discovery mechanism requires successful replication to all
+	/// `kademlia_replication_factor` peers to consider record successfully put.
+	#[arg(long)]
+	pub kademlia_replication_factor: Option<NonZeroUsize>,
 
 	/// Join the IPFS network and serve transactions over bitswap protocol.
 	#[arg(long)]
@@ -233,6 +239,7 @@ impl NetworkParams {
 			enable_dht_random_walk: !self.reserved_only,
 			allow_non_globals_in_dht,
 			kademlia_disjoint_query_paths: self.kademlia_disjoint_query_paths,
+			kademlia_replication_factor: self.kademlia_replication_factor,
 			yamux_window_size: None,
 			ipfs_server: self.ipfs_server,
 			sync_mode: self.sync.into(),

--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -122,10 +122,11 @@ pub struct NetworkParams {
 	pub kademlia_disjoint_query_paths: bool,
 
 	/// Kademlia replication factor determines to how many closest peers a record is replicated to.
-	/// Default value is 20. Discovery mechanism requires successful replication to all
+	///
+	/// Discovery mechanism requires successful replication to all
 	/// `kademlia_replication_factor` peers to consider record successfully put.
-	#[arg(long)]
-	pub kademlia_replication_factor: Option<NonZeroUsize>,
+	#[arg(long, default_value = "20")]
+	pub kademlia_replication_factor: NonZeroUsize,
 
 	/// Join the IPFS network and serve transactions over bitswap protocol.
 	#[arg(long)]

--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -240,7 +240,7 @@ impl NetworkParams {
 			enable_dht_random_walk: !self.reserved_only,
 			allow_non_globals_in_dht,
 			kademlia_disjoint_query_paths: self.kademlia_disjoint_query_paths,
-			kademlia_replication_factor: Some(self.kademlia_replication_factor),
+			kademlia_replication_factor: self.kademlia_replication_factor,
 			yamux_window_size: None,
 			ipfs_server: self.ipfs_server,
 			sync_mode: self.sync.into(),

--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -50,6 +50,7 @@ use std::{
 	io::{self, Write},
 	iter,
 	net::Ipv4Addr,
+	num::NonZeroUsize,
 	path::{Path, PathBuf},
 	pin::Pin,
 	str::{self, FromStr},
@@ -605,6 +606,9 @@ pub struct NetworkConfiguration {
 	/// the presence of potentially adversarial nodes.
 	pub kademlia_disjoint_query_paths: bool,
 
+	/// None will end up using default Kademlia value.
+	pub kademlia_replication_factor: Option<NonZeroUsize>,
+
 	/// Enable serving block data over IPFS bitswap.
 	pub ipfs_server: bool,
 
@@ -656,6 +660,7 @@ impl NetworkConfiguration {
 			enable_dht_random_walk: true,
 			allow_non_globals_in_dht: false,
 			kademlia_disjoint_query_paths: false,
+			kademlia_replication_factor: None,
 			yamux_window_size: None,
 			ipfs_server: false,
 		}

--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -22,6 +22,7 @@
 //! See the documentation of [`Params`].
 
 pub use crate::{
+	discovery::DEFAULT_KADEMLIA_REPLICATION_FACTOR,
 	protocol::NotificationsSink,
 	request_responses::{
 		IncomingRequest, OutgoingResponse, ProtocolConfig as RequestResponseConfig,
@@ -606,8 +607,11 @@ pub struct NetworkConfiguration {
 	/// the presence of potentially adversarial nodes.
 	pub kademlia_disjoint_query_paths: bool,
 
-	/// None will end up using default Kademlia value.
-	pub kademlia_replication_factor: Option<NonZeroUsize>,
+	/// Kademlia replication factor determines to how many closest peers a record is replicated to.
+	///
+	/// Discovery mechanism requires successful replication to all
+	/// `kademlia_replication_factor` peers to consider record successfully put.
+	pub kademlia_replication_factor: NonZeroUsize,
 
 	/// Enable serving block data over IPFS bitswap.
 	pub ipfs_server: bool,
@@ -660,7 +664,8 @@ impl NetworkConfiguration {
 			enable_dht_random_walk: true,
 			allow_non_globals_in_dht: false,
 			kademlia_disjoint_query_paths: false,
-			kademlia_replication_factor: None,
+			kademlia_replication_factor: NonZeroUsize::new(DEFAULT_KADEMLIA_REPLICATION_FACTOR)
+				.expect("value is a constant; constant is non-zero; qed."),
 			yamux_window_size: None,
 			ipfs_server: false,
 		}

--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -101,6 +101,7 @@ pub struct DiscoveryConfig {
 	enable_mdns: bool,
 	kademlia_disjoint_query_paths: bool,
 	kademlia_protocols: Vec<Vec<u8>>,
+	kademlia_replication_factor: Option<NonZeroUsize>,
 }
 
 impl DiscoveryConfig {
@@ -116,6 +117,7 @@ impl DiscoveryConfig {
 			enable_mdns: false,
 			kademlia_disjoint_query_paths: false,
 			kademlia_protocols: Vec::new(),
+			kademlia_replication_factor: None,
 		}
 	}
 
@@ -182,6 +184,12 @@ impl DiscoveryConfig {
 		self
 	}
 
+	/// Sets Kademlia replication factor.
+	pub fn with_kademlia_replication_factor(&mut self, value: NonZeroUsize) -> &mut Self {
+		self.kademlia_replication_factor = Some(value);
+		self
+	}
+
 	/// Create a `DiscoveryBehaviour` from this config.
 	pub fn finish(self) -> DiscoveryBehaviour {
 		let Self {
@@ -194,10 +202,16 @@ impl DiscoveryConfig {
 			enable_mdns,
 			kademlia_disjoint_query_paths,
 			kademlia_protocols,
+			kademlia_replication_factor,
 		} = self;
 
 		let kademlia = if !kademlia_protocols.is_empty() {
 			let mut config = KademliaConfig::default();
+
+			if let Some(replication_factor) = kademlia_replication_factor {
+				config.set_replication_factor(replication_factor);
+			}
+
 			config.set_protocol_names(kademlia_protocols.into_iter().map(Into::into).collect());
 			// By default Kademlia attempts to insert all peers into its routing table once a
 			// dialing attempt succeeds. In order to control which peer is added, disable the

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -320,12 +320,7 @@ where
 				config.use_kademlia_disjoint_query_paths(
 					network_config.kademlia_disjoint_query_paths,
 				);
-
-				if let Some(kademlia_replication_factor) =
-					network_config.kademlia_replication_factor
-				{
-					config.with_kademlia_replication_factor(kademlia_replication_factor);
-				}
+				config.with_kademlia_replication_factor(network_config.kademlia_replication_factor);
 
 				match network_config.transport {
 					TransportConfig::MemoryOnly => {

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -321,6 +321,12 @@ where
 					network_config.kademlia_disjoint_query_paths,
 				);
 
+				if let Some(kademlia_replication_factor) =
+					network_config.kademlia_replication_factor
+				{
+					config.with_kademlia_replication_factor(kademlia_replication_factor);
+				}
+
 				match network_config.transport {
 					TransportConfig::MemoryOnly => {
 						config.with_mdns(false);


### PR DESCRIPTION
## What does it do?

Exposes setting Kademlia replication factor through node's CLI.

## Why?

Default Kademlia replication factor is 20. In environments (testing for example) with less than 20 nodes `AuthorityDiscovery` fails to publish DHT records containing node's `Multiaddrs`. So to make `AuthorityDiscovery` work in test environments it's  useful to have option to manually adjust Kademlia replication factor.