### PR TITLE
Fixes link to inflation documentation

### DIFF
--- a/frame/staking/reward-fn/src/lib.rs
+++ b/frame/staking/reward-fn/src/lib.rs
@@ -41,7 +41,7 @@ use sp_arithmetic::{
 /// The result is meant to be scaled with minimum inflation and maximum inflation.
 ///
 /// (as detailed
-/// [here](https://research.web3.foundation/en/latest/polkadot/economics/1-token-economics.html#inflation-model-with-parachains))
+/// [here](https://research.web3.foundation/Polkadot/overview/token-economics#inflation-model-with-parachains))
 ///
 /// Arguments are:
 /// * `stake`: The fraction of total issued tokens that actively staked behind validators. Known as


### PR DESCRIPTION
The compute_inflation function documentation for how the inflation is calculated pointed to a dead URL since the original documentation has moved. This pull request updates the documentation URL with the current working documentation link.