### PR TITLE
Ability to pause Substrate sync on the fly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,6 +727,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8928,6 +8934,7 @@ name = "sc-cli"
 version = "0.10.0-dev"
 dependencies = [
  "array-bytes 4.2.0",
+ "atomic",
  "chrono",
  "clap 4.3.2",
  "fdlimit",
@@ -9499,6 +9506,7 @@ dependencies = [
  "async-channel",
  "async-trait",
  "asynchronous-codec",
+ "atomic",
  "bytes",
  "either",
  "fnv",
@@ -9649,6 +9657,7 @@ dependencies = [
  "array-bytes 4.2.0",
  "async-channel",
  "async-trait",
+ "atomic",
  "fork-tree",
  "futures",
  "futures-timer",
@@ -9686,6 +9695,7 @@ name = "sc-network-test"
 version = "0.8.0"
 dependencies = [
  "async-trait",
+ "atomic",
  "futures",
  "futures-timer",
  "libp2p",

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 array-bytes = "4.1"
+atomic = "0.5.3"
 chrono = "0.4.10"
 clap = { version = "4.2.5", features = ["derive", "string"] }
 fdlimit = "0.2.1"

--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -17,6 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{arg_enums::SyncMode, params::node_key_params::NodeKeyParams};
+use atomic::Atomic;
 use clap::Args;
 use sc_network::{
 	config::{
@@ -28,7 +29,7 @@ use sc_service::{
 	config::{Multiaddr, MultiaddrWithPeerId},
 	ChainSpec, ChainType,
 };
-use std::{borrow::Cow, num::NonZeroUsize, path::PathBuf};
+use std::{borrow::Cow, num::NonZeroUsize, path::PathBuf, sync::Arc};
 
 /// Parameters used to create the network configuration.
 #[derive(Debug, Clone, Args)]
@@ -243,7 +244,7 @@ impl NetworkParams {
 			kademlia_replication_factor: self.kademlia_replication_factor,
 			yamux_window_size: None,
 			ipfs_server: self.ipfs_server,
-			sync_mode: self.sync.into(),
+			sync_mode: Arc::new(Atomic::new(self.sync.into())),
 		}
 	}
 }

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -18,6 +18,7 @@ array-bytes = "4.1"
 async-channel = "1.8.0"
 async-trait = "0.1"
 asynchronous-codec = "0.6"
+atomic = "0.5.3"
 bytes = "1"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
 either = "1.5.3"

--- a/client/network/common/src/sync.rs
+++ b/client/network/common/src/sync.rs
@@ -203,6 +203,8 @@ pub enum SyncMode {
 	},
 	/// Warp sync - verify authority set transitions and the latest state.
 	Warp,
+	/// Sync is paused.
+	Paused,
 }
 
 impl SyncMode {

--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -44,6 +44,7 @@ pub use sc_network_common::{
 use sc_utils::mpsc::TracingUnboundedSender;
 use sp_runtime::traits::Block as BlockT;
 
+use atomic::Atomic;
 use std::{
 	error::Error,
 	fmt, fs,
@@ -55,6 +56,7 @@ use std::{
 	path::{Path, PathBuf},
 	pin::Pin,
 	str::{self, FromStr},
+	sync::Arc,
 };
 
 pub use libp2p::{
@@ -558,8 +560,8 @@ pub struct NetworkConfiguration {
 	/// Maximum number of blocks per request.
 	pub max_blocks_per_request: u32,
 
-	/// Initial syncing mode.
-	pub sync_mode: SyncMode,
+	/// Syncing mode.
+	pub sync_mode: Arc<Atomic<SyncMode>>,
 
 	/// True if Kademlia random discovery should be enabled.
 	///
@@ -626,7 +628,7 @@ impl NetworkConfiguration {
 			transport: TransportConfig::Normal { enable_mdns: false, allow_private_ip: true },
 			max_parallel_downloads: 5,
 			max_blocks_per_request: 64,
-			sync_mode: SyncMode::Full,
+			sync_mode: Arc::new(Atomic::new(SyncMode::Full)),
 			enable_dht_random_walk: true,
 			allow_non_globals_in_dht: false,
 			kademlia_disjoint_query_paths: false,

--- a/client/network/sync/Cargo.toml
+++ b/client/network/sync/Cargo.toml
@@ -19,6 +19,7 @@ prost-build = "0.11"
 array-bytes = "4.1"
 async-channel = "1.8.0"
 async-trait = "0.1.58"
+atomic = "0.5.3"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
 futures = "0.3.21"
 futures-timer = "3.0.2"

--- a/client/network/sync/src/engine.rs
+++ b/client/network/sync/src/engine.rs
@@ -284,7 +284,7 @@ where
 		warp_sync_protocol_name: Option<ProtocolName>,
 		rx: sc_utils::mpsc::TracingUnboundedReceiver<sc_network::SyncEvent<B>>,
 	) -> Result<(Self, SyncingService<B>, NonDefaultSetConfig), ClientError> {
-		let mode = net_config.network_config.sync_mode;
+		let mode = Arc::clone(&net_config.network_config.sync_mode);
 		let max_parallel_downloads = net_config.network_config.max_parallel_downloads;
 		let max_blocks_per_request = if net_config.network_config.max_blocks_per_request >
 			crate::MAX_BLOCKS_IN_RESPONSE as u32

--- a/client/network/test/Cargo.toml
+++ b/client/network/test/Cargo.toml
@@ -15,6 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 tokio = "1.22.0"
 async-trait = "0.1.57"
+atomic = "0.5.3"
 futures = "0.3.21"
 futures-timer = "3.0.1"
 libp2p = "0.51.3"

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -28,11 +28,12 @@ use std::{
 	collections::HashMap,
 	marker::PhantomData,
 	pin::Pin,
-	sync::Arc,
+	sync::{atomic::Ordering, Arc},
 	task::{Context as FutureContext, Poll},
 	time::Duration,
 };
 
+use atomic::Atomic;
 use futures::{channel::oneshot, future::BoxFuture, pin_mut, prelude::*};
 use libp2p::{build_multiaddr, PeerId};
 use log::trace;
@@ -701,7 +702,7 @@ pub struct FullPeerConfig {
 	/// Whether the full peer should have the authority role.
 	pub is_authority: bool,
 	/// Syncing mode
-	pub sync_mode: SyncMode,
+	pub sync_mode: Arc<Atomic<SyncMode>>,
 	/// Extra genesis storage.
 	pub extra_storage: Option<sp_core::storage::Storage>,
 	/// Enable transaction indexing.
@@ -770,7 +771,10 @@ where
 			*genesis_extra_storage = storage;
 		}
 
-		if matches!(config.sync_mode, SyncMode::LightState { .. } | SyncMode::Warp) {
+		if matches!(
+			config.sync_mode.load(Ordering::Acquire),
+			SyncMode::LightState { .. } | SyncMode::Warp
+		) {
 			test_client_builder = test_client_builder.set_no_genesis();
 		}
 		let backend = test_client_builder.backend();

--- a/client/network/test/src/sync.rs
+++ b/client/network/test/src/sync.rs
@@ -1131,8 +1131,10 @@ async fn syncs_state() {
 		net.add_full_peer_with_config(config_one);
 		let mut config_two = FullPeerConfig::default();
 		config_two.extra_storage = Some(genesis_storage);
-		config_two.sync_mode =
-			SyncMode::LightState { skip_proofs: *skip_proofs, storage_chain_mode: false };
+		config_two.sync_mode = Arc::new(Atomic::new(SyncMode::LightState {
+			skip_proofs: *skip_proofs,
+			storage_chain_mode: false,
+		}));
 		net.add_full_peer_with_config(config_two);
 		let hashes = net.peer(0).push_blocks(64, false);
 		// Wait for peer 1 to sync header chain.
@@ -1175,7 +1177,10 @@ async fn syncs_indexed_blocks() {
 	net.add_full_peer_with_config(FullPeerConfig { storage_chain: true, ..Default::default() });
 	net.add_full_peer_with_config(FullPeerConfig {
 		storage_chain: true,
-		sync_mode: SyncMode::LightState { skip_proofs: false, storage_chain_mode: true },
+		sync_mode: Arc::new(Atomic::new(SyncMode::LightState {
+			skip_proofs: false,
+			storage_chain_mode: true,
+		})),
 		..Default::default()
 	});
 	net.peer(0).generate_blocks_at(
@@ -1228,7 +1233,7 @@ async fn warp_sync() {
 	net.add_full_peer_with_config(Default::default());
 	net.add_full_peer_with_config(Default::default());
 	net.add_full_peer_with_config(FullPeerConfig {
-		sync_mode: SyncMode::Warp,
+		sync_mode: Arc::new(Atomic::new(SyncMode::Warp)),
 		..Default::default()
 	});
 	let gap_end = net.peer(0).push_blocks(63, false).pop().unwrap();
@@ -1269,7 +1274,7 @@ async fn warp_sync_to_target_block() {
 	let target_block = net.peer(0).client.header(target).unwrap().unwrap();
 
 	net.add_full_peer_with_config(FullPeerConfig {
-		sync_mode: SyncMode::Warp,
+		sync_mode: Arc::new(Atomic::new(SyncMode::Warp)),
 		target_block: Some(target_block),
 		..Default::default()
 	});

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -797,7 +797,7 @@ where
 			SyncMode::LightState { .. } =>
 				return Err("Fast sync doesn't work for archive nodes".into()),
 			SyncMode::Warp => return Err("Warp sync doesn't work for archive nodes".into()),
-			SyncMode::Full => {},
+			SyncMode::Full | SyncMode::Paused => {},
 		}
 	}
 

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -41,6 +41,7 @@ use std::{
 	io, iter,
 	net::SocketAddr,
 	path::{Path, PathBuf},
+	sync::atomic::Ordering,
 };
 use tempfile::TempDir;
 
@@ -234,7 +235,10 @@ impl Configuration {
 	/// Returns true if the genesis state writting will be skipped while initializing the genesis
 	/// block.
 	pub fn no_genesis(&self) -> bool {
-		matches!(self.network.sync_mode, SyncMode::LightState { .. } | SyncMode::Warp { .. })
+		matches!(
+			self.network.sync_mode.load(Ordering::Acquire),
+			SyncMode::LightState { .. } | SyncMode::Warp { .. }
+		)
 	}
 
 	/// Returns the database config for creating the backend.


### PR DESCRIPTION
This builds on https://github.com/paritytech/substrate/pull/14465 with the goal to be able to pause Substrate's built-in sync mechanism.

There is not that much flexibility to Substrate's sync right now, so this was my next best idea that is relatively simple.

In Subspace we have a separate sync mechanism for archival history that leverages distributed storage network of our protocol and Substrate's sync is only used to sync the tip of the chain.

The issue is that due to nodes being pruned, requests done by Substrate's sync mechanism are doomed to fail and result in frequent disconnections and decrease of peer reputation. We avoid that by pausing Substrate sync completely until we are close enough to the tip for Substrate sync to succeed.

Here is an example of how it is used in our protocol right now (not enabled by default for now, but we're working on it): https://github.com/subspace/subspace/pull/1602/files?file-filters%5B%5D=.rs&show-viewed-files=true#diff-8d08a90676fed94fe41260405e5c5ef3bba7f1774bfbc252c8329dd25d2f75f2R194-R214