### PR TITLE
fix feature flag for frame-system-benchmarking

### DIFF
--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -91,7 +91,6 @@ std = [
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
-	"frame-system-benchmarking/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
 	"pallet-grandpa/runtime-benchmarks",

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -296,7 +296,6 @@ runtime-benchmarks = [
 	"pallet-nft-fractionalization/runtime-benchmarks",
 	"pallet-vesting/runtime-benchmarks",
 	"pallet-whitelist/runtime-benchmarks",
-	"frame-system-benchmarking/runtime-benchmarks",
 ]
 try-runtime = [
 	"frame-try-runtime/try-runtime",

--- a/frame/system/benchmarking/Cargo.toml
+++ b/frame/system/benchmarking/Cargo.toml
@@ -15,9 +15,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
-frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../../benchmarking" }
-frame-support = { version = "4.0.0-dev", default-features = false, path = "../../support" }
-frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system" }
+frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../../benchmarking", features = ["runtime-benchmarks"] }
+frame-support = { version = "4.0.0-dev", default-features = false, path = "../../support", features = ["runtime-benchmarks"] }
+frame-system = { version = "4.0.0-dev", default-features = false, path = "../../system", features = ["runtime-benchmarks"] }
 sp-core = { version = "21.0.0", default-features = false, path = "../../../primitives/core" }
 sp-runtime = { version = "24.0.0", default-features = false, path = "../../../primitives/runtime" }
 sp-std = { version = "8.0.0", default-features = false, path = "../../../primitives/std" }
@@ -38,10 +38,4 @@ std = [
 	"sp-core/std",
 	"sp-runtime/std",
 	"sp-std/std",
-]
-
-runtime-benchmarks = [
-	"frame-benchmarking/runtime-benchmarks",
-	"frame-support/runtime-benchmarks",
-	"frame-system/runtime-benchmarks",
 ]

--- a/frame/system/benchmarking/src/lib.rs
+++ b/frame/system/benchmarking/src/lib.rs
@@ -18,7 +18,6 @@
 // Benchmarks for Utility Pallet
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg(feature = "runtime-benchmarks")]
 
 use codec::Encode;
 use frame_benchmarking::{


### PR DESCRIPTION
A required feature flag doesn't make sense.