### PR TITLE
Don't use fixed nominator count for report_equivocation weight calculation

### DIFF
--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -216,6 +216,7 @@ impl pallet_grandpa::Config for Runtime {
 
 	type WeightInfo = ();
 	type MaxAuthorities = ConstU32<32>;
+	type MaxNominators = ConstU32<0>;
 	type MaxSetIdSessionEntries = ConstU64<0>;
 
 	type KeyOwnerProof = sp_core::Void;

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -418,6 +418,7 @@ impl pallet_babe::Config for Runtime {
 	type DisabledValidators = Session;
 	type WeightInfo = ();
 	type MaxAuthorities = MaxAuthorities;
+	type MaxNominators = MaxNominatorRewardedPerValidator;
 	type KeyOwnerProof =
 		<Historical as KeyOwnerProofSystem<(KeyTypeId, pallet_babe::AuthorityId)>>::Proof;
 	type EquivocationReportSystem =
@@ -1356,6 +1357,7 @@ impl pallet_grandpa::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
 	type MaxAuthorities = MaxAuthorities;
+	type MaxNominators = MaxNominatorRewardedPerValidator;
 	type MaxSetIdSessionEntries = MaxSetIdSessionEntries;
 	type KeyOwnerProof = <Historical as KeyOwnerProofSystem<(KeyTypeId, GrandpaId)>>::Proof;
 	type EquivocationReportSystem =

--- a/frame/babe/src/default_weights.rs
+++ b/frame/babe/src/default_weights.rs
@@ -28,14 +28,10 @@ impl crate::WeightInfo for () {
 		DbWeight::get().writes(1)
 	}
 
-	fn report_equivocation(validator_count: u32) -> Weight {
+	fn report_equivocation(validator_count: u32, max_nominators_per_validator: u32) -> Weight {
 		// we take the validator set count from the membership proof to
 		// calculate the weight but we set a floor of 100 validators.
 		let validator_count = validator_count.max(100) as u64;
-
-		// worst case we are considering is that the given offender
-		// is backed by 200 nominators
-		const MAX_NOMINATORS: u64 = 200;
 
 		// checking membership proof
 		Weight::from_parts(35u64 * WEIGHT_REF_TIME_PER_MICROS, 0)
@@ -49,10 +45,10 @@ impl crate::WeightInfo for () {
 			// report offence
 			.saturating_add(Weight::from_parts(110u64 * WEIGHT_REF_TIME_PER_MICROS, 0))
 			.saturating_add(Weight::from_parts(
-				25u64 * WEIGHT_REF_TIME_PER_MICROS * MAX_NOMINATORS,
+				25u64 * WEIGHT_REF_TIME_PER_MICROS * max_nominators_per_validator as u64,
 				0,
 			))
-			.saturating_add(DbWeight::get().reads(14 + 3 * MAX_NOMINATORS))
-			.saturating_add(DbWeight::get().writes(10 + 3 * MAX_NOMINATORS))
+			.saturating_add(DbWeight::get().reads(14 + 3 * max_nominators_per_validator as u64))
+			.saturating_add(DbWeight::get().writes(10 + 3 * max_nominators_per_validator as u64))
 	}
 }

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -71,7 +71,7 @@ pub use pallet::*;
 
 pub trait WeightInfo {
 	fn plan_config_change() -> Weight;
-	fn report_equivocation(validator_count: u32) -> Weight;
+	fn report_equivocation(validator_count: u32, max_nominators_per_validator: u32) -> Weight;
 }
 
 /// Trigger an epoch change, if any should take place.
@@ -151,6 +151,10 @@ pub mod pallet {
 		/// Max number of authorities allowed
 		#[pallet::constant]
 		type MaxAuthorities: Get<u32>;
+
+		/// The maximum number of nominators for each validator.
+		#[pallet::constant]
+		type MaxNominators: Get<u32>;
 
 		/// The proof of key ownership, used for validating equivocation reports.
 		/// The proof must include the session index and validator count of the
@@ -404,6 +408,7 @@ pub mod pallet {
 		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::report_equivocation(
 			key_owner_proof.validator_count(),
+			T::MaxNominators::get(),
 		))]
 		pub fn report_equivocation(
 			origin: OriginFor<T>,
@@ -430,6 +435,7 @@ pub mod pallet {
 		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config>::WeightInfo::report_equivocation(
 			key_owner_proof.validator_count(),
+			T::MaxNominators::get(),
 		))]
 		pub fn report_equivocation_unsigned(
 			origin: OriginFor<T>,

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -228,6 +228,7 @@ impl Config for Test {
 	type DisabledValidators = Session;
 	type WeightInfo = ();
 	type MaxAuthorities = ConstU32<10>;
+	type MaxNominators = ConstU32<100>;
 	type KeyOwnerProof = <Historical as KeyOwnerProofSystem<(KeyTypeId, AuthorityId)>>::Proof;
 	type EquivocationReportSystem =
 		super::EquivocationReportSystem<Self, Offences, Historical, ReportLongevity>;

--- a/frame/babe/src/tests.rs
+++ b/frame/babe/src/tests.rs
@@ -815,7 +815,7 @@ fn report_equivocation_has_valid_weight() {
 	// the weight depends on the size of the validator set,
 	// but there's a lower bound of 100 validators.
 	assert!((1..=100)
-		.map(<Test as Config>::WeightInfo::report_equivocation)
+		.map(|validators| <Test as Config>::WeightInfo::report_equivocation(validators, 1000))
 		.collect::<Vec<_>>()
 		.windows(2)
 		.all(|w| w[0] == w[1]));
@@ -823,7 +823,7 @@ fn report_equivocation_has_valid_weight() {
 	// after 100 validators the weight should keep increasing
 	// with every extra validator.
 	assert!((100..=1000)
-		.map(<Test as Config>::WeightInfo::report_equivocation)
+		.map(|validators| <Test as Config>::WeightInfo::report_equivocation(validators, 1000))
 		.collect::<Vec<_>>()
 		.windows(2)
 		.all(|w| w[0].ref_time() < w[1].ref_time()));

--- a/frame/beefy-mmr/src/mock.rs
+++ b/frame/beefy-mmr/src/mock.rs
@@ -123,6 +123,7 @@ impl pallet_mmr::Config for Test {
 impl pallet_beefy::Config for Test {
 	type BeefyId = BeefyId;
 	type MaxAuthorities = ConstU32<100>;
+	type MaxNominators = ConstU32<1000>;
 	type MaxSetIdSessionEntries = ConstU64<100>;
 	type OnNewValidatorSet = BeefyMmr;
 	type WeightInfo = ();

--- a/frame/beefy/src/default_weights.rs
+++ b/frame/beefy/src/default_weights.rs
@@ -24,13 +24,10 @@ use frame_support::weights::{
 };
 
 impl crate::WeightInfo for () {
-	fn report_equivocation(validator_count: u32) -> Weight {
+	fn report_equivocation(validator_count: u32, max_nominators_per_validator: u32) -> Weight {
 		// we take the validator set count from the membership proof to
 		// calculate the weight but we set a floor of 100 validators.
 		let validator_count = validator_count.max(100) as u64;
-
-		// worst case we are considering is that the given offender is backed by 200 nominators
-		const MAX_NOMINATORS: u64 = 200;
 
 		// checking membership proof
 		Weight::from_parts(35u64 * WEIGHT_REF_TIME_PER_MICROS, 0)
@@ -44,11 +41,11 @@ impl crate::WeightInfo for () {
 			// report offence
 			.saturating_add(Weight::from_parts(110u64 * WEIGHT_REF_TIME_PER_MICROS, 0))
 			.saturating_add(Weight::from_parts(
-				25u64 * WEIGHT_REF_TIME_PER_MICROS * MAX_NOMINATORS,
+				25u64 * WEIGHT_REF_TIME_PER_MICROS * max_nominators_per_validator as u64,
 				0,
 			))
-			.saturating_add(DbWeight::get().reads(14 + 3 * MAX_NOMINATORS))
-			.saturating_add(DbWeight::get().writes(10 + 3 * MAX_NOMINATORS))
+			.saturating_add(DbWeight::get().reads(14 + 3 * max_nominators_per_validator as u64))
+			.saturating_add(DbWeight::get().writes(10 + 3 * max_nominators_per_validator as u64))
 			// fetching set id -> session index mappings
 			.saturating_add(DbWeight::get().reads(2))
 	}

--- a/frame/beefy/src/lib.rs
+++ b/frame/beefy/src/lib.rs
@@ -78,6 +78,10 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxAuthorities: Get<u32>;
 
+		/// The maximum number of nominators for each validator.
+		#[pallet::constant]
+		type MaxNominators: Get<u32>;
+
 		/// The maximum number of entries to keep in the set id to session index mapping.
 		///
 		/// Since the `SetIdSession` map is only used for validating equivocations this
@@ -203,7 +207,10 @@ pub mod pallet {
 		/// against the extracted offender. If both are valid, the offence
 		/// will be reported.
 		#[pallet::call_index(0)]
-		#[pallet::weight(T::WeightInfo::report_equivocation(key_owner_proof.validator_count()))]
+		#[pallet::weight(T::WeightInfo::report_equivocation(
+			key_owner_proof.validator_count(),
+			T::MaxNominators::get(),
+		))]
 		pub fn report_equivocation(
 			origin: OriginFor<T>,
 			equivocation_proof: Box<
@@ -235,7 +242,10 @@ pub mod pallet {
 		/// if the block author is defined it will be defined as the equivocation
 		/// reporter.
 		#[pallet::call_index(1)]
-		#[pallet::weight(T::WeightInfo::report_equivocation(key_owner_proof.validator_count()))]
+		#[pallet::weight(T::WeightInfo::report_equivocation(
+			key_owner_proof.validator_count(),
+			T::MaxNominators::get(),
+		))]
 		pub fn report_equivocation_unsigned(
 			origin: OriginFor<T>,
 			equivocation_proof: Box<
@@ -441,5 +451,5 @@ impl<T: Config> IsMember<T::BeefyId> for Pallet<T> {
 }
 
 pub trait WeightInfo {
-	fn report_equivocation(validator_count: u32) -> Weight;
+	fn report_equivocation(validator_count: u32, max_nominators_per_validator: u32) -> Weight;
 }

--- a/frame/beefy/src/mock.rs
+++ b/frame/beefy/src/mock.rs
@@ -117,6 +117,7 @@ parameter_types! {
 impl pallet_beefy::Config for Test {
 	type BeefyId = BeefyId;
 	type MaxAuthorities = ConstU32<100>;
+	type MaxNominators = ConstU32<1000>;
 	type MaxSetIdSessionEntries = MaxSetIdSessionEntries;
 	type OnNewValidatorSet = ();
 	type WeightInfo = ();

--- a/frame/beefy/src/tests.rs
+++ b/frame/beefy/src/tests.rs
@@ -716,7 +716,7 @@ fn report_equivocation_has_valid_weight() {
 	// the weight depends on the size of the validator set,
 	// but there's a lower bound of 100 validators.
 	assert!((1..=100)
-		.map(<Test as Config>::WeightInfo::report_equivocation)
+		.map(|validators| <Test as Config>::WeightInfo::report_equivocation(validators, 1000))
 		.collect::<Vec<_>>()
 		.windows(2)
 		.all(|w| w[0] == w[1]));
@@ -724,7 +724,7 @@ fn report_equivocation_has_valid_weight() {
 	// after 100 validators the weight should keep increasing
 	// with every extra validator.
 	assert!((100..=1000)
-		.map(<Test as Config>::WeightInfo::report_equivocation)
+		.map(|validators| <Test as Config>::WeightInfo::report_equivocation(validators, 1000))
 		.collect::<Vec<_>>()
 		.windows(2)
 		.all(|w| w[0].ref_time() < w[1].ref_time()));

--- a/frame/grandpa/src/default_weights.rs
+++ b/frame/grandpa/src/default_weights.rs
@@ -24,14 +24,10 @@ use frame_support::weights::{
 };
 
 impl crate::WeightInfo for () {
-	fn report_equivocation(validator_count: u32) -> Weight {
+	fn report_equivocation(validator_count: u32, max_nominators_per_validator: u32) -> Weight {
 		// we take the validator set count from the membership proof to
 		// calculate the weight but we set a floor of 100 validators.
 		let validator_count = validator_count.max(100) as u64;
-
-		// worst case we are considering is that the given offender
-		// is backed by 200 nominators
-		const MAX_NOMINATORS: u64 = 200;
 
 		// checking membership proof
 		Weight::from_parts(35u64 * WEIGHT_REF_TIME_PER_MICROS, 0)
@@ -45,11 +41,11 @@ impl crate::WeightInfo for () {
 			// report offence
 			.saturating_add(Weight::from_parts(110u64 * WEIGHT_REF_TIME_PER_MICROS, 0))
 			.saturating_add(Weight::from_parts(
-				25u64 * WEIGHT_REF_TIME_PER_MICROS * MAX_NOMINATORS,
+				25u64 * WEIGHT_REF_TIME_PER_MICROS * max_nominators_per_validator as u64,
 				0,
 			))
-			.saturating_add(DbWeight::get().reads(14 + 3 * MAX_NOMINATORS))
-			.saturating_add(DbWeight::get().writes(10 + 3 * MAX_NOMINATORS))
+			.saturating_add(DbWeight::get().reads(14 + 3 * max_nominators_per_validator as u64))
+			.saturating_add(DbWeight::get().writes(10 + 3 * max_nominators_per_validator as u64))
 			// fetching set id -> session index mappings
 			.saturating_add(DbWeight::get().reads(2))
 	}

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -94,6 +94,10 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxAuthorities: Get<u32>;
 
+		/// The maximum number of nominators for each validator.
+		#[pallet::constant]
+		type MaxNominators: Get<u32>;
+
 		/// The maximum number of entries to keep in the set id to session index mapping.
 		///
 		/// Since the `SetIdSession` map is only used for validating equivocations this
@@ -188,7 +192,10 @@ pub mod pallet {
 		/// against the extracted offender. If both are valid, the offence
 		/// will be reported.
 		#[pallet::call_index(0)]
-		#[pallet::weight(T::WeightInfo::report_equivocation(key_owner_proof.validator_count()))]
+		#[pallet::weight(T::WeightInfo::report_equivocation(
+			key_owner_proof.validator_count(),
+			T::MaxNominators::get(),
+		))]
 		pub fn report_equivocation(
 			origin: OriginFor<T>,
 			equivocation_proof: Box<EquivocationProof<T::Hash, T::BlockNumber>>,
@@ -214,7 +221,10 @@ pub mod pallet {
 		/// if the block author is defined it will be defined as the equivocation
 		/// reporter.
 		#[pallet::call_index(1)]
-		#[pallet::weight(T::WeightInfo::report_equivocation(key_owner_proof.validator_count()))]
+		#[pallet::weight(T::WeightInfo::report_equivocation(
+			key_owner_proof.validator_count(),
+			T::MaxNominators::get(),
+		))]
 		pub fn report_equivocation_unsigned(
 			origin: OriginFor<T>,
 			equivocation_proof: Box<EquivocationProof<T::Hash, T::BlockNumber>>,
@@ -362,7 +372,7 @@ pub mod pallet {
 }
 
 pub trait WeightInfo {
-	fn report_equivocation(validator_count: u32) -> Weight;
+	fn report_equivocation(validator_count: u32, max_nominators_per_validator: u32) -> Weight;
 	fn note_stalled() -> Weight;
 }
 

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -230,6 +230,7 @@ impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
 	type MaxAuthorities = ConstU32<100>;
+	type MaxNominators = ConstU32<1000>;
 	type MaxSetIdSessionEntries = MaxSetIdSessionEntries;
 	type KeyOwnerProof = <Historical as KeyOwnerProofSystem<(KeyTypeId, AuthorityId)>>::Proof;
 	type EquivocationReportSystem =

--- a/frame/grandpa/src/tests.rs
+++ b/frame/grandpa/src/tests.rs
@@ -838,7 +838,7 @@ fn report_equivocation_has_valid_weight() {
 	// the weight depends on the size of the validator set,
 	// but there's a lower bound of 100 validators.
 	assert!((1..=100)
-		.map(<Test as Config>::WeightInfo::report_equivocation)
+		.map(|validators| <Test as Config>::WeightInfo::report_equivocation(validators, 1000))
 		.collect::<Vec<_>>()
 		.windows(2)
 		.all(|w| w[0] == w[1]));
@@ -846,7 +846,7 @@ fn report_equivocation_has_valid_weight() {
 	// after 100 validators the weight should keep increasing
 	// with every extra validator.
 	assert!((100..=1000)
-		.map(<Test as Config>::WeightInfo::report_equivocation)
+		.map(|validators| <Test as Config>::WeightInfo::report_equivocation(validators, 1000))
 		.collect::<Vec<_>>()
 		.windows(2)
 		.all(|w| w[0].ref_time() < w[1].ref_time()));

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -421,6 +421,7 @@ impl pallet_babe::Config for Runtime {
 	type EquivocationReportSystem = ();
 	type WeightInfo = ();
 	type MaxAuthorities = ConstU32<10>;
+	type MaxNominators = ConstU32<100>;
 }
 
 /// Adds one to the given input and returns the final result.


### PR DESCRIPTION
This PR changes the `report_equivocation` weight calculation to take into account the runtime configured maximum number of nominators per validator, rather than using a constant value.

polkadot companion: https://github.com/paritytech/polkadot/pull/7432