### PR TITLE
Upgrade wasm-opt to 0.113

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13084,9 +13084,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fef6d0d508f08334e0ab0e6877feb4c0ecb3956bcf2cb950699b22fedf3e9c"
+checksum = "65a2799e08026234b07b44da6363703974e75be21430cef00756bbc438c8ff8a"
 dependencies = [
  "anyhow",
  "libc",
@@ -13100,9 +13100,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-cxx-sys"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc816bbc1596c8f2e8127e137a760c798023ef3d378f2ae51f0f1840e2dfa445"
+checksum = "c8d26f86d1132245e8bcea8fac7f02b10fb885b6696799969c94d7d3c14db5e1"
 dependencies = [
  "anyhow",
  "cxx",
@@ -13112,9 +13112,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-sys"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40199e4f68ef1071b3c6d0bd8026a12b481865d4b9e49c156932ea9a6234dd14"
+checksum = "497d069cd3420cdd52154a320b901114a20946878e2de62c670f9d906e472370"
 dependencies = [
  "anyhow",
  "cc",

--- a/utils/wasm-builder/Cargo.toml
+++ b/utils/wasm-builder/Cargo.toml
@@ -22,5 +22,5 @@ toml = "0.7.3"
 walkdir = "2.3.2"
 sp-maybe-compressed-blob = { version = "4.1.0-dev", path = "../../primitives/maybe-compressed-blob" }
 filetime = "0.2.16"
-wasm-opt = "0.112"
+wasm-opt = "0.113"
 parity-wasm = "0.45"


### PR DESCRIPTION
# Description

Just keeping wasm-opt updated.

There isn't much to be aware of in the binaryen 113 release notes:
https://github.com/WebAssembly/binaryen/blob/main/CHANGELOG.md#v113

wasm-opt has a minimum rust version of 1.48,
but wasm-opt's cxx dependency has recently changed their minimum rust version to 1.60. it should still be possible to resolve a crate graph that is 1.48 compatible, and I think this lockfile is, but if the cxx dependency in the lockfile is ever re-resolved cargo will probably pick a cxx that is not 1.48 compatible.
