### PR TITLE
fix on-runtime-upgrade --checks docs

### DIFF
--- a/utils/frame/try-runtime/cli/src/commands/on_runtime_upgrade.rs
+++ b/utils/frame/try-runtime/cli/src/commands/on_runtime_upgrade.rs
@@ -32,9 +32,10 @@ pub struct OnRuntimeUpgradeCmd {
 
 	/// Select which optional checks to perform. Selects all when no value is given.
 	///
-	/// - `none`: Perform no checks (default when the arg is not present).
-	/// - `all`: Perform all checks (default when the arg is present).
-	/// - `pre-and-post`: Perform pre- and post-upgrade checks.
+	/// - `none`: Perform no checks.
+	/// - `all`: Perform all checks (default when --checks is present with no value).
+	/// - `pre-and-post`: Perform pre- and post-upgrade checks (default when the arg is not
+	///   present).
 	/// - `try-state`: Perform the try-state checks.
 	///
 	/// Performing any checks will potentially invalidate the measured PoV/Weight.


### PR DESCRIPTION
`default_value` is actually `pre-and-post`, not `none`