### PR TITLE
[network] Add peer states consistency check to the `fuzz` test

### DIFF
--- a/client/network/src/lib.rs
+++ b/client/network/src/lib.rs
@@ -247,6 +247,8 @@ mod protocol;
 mod service;
 
 #[cfg(test)]
+mod fuzz;
+#[cfg(test)]
 mod mock;
 
 pub mod config;

--- a/client/network/src/protocol_controller.rs
+++ b/client/network/src/protocol_controller.rs
@@ -232,7 +232,7 @@ impl ProtocolHandle {
 
 /// Direction of a connection
 #[derive(Clone, Copy, Debug)]
-enum Direction {
+pub(crate) enum Direction {
 	Inbound,
 	Outbound,
 }
@@ -816,6 +816,17 @@ impl ProtocolController {
 			self.nodes.insert(peer_id, Direction::Outbound);
 			self.start_connection(peer_id);
 		})
+	}
+
+	/// Return all connected nodes for testing purposes.
+	#[cfg(test)]
+	pub(crate) fn connected_peers(&self) -> impl Iterator<Item = (&PeerId, &Direction)> {
+		self.nodes.iter().chain(self.reserved_nodes.iter().filter_map(
+			|(peer, state)| match state {
+				PeerState::Connected(direction) => Some((peer, direction)),
+				PeerState::NotConnected => None,
+			},
+		))
 	}
 }
 

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -20,8 +20,6 @@
 #[cfg(test)]
 mod block_import;
 #[cfg(test)]
-mod fuzz;
-#[cfg(test)]
 mod service;
 #[cfg(test)]
 mod sync;


### PR DESCRIPTION
This PR extends the fuzz test to check the consistency of `ProtocolController` peers view and `Notifications` peers view. The target branch is set to another PR, because the work is based on it.