### PR TITLE
Inject `FromSwarm::NewListenAddr` to mDNS

### DIFF
--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -663,6 +663,10 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 			},
 			FromSwarm::NewListenAddr(e) => {
 				self.kademlia.on_swarm_event(FromSwarm::NewListenAddr(e));
+
+				if let Some(ref mut mdns) = self.mdns {
+					mdns.on_swarm_event(FromSwarm::NewListenAddr(e));
+				}
 			},
 		}
 	}


### PR DESCRIPTION
`NewListenAddr` was not injected to mDNS which prevented peers from discovering each other

Fixes https://github.com/paritytech/polkadot/issues/7428