### PR TITLE
sc-cli: Remove `SubstrateCli::native_runtime_version` function

### DIFF
--- a/bin/node-template/node/src/command.rs
+++ b/bin/node-template/node/src/command.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use frame_benchmarking_cli::{BenchmarkCmd, ExtrinsicFactory, SUBSTRATE_REFERENCE_HARDWARE};
 use node_template_runtime::{Block, EXISTENTIAL_DEPOSIT};
-use sc_cli::{ChainSpec, RuntimeVersion, SubstrateCli};
+use sc_cli::SubstrateCli;
 use sc_service::PartialComponents;
 use sp_keyring::Sr25519Keyring;
 
@@ -45,10 +45,6 @@ impl SubstrateCli for Cli {
 			path =>
 				Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?),
 		})
-	}
-
-	fn native_runtime_version(_: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
-		&node_template_runtime::VERSION
 	}
 }
 

--- a/bin/node/cli/src/command.rs
+++ b/bin/node/cli/src/command.rs
@@ -26,7 +26,7 @@ use frame_benchmarking_cli::*;
 use kitchensink_runtime::{ExistentialDeposit, RuntimeApi};
 use node_executor::ExecutorDispatch;
 use node_primitives::Block;
-use sc_cli::{ChainSpec, Result, RuntimeVersion, SubstrateCli};
+use sc_cli::{Result, SubstrateCli};
 use sc_service::PartialComponents;
 use sp_keyring::Sr25519Keyring;
 
@@ -78,10 +78,6 @@ impl SubstrateCli for Cli {
 				Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?),
 		};
 		Ok(spec)
-	}
-
-	fn native_runtime_version(_: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
-		&kitchensink_runtime::VERSION
 	}
 }
 

--- a/bin/node/executor/benches/bench.rs
+++ b/bin/node/executor/benches/bench.rs
@@ -19,8 +19,8 @@ use codec::{Decode, Encode};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use frame_support::Hashable;
 use kitchensink_runtime::{
-	constants::currency::*, Block, BuildStorage, CheckedExtrinsic, GenesisConfig, Header,
-	RuntimeCall, UncheckedExtrinsic,
+	constants::currency::*, Block, BuildStorage, CheckedExtrinsic, Header, RuntimeCall,
+	RuntimeGenesisConfig, UncheckedExtrinsic,
 };
 use node_executor::ExecutorDispatch;
 use node_primitives::{BlockNumber, Hash};
@@ -67,7 +67,7 @@ fn sign(xt: CheckedExtrinsic) -> UncheckedExtrinsic {
 	node_testing::keyring::sign(xt, SPEC_VERSION, TRANSACTION_VERSION, GENESIS_HASH)
 }
 
-fn new_test_ext(genesis_config: &GenesisConfig) -> TestExternalities<BlakeTwo256> {
+fn new_test_ext(genesis_config: &RuntimeGenesisConfig) -> TestExternalities<BlakeTwo256> {
 	let mut test_ext = TestExternalities::new_with_code(
 		compact_code_unwrap(),
 		genesis_config.build_storage().unwrap(),
@@ -157,7 +157,7 @@ fn construct_block<E: Externalities>(
 }
 
 fn test_blocks(
-	genesis_config: &GenesisConfig,
+	genesis_config: &RuntimeGenesisConfig,
 	executor: &NativeElseWasmExecutor<ExecutorDispatch>,
 ) -> Vec<(Vec<u8>, Hash)> {
 	let mut test_ext = new_test_ext(genesis_config);

--- a/client/cli/src/commands/insert_key.rs
+++ b/client/cli/src/commands/insert_key.rs
@@ -125,10 +125,6 @@ mod tests {
 			"test".into()
 		}
 
-		fn native_runtime_version(_: &Box<dyn ChainSpec>) -> &'static sp_version::RuntimeVersion {
-			unimplemented!("Not required in tests")
-		}
-
 		fn load_spec(&self, _: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 			Ok(Box::new(GenericChainSpec::from_genesis(
 				"test",

--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -248,6 +248,4 @@ pub trait SubstrateCli: Sized {
 		command.init(&Self::support_url(), &Self::impl_version(), logger_hook, &config)?;
 		Runner::new(config, tokio_runtime, signals)
 	}
-	/// Native runtime version.
-	fn native_runtime_version(chain_spec: &Box<dyn ChainSpec>) -> &'static RuntimeVersion;
 }

--- a/client/cli/src/runner.rs
+++ b/client/cli/src/runner.rs
@@ -187,22 +187,17 @@ pub fn print_node_infos<C: SubstrateCli>(config: &Configuration) {
 			.path()
 			.map_or_else(|| "<unknown>".to_owned(), |p| p.display().to_string())
 	);
-	info!("⛓  Native runtime: {}", C::native_runtime_version(&config.chain_spec));
 }
 
 #[cfg(test)]
 mod tests {
+	use super::*;
+	use sc_network::config::NetworkConfiguration;
+	use sc_service::{Arc, ChainType, GenericChainSpec, NoExtension};
 	use std::{
 		path::PathBuf,
 		sync::atomic::{AtomicU64, Ordering},
 	};
-
-	use sc_network::config::NetworkConfiguration;
-	use sc_service::{Arc, ChainType, GenericChainSpec, NoExtension};
-	use sp_runtime::create_runtime_str;
-	use sp_version::create_apis_vec;
-
-	use super::*;
 
 	struct Cli;
 
@@ -236,23 +231,6 @@ mod tests {
 			_: &str,
 		) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
 			Err("nope".into())
-		}
-
-		fn native_runtime_version(
-			_: &Box<dyn sc_service::ChainSpec>,
-		) -> &'static sp_version::RuntimeVersion {
-			const VERSION: sp_version::RuntimeVersion = sp_version::RuntimeVersion {
-				spec_name: create_runtime_str!("spec"),
-				impl_name: create_runtime_str!("name"),
-				authoring_version: 0,
-				spec_version: 0,
-				impl_version: 0,
-				apis: create_apis_vec!([]),
-				transaction_version: 2,
-				state_version: 0,
-			};
-
-			&VERSION
 		}
 	}
 


### PR DESCRIPTION
The native runtime will be removed in the near future and thus this function will not be required anymore.

# Code changes

Downstream users just need to remove `native_runtime_version` from their implementation of the `SubstrateCli` trait.

polkadot companion: https://github.com/paritytech/polkadot/pull/7459
cumulus companion: https://github.com/paritytech/cumulus/pull/2821

