### PR TITLE
let `initialize` function in `pallet-grandpa`/`pallet-babe` and other session managed pallets be `pub`

### DIFF
--- a/frame/authority-discovery/src/lib.rs
+++ b/frame/authority-discovery/src/lib.rs
@@ -97,7 +97,7 @@ impl<T: Config> Pallet<T> {
 		NextKeys::<T>::get()
 	}
 
-	fn initialize_keys(keys: &Vec<AuthorityId>) {
+	pub fn initialize_keys(keys: &Vec<AuthorityId>) {
 		if !keys.is_empty() {
 			assert!(Keys::<T>::get().is_empty(), "Keys are already initialized!");
 

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -750,7 +750,7 @@ impl<T: Config> Pallet<T> {
 		}
 	}
 
-	fn initialize_genesis_authorities(authorities: &[(AuthorityId, BabeAuthorityWeight)]) {
+	pub fn initialize_genesis_authorities(authorities: &[(AuthorityId, BabeAuthorityWeight)]) {
 		if !authorities.is_empty() {
 			assert!(Authorities::<T>::get().is_empty(), "Authorities are already initialized!");
 			let bounded_authorities =

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -511,7 +511,7 @@ impl<T: Config> Pallet<T> {
 
 	// Perform module initialization, abstracted so that it can be called either through genesis
 	// config builder or through `on_genesis_session`.
-	fn initialize(authorities: &AuthorityList) {
+	pub fn initialize(authorities: &AuthorityList) {
 		if !authorities.is_empty() {
 			assert!(Self::grandpa_authorities().is_empty(), "Authorities are already initialized!");
 			Self::set_grandpa_authorities(authorities);

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -719,7 +719,7 @@ impl<T: Config> Pallet<T> {
 		res
 	}
 
-	fn initialize_keys(keys: &[T::AuthorityId]) {
+	pub fn initialize_keys(keys: &[T::AuthorityId]) {
 		if !keys.is_empty() {
 			assert!(Keys::<T>::get().is_empty(), "Keys are already initialized!");
 			let bounded_keys = <BoundedSlice<'_, _, T::MaxKeys>>::try_from(keys)


### PR DESCRIPTION
close #14555

In this pr, we hope to let those function be `pub`, which is called under `OneSessionHandler::on_genesis_session` function.

More details pleases refers to issue #14555 

