### PR TITLE
Contracts: Bugfix Wasm prepare check for chain extension

### DIFF
--- a/frame/contracts/fixtures/chain_extension.wat
+++ b/frame/contracts/fixtures/chain_extension.wat
@@ -1,7 +1,7 @@
 ;; Call chain extension by passing through input and output of this contract
 (module
-	(import "seal0" "seal_call_chain_extension"
-		(func $seal_call_chain_extension (param i32 i32 i32 i32 i32) (result i32))
+	(import "seal0" "call_chain_extension"
+		(func $call_chain_extension (param i32 i32 i32 i32 i32) (result i32))
 	)
 	(import "seal0" "seal_input" (func $seal_input (param i32 i32)))
 	(import "seal0" "seal_return" (func $seal_return (param i32 i32 i32)))
@@ -30,7 +30,7 @@
 		(call $seal_input (i32.const 4) (i32.const 0))
 
 		;; the chain extension passes through the input and returns it as output
-		(call $seal_call_chain_extension
+		(call $call_chain_extension
 			(i32.load (i32.const 4))	;; id
 			(i32.const 4)				;; input_ptr
 			(i32.load (i32.const 0))	;; input_len

--- a/frame/contracts/src/wasm/prepare.rs
+++ b/frame/contracts/src/wasm/prepare.rs
@@ -168,8 +168,8 @@ impl LoadedModule {
 					let _ = import.ty().func().ok_or("expected a function")?;
 
 					if !<T as Config>::ChainExtension::enabled() &&
-						import.name().as_bytes() == b"seal_call_chain_extension" ||
-						import.name().as_bytes() == b"call_chain_extension"
+						(import.name().as_bytes() == b"seal_call_chain_extension" ||
+							import.name().as_bytes() == b"call_chain_extension")
 					{
 						return Err("Module uses chain extensions but chain extensions are disabled")
 					}


### PR DESCRIPTION
A subtle bug in the boolean predicate for checking against chain extension imports prevents importing the non-prefixed version even if chain extension are enabled.