### PR TITLE
contracts: stabilize `[seal0] instantiation_nonce()`

### DIFF
--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -2819,7 +2819,6 @@ pub mod env {
 	///
 	/// The nonce is incremented for each successful contract instantiation. This is a
 	/// sensible default salt for contract instantiations.
-	#[unstable]
 	fn instantiation_nonce(ctx: _, _memory: _) -> Result<u64, TrapReason> {
 		ctx.charge_gas(RuntimeCosts::InstantationNonce)?;
 		Ok(ctx.ext.nonce())


### PR DESCRIPTION
Stabilize the `[seal0] instantiation_nonce()` runtime API. Covered by [this](https://github.com/hyperledger/solang/blob/22d3633f358bf27b94e68a00c2346305b980cb67/integration/substrate/create_contract.spec.ts#L53) integration test in Solang.