### PR TITLE
Nomination pools: disallow setting above global max commission 

### DIFF
--- a/frame/nomination-pools/src/tests.rs
+++ b/frame/nomination-pools/src/tests.rs
@@ -5915,6 +5915,13 @@ mod commission {
 				Error::<Runtime>::DoesNotHavePermission
 			);
 
+			// Cannot set max commission above GlobalMaxCommission
+			assert_noop!(Pools::set_commission_max(
+				RuntimeOrigin::signed(900),
+				1,
+				Perbill::from_percent(100)
+			), Error::<Runtime>::CommissionExceedsGlobalMaximum);
+
 			// Set a max commission commission pool 1 to 80%
 			assert_ok!(Pools::set_commission_max(
 				RuntimeOrigin::signed(900),

--- a/frame/nomination-pools/src/tests.rs
+++ b/frame/nomination-pools/src/tests.rs
@@ -5916,11 +5916,14 @@ mod commission {
 			);
 
 			// Cannot set max commission above GlobalMaxCommission
-			assert_noop!(Pools::set_commission_max(
-				RuntimeOrigin::signed(900),
-				1,
-				Perbill::from_percent(100)
-			), Error::<Runtime>::CommissionExceedsGlobalMaximum);
+			assert_noop!(
+				Pools::set_commission_max(
+					RuntimeOrigin::signed(900),
+					1,
+					Perbill::from_percent(100)
+				),
+				Error::<Runtime>::CommissionExceedsGlobalMaximum
+			);
 
 			// Set a max commission commission pool 1 to 80%
 			assert_ok!(Pools::set_commission_max(

--- a/frame/nomination-pools/src/tests.rs
+++ b/frame/nomination-pools/src/tests.rs
@@ -6591,7 +6591,7 @@ mod commission {
 	}
 
 	#[test]
-	fn global_max_prevents_100_percent_commission_payout() {
+	fn global_max_caps_max_commission_payout() {
 		ExtBuilder::default().build_and_execute(|| {
 			// Note: GlobalMaxCommission is set at 90%.
 


### PR DESCRIPTION
This PR forces pools to not have a commission configured above `GlobalMaxCommission`. The current code allows users to set a current commission and max commission above `GlobalMaxCommission`, without any error or warning when doing so. 

This PR explicitly fails the `set_commission_current` and `set_max_commission` calls if the provided commission is more than `GlobalMaxCommission`.

- [x] Add a check in `try_update_current` to not be above `GlobalMaxCommission`.
- [x] Add a check in `try_update_max` to not be above `GlobalMaxCommission`.
- [x] Amend `global_max_caps_max_commission_payout` test to account for `try_update_current` check.
- [x] Amend `set_commission_max_works_with_error_tests` for `try_update_max` check.