### PR TITLE
remove `OnStakerSlash` replace with `OnStakingEvents`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3165,6 +3165,7 @@ dependencies = [
  "frame-system",
  "num-format",
  "pallet-staking",
+ "sp-staking",
 ]
 
 [[package]]
@@ -6547,6 +6548,7 @@ dependencies = [
  "sp-io",
  "sp-npos-elections",
  "sp-runtime",
+ "sp-staking",
  "sp-std",
  "sp-tracing",
  "substrate-test-utils",
@@ -11526,6 +11528,7 @@ dependencies = [
 name = "sp-staking"
 version = "4.0.0-dev"
 dependencies = [
+ "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "serde",

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -38,7 +38,7 @@ use frame_support::{
 		tokens::{nonfungibles_v2::Inspect, GetSalary, PayFromAccount},
 		AsEnsureOriginWithArg, ConstBool, ConstU128, ConstU16, ConstU32, Currency, EitherOfDiverse,
 		EqualPrivilegeOnly, Everything, Imbalance, InstanceFilter, KeyOwnerProofSystem,
-		LockIdentifier, Nothing, OnUnbalanced, U128CurrencyToVote, WithdrawReasons,
+		LockIdentifier, Nothing, OnUnbalanced, WithdrawReasons,
 	},
 	weights::{
 		constants::{
@@ -575,7 +575,7 @@ impl pallet_staking::Config for Runtime {
 	type Currency = Balances;
 	type CurrencyBalance = Balance;
 	type UnixTime = Timestamp;
-	type CurrencyToVote = U128CurrencyToVote;
+	type CurrencyToVote = sp_staking::currency_to_vote::U128CurrencyToVote;
 	type RewardRemainder = Treasury;
 	type RuntimeEvent = RuntimeEvent;
 	type Slash = Treasury; // send the slashed funds to the treasury.
@@ -600,7 +600,7 @@ impl pallet_staking::Config for Runtime {
 	type TargetList = pallet_staking::UseValidatorsMap<Self>;
 	type MaxUnlockingChunks = ConstU32<32>;
 	type HistoryDepth = HistoryDepth;
-	type OnStakerSlash = NominationPools;
+	type EventListeners = NominationPools;
 	type WeightInfo = pallet_staking::weights::SubstrateWeight<Runtime>;
 	type BenchmarkingConfig = StakingBenchmarkingConfig;
 }
@@ -1047,7 +1047,7 @@ impl pallet_elections_phragmen::Config for Runtime {
 	// NOTE: this implies that council's genesis members cannot be set directly and must come from
 	// this module.
 	type InitializeMembers = Council;
-	type CurrencyToVote = U128CurrencyToVote;
+	type CurrencyToVote = sp_staking::currency_to_vote::U128CurrencyToVote;
 	type CandidacyBond = CandidacyBond;
 	type VotingBondBase = VotingBondBase;
 	type VotingBondFactor = VotingBondFactor;

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -182,7 +182,7 @@ impl onchain::Config for OnChainSeqPhragmen {
 impl pallet_staking::Config for Test {
 	type MaxNominations = ConstU32<16>;
 	type RewardRemainder = ();
-	type CurrencyToVote = frame_support::traits::SaturatingCurrencyToVote;
+	type CurrencyToVote = ();
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
 	type CurrencyBalance = <Self as pallet_balances::Config>::Balance;
@@ -204,7 +204,7 @@ impl pallet_staking::Config for Test {
 	type TargetList = pallet_staking::UseValidatorsMap<Self>;
 	type MaxUnlockingChunks = ConstU32<32>;
 	type HistoryDepth = ConstU32<84>;
-	type OnStakerSlash = ();
+	type EventListeners = ();
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/beefy/src/mock.rs
+++ b/frame/beefy/src/mock.rs
@@ -206,7 +206,7 @@ impl onchain::Config for OnChainSeqPhragmen {
 impl pallet_staking::Config for Test {
 	type MaxNominations = ConstU32<16>;
 	type RewardRemainder = ();
-	type CurrencyToVote = frame_support::traits::SaturatingCurrencyToVote;
+	type CurrencyToVote = ();
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
 	type CurrencyBalance = <Self as pallet_balances::Config>::Balance;
@@ -228,7 +228,7 @@ impl pallet_staking::Config for Test {
 	type TargetList = pallet_staking::UseValidatorsMap<Self>;
 	type MaxUnlockingChunks = ConstU32<32>;
 	type HistoryDepth = ConstU32<84>;
-	type OnStakerSlash = ();
+	type EventListeners = ();
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/election-provider-multi-phase/test-staking-e2e/src/mock.rs
+++ b/frame/election-provider-multi-phase/test-staking-e2e/src/mock.rs
@@ -265,7 +265,7 @@ impl pallet_staking::Config for Runtime {
 	type Currency = Balances;
 	type CurrencyBalance = Balance;
 	type UnixTime = Timestamp;
-	type CurrencyToVote = sp_staking::currency_to_vote::SaturatingCurrencyToVote;
+	type CurrencyToVote = ();
 	type RewardRemainder = ();
 	type RuntimeEvent = RuntimeEvent;
 	type Slash = (); // burn slashes

--- a/frame/election-provider-multi-phase/test-staking-e2e/src/mock.rs
+++ b/frame/election-provider-multi-phase/test-staking-e2e/src/mock.rs
@@ -265,7 +265,7 @@ impl pallet_staking::Config for Runtime {
 	type Currency = Balances;
 	type CurrencyBalance = Balance;
 	type UnixTime = Timestamp;
-	type CurrencyToVote = traits::SaturatingCurrencyToVote;
+	type CurrencyToVote = sp_staking::currency_to_vote::SaturatingCurrencyToVote;
 	type RewardRemainder = ();
 	type RuntimeEvent = RuntimeEvent;
 	type Slash = (); // burn slashes
@@ -285,7 +285,7 @@ impl pallet_staking::Config for Runtime {
 	type TargetList = pallet_staking::UseValidatorsMap<Self>;
 	type MaxUnlockingChunks = ConstU32<32>;
 	type HistoryDepth = HistoryDepth;
-	type OnStakerSlash = ();
+	type EventListeners = ();
 	type WeightInfo = pallet_staking::weights::SubstrateWeight<Runtime>;
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 }

--- a/frame/elections-phragmen/Cargo.toml
+++ b/frame/elections-phragmen/Cargo.toml
@@ -26,6 +26,7 @@ sp-io = { version = "23.0.0", default-features = false, path = "../../primitives
 sp-npos-elections = { version = "4.0.0-dev", default-features = false, path = "../../primitives/npos-elections" }
 sp-runtime = { version = "24.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-std = { version = "8.0.0", default-features = false, path = "../../primitives/std" }
+sp-staking = { default-features = false, path = "../../primitives/staking" }
 
 [dev-dependencies]
 pallet-balances = { version = "4.0.0-dev", path = "../balances" }

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -101,9 +101,9 @@
 use codec::{Decode, Encode};
 use frame_support::{
 	traits::{
-		defensive_prelude::*, ChangeMembers, Contains, ContainsLengthBound, Currency,
-		CurrencyToVote, Get, InitializeMembers, LockIdentifier, LockableCurrency, OnUnbalanced,
-		ReservableCurrency, SortedMembers, WithdrawReasons,
+		defensive_prelude::*, ChangeMembers, Contains, ContainsLengthBound, Currency, Get,
+		InitializeMembers, LockIdentifier, LockableCurrency, OnUnbalanced, ReservableCurrency,
+		SortedMembers, WithdrawReasons,
 	},
 	weights::Weight,
 };
@@ -113,6 +113,7 @@ use sp_runtime::{
 	traits::{Saturating, StaticLookup, Zero},
 	DispatchError, Perbill, RuntimeDebug,
 };
+use sp_staking::currency_to_vote::CurrencyToVote;
 use sp_std::{cmp::Ordering, prelude::*};
 
 #[cfg(any(feature = "try-runtime", test))]
@@ -1424,7 +1425,7 @@ mod tests {
 		type PalletId = ElectionsPhragmenPalletId;
 		type RuntimeEvent = RuntimeEvent;
 		type Currency = Balances;
-		type CurrencyToVote = frame_support::traits::SaturatingCurrencyToVote;
+		type CurrencyToVote = sp_staking::currency_to_vote::SaturatingCurrencyToVote;
 		type ChangeMembers = TestChangeMembers;
 		type InitializeMembers = ();
 		type CandidacyBond = CandidacyBond;

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -1425,7 +1425,7 @@ mod tests {
 		type PalletId = ElectionsPhragmenPalletId;
 		type RuntimeEvent = RuntimeEvent;
 		type Currency = Balances;
-		type CurrencyToVote = sp_staking::currency_to_vote::SaturatingCurrencyToVote;
+		type CurrencyToVote = ();
 		type ChangeMembers = TestChangeMembers;
 		type InitializeMembers = ();
 		type CandidacyBond = CandidacyBond;

--- a/frame/fast-unstake/src/mock.rs
+++ b/frame/fast-unstake/src/mock.rs
@@ -137,7 +137,7 @@ impl pallet_staking::Config for Runtime {
 	type Currency = Balances;
 	type CurrencyBalance = Balance;
 	type UnixTime = pallet_timestamp::Pallet<Self>;
-	type CurrencyToVote = frame_support::traits::SaturatingCurrencyToVote;
+	type CurrencyToVote = ();
 	type RewardRemainder = ();
 	type RuntimeEvent = RuntimeEvent;
 	type Slash = ();
@@ -157,7 +157,7 @@ impl pallet_staking::Config for Runtime {
 	type VoterList = pallet_staking::UseNominatorsAndValidatorsMap<Self>;
 	type TargetList = pallet_staking::UseValidatorsMap<Self>;
 	type MaxUnlockingChunks = ConstU32<32>;
-	type OnStakerSlash = ();
+	type EventListeners = ();
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -187,7 +187,7 @@ impl onchain::Config for OnChainSeqPhragmen {
 impl pallet_staking::Config for Test {
 	type MaxNominations = ConstU32<16>;
 	type RewardRemainder = ();
-	type CurrencyToVote = frame_support::traits::SaturatingCurrencyToVote;
+	type CurrencyToVote = ();
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
 	type CurrencyBalance = <Self as pallet_balances::Config>::Balance;
@@ -209,7 +209,7 @@ impl pallet_staking::Config for Test {
 	type TargetList = pallet_staking::UseValidatorsMap<Self>;
 	type MaxUnlockingChunks = ConstU32<32>;
 	type HistoryDepth = ConstU32<84>;
-	type OnStakerSlash = ();
+	type EventListeners = ();
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/nomination-pools/benchmarking/src/mock.rs
+++ b/frame/nomination-pools/benchmarking/src/mock.rs
@@ -120,7 +120,6 @@ impl pallet_staking::Config for Runtime {
 	type TargetList = pallet_staking::UseValidatorsMap<Self>;
 	type MaxUnlockingChunks = ConstU32<32>;
 	type HistoryDepth = ConstU32<84>;
-	type OnStakerSlash = Pools;
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/nomination-pools/benchmarking/src/mock.rs
+++ b/frame/nomination-pools/benchmarking/src/mock.rs
@@ -99,7 +99,7 @@ impl pallet_staking::Config for Runtime {
 	type Currency = Balances;
 	type CurrencyBalance = Balance;
 	type UnixTime = pallet_timestamp::Pallet<Self>;
-	type CurrencyToVote = frame_support::traits::SaturatingCurrencyToVote;
+	type CurrencyToVote = ();
 	type RewardRemainder = ();
 	type RuntimeEvent = RuntimeEvent;
 	type Slash = ();
@@ -120,6 +120,7 @@ impl pallet_staking::Config for Runtime {
 	type TargetList = pallet_staking::UseValidatorsMap<Self>;
 	type MaxUnlockingChunks = ConstU32<32>;
 	type HistoryDepth = ConstU32<84>;
+	type EventListeners = Pools;
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/nomination-pools/src/lib.rs
+++ b/frame/nomination-pools/src/lib.rs
@@ -326,7 +326,7 @@
 //!
 //! This section assumes that the slash computation is executed by
 //! `pallet_staking::StakingLedger::slash`, which passes the information to this pallet via
-//! [`sp_staking::OnStakingEvents::on_slash`].
+//! [`sp_staking::OnStakingUpdate::on_slash`].
 //!
 //! Unbonding pools need to be slashed to ensure all nominators whom where in the bonded pool while
 //! it was backing a validator that equivocated are punished. Without these measures a member could

--- a/frame/nomination-pools/src/lib.rs
+++ b/frame/nomination-pools/src/lib.rs
@@ -326,7 +326,7 @@
 //!
 //! This section assumes that the slash computation is executed by
 //! `pallet_staking::StakingLedger::slash`, which passes the information to this pallet via
-//! [`sp_staking::OnStakerSlash::on_slash`].
+//! [`sp_staking::OnStakingEvents::on_slash`].
 //!
 //! Unbonding pools need to be slashed to ensure all nominators whom where in the bonded pool while
 //! it was backing a validator that equivocated are punished. Without these measures a member could
@@ -375,7 +375,7 @@ use sp_runtime::{
 	},
 	FixedPointNumber, Perbill,
 };
-use sp_staking::{EraIndex, OnStakerSlash, StakingInterface};
+use sp_staking::{EraIndex, StakingInterface};
 use sp_std::{collections::btree_map::BTreeMap, fmt::Debug, ops::Div, vec::Vec};
 
 #[cfg(any(feature = "try-runtime", feature = "fuzzing", test, debug_assertions))]
@@ -3265,7 +3265,7 @@ impl<T: Config> Pallet<T> {
 	}
 }
 
-impl<T: Config> OnStakerSlash<T::AccountId, BalanceOf<T>> for Pallet<T> {
+impl<T: Config> sp_staking::OnStakingUpdate<T::AccountId, BalanceOf<T>> for Pallet<T> {
 	fn on_slash(
 		pool_account: &T::AccountId,
 		// Bonded balance is always read directly from staking, therefore we don't need to update

--- a/frame/nomination-pools/src/lib.rs
+++ b/frame/nomination-pools/src/lib.rs
@@ -341,10 +341,6 @@
 //! in addition to the unbonding pools. For maintenance simplicity these are not implemented.
 //! Related: <https://github.com/paritytech/substrate/issues/10860>
 //!
-//! **Relevant methods:**
-//!
-//! * [`Pallet::on_slash`]
-//!
 //! ### Limitations
 //!
 //! * PoolMembers cannot vote with their staked funds because they are transferred into the pools

--- a/frame/nomination-pools/src/mock.rs
+++ b/frame/nomination-pools/src/mock.rs
@@ -47,6 +47,7 @@ impl StakingMock {
 impl sp_staking::StakingInterface for StakingMock {
 	type Balance = Balance;
 	type AccountId = AccountId;
+	type CurrencyToVote = sp_staking::currency_to_vote::SaturatingCurrencyToVote;
 
 	fn minimum_nominator_bond() -> Self::Balance {
 		StakingMinBond::get()

--- a/frame/nomination-pools/src/mock.rs
+++ b/frame/nomination-pools/src/mock.rs
@@ -47,7 +47,7 @@ impl StakingMock {
 impl sp_staking::StakingInterface for StakingMock {
 	type Balance = Balance;
 	type AccountId = AccountId;
-	type CurrencyToVote = sp_staking::currency_to_vote::SaturatingCurrencyToVote;
+	type CurrencyToVote = ();
 
 	fn minimum_nominator_bond() -> Self::Balance {
 		StakingMinBond::get()

--- a/frame/nomination-pools/test-staking/src/mock.rs
+++ b/frame/nomination-pools/test-staking/src/mock.rs
@@ -134,7 +134,7 @@ impl pallet_staking::Config for Runtime {
 	type TargetList = pallet_staking::UseValidatorsMap<Self>;
 	type MaxUnlockingChunks = ConstU32<32>;
 	type HistoryDepth = ConstU32<84>;
-	type EventListeners = ();
+	type EventListeners = Pools;
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/nomination-pools/test-staking/src/mock.rs
+++ b/frame/nomination-pools/test-staking/src/mock.rs
@@ -113,7 +113,7 @@ impl pallet_staking::Config for Runtime {
 	type Currency = Balances;
 	type CurrencyBalance = Balance;
 	type UnixTime = pallet_timestamp::Pallet<Self>;
-	type CurrencyToVote = frame_support::traits::SaturatingCurrencyToVote;
+	type CurrencyToVote = ();
 	type RewardRemainder = ();
 	type RuntimeEvent = RuntimeEvent;
 	type Slash = ();
@@ -134,7 +134,7 @@ impl pallet_staking::Config for Runtime {
 	type TargetList = pallet_staking::UseValidatorsMap<Self>;
 	type MaxUnlockingChunks = ConstU32<32>;
 	type HistoryDepth = ConstU32<84>;
-	type OnStakerSlash = Pools;
+	type EventListeners = ();
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -162,7 +162,7 @@ impl pallet_staking::Config for Test {
 	type Currency = Balances;
 	type CurrencyBalance = <Self as pallet_balances::Config>::Balance;
 	type UnixTime = pallet_timestamp::Pallet<Self>;
-	type CurrencyToVote = frame_support::traits::SaturatingCurrencyToVote;
+	type CurrencyToVote = ();
 	type RewardRemainder = ();
 	type RuntimeEvent = RuntimeEvent;
 	type Slash = ();
@@ -182,6 +182,7 @@ impl pallet_staking::Config for Test {
 	type TargetList = pallet_staking::UseValidatorsMap<Self>;
 	type MaxUnlockingChunks = ConstU32<32>;
 	type HistoryDepth = ConstU32<84>;
+	type EventListeners = ();
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -182,7 +182,6 @@ impl pallet_staking::Config for Test {
 	type TargetList = pallet_staking::UseValidatorsMap<Self>;
 	type MaxUnlockingChunks = ConstU32<32>;
 	type HistoryDepth = ConstU32<84>;
-	type OnStakerSlash = ();
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/root-offences/src/mock.rs
+++ b/frame/root-offences/src/mock.rs
@@ -149,17 +149,6 @@ impl onchain::Config for OnChainSeqPhragmen {
 	type TargetsBound = ConstU32<{ u32::MAX }>;
 }
 
-pub struct OnStakerSlashMock<T: Config>(core::marker::PhantomData<T>);
-impl<T: Config> sp_staking::OnStakerSlash<AccountId, Balance> for OnStakerSlashMock<T> {
-	fn on_slash(
-		_pool_account: &AccountId,
-		slashed_bonded: Balance,
-		slashed_chunks: &BTreeMap<EraIndex, Balance>,
-	) {
-		LedgerSlashPerEra::set((slashed_bonded, slashed_chunks.clone()));
-	}
-}
-
 parameter_types! {
 	pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
 	pub static Offset: BlockNumber = 0;
@@ -176,7 +165,7 @@ impl pallet_staking::Config for Test {
 	type Currency = Balances;
 	type CurrencyBalance = <Self as pallet_balances::Config>::Balance;
 	type UnixTime = Timestamp;
-	type CurrencyToVote = frame_support::traits::SaturatingCurrencyToVote;
+	type CurrencyToVote = ();
 	type RewardRemainder = ();
 	type RuntimeEvent = RuntimeEvent;
 	type Slash = ();
@@ -196,7 +185,7 @@ impl pallet_staking::Config for Test {
 	type MaxUnlockingChunks = ConstU32<32>;
 	type HistoryDepth = ConstU32<84>;
 	type VoterList = pallet_staking::UseNominatorsAndValidatorsMap<Self>;
-	type OnStakerSlash = OnStakerSlashMock<Test>;
+	type EventListeners = ();
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -164,7 +164,7 @@ impl pallet_staking::Config for Test {
 	type Currency = Balances;
 	type CurrencyBalance = <Self as pallet_balances::Config>::Balance;
 	type UnixTime = pallet_timestamp::Pallet<Self>;
-	type CurrencyToVote = frame_support::traits::SaturatingCurrencyToVote;
+	type CurrencyToVote = ();
 	type RewardRemainder = ();
 	type RuntimeEvent = RuntimeEvent;
 	type Slash = ();
@@ -184,6 +184,7 @@ impl pallet_staking::Config for Test {
 	type HistoryDepth = ConstU32<84>;
 	type VoterList = pallet_staking::UseNominatorsAndValidatorsMap<Self>;
 	type TargetList = pallet_staking::UseValidatorsMap<Self>;
+	type EventListeners = ();
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -184,7 +184,6 @@ impl pallet_staking::Config for Test {
 	type HistoryDepth = ConstU32<84>;
 	type VoterList = pallet_staking::UseNominatorsAndValidatorsMap<Self>;
 	type TargetList = pallet_staking::UseValidatorsMap<Self>;
-	type OnStakerSlash = ();
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -26,13 +26,13 @@ use frame_election_provider_support::SortedListProvider;
 use frame_support::{
 	dispatch::UnfilteredDispatchable,
 	pallet_prelude::*,
-	traits::{Currency, CurrencyToVote, Get, Imbalance},
+	traits::{Currency, Get, Imbalance},
 };
 use sp_runtime::{
 	traits::{Bounded, One, StaticLookup, TrailingZeroInput, Zero},
 	Perbill, Percent,
 };
-use sp_staking::SessionIndex;
+use sp_staking::{currency_to_vote::CurrencyToVote, SessionIndex};
 use sp_std::prelude::*;
 
 pub use frame_benchmarking::v1::{

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -314,7 +314,7 @@ use sp_runtime::{
 pub use sp_staking::StakerStatus;
 use sp_staking::{
 	offence::{Offence, OffenceError, ReportOffence},
-	EraIndex, SessionIndex,
+	EraIndex, OnStakingUpdate, SessionIndex,
 };
 use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 pub use weights::WeightInfo;
@@ -549,7 +549,7 @@ impl<T: Config> StakingLedger<T> {
 	///
 	/// `slash_era` is the era in which the slash (which is being enacted now) actually happened.
 	///
-	/// This calls `Config::OnStakerSlash::on_slash` with information as to how the slash was
+	/// This calls `Config::OnStakingEvents::on_slash` with information as to how the slash was
 	/// applied.
 	pub fn slash(
 		&mut self,
@@ -562,7 +562,6 @@ impl<T: Config> StakingLedger<T> {
 		}
 
 		use sp_runtime::PerThing as _;
-		use sp_staking::OnStakerSlash as _;
 		let mut remaining_slash = slash_amount;
 		let pre_slash_total = self.total;
 
@@ -667,7 +666,7 @@ impl<T: Config> StakingLedger<T> {
 		// clean unlocking chunks that are set to zero.
 		self.unlocking.retain(|c| !c.value.is_zero());
 
-		T::OnStakerSlash::on_slash(&self.stash, self.active, &slashed_unlocking);
+		T::EventListeners::on_slash(&self.stash, self.active, &slashed_unlocking);
 		pre_slash_total.saturating_sub(self.total)
 	}
 }

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -549,7 +549,7 @@ impl<T: Config> StakingLedger<T> {
 	///
 	/// `slash_era` is the era in which the slash (which is being enacted now) actually happened.
 	///
-	/// This calls `Config::OnStakingEvents::on_slash` with information as to how the slash was
+	/// This calls `Config::OnStakingUpdate::on_slash` with information as to how the slash was
 	/// applied.
 	pub fn slash(
 		&mut self,

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -236,7 +236,6 @@ parameter_types! {
 	pub static HistoryDepth: u32 = 80;
 	pub static MaxUnlockingChunks: u32 = 32;
 	pub static RewardOnUnbalanceWasCalled: bool = false;
-	pub static LedgerSlashPerEra: (BalanceOf<Test>, BTreeMap<EraIndex, BalanceOf<Test>>) = (Zero::zero(), BTreeMap::new());
 	pub static MaxWinners: u32 = 100;
 }
 
@@ -268,8 +267,14 @@ impl OnUnbalanced<PositiveImbalanceOf<Test>> for MockReward {
 	}
 }
 
-pub struct OnStakerSlashMock<T: Config>(core::marker::PhantomData<T>);
-impl<T: Config> sp_staking::OnStakerSlash<AccountId, Balance> for OnStakerSlashMock<T> {
+parameter_types! {
+	pub static LedgerSlashPerEra:
+		(BalanceOf<Test>, BTreeMap<EraIndex, BalanceOf<Test>>) =
+		(Zero::zero(), BTreeMap::new());
+}
+
+pub struct EventListenerMock;
+impl OnStakingUpdate<AccountId, Balance> for EventListenerMock {
 	fn on_slash(
 		_pool_account: &AccountId,
 		slashed_bonded: Balance,
@@ -284,7 +289,7 @@ impl crate::pallet::pallet::Config for Test {
 	type Currency = Balances;
 	type CurrencyBalance = <Self as pallet_balances::Config>::Balance;
 	type UnixTime = Timestamp;
-	type CurrencyToVote = frame_support::traits::SaturatingCurrencyToVote;
+	type CurrencyToVote = sp_staking::currency_to_vote::SaturatingCurrencyToVote;
 	type RewardRemainder = RewardRemainderMock;
 	type RuntimeEvent = RuntimeEvent;
 	type Slash = ();
@@ -305,7 +310,7 @@ impl crate::pallet::pallet::Config for Test {
 	type TargetList = UseValidatorsMap<Self>;
 	type MaxUnlockingChunks = MaxUnlockingChunks;
 	type HistoryDepth = HistoryDepth;
-	type OnStakerSlash = OnStakerSlashMock<Test>;
+	type EventListeners = EventListenerMock;
 	type BenchmarkingConfig = TestBenchmarkingConfig;
 	type WeightInfo = ();
 }

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -289,7 +289,7 @@ impl crate::pallet::pallet::Config for Test {
 	type Currency = Balances;
 	type CurrencyBalance = <Self as pallet_balances::Config>::Balance;
 	type UnixTime = Timestamp;
-	type CurrencyToVote = sp_staking::currency_to_vote::SaturatingCurrencyToVote;
+	type CurrencyToVote = ();
 	type RewardRemainder = RewardRemainderMock;
 	type RuntimeEvent = RuntimeEvent;
 	type Slash = ();

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -26,8 +26,8 @@ use frame_support::{
 	dispatch::WithPostDispatchInfo,
 	pallet_prelude::*,
 	traits::{
-		Currency, CurrencyToVote, Defensive, DefensiveResult, EstimateNextNewSession, Get,
-		Imbalance, LockableCurrency, OnUnbalanced, TryCollect, UnixTime, WithdrawReasons,
+		Currency, Defensive, DefensiveResult, EstimateNextNewSession, Get, Imbalance,
+		LockableCurrency, OnUnbalanced, TryCollect, UnixTime, WithdrawReasons,
 	},
 	weights::Weight,
 };
@@ -76,6 +76,7 @@ impl<T: Config> Pallet<T> {
 		stash: &T::AccountId,
 		issuance: BalanceOf<T>,
 	) -> VoteWeight {
+		use sp_staking::currency_to_vote::CurrencyToVote;
 		T::CurrencyToVote::to_vote(Self::slashable_balance_of(stash), issuance)
 	}
 
@@ -618,6 +619,7 @@ impl<T: Config> Pallet<T> {
 	) -> BoundedVec<(T::AccountId, Exposure<T::AccountId, BalanceOf<T>>), MaxWinnersOf<T>> {
 		let total_issuance = T::Currency::total_issuance();
 		let to_currency = |e: frame_election_provider_support::ExtendedBalance| {
+			use sp_staking::currency_to_vote::CurrencyToVote;
 			T::CurrencyToVote::to_currency(e, total_issuance)
 		};
 
@@ -1568,10 +1570,10 @@ impl<T: Config> SortedListProvider<T::AccountId> for UseNominatorsAndValidatorsM
 	}
 }
 
-// NOTE: in this entire impl block, the assumption is that `who` is a stash account.
 impl<T: Config> StakingInterface for Pallet<T> {
 	type AccountId = T::AccountId;
 	type Balance = BalanceOf<T>;
+	type CurrencyToVote = T::CurrencyToVote;
 
 	fn minimum_nominator_bond() -> Self::Balance {
 		MinNominatorBond::<T>::get()

--- a/frame/staking/src/pallet/impls.rs
+++ b/frame/staking/src/pallet/impls.rs
@@ -38,6 +38,7 @@ use sp_runtime::{
 	Perbill,
 };
 use sp_staking::{
+	currency_to_vote::CurrencyToVote,
 	offence::{DisableStrategy, OffenceDetails, OnOffenceHandler},
 	EraIndex, SessionIndex, Stake, StakingInterface,
 };
@@ -76,7 +77,6 @@ impl<T: Config> Pallet<T> {
 		stash: &T::AccountId,
 		issuance: BalanceOf<T>,
 	) -> VoteWeight {
-		use sp_staking::currency_to_vote::CurrencyToVote;
 		T::CurrencyToVote::to_vote(Self::slashable_balance_of(stash), issuance)
 	}
 
@@ -619,7 +619,6 @@ impl<T: Config> Pallet<T> {
 	) -> BoundedVec<(T::AccountId, Exposure<T::AccountId, BalanceOf<T>>), MaxWinnersOf<T>> {
 		let total_issuance = T::Currency::total_issuance();
 		let to_currency = |e: frame_election_provider_support::ExtendedBalance| {
-			use sp_staking::currency_to_vote::CurrencyToVote;
 			T::CurrencyToVote::to_currency(e, total_issuance)
 		};
 

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -24,7 +24,7 @@ use frame_support::{
 	dispatch::Codec,
 	pallet_prelude::*,
 	traits::{
-		Currency, CurrencyToVote, Defensive, DefensiveResult, DefensiveSaturating, EnsureOrigin,
+		Currency, Defensive, DefensiveResult, DefensiveSaturating, EnsureOrigin,
 		EstimateNextNewSession, Get, LockIdentifier, LockableCurrency, OnUnbalanced, TryCollect,
 		UnixTime,
 	},
@@ -113,7 +113,7 @@ pub mod pallet {
 		/// in 128.
 		/// Consequently, the backward convert is used convert the u128s from sp-elections back to a
 		/// [`BalanceOf`].
-		type CurrencyToVote: CurrencyToVote<BalanceOf<Self>>;
+		type CurrencyToVote: sp_staking::currency_to_vote::CurrencyToVote<BalanceOf<Self>>;
 
 		/// Something that provides the election functionality.
 		type ElectionProvider: ElectionProvider<
@@ -261,9 +261,11 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxUnlockingChunks: Get<u32>;
 
-		/// A hook called when any staker is slashed. Mostly likely this can be a no-op unless
-		/// other pallets exist that are affected by slashing per-staker.
-		type OnStakerSlash: sp_staking::OnStakerSlash<Self::AccountId, BalanceOf<Self>>;
+		/// Something that listens to staking updates and performs actions based on the data it
+		/// receives.
+		///
+		/// WARNING: this only reports slashing events for the time being.
+		type EventListeners: sp_staking::OnStakingUpdate<Self::AccountId, BalanceOf<Self>>;
 
 		/// Some parameters of the benchmarking.
 		type BenchmarkingConfig: BenchmarkingConfig;

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -102,10 +102,7 @@ pub use dispatch::{
 };
 
 mod voting;
-pub use voting::{
-	ClassCountOf, CurrencyToVote, PollStatus, Polling, SaturatingCurrencyToVote,
-	U128CurrencyToVote, VoteTally,
-};
+pub use voting::{ClassCountOf, PollStatus, Polling, VoteTally};
 
 mod preimages;
 pub use preimages::{Bounded, BoundedInline, FetchResult, Hash, QueryPreimage, StorePreimage};

--- a/frame/support/src/traits/voting.rs
+++ b/frame/support/src/traits/voting.rs
@@ -20,80 +20,9 @@
 
 use crate::dispatch::{DispatchError, Parameter};
 use codec::{HasCompact, MaxEncodedLen};
-use sp_arithmetic::{
-	traits::{SaturatedConversion, UniqueSaturatedFrom, UniqueSaturatedInto},
-	Perbill,
-};
+use sp_arithmetic::Perbill;
 use sp_runtime::traits::Member;
 use sp_std::prelude::*;
-
-/// A trait similar to `Convert` to convert values from `B` an abstract balance type
-/// into u64 and back from u128. (This conversion is used in election and other places where complex
-/// calculation over balance type is needed)
-///
-/// Total issuance of the currency is passed in, but an implementation of this trait may or may not
-/// use it.
-///
-/// # WARNING
-///
-/// the total issuance being passed in implies that the implementation must be aware of the fact
-/// that its values can affect the outcome. This implies that if the vote value is dependent on the
-/// total issuance, it should never ber written to storage for later re-use.
-pub trait CurrencyToVote<B> {
-	/// Convert balance to u64.
-	fn to_vote(value: B, issuance: B) -> u64;
-
-	/// Convert u128 to balance.
-	fn to_currency(value: u128, issuance: B) -> B;
-}
-
-/// An implementation of `CurrencyToVote` tailored for chain's that have a balance type of u128.
-///
-/// The factor is the `(total_issuance / u64::MAX).max(1)`, represented as u64. Let's look at the
-/// important cases:
-///
-/// If the chain's total issuance is less than u64::MAX, this will always be 1, which means that
-/// the factor will not have any effect. In this case, any account's balance is also less. Thus,
-/// both of the conversions are basically an `as`; Any balance can fit in u64.
-///
-/// If the chain's total issuance is more than 2*u64::MAX, then a factor might be multiplied and
-/// divided upon conversion.
-pub struct U128CurrencyToVote;
-
-impl U128CurrencyToVote {
-	fn factor(issuance: u128) -> u128 {
-		(issuance / u64::MAX as u128).max(1)
-	}
-}
-
-impl CurrencyToVote<u128> for U128CurrencyToVote {
-	fn to_vote(value: u128, issuance: u128) -> u64 {
-		(value / Self::factor(issuance)).saturated_into()
-	}
-
-	fn to_currency(value: u128, issuance: u128) -> u128 {
-		value.saturating_mul(Self::factor(issuance))
-	}
-}
-
-/// A naive implementation of `CurrencyConvert` that simply saturates all conversions.
-///
-/// # Warning
-///
-/// This is designed to be used mostly for testing. Use with care, and think about the consequences.
-pub struct SaturatingCurrencyToVote;
-
-impl<B: UniqueSaturatedInto<u64> + UniqueSaturatedFrom<u128>> CurrencyToVote<B>
-	for SaturatingCurrencyToVote
-{
-	fn to_vote(value: B, _: B) -> u64 {
-		value.unique_saturated_into()
-	}
-
-	fn to_currency(value: u128, _: B) -> B {
-		B::unique_saturated_from(value)
-	}
-}
 
 pub trait VoteTally<Votes, Class> {
 	fn new(_: Class) -> Self;

--- a/primitives/staking/Cargo.toml
+++ b/primitives/staking/Cargo.toml
@@ -16,9 +16,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 serde = { version = "1.0.163", default-features = false, features = ["derive", "alloc"], optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
-sp-core = { version = "21.0.0", default-features = false, path = "../core" }
-sp-runtime = { version = "24.0.0", default-features = false, path = "../runtime" }
-sp-std = { version = "8.0.0", default-features = false, path = "../std" }
+impl-trait-for-tuples = "0.2.2"
+
+sp-core = { default-features = false, path = "../core" }
+sp-runtime = { default-features = false, path = "../runtime" }
+sp-std = { default-features = false, path = "../std" }
 
 [features]
 default = ["std"]

--- a/primitives/staking/src/currency_to_vote.rs
+++ b/primitives/staking/src/currency_to_vote.rs
@@ -1,0 +1,101 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2019-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sp_runtime::{
+	traits::{UniqueSaturatedFrom, UniqueSaturatedInto},
+	SaturatedConversion,
+};
+
+/// A trait similar to `Convert` to convert values from `B` an abstract balance type
+/// into u64 and back from u128. (This conversion is used in election and other places where complex
+/// calculation over balance type is needed)
+///
+/// Total issuance of the currency is passed in, but an implementation of this trait may or may not
+/// use it.
+///
+/// # WARNING
+///
+/// the total issuance being passed in implies that the implementation must be aware of the fact
+/// that its values can affect the outcome. This implies that if the vote value is dependent on the
+/// total issuance, it should never ber written to storage for later re-use.
+pub trait CurrencyToVote<B> {
+	/// Convert balance to u64.
+	fn to_vote(value: B, issuance: B) -> u64;
+
+	/// Convert u128 to balance.
+	fn to_currency(value: u128, issuance: B) -> B;
+}
+
+/// An implementation of `CurrencyToVote` tailored for chain's that have a balance type of u128.
+///
+/// The factor is the `(total_issuance / u64::MAX).max(1)`, represented as u64. Let's look at the
+/// important cases:
+///
+/// If the chain's total issuance is less than u64::MAX, this will always be 1, which means that
+/// the factor will not have any effect. In this case, any account's balance is also less. Thus,
+/// both of the conversions are basically an `as`; Any balance can fit in u64.
+///
+/// If the chain's total issuance is more than 2*u64::MAX, then a factor might be multiplied and
+/// divided upon conversion.
+pub struct U128CurrencyToVote;
+
+impl U128CurrencyToVote {
+	fn factor(issuance: u128) -> u128 {
+		(issuance / u64::MAX as u128).max(1)
+	}
+}
+
+impl CurrencyToVote<u128> for U128CurrencyToVote {
+	fn to_vote(value: u128, issuance: u128) -> u64 {
+		(value / Self::factor(issuance)).saturated_into()
+	}
+
+	fn to_currency(value: u128, issuance: u128) -> u128 {
+		value.saturating_mul(Self::factor(issuance))
+	}
+}
+
+/// A naive implementation of `CurrencyConvert` that simply saturates all conversions.
+///
+/// # Warning
+///
+/// This is designed to be used mostly for testing. Use with care, and think about the consequences.
+pub struct SaturatingCurrencyToVote;
+
+impl<B: UniqueSaturatedInto<u64> + UniqueSaturatedFrom<u128>> CurrencyToVote<B>
+	for SaturatingCurrencyToVote
+{
+	fn to_vote(value: B, _: B) -> u64 {
+		value.unique_saturated_into()
+	}
+
+	fn to_currency(value: u128, _: B) -> B {
+		B::unique_saturated_from(value)
+	}
+}
+
+#[cfg(feature = "std")]
+impl<B: UniqueSaturatedInto<u64> + UniqueSaturatedFrom<u128>> CurrencyToVote<B> for () {
+	fn to_vote(value: B, issuance: B) -> u64 {
+		SaturatingCurrencyToVote::to_vote(value, issuance)
+	}
+
+	/// Convert u128 to balance.
+	fn to_currency(value: u128, issuance: B) -> B {
+		SaturatingCurrencyToVote::to_currency(value, issuance)
+	}
+}

--- a/primitives/staking/src/lib.rs
+++ b/primitives/staking/src/lib.rs
@@ -20,12 +20,16 @@
 //! A crate which contains primitives that are useful for implementation that uses staking
 //! approaches in general. Definitions related to sessions, slashing, etc go here.
 
+use crate::currency_to_vote::CurrencyToVote;
+use codec::{FullCodec, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_core::RuntimeDebug;
-use sp_runtime::{DispatchError, DispatchResult};
-use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
+use sp_runtime::{DispatchError, DispatchResult, Saturating};
+use sp_std::{collections::btree_map::BTreeMap, ops::Sub, vec::Vec};
 
 pub mod offence;
+
+pub mod currency_to_vote;
 
 /// Simple index type with which we can count sessions.
 pub type SessionIndex = u32;
@@ -45,32 +49,9 @@ pub enum StakerStatus<AccountId> {
 	Nominator(Vec<AccountId>),
 }
 
-/// Trait describing something that implements a hook for any operations to perform when a staker is
-/// slashed.
-pub trait OnStakerSlash<AccountId, Balance> {
-	/// A hook for any operations to perform when a staker is slashed.
-	///
-	/// # Arguments
-	///
-	/// * `stash` - The stash of the staker whom the slash was applied to.
-	/// * `slashed_active` - The new bonded balance of the staker after the slash was applied.
-	/// * `slashed_unlocking` - A map of slashed eras, and the balance of that unlocking chunk after
-	///   the slash is applied. Any era not present in the map is not affected at all.
-	fn on_slash(
-		stash: &AccountId,
-		slashed_active: Balance,
-		slashed_unlocking: &BTreeMap<EraIndex, Balance>,
-	);
-}
-
-impl<AccountId, Balance> OnStakerSlash<AccountId, Balance> for () {
-	fn on_slash(_: &AccountId, _: Balance, _: &BTreeMap<EraIndex, Balance>) {
-		// Nothing to do here
-	}
-}
-
 /// A struct that reflects stake that an account has in the staking system. Provides a set of
 /// methods to operate on it's properties. Aimed at making `StakingInterface` more concise.
+#[derive(RuntimeDebug, Clone, Copy, Eq, PartialEq, Default)]
 pub struct Stake<Balance> {
 	/// The total stake that `stash` has in the staking system. This includes the
 	/// `active` stake, and any funds currently in the process of unbonding via
@@ -87,16 +68,88 @@ pub struct Stake<Balance> {
 	pub active: Balance,
 }
 
+/// A generic staking event listener.
+///
+/// Note that the interface is designed in a way that the events are fired post-action, so any
+/// pre-action data that is needed needs to be passed to interface methods. The rest of the data can
+/// be retrieved by using `StakingInterface`.
+#[impl_trait_for_tuples::impl_for_tuples(10)]
+pub trait OnStakingUpdate<AccountId, Balance> {
+	/// Fired when the stake amount of someone updates.
+	///
+	/// This is effectively any changes to the bond amount, such as bonding more funds, and
+	/// unbonding.
+	fn on_stake_update(_who: &AccountId, _prev_stake: Option<Stake<Balance>>) {}
+
+	/// Fired when someone sets their intention to nominate.
+	///
+	/// This should never be fired for for existing nominators.
+	fn on_nominator_add(_who: &AccountId) {}
+
+	/// Fired when an existing nominator updates their nominations.
+	///
+	/// Note that this is not fired when a nominator changes their stake. For that,
+	/// `on_stake_update` should be used, followed by querying whether `who` was a validator or a
+	/// nominator.
+	fn on_nominator_update(_who: &AccountId, _prev_nominations: Vec<AccountId>) {}
+
+	/// Fired when someone removes their intention to nominate, either due to chill or validating.
+	///
+	/// The set of nominations at the time of removal is provided as it can no longer be fetched in
+	/// any way.
+	fn on_nominator_remove(_who: &AccountId, _nominations: Vec<AccountId>) {}
+
+	/// Fired when someone sets their intention to validate.
+	///
+	/// Note validator preference changes are not communicated, but could be added if needed.
+	fn on_validator_add(_who: &AccountId) {}
+
+	/// Fired when an existing validator updates their preferences.
+	///
+	/// Note validator preference changes are not communicated, but could be added if needed.
+	fn on_validator_update(_who: &AccountId) {}
+
+	/// Fired when someone removes their intention to validate, either due to chill or nominating.
+	fn on_validator_remove(_who: &AccountId) {}
+
+	/// Fired when someone is fully unstaked.
+	fn on_unstake(_who: &AccountId) {}
+
+	/// Fired when a staker is slashed.
+	///
+	/// * `stash` - The stash of the staker whom the slash was applied to.
+	/// * `slashed_active` - The new bonded balance of the staker after the slash was applied.
+	/// * `slashed_unlocking` - A map of slashed eras, and the balance of that unlocking chunk after
+	///   the slash is applied. Any era not present in the map is not affected at all.
+	fn on_slash(
+		_stash: &AccountId,
+		_slashed_active: Balance,
+		_slashed_unlocking: &BTreeMap<EraIndex, Balance>,
+	) {
+	}
+}
+
 /// A generic representation of a staking implementation.
 ///
 /// This interface uses the terminology of NPoS, but it is aims to be generic enough to cover other
 /// implementations as well.
 pub trait StakingInterface {
 	/// Balance type used by the staking system.
-	type Balance: PartialEq;
+	type Balance: Sub<Output = Self::Balance>
+		+ Ord
+		+ PartialEq
+		+ Default
+		+ Copy
+		+ MaxEncodedLen
+		+ FullCodec
+		+ TypeInfo
+		+ Saturating;
 
-	/// AccountId type used by the staking system
-	type AccountId;
+	/// AccountId type used by the staking system.
+	type AccountId: Clone + sp_std::fmt::Debug;
+
+	/// Means of converting Currency to VoteWeight.
+	type CurrencyToVote: CurrencyToVote<Self::Balance>;
 
 	/// The minimum amount required to bond in order to set nomination intentions. This does not
 	/// necessarily mean the nomination will be counted in an election, but instead just enough to
@@ -195,8 +248,12 @@ pub trait StakingInterface {
 	/// Return the status of the given staker, `None` if not staked at all.
 	fn status(who: &Self::AccountId) -> Result<StakerStatus<Self::AccountId>, DispatchError>;
 
+	/// Checks whether or not this is a validator account.
+	fn is_validator(who: &Self::AccountId) -> bool {
+		Self::status(who).map(|s| matches!(s, StakerStatus::Validator)).unwrap_or(false)
+	}
+
 	/// Get the nominations of a stash, if they are a nominator, `None` otherwise.
-	#[cfg(feature = "runtime-benchmarks")]
 	fn nominations(who: &Self::AccountId) -> Option<Vec<Self::AccountId>> {
 		match Self::status(who) {
 			Ok(StakerStatus::Nominator(t)) => Some(t),

--- a/primitives/staking/src/lib.rs
+++ b/primitives/staking/src/lib.rs
@@ -83,7 +83,7 @@ pub trait OnStakingUpdate<AccountId, Balance> {
 
 	/// Fired when someone sets their intention to nominate.
 	///
-	/// This should never be fired for for existing nominators.
+	/// This should never be fired for existing nominators.
 	fn on_nominator_add(_who: &AccountId) {}
 
 	/// Fired when an existing nominator updates their nominations.

--- a/utils/frame/generate-bags/Cargo.toml
+++ b/utils/frame/generate-bags/Cargo.toml
@@ -14,6 +14,7 @@ frame-support = { version = "4.0.0-dev", path = "../../../frame/support" }
 frame-election-provider-support = { version = "4.0.0-dev", path = "../../../frame/election-provider-support" }
 frame-system = { version = "4.0.0-dev", path = "../../../frame/system" }
 pallet-staking = { version = "4.0.0-dev", path = "../../../frame/staking" }
+sp-staking = { version = "4.0.0-dev", path = "../../../primitives/staking" }
 
 # third party
 chrono = { version = "0.4.19" }

--- a/utils/frame/generate-bags/src/lib.rs
+++ b/utils/frame/generate-bags/src/lib.rs
@@ -70,7 +70,7 @@ fn existential_weight<T: pallet_staking::Config>(
 	total_issuance: u128,
 	minimum_balance: u128,
 ) -> VoteWeight {
-	use frame_support::traits::CurrencyToVote;
+	use sp_staking::currency_to_vote::CurrencyToVote;
 
 	T::CurrencyToVote::to_vote(
 		minimum_balance

--- a/utils/frame/generate-bags/src/lib.rs
+++ b/utils/frame/generate-bags/src/lib.rs
@@ -18,8 +18,7 @@
 //! Support code to ease the process of generating bag thresholds.
 //!
 //! NOTE: this assume the runtime implements [`pallet_staking::Config`], as it requires an
-//! implementation of the traits [`frame_support::traits::Currency`] and
-//! [`frame_support::traits::CurrencyToVote`].
+//! implementation of the traits [`frame_support::traits::Currency`] and `CurrencyToVote`.
 //!
 //! The process of adding bags to a runtime requires only four steps.
 //!


### PR DESCRIPTION
follow-up to https://github.com/paritytech/substrate/pull/14023, step towards https://github.com/paritytech/polkadot-sdk/issues/443.

Full branch that that I am breaking down is https://github.com/paritytech/substrate/tree/kiz-voter-list-stuff

Removes `OnStakerSlash`, replaces with `OnStakingEvents`, which is a strict super-set. 

Has no functional change. 

No need to be delicate with the deprecation, as these are internal-only crates. 

Audit can be done in the final PR that adds full approval stake tracking. 

polkadot companion: https://github.com/paritytech/polkadot/pull/7475