### PR TITLE
nom-pool try-state: improve logs

### DIFF
--- a/frame/nomination-pools/src/lib.rs
+++ b/frame/nomination-pools/src/lib.rs
@@ -3135,16 +3135,18 @@ impl<T: Config> Pallet<T> {
 		RewardPools::<T>::iter_keys().try_for_each(|id| -> Result<(), TryRuntimeError> {
 			// the sum of the pending rewards must be less than the leftover balance. Since the
 			// reward math rounds down, we might accumulate some dust here.
-			log!(
-				trace,
-				"pool {:?}, sum pending rewards = {:?}, remaining balance = {:?}",
-				id,
-				pools_members_pending_rewards.get(&id),
-				RewardPool::<T>::current_balance(id)
-			);
+			let pending_rewards_lt_leftover_bal = RewardPool::<T>::current_balance(id) >=
+				pools_members_pending_rewards.get(&id).copied().unwrap_or_default();
+			if !pending_rewards_lt_leftover_bal {
+				log::warn!(
+					"pool {:?}, sum pending rewards = {:?}, remaining balance = {:?}",
+					id,
+					pools_members_pending_rewards.get(&id),
+					RewardPool::<T>::current_balance(id)
+				);
+			}
 			ensure!(
-				RewardPool::<T>::current_balance(id) >=
-					pools_members_pending_rewards.get(&id).copied().unwrap_or_default(),
+				pending_rewards_lt_leftover_bal,
 				"The sum of the pending rewards must be less than the leftover balance."
 			);
 			Ok(())


### PR DESCRIPTION
Updated while investigating https://github.com/paritytech/polkadot-sdk/issues/158

Some nom pool try-state logs are always trace. Trace is pretty unintelligible, this PR updates them to only emit when they are highlighting inconsistent state and changes them to warn.