### PR TITLE
Add `try`-versions of prefix iterators

### DIFF
--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -29,6 +29,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate core;
 /// Export ourself as `frame_support` to make tests happy.
 extern crate self as frame_support;
 

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -29,7 +29,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate core;
 /// Export ourself as `frame_support` to make tests happy.
 extern crate self as frame_support;
 

--- a/frame/support/src/storage/generator/double_map.rs
+++ b/frame/support/src/storage/generator/double_map.rs
@@ -392,15 +392,10 @@ where
 
 	fn iter_key_prefix(k1: impl EncodeLike<K1>) -> Self::PartialKeyIterator {
 		let prefix = G::storage_double_map_final_key1(k1);
-		Self::PartialKeyIterator {
-			prefix: prefix.clone(),
-			previous_key: prefix,
-			drain: false,
-			closure: |raw_key_without_prefix| {
-				let mut key_material = G::Hasher2::reverse(raw_key_without_prefix);
-				K2::decode(&mut key_material)
-			},
-		}
+		Self::PartialKeyIterator::new(prefix.clone(), prefix, |raw_key_without_prefix| {
+			let mut key_material = G::Hasher2::reverse(raw_key_without_prefix);
+			K2::decode(&mut key_material)
+		})
 	}
 
 	fn iter_key_prefix_from(
@@ -443,18 +438,13 @@ where
 
 	fn iter_keys() -> Self::FullKeyIterator {
 		let prefix = G::prefix_hash();
-		Self::FullKeyIterator {
-			prefix: prefix.clone(),
-			previous_key: prefix,
-			drain: false,
-			closure: |raw_key_without_prefix| {
-				let mut k1_k2_material = G::Hasher1::reverse(raw_key_without_prefix);
-				let k1 = K1::decode(&mut k1_k2_material)?;
-				let mut k2_material = G::Hasher2::reverse(k1_k2_material);
-				let k2 = K2::decode(&mut k2_material)?;
-				Ok((k1, k2))
-			},
-		}
+		Self::FullKeyIterator::new(prefix.clone(), prefix, |raw_key_without_prefix| {
+			let mut k1_k2_material = G::Hasher1::reverse(raw_key_without_prefix);
+			let k1 = K1::decode(&mut k1_k2_material)?;
+			let mut k2_material = G::Hasher2::reverse(k1_k2_material);
+			let k2 = K2::decode(&mut k2_material)?;
+			Ok((k1, k2))
+		})
 	}
 
 	fn iter_keys_from(starting_raw_key: Vec<u8>) -> Self::FullKeyIterator {

--- a/frame/support/src/storage/generator/double_map.rs
+++ b/frame/support/src/storage/generator/double_map.rs
@@ -402,7 +402,7 @@ where
 	}
 
 	fn drain_prefix(k1: impl EncodeLike<K1>) -> Self::PrefixIterator {
-		let mut iterator = Self::iter_prefix(k1);
+		let iterator = Self::iter_prefix(k1);
 		iterator.drain()
 	}
 
@@ -441,7 +441,7 @@ where
 	}
 
 	fn drain() -> Self::Iterator {
-		let mut iterator = Self::iter();
+		let iterator = Self::iter();
 		iterator.drain()
 	}
 

--- a/frame/support/src/storage/generator/map.rs
+++ b/frame/support/src/storage/generator/map.rs
@@ -152,15 +152,10 @@ where
 	/// Enumerate all keys in the map.
 	fn iter_keys() -> Self::KeyIterator {
 		let prefix = G::prefix_hash();
-		KeyPrefixIterator {
-			prefix: prefix.clone(),
-			previous_key: prefix,
-			drain: false,
-			closure: |raw_key_without_prefix| {
-				let mut key_material = G::Hasher::reverse(raw_key_without_prefix);
-				K::decode(&mut key_material)
-			},
-		}
+		KeyPrefixIterator::new(prefix.clone(), prefix, |raw_key_without_prefix| {
+			let mut key_material = G::Hasher::reverse(raw_key_without_prefix);
+			K::decode(&mut key_material)
+		})
 	}
 
 	/// Enumerate all keys in the map after a given key.

