### PR TITLE
Add missing workspace member

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,6 +244,7 @@ members = [
 	"primitives/weights",
 	"scripts/ci/node-template-release",
 	"test-utils",
+	"test-utils/cli",
 	"test-utils/client",
 	"test-utils/derive",
 	"test-utils/runtime",


### PR DESCRIPTION
Checked with `python check-deps.py substrate/` [script](https://github.com/ggwpez/substrate-scripts/blob/80ed86c1b929b9fafa17ba02ec9f310fe8d6c51b/import-runtime-repos/check-deps.py).