### PR TITLE
feat: default BuildStorage for Fn

### DIFF
--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -29,13 +29,13 @@ sp-core = { version = "21.0.0", default-features = false, path = "../core" }
 sp-io = { version = "23.0.0", default-features = false, path = "../io" }
 sp-std = { version = "8.0.0", default-features = false, path = "../std" }
 sp-weights = { version = "20.0.0", default-features = false, path = "../weights" }
+sp-state-machine = { version = "0.28.0", default-features = false, path = "../state-machine" }
 
 [dev-dependencies]
 rand = "0.8.5"
 serde_json = "1.0.85"
 zstd = { version = "0.12.3", default-features = false }
 sp-api = { version = "4.0.0-dev", path = "../api" }
-sp-state-machine = { version = "0.28.0", path = "../state-machine" }
 sp-tracing = { version = "10.0.0", path = "../../primitives/tracing" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }
 
@@ -57,6 +57,7 @@ std = [
 	"sp-io/std",
 	"sp-std/std",
 	"sp-weights/std",
+	"sp-state-machine/std"
 ]
 
 # Serde support without relying on std features.

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -197,6 +197,16 @@ pub trait BuildStorage {
 	fn assimilate_storage(&self, storage: &mut sp_core::storage::Storage) -> Result<(), String>;
 }
 
+#[cfg(feature = "std")]
+impl<F> BuildStorage for F
+	where
+		F: Fn() -> Result<(), String>,
+{
+	fn assimilate_storage(&self, storage: &mut sp_core::storage::Storage) -> Result<(), String> {
+		sp_state_machine::BasicExternalities::execute_with_storage(storage, || (*self)())
+	}
+}
+
 /// Something that can build the genesis storage of a module.
 #[cfg(feature = "std")]
 pub trait BuildModuleGenesisStorage<T, I>: Sized {


### PR DESCRIPTION
Provides a `BuildStorage` impl for every `Fn` which is handy when starting a Node with a more complex genesis for development. 

