### PR TITLE
Export trait `HandleMessage`

### DIFF
--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -111,8 +111,9 @@ pub use preimages::{Bounded, BoundedInline, FetchResult, Hash, QueryPreimage, St
 
 mod messages;
 pub use messages::{
-	EnqueueMessage, ExecuteOverweightError, Footprint, HandleMessage, NoopServiceQueues,
-	ProcessMessage, ProcessMessageError, QueuePausedQuery, ServiceQueues, TransformOrigin,
+	EnqueueMessage, EnqueueWithOrigin, ExecuteOverweightError, Footprint, HandleMessage,
+	NoopServiceQueues, ProcessMessage, ProcessMessageError, QueuePausedQuery, ServiceQueues,
+	TransformOrigin,
 };
 
 #[cfg(feature = "try-runtime")]

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -111,8 +111,8 @@ pub use preimages::{Bounded, BoundedInline, FetchResult, Hash, QueryPreimage, St
 
 mod messages;
 pub use messages::{
-	EnqueueMessage, ExecuteOverweightError, Footprint, NoopServiceQueues, ProcessMessage,
-	ProcessMessageError, QueuePausedQuery, ServiceQueues, TransformOrigin,
+	EnqueueMessage, ExecuteOverweightError, Footprint, HandleMessage, NoopServiceQueues,
+	ProcessMessage, ProcessMessageError, QueuePausedQuery, ServiceQueues, TransformOrigin,
 };
 
 #[cfg(feature = "try-runtime")]


### PR DESCRIPTION
Changes:
- Export trait `HandleMessage` and its adapter type `EnqueueWithOrigin`.

Can be used for https://github.com/paritytech/cumulus/pull/2157/