### PR TITLE
[Do not merge] migration to ci-unified image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,7 +48,7 @@ variables:
   CARGO_INCREMENTAL: 0
   DOCKER_OS: "debian:bullseye"
   ARCH: "x86_64"
-  CI_IMAGE: "paritytech/ci-linux:production"
+  CI_IMAGE: "paritytech/ci-unified:bullseye-1.70.0-2023-05-23"
   BUILDAH_IMAGE: "quay.io/buildah/stable:v1.29"
   BUILDAH_COMMAND: "buildah --storage-driver overlay2"
   RELENG_SCRIPTS_BRANCH: "master"


### PR DESCRIPTION
New [ci-unified](https://github.com/paritytech/scripts/tree/master/dockerfiles/ci-unified) image for pipelines ($CI_IMAGE)
Replaces base-ci-linux and derived
Relates to [Finish and settle down on the ci-unified image #821](https://github.com/paritytech/ci_cd/issues/821)