--- a/frame/support/src/storage/generator/map.rs
+++ b/frame/support/src/storage/generator/map.rs
@@ -161,7 +161,7 @@ where
 
 	/// Enumerate all elements in the map.
 	fn drain() -> Self::Iterator {
-		let mut iterator = Self::iter();
+		let iterator = Self::iter();
 		iterator.drain()
 	}
 

--- a/frame/support/src/storage/generator/map.rs
+++ b/frame/support/src/storage/generator/map.rs
@@ -130,16 +130,10 @@ where
 	/// Enumerate all elements in the map.
 	fn iter() -> Self::Iterator {
 		let prefix = G::prefix_hash();
-		PrefixIterator {
-			prefix: prefix.clone(),
-			previous_key: prefix,
-			drain: false,
-			closure: |raw_key_without_prefix, mut raw_value| {
-				let mut key_material = G::Hasher::reverse(raw_key_without_prefix);
-				Ok((K::decode(&mut key_material)?, V::decode(&mut raw_value)?))
-			},
-			phantom: Default::default(),
-		}
+		PrefixIterator::new(prefix.clone(), prefix, |raw_key_without_prefix, mut raw_value| {
+			let mut key_material = G::Hasher::reverse(raw_key_without_prefix);
+			Ok((K::decode(&mut key_material)?, V::decode(&mut raw_value)?))
+		})
 	}
 
 	/// Enumerate all elements in the map after a given key.
@@ -168,8 +162,7 @@ where
 	/// Enumerate all elements in the map.
 	fn drain() -> Self::Iterator {
 		let mut iterator = Self::iter();
-		iterator.drain = true;
-		iterator
+		iterator.drain()
 	}
 
 	fn translate<O: Decode, F: FnMut(K, O) -> Option<V>>(mut f: F) {

--- a/frame/support/src/storage/generator/nmap.rs
+++ b/frame/support/src/storage/generator/nmap.rs
@@ -365,7 +365,7 @@ impl<K: ReversibleKeyGenerator, V: FullCodec, G: StorageNMap<K, V>>
 	where
 		K: HasReversibleKeyPrefix<KP>,
 	{
-		let mut iter = Self::iter_prefix(kp);
+		let iter = Self::iter_prefix(kp);
 		iter.drain()
 	}
 
@@ -394,7 +394,7 @@ impl<K: ReversibleKeyGenerator, V: FullCodec, G: StorageNMap<K, V>>
 	}
 
 	fn drain() -> Self::Iterator {
-		let mut iterator = Self::iter();
+		let iterator = Self::iter();
 		iterator.drain()
 	}
 

--- a/frame/support/src/storage/generator/nmap.rs
+++ b/frame/support/src/storage/generator/nmap.rs
@@ -356,12 +356,7 @@ impl<K: ReversibleKeyGenerator, V: FullCodec, G: StorageNMap<K, V>>
 		K: HasReversibleKeyPrefix<KP>,
 	{
 		let prefix = G::storage_n_map_partial_key(kp);
-		KeyPrefixIterator {
-			prefix: prefix.clone(),
-			previous_key: prefix,
-			drain: false,
-			closure: K::decode_partial_key,
-		}
+		KeyPrefixIterator::new(prefix.clone(), prefix, K::decode_partial_key)
 	}
 
 	fn iter_key_prefix_from<KP>(
@@ -409,15 +404,10 @@ impl<K: ReversibleKeyGenerator, V: FullCodec, G: StorageNMap<K, V>>
 
 	fn iter_keys_from(starting_raw_key: Vec<u8>) -> Self::KeyIterator {
 		let prefix = G::prefix_hash();
-		Self::KeyIterator {
-			prefix,
-			previous_key: starting_raw_key,
-			drain: false,
-			closure: |raw_key_without_prefix| {
-				let (final_key, _) = K::decode_final_key(raw_key_without_prefix)?;
-				Ok(final_key)
-			},
-		}
+		Self::KeyIterator::new(prefix, starting_raw_key, |raw_key_without_prefix| {
+			let (final_key, _) = K::decode_final_key(raw_key_without_prefix)?;
+			Ok(final_key)
+		})
 	}
 
 	fn drain() -> Self::Iterator {

--- a/frame/support/src/storage/migration.rs
+++ b/frame/support/src/storage/migration.rs
@@ -186,7 +186,7 @@ pub fn storage_iter_with_suffix<T: Decode + Sized>(
 		Ok((raw_key_without_prefix.to_vec(), value))
 	};
 
-	PrefixIterator { prefix, previous_key, drain: false, closure, phantom: Default::default() }
+	PrefixIterator::new(prefix, previous_key, closure)
 }
 
 /// Construct iterator to iterate over map items in `module` for the map called `item`.
@@ -219,7 +219,7 @@ pub fn storage_key_iter_with_suffix<
 		let value = T::decode(&mut raw_value)?;
 		Ok((key, value))
 	};
