### PR TITLE
Re-add deprecated `--execution` arg on `benchmark pallet`

### DIFF
--- a/bin/node/cli/tests/benchmark_block_works.rs
+++ b/bin/node/cli/tests/benchmark_block_works.rs
@@ -39,7 +39,7 @@ async fn benchmark_block_works() {
 		.arg(base_dir.path())
 		.args(["--from", "1", "--to", "1"])
 		.args(["--repeat", "1"])
-		.args(["--execution=wasm", "--wasm-execution=compiled"])
+		.args(["--wasm-execution=compiled"])
 		.status()
 		.unwrap();
 

--- a/bin/node/cli/tests/benchmark_block_works.rs
+++ b/bin/node/cli/tests/benchmark_block_works.rs
@@ -39,7 +39,7 @@ async fn benchmark_block_works() {
 		.arg(base_dir.path())
 		.args(["--from", "1", "--to", "1"])
 		.args(["--repeat", "1"])
-		.args(["--wasm-execution", "compiled"])
+		.args(["--execution=wasm", "--wasm-execution=compiled"])
 		.status()
 		.unwrap();
 

--- a/bin/node/cli/tests/benchmark_extrinsic_works.rs
+++ b/bin/node/cli/tests/benchmark_extrinsic_works.rs
@@ -39,6 +39,7 @@ fn benchmark_extrinsic(pallet: &str, extrinsic: &str) {
 		.args(&["--pallet", pallet, "--extrinsic", extrinsic])
 		// Run with low repeats for faster execution.
 		.args(["--warmup=10", "--repeat=10", "--max-ext-per-block=10"])
+		.args(["--execution=wasm", "--wasm-execution=compiled"])
 		.status()
 		.unwrap();
 

--- a/bin/node/cli/tests/benchmark_extrinsic_works.rs
+++ b/bin/node/cli/tests/benchmark_extrinsic_works.rs
@@ -39,7 +39,7 @@ fn benchmark_extrinsic(pallet: &str, extrinsic: &str) {
 		.args(&["--pallet", pallet, "--extrinsic", extrinsic])
 		// Run with low repeats for faster execution.
 		.args(["--warmup=10", "--repeat=10", "--max-ext-per-block=10"])
-		.args(["--execution=wasm", "--wasm-execution=compiled"])
+		.args(["--wasm-execution=compiled"])
 		.status()
 		.unwrap();
 

--- a/bin/node/cli/tests/benchmark_overhead_works.rs
+++ b/bin/node/cli/tests/benchmark_overhead_works.rs
@@ -36,6 +36,7 @@ fn benchmark_overhead_works() {
 		.args(["--warmup", "10", "--repeat", "10"])
 		.args(["--add", "100", "--mul", "1.2", "--metric", "p75"])
 		.args(["--max-ext-per-block", "10"])
+		.args(["--execution=wasm", "--wasm-execution=compiled"])
 		.status()
 		.unwrap();
 	assert!(status.success());

--- a/bin/node/cli/tests/benchmark_overhead_works.rs
+++ b/bin/node/cli/tests/benchmark_overhead_works.rs
@@ -36,7 +36,7 @@ fn benchmark_overhead_works() {
 		.args(["--warmup", "10", "--repeat", "10"])
 		.args(["--add", "100", "--mul", "1.2", "--metric", "p75"])
 		.args(["--max-ext-per-block", "10"])
-		.args(["--execution=wasm", "--wasm-execution=compiled"])
+		.args(["--wasm-execution=compiled"])
 		.status()
 		.unwrap();
 	assert!(status.success());

--- a/bin/node/cli/tests/benchmark_pallet_works.rs
+++ b/bin/node/cli/tests/benchmark_pallet_works.rs
@@ -40,7 +40,6 @@ fn benchmark_pallet(steps: u32, repeat: u32, should_work: bool) {
 		.args(["--pallet", "frame-benchmarking", "--extrinsic", "addition"])
 		.args(["--steps", &format!("{}", steps), "--repeat", &format!("{}", repeat)])
 		.args([
-			"--execution=wasm",
 			"--wasm-execution=compiled",
 			"--no-storage-info",
 			"--no-median-slopes",

--- a/bin/node/cli/tests/benchmark_pallet_works.rs
+++ b/bin/node/cli/tests/benchmark_pallet_works.rs
@@ -34,16 +34,21 @@ fn benchmark_pallet_works() {
 }
 
 fn benchmark_pallet(steps: u32, repeat: u32, should_work: bool) {
-	let output = Command::new(cargo_bin("substrate"))
+	let status = Command::new(cargo_bin("substrate"))
 		.args(["benchmark", "pallet", "--dev"])
 		// Use the `addition` benchmark since is the fastest.
 		.args(["--pallet", "frame-benchmarking", "--extrinsic", "addition"])
 		.args(["--steps", &format!("{}", steps), "--repeat", &format!("{}", repeat)])
-		.output()
+		.args([
+			"--execution=wasm",
+			"--wasm-execution=compiled",
+			"--no-storage-info",
+			"--no-median-slopes",
+			"--no-min-squares",
+			"--heap-pages=4096",
+		])
+		.status()
 		.unwrap();
 
-	if output.status.success() != should_work {
-		let log = String::from_utf8_lossy(&output.stderr).to_string();
-		panic!("Test failed:\n{}", log);
-	}
+	assert_eq!(status.success(), should_work);
 }

--- a/primitives/core/src/defer.rs
+++ b/primitives/core/src/defer.rs
@@ -25,6 +25,13 @@
 #[must_use]
 pub struct DeferGuard<F: FnOnce()>(pub Option<F>);
 
+impl<F: FnOnce()> DeferGuard<F> {
+	/// Creates a new `DeferGuard` with the given closure.
+	pub fn new(f: F) -> Self {
+		Self(Some(f))
+	}
+}
+
 impl<F: FnOnce()> Drop for DeferGuard<F> {
 	fn drop(&mut self) {
 		self.0.take().map(|f| f());

--- a/utils/frame/benchmarking-cli/src/pallet/command.rs
+++ b/utils/frame/benchmarking-cli/src/pallet/command.rs
@@ -147,6 +147,16 @@ impl PalletCmd {
 		<<<BB as BlockT>::Header as HeaderT>::Number as std::str::FromStr>::Err: std::fmt::Debug,
 		ExtraHostFunctions: sp_wasm_interface::HostFunctions,
 	{
+		let _d = self.execution.as_ref().map(|exec| {
+			// We print the warning at the end, since there is often A LOT of output.
+			sp_core::defer::DeferGuard::new(move || {
+				log::warn!(
+					target: LOG_TARGET,
+					"⚠️  Argument `--execution` is deprecated. Its value of `{exec}` has on effect.",
+				)
+			})
+		});
+
 		if let Some(output_path) = &self.output {
 			if !output_path.is_dir() && output_path.file_name().is_none() {
 				return Err("Output file or path is invalid!".into())

--- a/utils/frame/benchmarking-cli/src/pallet/mod.rs
+++ b/utils/frame/benchmarking-cli/src/pallet/mod.rs
@@ -150,6 +150,10 @@ pub struct PalletCmd {
 	)]
 	pub wasmtime_instantiation_strategy: WasmtimeInstantiationStrategy,
 
+	/// DEPRECATED: This argument has no effect.
+	#[arg(long = "execution")]
+	pub execution: Option<String>,
+
 	/// Limit the memory the database cache can use.
 	#[arg(long = "db-cache", value_name = "MiB", default_value_t = 1024)]
 	pub database_cache_size: u32,


### PR DESCRIPTION
Changes:
- Re-add the `--execution` arg on command `benchmark pallet` that was removed in [#14387](https://github.com/paritytech/substrate/pull/14387). It is a No-OP and prints `⚠️  Argument --execution is deprecated. Its value of wasm will be ignore` now upon usage.
- Add `DeferGuard::new` as convenience function.
- Extend `benchmark *` cmd tests.