### PR TITLE
Removes `pallet::call_index` from `dev_mode` example

### DIFF
--- a/frame/examples/dev-mode/src/lib.rs
+++ b/frame/examples/dev-mode/src/lib.rs
@@ -78,8 +78,8 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// No need to define a `call_index` attribute here because of `dev_mode`.
-		/// No need to define a `weight` attribute here because of `dev_mode`.
+		// No need to define a `call_index` attribute here because of `dev_mode`.
+		// No need to define a `weight` attribute here because of `dev_mode`.
 		pub fn set_bar(
 			origin: OriginFor<T>,
 			#[pallet::compact] new_value: T::Balance,

--- a/frame/examples/dev-mode/src/lib.rs
+++ b/frame/examples/dev-mode/src/lib.rs
@@ -60,7 +60,7 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
-		#[pallet::call_index(0)]
+		/// No need to define a `call_index` attribute here because of `dev_mode`.
 		/// No need to define a `weight` attribute here because of `dev_mode`.
 		pub fn add_dummy(origin: OriginFor<T>, id: T::AccountId) -> DispatchResult {
 			ensure_root(origin)?;
@@ -78,7 +78,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		#[pallet::call_index(1)]
+		/// No need to define a `call_index` attribute here because of `dev_mode`.
 		/// No need to define a `weight` attribute here because of `dev_mode`.
 		pub fn set_bar(
 			origin: OriginFor<T>,

--- a/frame/examples/dev-mode/src/lib.rs
+++ b/frame/examples/dev-mode/src/lib.rs
@@ -60,8 +60,8 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
-		/// No need to define a `call_index` attribute here because of `dev_mode`.
-		/// No need to define a `weight` attribute here because of `dev_mode`.
+		// No need to define a `call_index` attribute here because of `dev_mode`.
+		// No need to define a `weight` attribute here because of `dev_mode`.
 		pub fn add_dummy(origin: OriginFor<T>, id: T::AccountId) -> DispatchResult {
 			ensure_root(origin)?;
 

--- a/frame/support/procedural/src/lib.rs
+++ b/frame/support/procedural/src/lib.rs
@@ -468,6 +468,8 @@ pub fn construct_runtime(input: TokenStream) -> TokenStream {
 /// * Weights no longer need to be specified on every `#[pallet::call]` declaration. By default, dev
 ///   mode pallets will assume a weight of zero (`0`) if a weight is not specified. This is
 ///   equivalent to specifying `#[weight(0)]` on all calls that do not specify a weight.
+/// * Call index no longer needs to be specified on every `#[pallet::call]` declaration. By default,
+///   dev mode pallets will assume a call index based on the order of the call.
 /// * All storages are marked as unbounded, meaning you do not need to implement `MaxEncodedLen` on
 ///   storage types. This is equivalent to specifying `#[pallet::unbounded]` on all storage type
 ///   definitions.

--- a/frame/support/test/tests/pallet_ui/dev_mode_without_arg_call_index.rs
+++ b/frame/support/test/tests/pallet_ui/dev_mode_without_arg_call_index.rs
@@ -1,0 +1,31 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::OriginFor;
+
+	// The struct on which we build all of our Pallet logic.
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	// Your Pallet's configuration trait, representing custom external types and interfaces.
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	// Your Pallet's callable functions.
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::weight(0)]
+		pub fn my_call(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	// Your Pallet's internal functions.
+	impl<T: Config> Pallet<T> {}
+}
+
+fn main() {}

--- a/frame/support/test/tests/pallet_ui/dev_mode_without_arg_call_index.stderr
+++ b/frame/support/test/tests/pallet_ui/dev_mode_without_arg_call_index.stderr
@@ -1,0 +1,24 @@
+error: use of deprecated constant `pallet::warnings::ImplicitCallIndex_0::_w`:
+               It is deprecated to use implicit call indices.
+               Please instead ensure that all calls have a `pallet::call_index` attribute or put the pallet into `dev` mode.
+
+               For more info see:
+                   <https://github.com/paritytech/substrate/pull/12891>
+                   <https://github.com/paritytech/substrate/pull/11381>
+  --> tests/pallet_ui/dev_mode_without_arg_call_index.rs:22:10
+   |
+22 |         pub fn my_call(_origin: OriginFor<T>) -> DispatchResult {
+   |                ^^^^^^^
+   |
+   = note: `-D deprecated` implied by `-D warnings`
+
+error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
+               It is deprecated to use hard-coded constant as call weight.
+               Please instead benchmark all calls or put the pallet into `dev` mode.
+
+               For more info see:
+                   <https://github.com/paritytech/substrate/pull/13798>
+  --> tests/pallet_ui/dev_mode_without_arg_call_index.rs:21:20
+   |
+21 |         #[pallet::weight(0)]
+   |                          ^


### PR DESCRIPTION
`pallet::call_index` is not needed to be specified when in `dev_mode`. This PR removes it from the respective example.