### PR TITLE
Contracts: Better migration types

### DIFF
--- a/frame/contracts/src/migration/v9.rs
+++ b/frame/contracts/src/migration/v9.rs
@@ -23,12 +23,10 @@ use crate::{
 	CodeHash, Config, Determinism, Pallet, Weight, LOG_TARGET,
 };
 use codec::{Decode, Encode};
-use frame_support::{
-	codec, pallet_prelude::*, storage_alias, BoundedVec, DefaultNoBound, Identity,
-};
+use frame_support::{codec, pallet_prelude::*, storage_alias, DefaultNoBound, Identity};
 #[cfg(feature = "try-runtime")]
 use sp_runtime::TryRuntimeError;
-use sp_std::{marker::PhantomData, prelude::*};
+use sp_std::prelude::*;
 
 mod old {
 	use super::*;
@@ -79,8 +77,7 @@ type CodeStorage<T: Config> = StorageMap<Pallet<T>, Identity, CodeHash<T>, Prefa
 
 #[derive(Encode, Decode, MaxEncodedLen, DefaultNoBound)]
 pub struct Migration<T: Config> {
-	last_key: Option<BoundedVec<u8, ConstU32<256>>>,
-	_phantom: PhantomData<T>,
+	last_code_hash: Option<CodeHash<T>>,
 }
 
 impl<T: Config> MigrationStep for Migration<T> {
@@ -91,8 +88,8 @@ impl<T: Config> MigrationStep for Migration<T> {
 	}
 
 	fn step(&mut self) -> (IsFinished, Weight) {
-		let mut iter = if let Some(last_key) = self.last_key.take() {
-			old::CodeStorage::<T>::iter_from(last_key.to_vec())
+		let mut iter = if let Some(last_key) = self.last_code_hash.take() {
+			old::CodeStorage::<T>::iter_from(old::CodeStorage::<T>::hashed_key_for(last_key))
 		} else {
 			old::CodeStorage::<T>::iter()
 		};
@@ -108,7 +105,7 @@ impl<T: Config> MigrationStep for Migration<T> {
 				determinism: Determinism::Enforced,
 			};
 			CodeStorage::<T>::insert(key, module);
-			self.last_key = Some(iter.last_raw_key().to_vec().try_into().unwrap());
+			self.last_code_hash = Some(key);
 			(IsFinished::No, T::WeightInfo::v9_migration_step(len))
 		} else {
 			log::debug!(target: LOG_TARGET, "No more contracts code to migrate");


### PR DESCRIPTION
The v9 migration currently assumes that the migration fits into a bounded vector of 256 bits. While this is typically true in practice because the code hash is an alias for ` <T as frame_system::Config>::Hash`, which is usually set to `BlakeTwo256` or a similar hash function, the code should not make assumptions about it.

Same goes for v10 and the migration keys that should use `T::AccountId`.