-	PrefixIterator { prefix, previous_key, drain: false, closure, phantom: Default::default() }
+	PrefixIterator::new(prefix, previous_key, closure)
 }
 
 /// Get a particular value in storage by the `module`, the map's `item` name and the key `hash`.
@@ -375,13 +375,11 @@ pub fn move_prefix(from_prefix: &[u8], to_prefix: &[u8]) {
 		return
 	}
 
-	let iter = PrefixIterator::<_> {
-		prefix: from_prefix.to_vec(),
-		previous_key: from_prefix.to_vec(),
-		drain: true,
-		closure: |key, value| Ok((key.to_vec(), value.to_vec())),
-		phantom: Default::default(),
-	};
+	let iter =
+		PrefixIterator::<_>::new(from_prefix.to_vec(), from_prefix.to_vec(), |key, value| {
+			Ok((key.to_vec(), value.to_vec()))
+		})
+		.drain();
 
 	for (key, value) in iter {
 		let full_key = [to_prefix, &key].concat();

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -1030,7 +1030,7 @@ impl<T, OnRemoval> PrefixIterator<T, OnRemoval> {
 	}
 
 	/// Mutate this iterator into a draining iterator; items iterated are removed from storage.
-	pub fn drain(mut self) -> Self {
+	pub fn drain(self) -> Self {
 		Self { iter: self.iter.drain() }
 	}
 }
@@ -1330,7 +1330,7 @@ pub struct ChildTriePrefixIterator<T> {
 
 impl<T> ChildTriePrefixIterator<T> {
 	/// Mutate this iterator into a draining iterator; items iterated are removed from storage.
-	pub fn drain(mut self) -> Self {
+	pub fn drain(self) -> Self {
 		Self { iter: self.iter.drain() }
 	}
 }

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -868,7 +868,7 @@ impl<T, OnRemoval1> TryPrefixIterator<T, OnRemoval1> {
 	}
 }
 
-/// Error returned by `TryPrefixIterator`.
+/// Error returned by [`TryPrefixIterator`].
 #[derive(RuntimeDebug, Clone, Eq, PartialEq)]
 pub enum TryPrefixIteratorError {
 	KeyWithoutValue { previous_key: Vec<u8> },

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
@@ -50,4 +50,4 @@ error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeDecode` is
 17 |     #[pallet::call]
    |               ^^^^ the trait `WrapperTypeDecode` is not implemented for `<T as pallet::Config>::Bar`
    |
-   = note: required for `<T as pallet::Config>::Bar` to implement `Decode`
+   = note: required for `<T as pallet::Config>::Bar` to implement `parity_scale_codec::Decode`

--- a/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.stderr
+++ b/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.stderr
@@ -9,7 +9,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
              Box<T>
              Rc<T>
              frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
-   = note: required for `Bar` to implement `Decode`
+   = note: required for `Bar` to implement `parity_scale_codec::Decode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `PartialStorageInfoTrait`
 
@@ -84,7 +84,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
              Box<T>
              Rc<T>
              frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
-   = note: required for `Bar` to implement `Decode`
+   = note: required for `Bar` to implement `parity_scale_codec::Decode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
 

--- a/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.stderr
+++ b/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.stderr
@@ -9,7 +9,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
              Box<T>
              Rc<T>
              frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
-   = note: required for `Bar` to implement `Decode`
+   = note: required for `Bar` to implement `parity_scale_codec::Decode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `PartialStorageInfoTrait`
 
@@ -84,7 +84,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
              Box<T>
              Rc<T>
              frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
-   = note: required for `Bar` to implement `Decode`
+   = note: required for `Bar` to implement `parity_scale_codec::Decode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
 


### PR DESCRIPTION
Can be very useful in migrations to avoid mistakes