### PR TITLE
update to docify 0.2.0 / crate-relative embed paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2133,23 +2133,22 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "docify"
-version = "0.1.14"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15aa210b350ff62db3149ac5d0b2a0287c01ee91354e16290de344082b2b3ff6"
+checksum = "f6491709f76fb7ceb951244daf624d480198b427556084391d6e3c33d3ae74b9"
 dependencies = [
  "docify_macros",
 ]
 
 [[package]]
 name = "docify_macros"
-version = "0.1.14"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf3504ed030133996c59a9954669a7a4f869f93a7e74389e16149843db16f57"
+checksum = "ffc5338a9f72ce29a81377d9039798fcc926fb471b2004666caf48e446dffbbf"
 dependencies = [
  "common-path",
  "derive-syn-parse",
- "lazy_static",
- "prettyplease 0.2.6",
+ "once_cell",
  "proc-macro2",
  "quote",
  "regex",

--- a/frame/fast-unstake/Cargo.toml
+++ b/frame/fast-unstake/Cargo.toml
@@ -27,7 +27,7 @@ frame-election-provider-support = { default-features = false, path = "../electio
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, path = "../benchmarking" }
 
-docify = "0.1.13"
+docify = "0.2.0"
 
 [dev-dependencies]
 pallet-staking-reward-curve = { version = "4.0.0-dev", path = "../staking/reward-curve" }

--- a/frame/fast-unstake/src/lib.rs
+++ b/frame/fast-unstake/src/lib.rs
@@ -71,10 +71,10 @@
 //! ### Example
 //!
 //! 1. Fast-unstake with multiple participants in the queue.
-#![doc = docify::embed!("frame/fast-unstake/src/tests.rs", successful_multi_queue)]
+#![doc = docify::embed!("src/tests.rs", successful_multi_queue)]
 //!
 //! 2. Fast unstake failing because a nominator is exposed.
-#![doc = docify::embed!("frame/fast-unstake/src/tests.rs", exposed_nominator_cannot_unstake)]
+#![doc = docify::embed!("src/tests.rs", exposed_nominator_cannot_unstake)]
 //!
 //! ## Pallet API
 //!


### PR DESCRIPTION
This PR updates to docify [v0.2.0](https://github.com/sam0x17/docify/releases/tag/v0.2.0) which re-works the embed paths system to use crate-relative paths rather than workspace relative paths. This will allow workspace sub-crates that embed docify examples to deploy to crates.io / docs.rs / etc successfully.

Also worth noting is as of 0.2.0 embedding examples from a parent directory is now an _anti-pattern_ as this will fail when you go to deploy the crate to crates.io since that path will not exist (cargo stages crates in an isolated directory that is missing workspace directory parents). Embedding examples from a sub-directory is still fine and encouraged, you should just never have an embed path that starts with `../`. Note that this has never worked when you go to deploy to crates.io, we just didn't try it before.

Included in this PR:
* update to docify v0.2.0
* update docify embed paths to be crate-relative rather than workspace relative

