### PR TITLE
node-template: Remove accidentally added dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5581,7 +5581,6 @@ dependencies = [
  "sc-offchain",
  "sc-rpc-api",
  "sc-service",
- "sc-statement-store",
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-transaction-pool-api",

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -29,7 +29,6 @@ sc-telemetry = { version = "4.0.0-dev", path = "../../../client/telemetry" }
 sc-transaction-pool = { version = "4.0.0-dev", path = "../../../client/transaction-pool" }
 sc-transaction-pool-api = { version = "4.0.0-dev", path = "../../../client/transaction-pool/api" }
 sc-offchain = { version = "4.0.0-dev", path = "../../../client/offchain" }
-sc-statement-store = { version = "4.0.0-dev", path = "../../../client/statement-store" }
 sc-consensus-aura = { version = "0.10.0-dev", path = "../../../client/consensus/aura" }
 sp-consensus-aura = { version = "0.10.0-dev", path = "../../../primitives/consensus/aura" }
 sc-consensus = { version = "0.10.0-dev", path = "../../../client/consensus/common" }


### PR DESCRIPTION
`sc-statement-store` isn't used by the template and thus, should not appear in the `Cargo.toml`.


Fixes comment: https://github.com/paritytech/substrate/pull/14387/files#r1260005073