### PR TITLE
Fix sync service not knowing that blocks were manually imported

### DIFF
--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -162,7 +162,7 @@ async fn build_network_future<
 	sync_service: Arc<SyncingService<B>>,
 	announce_imported_blocks: bool,
 ) {
-	let mut imported_blocks_stream = client.import_notification_stream().fuse();
+	let mut imported_blocks_stream = client.every_import_notification_stream().fuse();
 
 	// Stream of finalized blocks reported by the client.
 	let mut finality_notification_stream = client.finality_notification_stream().fuse();


### PR DESCRIPTION
# Description

This PR addresses https://github.com/paritytech/substrate/issues/14442 by removing the need for workaround mentioned in https://github.com/paritytech/substrate/issues/14442#issuecomment-1604254755

With this change even blocks that were manually imported with `ImportQueueService::import_blocks` will be correctly picked up by sync service and allow to request relevant blocks from network peers.

Not 100% sure if there are any negative side effects from `sync_service.announce_block` call here (blocks imported are not necessarily anywhere close to the tip, so announcements might be not very useful), need someone with better context to look into it.