### PR TITLE
Add `with_pays_fee` for conversion to `DispatchErrorWithPostInfo`

### DIFF
--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -328,7 +328,7 @@ impl sp_runtime::traits::Printable for PostDispatchInfo {
 }
 
 /// Allows easy conversion from `DispatchError` to `DispatchErrorWithPostInfo` for dispatchables
-/// that want to return a custom a posterior weight on error.
+/// that want to return a custom posterior weight or fee payment decision on error.
 pub trait WithPostDispatchInfo {
 	/// Call this on your modules custom errors type in order to return a custom weight on error.
 	///
@@ -339,6 +339,7 @@ pub trait WithPostDispatchInfo {
 	/// ensure!(who == me, Error::<T>::NotMe.with_weight(200_000));
 	/// ```
 	fn with_weight(self, actual_weight: Weight) -> DispatchErrorWithPostInfo;
+	fn with_pays_fee(self, pays_fee: Pays) -> DispatchErrorWithPostInfo;
 }
 
 impl<T> WithPostDispatchInfo for T
@@ -351,6 +352,12 @@ where
 				actual_weight: Some(actual_weight),
 				pays_fee: Default::default(),
 			},
+			error: self.into(),
+		}
+	}
+	fn with_pays_fee(self, pays_fee: Pays) -> DispatchErrorWithPostInfo {
+		DispatchErrorWithPostInfo {
+			post_info: PostDispatchInfo { actual_weight: None, pays_fee },
 			error: self.into(),
 		}
 	}

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -339,6 +339,13 @@ pub trait WithPostDispatchInfo {
 	/// ensure!(who == me, Error::<T>::NotMe.with_weight(200_000));
 	/// ```
 	fn with_weight(self, actual_weight: Weight) -> DispatchErrorWithPostInfo;
+	/// Call this on your modules custom errors type in order to decide fee payment on error.
+	///
+	/// # Example
+	///
+	/// ```ignore
+	/// ensure!(validate(params), Error::<T>::NotMe.with_pays_fee(Pays::No));
+	/// ```
 	fn with_pays_fee(self, pays_fee: Pays) -> DispatchErrorWithPostInfo;
 }
 

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -344,7 +344,7 @@ pub trait WithPostDispatchInfo {
 	/// # Example
 	///
 	/// ```ignore
-	/// ensure!(validate(params), Error::<T>::NotMe.with_pays_fee(Pays::No));
+	/// ensure!(validate(params), Error::<T>::InvalidParameters.with_pays_fee(Pays::No));
 	/// ```
 	fn with_pays_fee(self, pays_fee: Pays) -> DispatchErrorWithPostInfo;
 }


### PR DESCRIPTION
# Description

Extend `WithPostDispatchInfo` to allow easier specification of `pays_fee` when converting to `DispatchErrorWithPostInfo`. 

At the time of PR that added `with_weight` (#5458), `pays_fee` field was not present, so it makes sense to add add such function.
For example, instead of 
```rust
let mut e = DispatchErrorWithPostInfo::from(Error::<T>::InvalidParameters);
e.pays_fee = Pays::No;
e
```
one can write
```rust
Error::<T>::InvalidParameters.with_pays_fee(Pays::No)
```


My motivation in making this change is inconvenience when working with errors returned from other functions. In particular, I had the following case:
```rust
Self::fallible_function().map_err(|e| {
	let mut e = DispatchErrorWithPostInfo::from(e);
	e.pays_fee = Pays::No;
	e
})?;
```
and this should be cleaner and easier to read:
```rust
Self::fallible_function().map_err(|e| e.with_pays_fee(Pays::No))?;
```

* I haven't found an issue about this and I'm not sure if it should be created, as it's mostly convenience PR.
* Apparently, I don't have permissions to add labels, but I suppose it's something like A0, B0, C1
* It doesn't change existing functions, only adds an extra one. Shouldn't break API, I guess. Correct me if I'm wrong please :)