### PR TITLE
client: fix invalid node name pattern regex

### DIFF
--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -513,8 +513,10 @@ mod tests {
 		// they'd get filtered for including a `.`
 		assert!(is_node_name_valid("http://visitme").is_err());
 		assert!(is_node_name_valid("http:/visitme").is_err());
+		assert!(is_node_name_valid("http:visitme").is_err());
 		assert!(is_node_name_valid("https://visitme").is_err());
 		assert!(is_node_name_valid("https:/visitme").is_err());
+		assert!(is_node_name_valid("https:visitme").is_err());
 		assert!(is_node_name_valid("www.visit.me").is_err());
 		assert!(is_node_name_valid("www.visit").is_err());
 		assert!(is_node_name_valid("hello\\world").is_err());

--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -394,6 +394,11 @@ impl CliConfiguration for RunCmd {
 /// Check whether a node name is considered as valid.
 pub fn is_node_name_valid(_name: &str) -> std::result::Result<(), &str> {
 	let name = _name.to_string();
+
+	if name.is_empty() {
+		return Err("Node name cannot be empty")
+	}
+
 	if name.chars().count() >= crate::NODE_NAME_MAX_LENGTH {
 		return Err("Node name too long")
 	}
@@ -498,6 +503,7 @@ mod tests {
 
 	#[test]
 	fn tests_node_name_bad() {
+		assert!(is_node_name_valid("").is_err());
 		assert!(is_node_name_valid(
 			"very very long names are really not very cool for the ui at all, really they're not"
 		)

--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -404,7 +404,7 @@ pub fn is_node_name_valid(_name: &str) -> std::result::Result<(), &str> {
 		return Err("Node name should not contain invalid chars such as '.' and '@'")
 	}
 
-	let invalid_patterns = r"^https?:/";
+	let invalid_patterns = r"^https?:";
 	let re = Regex::new(invalid_patterns).unwrap();
 	if re.is_match(&name) {
 		return Err("Node name should not contain urls")

--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -404,7 +404,7 @@ pub fn is_node_name_valid(_name: &str) -> std::result::Result<(), &str> {
 		return Err("Node name should not contain invalid chars such as '.' and '@'")
 	}
 
-	let invalid_patterns = r"^https?:\/\/";
+	let invalid_patterns = r"^https?:/";
 	let re = Regex::new(invalid_patterns).unwrap();
 	if re.is_match(&name) {
 		return Err("Node name should not contain urls")
@@ -503,10 +503,15 @@ mod tests {
 		)
 		.is_err());
 		assert!(is_node_name_valid("Dots.not.Ok").is_err());
-		assert!(is_node_name_valid("http://visit.me").is_err());
-		assert!(is_node_name_valid("https://visit.me").is_err());
+		// NOTE: the urls below don't include a domain otherwise
+		// they'd get filtered for including a `.`
+		assert!(is_node_name_valid("http://visitme").is_err());
+		assert!(is_node_name_valid("http:/visitme").is_err());
+		assert!(is_node_name_valid("https://visitme").is_err());
+		assert!(is_node_name_valid("https:/visitme").is_err());
 		assert!(is_node_name_valid("www.visit.me").is_err());
 		assert!(is_node_name_valid("www.visit").is_err());
+		assert!(is_node_name_valid("hello\\world").is_err());
 		assert!(is_node_name_valid("visit.www").is_err());
 		assert!(is_node_name_valid("email@domain").is_err());
 	}


### PR DESCRIPTION
See https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/3206771.

polkadot companion: https://github.com/paritytech/polkadot/pull/7484

(the companion above is fake, needed to unlock ci)