### PR TITLE
Delete 1D weight ctors and set explicit deprecation dates

### DIFF
--- a/frame/support/procedural/src/lib.rs
+++ b/frame/support/procedural/src/lib.rs
@@ -299,7 +299,7 @@ fn counter_prefix(prefix: &str) -> String {
 /// }
 /// ```
 #[proc_macro]
-#[deprecated(note = "Will be removed soon; use the attribute `#[pallet]` macro instead.
+#[deprecated(note = "Will be removed after July 2023; use the attribute `#[pallet]` macro instead.
 	For more info, see: <https://github.com/paritytech/substrate/pull/13705>")]
 pub fn decl_storage(input: TokenStream) -> TokenStream {
 	storage::decl_storage_impl(input)

--- a/frame/support/procedural/src/pallet/expand/store_trait.rs
+++ b/frame/support/procedural/src/pallet/expand/store_trait.rs
@@ -39,7 +39,7 @@ pub fn expand_store_trait(def: &mut Def) -> proc_macro2::TokenStream {
 	let warnig_struct_name = syn::Ident::new("Store", *attribute_span);
 	let warning: syn::ItemStruct = syn::parse_quote!(
 		#[deprecated(note = r"
-		Use of `#[pallet::generate_store(pub(super) trait Store)]` will be removed soon.
+		Use of `#[pallet::generate_store(pub(super) trait Store)]` will be removed after July 2023.
 		Check https://github.com/paritytech/substrate/pull/13535 for more details.")]
 		struct #warnig_struct_name;
 	);

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -899,7 +899,7 @@ impl<T> PaysFee<T> for (u64, Pays) {
 ///   in an externalities-provided environment. Implement
 ///   [`IntegrityTest`](./trait.IntegrityTest.html) trait.
 #[macro_export]
-#[deprecated(note = "Will be removed soon; use the attribute `#[pallet]` macro instead.
+#[deprecated(note = "Will be removed after July 2023; use the attribute `#[pallet]` macro instead.
 	For more info, see: <https://github.com/paritytech/substrate/pull/13705>")]
 macro_rules! decl_module {
 	// Entry point #1.

--- a/frame/support/src/error.rs
+++ b/frame/support/src/error.rs
@@ -67,7 +67,7 @@ pub use sp_runtime::traits::{BadOrigin, LookupError};
 /// For instantiable modules you also need to give the instance generic type and bound to the
 /// error declaration.
 #[macro_export]
-#[deprecated(note = "Will be removed soon; use the attribute `#[pallet]` macro instead.
+#[deprecated(note = "Will be removed after July 2023; use the attribute `#[pallet]` macro instead.
 	For more info, see: <https://github.com/paritytech/substrate/pull/13705>")]
 macro_rules! decl_error {
 	(

--- a/frame/support/src/event.rs
+++ b/frame/support/src/event.rs
@@ -101,7 +101,7 @@
 /// # fn main() {}
 /// ```
 #[macro_export]
-#[deprecated(note = "Will be removed soon; use the attribute `#[pallet]` macro instead.
+#[deprecated(note = "Will be removed after July 2023; use the attribute `#[pallet]` macro instead.
 	For more info, see: <https://github.com/paritytech/substrate/pull/13705>")]
 macro_rules! decl_event {
 	(

--- a/frame/support/src/storage/migration.rs
+++ b/frame/support/src/storage/migration.rs
@@ -37,18 +37,16 @@ pub struct StorageIterator<T> {
 
 impl<T> StorageIterator<T> {
 	/// Construct iterator to iterate over map items in `module` for the map called `item`.
-	#[deprecated(
-		note = "Please use the storage_iter or storage_iter_with_suffix functions instead"
-	)]
+	#[deprecated(note = "Will be removed after July 2023; Please use the storage_iter or \
+		storage_iter_with_suffix functions instead")]
 	pub fn new(module: &[u8], item: &[u8]) -> Self {
 		#[allow(deprecated)]
 		Self::with_suffix(module, item, &[][..])
 	}
 
 	/// Construct iterator to iterate over map items in `module` for the map called `item`.
-	#[deprecated(
-		note = "Please use the storage_iter or storage_iter_with_suffix functions instead"
-	)]
+	#[deprecated(note = "Will be removed after July 2023; Please use the storage_iter or \
+		storage_iter_with_suffix functions instead")]
 	pub fn with_suffix(module: &[u8], item: &[u8], suffix: &[u8]) -> Self {
 		let mut prefix = Vec::new();
 		let storage_prefix = storage_prefix(module, item);
@@ -102,18 +100,16 @@ pub struct StorageKeyIterator<K, T, H: ReversibleStorageHasher> {
 
 impl<K, T, H: ReversibleStorageHasher> StorageKeyIterator<K, T, H> {
 	/// Construct iterator to iterate over map items in `module` for the map called `item`.
-	#[deprecated(
-		note = "Please use the storage_key_iter or storage_key_iter_with_suffix functions instead"
-	)]
+	#[deprecated(note = "Will be removed after July 2023; Please use the storage_key_iter or \
+		storage_key_iter_with_suffix functions instead")]
 	pub fn new(module: &[u8], item: &[u8]) -> Self {
 		#[allow(deprecated)]
 		Self::with_suffix(module, item, &[][..])
 	}
 
 	/// Construct iterator to iterate over map items in `module` for the map called `item`.
-	#[deprecated(
-		note = "Please use the storage_key_iter or storage_key_iter_with_suffix functions instead"
-	)]
+	#[deprecated(note = "Will be removed after July 2023; Please use the storage_key_iter or \
+		storage_key_iter_with_suffix functions instead")]
 	pub fn with_suffix(module: &[u8], item: &[u8], suffix: &[u8]) -> Self {
 		let mut prefix = Vec::new();
 		let storage_prefix = storage_prefix(module, item);

--- a/frame/support/test/tests/pallet_ui/deprecated_store_attr.stderr
+++ b/frame/support/test/tests/pallet_ui/deprecated_store_attr.stderr
@@ -1,5 +1,5 @@
 error: use of deprecated struct `pallet::_::Store`:
-               Use of `#[pallet::generate_store(pub(super) trait Store)]` will be removed soon.
+               Use of `#[pallet::generate_store(pub(super) trait Store)]` will be removed after July 2023.
                Check https://github.com/paritytech/substrate/pull/13535 for more details.
  --> tests/pallet_ui/deprecated_store_attr.rs:7:3
   |

--- a/frame/support/test/tests/pallet_ui/store_trait_leak_private.stderr
+++ b/frame/support/test/tests/pallet_ui/store_trait_leak_private.stderr
@@ -1,5 +1,5 @@
 error: use of deprecated struct `pallet::_::Store`:
-               Use of `#[pallet::generate_store(pub(super) trait Store)]` will be removed soon.
+               Use of `#[pallet::generate_store(pub(super) trait Store)]` will be removed after July 2023.
                Check https://github.com/paritytech/substrate/pull/13535 for more details.
   --> tests/pallet_ui/store_trait_leak_private.rs:11:3
    |

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -240,9 +240,8 @@ pub mod pallet {
 	#[cfg(feature = "std")]
 	impl GenesisConfig {
 		/// Direct implementation of `GenesisBuild::assimilate_storage`.
-		#[deprecated(
-			note = "use `<GensisConfig<T, I> as GenesisBuild<T, I>>::assimilate_storage` instead"
-		)]
+		#[deprecated(note = "Will be removed after July 2023; use \
+			`<GensisConfig<T, I> as GenesisBuild<T, I>>::assimilate_storage` instead")]
 		pub fn assimilate_storage<T: Config<I>, I: 'static>(
 			&self,
 			storage: &mut sp_runtime::Storage,

--- a/primitives/weights/src/weight_v2.rs
+++ b/primitives/weights/src/weight_v2.rs
@@ -97,18 +97,6 @@ impl Weight {
 		}
 	}
 
-	/// Construct [`Weight`] with reference time weight and 0 storage size weight.
-	#[deprecated = "Will be removed soon; use `from_parts` instead."]
-	pub const fn from_ref_time(ref_time: u64) -> Self {
-		Self { ref_time, proof_size: 0 }
-	}
-
-	/// Construct [`Weight`] with storage size weight and 0 reference time weight.
-	#[deprecated = "Will be removed soon; use `from_parts` instead."]
-	pub const fn from_proof_size(proof_size: u64) -> Self {
-		Self { ref_time: 0, proof_size }
-	}
-
 	/// Construct [`Weight`] from weight parts, namely reference time and proof size weights.
 	pub const fn from_parts(ref_time: u64, proof_size: u64) -> Self {
 		Self { ref_time, proof_size }


### PR DESCRIPTION
Changes:
- Delete `Weight::from_ref_time` and `Weight::from_proof_size` after 3 months of grace period.
- Add explicit removal date of `July 2023` to various deprecated things that have already been deprecated for a while now.