### PR TITLE
[NFTs] Allow to set the default new item's metadata

### DIFF
--- a/frame/nfts/src/benchmarking.rs
+++ b/frame/nfts/src/benchmarking.rs
@@ -209,7 +209,12 @@ fn make_collection_config<T: Config<I>, I: 'static>(
 	CollectionConfig {
 		settings: CollectionSettings::from_disabled(disable_settings),
 		max_supply: None,
-		mint_settings: MintSettings::default(),
+		mint_settings: MintSettings {
+			default_item_metadata: Some(
+				vec![0; T::StringLimit::get() as usize].try_into().unwrap(),
+			),
+			..Default::default()
+		},
 	}
 }
 
@@ -645,12 +650,14 @@ benchmarks_instance_pallet! {
 
 	update_mint_settings {
 		let (collection, caller, _) = create_collection::<T, I>();
+		let default_item_metadata: BoundedVec<_, _> = vec![0u8; T::StringLimit::get() as usize].try_into().unwrap();
 		let mint_settings = MintSettings {
 			mint_type: MintType::HolderOf(T::Helper::collection(0)),
 			start_block: Some(One::one()),
 			end_block: Some(One::one()),
 			price: Some(ItemPrice::<T, I>::from(1u32)),
 			default_item_settings: ItemSettings::all_enabled(),
+			default_item_metadata: Some(default_item_metadata),
 		};
 	}: _(SystemOrigin::Signed(caller.clone()), collection, mint_settings)
 	verify {

--- a/frame/nfts/src/features/create_delete_item.rs
+++ b/frame/nfts/src/features/create_delete_item.rs
@@ -26,7 +26,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		mint_to: T::AccountId,
 		item_config: ItemConfig,
 		with_details_and_config: impl FnOnce(
-			&CollectionDetailsFor<T, I>,
+			&mut CollectionDetailsFor<T, I>,
 			&CollectionConfigFor<T, I>,
 		) -> DispatchResult,
 	) -> DispatchResult {

--- a/frame/nfts/src/features/settings.rs
+++ b/frame/nfts/src/features/settings.rs
@@ -59,11 +59,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	pub(crate) fn do_update_mint_settings(
 		maybe_check_origin: Option<T::AccountId>,
 		collection: T::CollectionId,
-		mint_settings: MintSettings<
-			BalanceOf<T, I>,
-			<T as SystemConfig>::BlockNumber,
-			T::CollectionId,
-		>,
+		mint_settings: MintSettingsOf<T, I>,
 	) -> DispatchResult {
 		if let Some(check_origin) = &maybe_check_origin {
 			ensure!(

--- a/frame/nfts/src/impl_nonfungibles.rs
+++ b/frame/nfts/src/impl_nonfungibles.rs
@@ -169,7 +169,7 @@ impl<T: Config<I>, I: 'static> Create<<T as SystemConfig>::AccountId, Collection
 			collection,
 			who.clone(),
 			admin.clone(),
-			*config,
+			config.clone(),
 			T::CollectionDeposit::get(),
 			Event::Created { collection, creator: who.clone(), owner: admin.clone() },
 		)?;

--- a/frame/nfts/src/tests.rs
+++ b/frame/nfts/src/tests.rs
@@ -454,6 +454,32 @@ fn mint_should_work() {
 }
 
 #[test]
+fn mint_with_default_metadata() {
+	new_test_ext().execute_with(|| {
+		Balances::make_free_balance_be(&account(2), 100);
+		assert_ok!(Nfts::force_create(
+			RuntimeOrigin::root(),
+			account(1),
+			CollectionConfig {
+				settings: CollectionSettings::all_enabled(),
+				max_supply: None,
+				mint_settings: MintSettings {
+					mint_type: MintType::Public,
+					default_item_metadata: Some(bvec![0, 1]),
+					..Default::default()
+				},
+			}
+		));
+		assert_ok!(Nfts::mint(RuntimeOrigin::signed(account(2)), 0, 42, account(2), None));
+		assert!(ItemMetadataOf::<Test>::contains_key(0, 42));
+		assert_eq!(Collection::<Test>::get(0).unwrap().item_metadatas, 1);
+
+		let metadata = ItemMetadataOf::<Test>::get(0, 42).unwrap();
+		assert_eq!(metadata.deposit, ItemMetadataDeposit { account: Some(account(2)), amount: 3 });
+	});
+}
+
+#[test]
 fn transfer_should_work() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Nfts::force_create(

--- a/frame/nfts/src/types.rs
+++ b/frame/nfts/src/types.rs
@@ -60,6 +60,13 @@ pub(super) type CollectionConfigFor<T, I = ()> = CollectionConfig<
 	BalanceOf<T, I>,
 	<T as SystemConfig>::BlockNumber,
 	<T as Config<I>>::CollectionId,
+	BoundedVec<u8, <T as Config<I>>::StringLimit>,
+>;
+pub(super) type MintSettingsOf<T, I = ()> = MintSettings<
+	BalanceOf<T, I>,
+	<T as SystemConfig>::BlockNumber,
+	<T as Config<I>>::CollectionId,
+	BoundedVec<u8, <T as Config<I>>::StringLimit>,
 >;
 pub(super) type PreSignedMintOf<T, I = ()> = PreSignedMint<
 	<T as Config<I>>::CollectionId,
@@ -290,8 +297,8 @@ pub enum MintType<CollectionId> {
 }
 
 /// Holds the information about minting.
-#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-pub struct MintSettings<Price, BlockNumber, CollectionId> {
+#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+pub struct MintSettings<Price, BlockNumber, CollectionId, BoundedString> {
 	/// Whether anyone can mint or if minters are restricted to some subset.
 	pub mint_type: MintType<CollectionId>,
 	/// An optional price per mint.
@@ -302,9 +309,13 @@ pub struct MintSettings<Price, BlockNumber, CollectionId> {
 	pub end_block: Option<BlockNumber>,
 	/// Default settings each item will get during the mint.
 	pub default_item_settings: ItemSettings,
+	/// Default metadata each item will get during the mint.
+	pub default_item_metadata: Option<BoundedString>,
 }
 
-impl<Price, BlockNumber, CollectionId> Default for MintSettings<Price, BlockNumber, CollectionId> {
+impl<Price, BlockNumber, CollectionId, BoundedString> Default
+	for MintSettings<Price, BlockNumber, CollectionId, BoundedString>
+{
 	fn default() -> Self {
 		Self {
 			mint_type: MintType::Issuer,
@@ -312,6 +323,7 @@ impl<Price, BlockNumber, CollectionId> Default for MintSettings<Price, BlockNumb
 			start_block: None,
 			end_block: None,
 			default_item_settings: ItemSettings::all_enabled(),
+			default_item_metadata: None,
 		}
 	}
 }
@@ -348,19 +360,19 @@ pub enum PalletAttributes<CollectionId> {
 }
 
 /// Collection's configuration.
-#[derive(
-	Clone, Copy, Decode, Default, Encode, MaxEncodedLen, PartialEq, RuntimeDebug, TypeInfo,
-)]
-pub struct CollectionConfig<Price, BlockNumber, CollectionId> {
+#[derive(Clone, Decode, Default, Encode, MaxEncodedLen, PartialEq, RuntimeDebug, TypeInfo)]
+pub struct CollectionConfig<Price, BlockNumber, CollectionId, BoundedString> {
 	/// Collection's settings.
 	pub settings: CollectionSettings,
 	/// Collection's max supply.
 	pub max_supply: Option<u32>,
 	/// Default settings each item will get during the mint.
-	pub mint_settings: MintSettings<Price, BlockNumber, CollectionId>,
+	pub mint_settings: MintSettings<Price, BlockNumber, CollectionId, BoundedString>,
 }
 
-impl<Price, BlockNumber, CollectionId> CollectionConfig<Price, BlockNumber, CollectionId> {
+impl<Price, BlockNumber, CollectionId, BoundedString>
+	CollectionConfig<Price, BlockNumber, CollectionId, BoundedString>
+{
 	pub fn is_setting_enabled(&self, setting: CollectionSetting) -> bool {
 		!self.settings.is_disabled(setting)
 	}


### PR DESCRIPTION
In public mints (drops), the newly minted items usually have some metadata pre-set, this new field would allow us to do this.
If we take any popular project, e.g. poaps, all of the received items have some image attached.
Without that field, the admin would require to monitor the new mints and set the metadata manually.

P. S. This is a breaking change that affects the `create()` method used to create collections and will require passing the new `default_item_metadata` param.
Although I hope the PolkadotJS API library will recognize the new param and set it to null without breaking anything.

TODO:

- [ ] migrations