### PR TITLE
chainHead_storage: Iterate over keys

### DIFF
--- a/client/rpc-spec-v2/src/chain_head/chain_head.rs
+++ b/client/rpc-spec-v2/src/chain_head/chain_head.rs
@@ -300,9 +300,7 @@ where
 		let items = items
 			.into_iter()
 			.map(|query| {
-				if query.queue_type != StorageQueryType::Value &&
-					query.queue_type != StorageQueryType::Hash
-				{
+				if query.queue_type == StorageQueryType::ClosestDescendantMerkleValue {
 					// Note: remove this once all types are implemented.
 					let _ = sink.reject(ChainHeadRpcError::InvalidParam(
 						"Storage query type not supported".into(),

--- a/client/rpc-spec-v2/src/chain_head/chain_head_storage.rs
+++ b/client/rpc-spec-v2/src/chain_head/chain_head_storage.rs
@@ -33,6 +33,18 @@ use super::{
 	hex_string, ErrorEvent,
 };
 
+/// The maximum number of items the `chainHead_storage` can return
+/// before paginations is required.
+const MAX_ITER_ITEMS: usize = 10;
+
+/// The query type of an interation.
+enum IterQueryType {
+	/// Iterating over (key, value) pairs.
+	Value,
+	/// Iterating over (key, hash) pairs.
+	Hash,
+}
+
 /// Generates the events of the `chainHead_storage` method.
 pub struct ChainHeadStorage<Client, Block, BE> {
 	/// Substrate client.
@@ -58,7 +70,10 @@ fn is_key_queryable(key: &[u8]) -> bool {
 }
 
 /// The result of making a query call.
-type QueryResult = Result<StorageResult<String>, ChainHeadStorageEvent<String>>;
+type QueryResult = Result<Option<StorageResult<String>>, ChainHeadStorageEvent<String>>;
+
+/// The result of iterating over keys.
+type QueryIterResult = Result<Vec<StorageResult<String>>, ChainHeadStorageEvent<String>>;
 
 impl<Client, Block, BE> ChainHeadStorage<Client, Block, BE>
 where
@@ -72,7 +87,7 @@ where
 		hash: Block::Hash,
 		key: &StorageKey,
 		child_key: Option<&ChildInfo>,
-	) -> Option<QueryResult> {
+	) -> QueryResult {
 		let result = if let Some(child_key) = child_key {
 			self.client.child_storage(hash, child_key, key)
 		} else {
@@ -81,17 +96,15 @@ where
 
 		result
 			.map(|opt| {
-				opt.map(|storage_data| {
-					QueryResult::Ok(StorageResult::<String> {
-						key: hex_string(&key.0),
-						result: StorageResultType::Value(hex_string(&storage_data.0)),
-					})
-				})
+				QueryResult::Ok(opt.map(|storage_data| StorageResult::<String> {
+					key: hex_string(&key.0),
+					result: StorageResultType::Value(hex_string(&storage_data.0)),
+				}))
 			})
 			.unwrap_or_else(|err| {
-				Some(QueryResult::Err(ChainHeadStorageEvent::<String>::Error(ErrorEvent {
+				QueryResult::Err(ChainHeadStorageEvent::<String>::Error(ErrorEvent {
 					error: err.to_string(),
-				})))
+				}))
 			})
 	}
 
@@ -101,7 +114,7 @@ where
 		hash: Block::Hash,
 		key: &StorageKey,
 		child_key: Option<&ChildInfo>,
-	) -> Option<QueryResult> {
+	) -> QueryResult {
 		let result = if let Some(child_key) = child_key {
 			self.client.child_storage_hash(hash, child_key, key)
 		} else {
@@ -110,36 +123,55 @@ where
 
 		result
 			.map(|opt| {
-				opt.map(|storage_data| {
-					QueryResult::Ok(StorageResult::<String> {
-						key: hex_string(&key.0),
-						result: StorageResultType::Hash(hex_string(&storage_data.as_ref())),
-					})
-				})
+				QueryResult::Ok(opt.map(|storage_data| StorageResult::<String> {
+					key: hex_string(&key.0),
+					result: StorageResultType::Hash(hex_string(&storage_data.as_ref())),
+				}))
 			})
 			.unwrap_or_else(|err| {
-				Some(QueryResult::Err(ChainHeadStorageEvent::<String>::Error(ErrorEvent {
+				QueryResult::Err(ChainHeadStorageEvent::<String>::Error(ErrorEvent {
 					error: err.to_string(),
-				})))
+				}))
 			})
 	}
 
-	/// Make the storage query.
-	fn query_storage(
+	/// Handle iterating over (key, value) or (key, hash) pairs.
+	fn query_storage_iter(
 		&self,
 		hash: Block::Hash,
-		query: &StorageQuery<StorageKey>,
+		key: &StorageKey,
 		child_key: Option<&ChildInfo>,
-	) -> Option<QueryResult> {
-		if !is_key_queryable(&query.key.0) {
-			return None
+		ty: IterQueryType,
+	) -> QueryIterResult {
+		let mut keys_iter = if let Some(child_key) = child_key {
+			self.client.child_storage_keys(hash, child_key.to_owned(), Some(key), None)
+		} else {
+			self.client.storage_keys(hash, Some(key), None)
+		}
+		.map_err(|err| {
+			ChainHeadStorageEvent::<String>::Error(ErrorEvent { error: err.to_string() })
+		})?;
+
+		let mut ret = Vec::with_capacity(MAX_ITER_ITEMS);
+		let mut maximum_iters = MAX_ITER_ITEMS;
+		while let Some(key) = keys_iter.next() {
+			if maximum_iters > 0 {
+				maximum_iters -= 1;
+			}
+
+			let result = match ty {
+				IterQueryType::Value => self.query_storage_value(hash, &key, child_key),
+				IterQueryType::Hash => self.query_storage_hash(hash, &key, child_key),
+			}?;
+
+			let Some(result) = result else {
+				continue
+			};
+
+			ret.push(result);
 		}
 
-		match query.queue_type {
-			StorageQueryType::Value => self.query_storage_value(hash, &query.key, child_key),
-			StorageQueryType::Hash => self.query_storage_hash(hash, &query.key, child_key),
-			_ => None,
-		}
+		QueryIterResult::Ok(ret)
 	}
 
 	/// Generate the block events for the `chainHead_storage` method.
@@ -159,19 +191,56 @@ where
 
 		let mut storage_results = Vec::with_capacity(items.len());
 		for item in items {
-			let Some(result) = self.query_storage(hash, &item, child_key.as_ref()) else {
-                continue
-            };
-
-			match result {
-				QueryResult::Ok(storage_result) => storage_results.push(storage_result),
-				QueryResult::Err(event) => {
-					let _ = sink.send(&event);
-					// If an error is encountered for any of the query items
-					// do not produce any other events.
-					return
-				},
+			if !is_key_queryable(&item.key.0) {
+				continue
 			}
+
+			match item.queue_type {
+				StorageQueryType::Value => {
+					match self.query_storage_value(hash, &item.key, child_key.as_ref()) {
+						Ok(Some(value)) => storage_results.push(value),
+						Ok(None) => continue,
+						Err(err) => {
+							let _ = sink.send(&err);
+							return
+						},
+					}
+				},
+				StorageQueryType::Hash =>
+					match self.query_storage_hash(hash, &item.key, child_key.as_ref()) {
+						Ok(Some(value)) => storage_results.push(value),
+						Ok(None) => continue,
+						Err(err) => {
+							let _ = sink.send(&err);
+							return
+						},
+					},
+				StorageQueryType::DescendantsValues => match self.query_storage_iter(
+					hash,
+					&item.key,
+					child_key.as_ref(),
+					IterQueryType::Value,
+				) {
+					Ok(values) => storage_results.extend(values),
+					Err(err) => {
+						let _ = sink.send(&err);
+						return
+					},
+				},
+				StorageQueryType::DescendantsHashes => match self.query_storage_iter(
+					hash,
+					&item.key,
+					child_key.as_ref(),
+					IterQueryType::Hash,
+				) {
+					Ok(values) => storage_results.extend(values),
+					Err(err) => {
+						let _ = sink.send(&err);
+						return
+					},
+				},
+				_ => continue,
+			};
 		}
 
 		if !storage_results.is_empty() {


### PR DESCRIPTION
This PR adds support to iterate over (key, value) and (key, hash) pairs.

At the moment, substrate will iterate over at most 10 keys producing at most 10 pairs.
This PR lays the ground for iteration and support for pagination will be added in:
-  https://github.com/paritytech/substrate/issues/14549 

A new tests checks
- the API can receive multiple items as argument
- iteration works as expected over (key, value) and (key, hash)

Closes https://github.com/paritytech/substrate/issues/14548.

// @paritytech/subxt-team 