### PR TITLE
sc-tracing: Only print events for whitelisted targets

### DIFF
--- a/client/tracing/src/lib.rs
+++ b/client/tracing/src/lib.rs
@@ -329,8 +329,9 @@ where
 
 	fn on_event(&self, event: &Event<'_>, ctx: Context<S>) {
 		if !self.check_target(event.metadata().target(), &event.metadata().level()) {
-			return;
+			return
 		}
+
 		let parent_id = event.parent().cloned().or_else(|| {
 			if event.is_contextual() {
 				ctx.lookup_current().map(|span| span.id())
@@ -349,7 +350,6 @@ where
 			parent_id,
 		};
 		self.dispatch_event(TraceHandlerEvents::Event(trace_event));
-	}
 	}
 
 	fn on_enter(&self, span: &Id, ctx: Context<S>) {

--- a/client/tracing/src/lib.rs
+++ b/client/tracing/src/lib.rs
@@ -328,24 +328,26 @@ where
 	}
 
 	fn on_event(&self, event: &Event<'_>, ctx: Context<S>) {
-		let parent_id = event.parent().cloned().or_else(|| {
-			if event.is_contextual() {
-				ctx.lookup_current().map(|span| span.id())
-			} else {
-				None
-			}
-		});
+		if self.check_target(event.metadata().target(), &event.metadata().level()) {
+			let parent_id = event.parent().cloned().or_else(|| {
+				if event.is_contextual() {
+					ctx.lookup_current().map(|span| span.id())
+				} else {
+					None
+				}
+			});
 
-		let mut values = Values::default();
-		event.record(&mut values);
-		let trace_event = TraceEvent {
-			name: event.metadata().name().to_owned(),
-			target: event.metadata().target().to_owned(),
-			level: *event.metadata().level(),
-			values,
-			parent_id,
-		};
-		self.dispatch_event(TraceHandlerEvents::Event(trace_event));
+			let mut values = Values::default();
+			event.record(&mut values);
+			let trace_event = TraceEvent {
+				name: event.metadata().name().to_owned(),
+				target: event.metadata().target().to_owned(),
+				level: *event.metadata().level(),
+				values,
+				parent_id,
+			};
+			self.dispatch_event(TraceHandlerEvents::Event(trace_event));
+		}
 	}
 
 	fn on_enter(&self, span: &Id, ctx: Context<S>) {


### PR DESCRIPTION
We should only print events for whitelisted targets, otherwise we may run into some stack overflow while printing the event.


