### PR TITLE
Whitelist key `:intrablock_entropy`

### DIFF
--- a/frame/benchmarking/src/v1.rs
+++ b/frame/benchmarking/src/v1.rs
@@ -1060,6 +1060,11 @@ macro_rules! impl_benchmark {
 					$crate::well_known_keys::EXTRINSIC_INDEX.into()
 				);
 				whitelist.push(extrinsic_index);
+				// Whitelist the `:intrablock_entropy`.
+				let intrablock_entropy = $crate::TrackedStorageKey::new(
+					$crate::well_known_keys::INTRABLOCK_ENTROPY.into()
+				);
+				whitelist.push(intrablock_entropy);
 
 				$crate::benchmarking::set_whitelist(whitelist.clone());
 

--- a/frame/support/procedural/src/benchmark.rs
+++ b/frame/support/procedural/src/benchmark.rs
@@ -551,6 +551,12 @@ pub fn benchmarks(
 						#krate::well_known_keys::EXTRINSIC_INDEX.into()
 					);
 					whitelist.push(extrinsic_index);
+					// Whitelist the `:intrablock_entropy`.
+					let intrablock_entropy = #krate::TrackedStorageKey::new(
+						#krate::well_known_keys::INTRABLOCK_ENTROPY.into()
+					);
+					whitelist.push(intrablock_entropy);
+
 					#krate::benchmarking::set_whitelist(whitelist.clone());
 					let mut results: #krate::Vec<#krate::BenchmarkResult> = #krate::Vec::new();
 

--- a/primitives/storage/src/lib.rs
+++ b/primitives/storage/src/lib.rs
@@ -205,6 +205,8 @@ pub mod well_known_keys {
 	pub const EXTRINSIC_INDEX: &[u8] = b":extrinsic_index";
 
 	/// Current intra-block entropy (a universally unique `[u8; 32]` value) is stored here.
+	///
+	/// Encodes to `0x3a696e747261626c6f636b5f656e74726f7079`.
 	pub const INTRABLOCK_ENTROPY: &[u8] = b":intrablock_entropy";
 
 	/// Prefix of child storage keys.


### PR DESCRIPTION
`System` is clearing this key in [`finalize`](https://github.com/paritytech/substrate/blob/b72c475803947121b3b475eb33ba5fc48f1fe5b6/frame/system/src/lib.rs#L1446) on every block.  
The key should therefore be included in the BaseBlock benchmark and not in the extrinsic weight. Discovered in https://github.com/paritytech/polkadot/pull/7077