### PR TITLE
[fix docs compiler warnings] Election Provider Multi-phase pallet

### DIFF
--- a/frame/election-provider-multi-phase/src/helpers.rs
+++ b/frame/election-provider-multi-phase/src/helpers.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Some helper functions/macros for this crate.
+//! Some helper functions and macros for this crate.
 
 use crate::{
 	unsigned::{MinerConfig, MinerVoterOf},
@@ -23,6 +23,12 @@ use crate::{
 };
 use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
+/// Macro to log messages with the system block number included.
+///
+/// This macro is a logging utility used within the crate. It allows logging messages with the
+/// system block number included as part of the log message.
+/// The macro provides a convenient way to log messages related to voting operations and include
+/// the current block number in the log for context.
 #[macro_export]
 macro_rules! log {
 	($level:tt, $pattern:expr $(, $values:expr)* $(,)?) => {
@@ -33,7 +39,13 @@ macro_rules! log {
 	};
 }
 
-// This is only useful for a context where a `<T: Config>` is not in scope.
+/// Macro to log messages without including the system block number in the log.
+///
+/// This macro is a logging utility used within the crate. It allows logging messages without
+/// including the system block number as part of the log message. It is particularly useful for log messages related to voting, as it includes an emoji "🗳️" to
+/// indicate their association with voting operations.
+/// 
+/// Note: this is only useful for a context where a `<T: Config>` is not in scope.
 #[macro_export]
 macro_rules! log_no_system {
 	($level:tt, $pattern:expr $(, $values:expr)* $(,)?) => {

--- a/frame/election-provider-multi-phase/src/helpers.rs
+++ b/frame/election-provider-multi-phase/src/helpers.rs
@@ -42,9 +42,10 @@ macro_rules! log {
 /// Macro to log messages without including the system block number in the log.
 ///
 /// This macro is a logging utility used within the crate. It allows logging messages without
-/// including the system block number as part of the log message. It is particularly useful for log messages related to voting, as it includes an emoji "🗳️" to
-/// indicate their association with voting operations.
-/// 
+/// including the system block number as part of the log message. It is particularly useful for log
+/// messages related to voting, as it includes an emoji "🗳️" to indicate their association with
+/// voting operations.
+///
 /// Note: this is only useful for a context where a `<T: Config>` is not in scope.
 #[macro_export]
 macro_rules! log_no_system {

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -1135,23 +1135,24 @@ pub mod pallet {
 	pub enum Event<T: Config> {
 		/// A solution was stored with the given compute.
 		///
-		/// If `origin` is `Some(AccountId)`, the stored solution was submitted in the signed phase by a miner with the `AccountId`. 
-		/// Otherwise, the solution was stored either during the unsigned phase or by
-		/// `T::ForceOrigin`.
+		/// If `origin` is `Some(AccountId)`, the stored solution was submitted in the signed phase
+		/// by a miner with the `AccountId`. Otherwise, the solution was stored either during the
+		/// unsigned phase or by `T::ForceOrigin`.
 		SolutionStored {
 			/// How the election was computed.
 			compute: ElectionCompute,
-			/// The origin of the solution. 
+			/// The origin of the solution.
 			origin: Option<T::AccountId>,
 			/// The previous solution was ejected to make room for this one.
 			prev_ejected: bool,
 		},
 		/// The election has been finalized, with the given computation and score.
-		ElectionFinalized { 
+		ElectionFinalized {
 			/// How the election was computed.
-			compute: ElectionCompute, 
+			compute: ElectionCompute,
 			/// The final election score.
-			score: ElectionScore },
+			score: ElectionScore,
+		},
 		/// An election failed.
 		///
 		/// Not much can be said about which computes failed in the process.
@@ -1159,15 +1160,16 @@ pub mod pallet {
 		/// An account has been rewarded for their signed submission being finalized.
 		Rewarded {
 			/// The account being rewarded.
-			account: <T as frame_system::Config>::AccountId, 
+			account: <T as frame_system::Config>::AccountId,
 			/// The amount being rewarded.
-			value: BalanceOf<T> },
+			value: BalanceOf<T>,
+		},
 		/// An account has been slashed for submitting an invalid signed submission.
-		Slashed { 
+		Slashed {
 			/// The account that has been slashed.
 			account: <T as frame_system::Config>::AccountId,
 			/// The amount being slashed.
-			value: BalanceOf<T> 
+			value: BalanceOf<T>,
 		},
 		/// There was a phase transition in a given round.
 		PhaseTransitioned {

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -1173,9 +1173,9 @@ pub mod pallet {
 		},
 		/// There was a phase transition in a given round.
 		PhaseTransitioned {
-			/// The current phase.
+			/// The previous phase.
 			from: Phase<BlockNumberFor<T>>,
-			/// The next phase.
+			/// The current phase.
 			to: Phase<BlockNumberFor<T>>,
 			/// The current round.
 			round: u32,

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -384,7 +384,7 @@ pub enum ElectionCompute {
 	Signed,
 	/// Election was computed with an unsigned submission.
 	Unsigned,
-	/// Election was computed using the fallback
+	/// Election was computed using the fallback.
 	Fallback,
 	/// Election was computed with emergency status.
 	Emergency,
@@ -573,6 +573,7 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config + SendTransactionTypes<Call<Self>> {
+		/// The overarching event type.
 		type RuntimeEvent: From<Event<Self>>
 			+ IsType<<Self as frame_system::Config>::RuntimeEvent>
 			+ TryInto<Event<Self>>;
@@ -1134,30 +1135,47 @@ pub mod pallet {
 	pub enum Event<T: Config> {
 		/// A solution was stored with the given compute.
 		///
-		/// The `origin` indicates the origin of the solution. If `origin` is `Some(AccountId)`,
-		/// the stored solution was submited in the signed phase by a miner with the `AccountId`.
+		/// If `origin` is `Some(AccountId)`, the stored solution was submitted in the signed phase by a miner with the `AccountId`. 
 		/// Otherwise, the solution was stored either during the unsigned phase or by
-		/// `T::ForceOrigin`. The `bool` is `true` when a previous solution was ejected to make
-		/// room for this one.
+		/// `T::ForceOrigin`.
 		SolutionStored {
+			/// How the election was computed.
 			compute: ElectionCompute,
+			/// The origin of the solution. 
 			origin: Option<T::AccountId>,
+			/// The previous solution was ejected to make room for this one.
 			prev_ejected: bool,
 		},
 		/// The election has been finalized, with the given computation and score.
-		ElectionFinalized { compute: ElectionCompute, score: ElectionScore },
+		ElectionFinalized { 
+			/// How the election was computed.
+			compute: ElectionCompute, 
+			/// The final election score.
+			score: ElectionScore },
 		/// An election failed.
 		///
 		/// Not much can be said about which computes failed in the process.
 		ElectionFailed,
 		/// An account has been rewarded for their signed submission being finalized.
-		Rewarded { account: <T as frame_system::Config>::AccountId, value: BalanceOf<T> },
+		Rewarded {
+			/// The account being rewarded.
+			account: <T as frame_system::Config>::AccountId, 
+			/// The amount being rewarded.
+			value: BalanceOf<T> },
 		/// An account has been slashed for submitting an invalid signed submission.
-		Slashed { account: <T as frame_system::Config>::AccountId, value: BalanceOf<T> },
+		Slashed { 
+			/// The account that has been slashed.
+			account: <T as frame_system::Config>::AccountId,
+			/// The amount being slashed.
+			value: BalanceOf<T> 
+		},
 		/// There was a phase transition in a given round.
 		PhaseTransitioned {
+			/// The current phase.
 			from: Phase<BlockNumberFor<T>>,
+			/// The next phase.
 			to: Phase<BlockNumberFor<T>>,
+			/// The current round.
 			round: u32,
 		},
 	}
@@ -1244,6 +1262,7 @@ pub mod pallet {
 	}
 
 	#[pallet::type_value]
+	/// The default value for the round.
 	pub fn DefaultForRound() -> u32 {
 		1
 	}

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -227,6 +227,7 @@
 //! account the weight of encode/decode in the `submit_unsigned` given its priority. Nonetheless,
 //! all operations on the solution and the snapshot are worthy of taking this into account.
 
+#![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};

--- a/frame/election-provider-multi-phase/src/migrations.rs
+++ b/frame/election-provider-multi-phase/src/migrations.rs
@@ -44,6 +44,10 @@
 /// - Stores the new data in the storage with the updated format.
 /// - Updates the current storage version to 1.
 ///
+/// In this migration, the storage value type `SubmissionIndicesOf` for the storage item `SignedSubmissionIndices` is changing from
+/// `BoundedBTreeMap<ElectionScore, u32, SignedMaxSubmissions>` to `BoundedVec<(ElectionScore, BlockNumber, u32), SignedMaxSubmissions>` to allow multiple submissions of same election score to be submitted.
+/// See https://github.com/paritytech/substrate/pull/14645 for more details about this update.
+///
 /// If `SignedSubmissionIndices` does not exist, the migration proceeds without performing
 /// any changes, and only updates the storage version.
 ///

--- a/frame/election-provider-multi-phase/src/migrations.rs
+++ b/frame/election-provider-multi-phase/src/migrations.rs
@@ -44,9 +44,10 @@
 /// - Stores the new data in the storage with the updated format.
 /// - Updates the current storage version to 1.
 ///
-/// In this migration, the storage value type `SubmissionIndicesOf` for the storage item `SignedSubmissionIndices` is changing from
-/// `BoundedBTreeMap<ElectionScore, u32, SignedMaxSubmissions>` to `BoundedVec<(ElectionScore, BlockNumber, u32), SignedMaxSubmissions>` to allow multiple submissions of same election score to be submitted.
-/// See https://github.com/paritytech/substrate/pull/14645 for more details about this update.
+/// In this migration, the storage value type `SubmissionIndicesOf` for the storage item
+/// `SignedSubmissionIndices` is changing from `BoundedBTreeMap<ElectionScore, u32,
+/// SignedMaxSubmissions>` to `BoundedVec<(ElectionScore, BlockNumber, u32), SignedMaxSubmissions>`
+/// to allow multiple submissions of same election score to be submitted. See https://github.com/paritytech/substrate/pull/14645 for more details about this update.
 ///
 /// If `SignedSubmissionIndices` does not exist, the migration proceeds without performing
 /// any changes, and only updates the storage version.

--- a/frame/election-provider-multi-phase/src/migrations.rs
+++ b/frame/election-provider-multi-phase/src/migrations.rs
@@ -25,7 +25,8 @@
 //! Each runtime upgrade may introduce changes to the storage layout, and to ensure
 //! smooth upgrades, a migration strategy is used.
 
-/// This module contains the migration logic for transitioning the storage from version 0 to version 1.
+/// This module contains the migration logic for transitioning the storage from version 0 to version
+/// 1.
 ///
 ///
 /// The `MigrateToV1` struct implements the `OnRuntimeUpgrade` trait, which is called
@@ -58,7 +59,7 @@ pub mod v1 {
 	use sp_std::collections::btree_map::BTreeMap;
 
 	use crate::*;
-	
+
 	/// The migration struct to perform storage updates from storage V0 to V1.
 	pub struct MigrateToV1<T>(sp_std::marker::PhantomData<T>);
 	impl<T: Config> OnRuntimeUpgrade for MigrateToV1<T> {

--- a/frame/election-provider-multi-phase/src/migrations.rs
+++ b/frame/election-provider-multi-phase/src/migrations.rs
@@ -15,6 +15,40 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Storage migrations for the Election Provider Multi-phase pallet.
+//!
+//! The Election Provider Multi-phase pallet provides the necessary functionality
+//! for running multi-phase elections in Substrate based blockchains. This module
+//! contains storage migration implementations to transition the storage from
+//! a previous version to the current one during runtime upgrades.
+//!
+//! Each runtime upgrade may introduce changes to the storage layout, and to ensure
+//! smooth upgrades, a migration strategy is used.
+
+/// This module contains the migration logic for transitioning the storage from version 0 to version 1.
+///
+///
+/// The `MigrateToV1` struct implements the `OnRuntimeUpgrade` trait, which is called
+/// during runtime upgrades. When the runtime is upgraded and this migration is executed,
+/// it checks the current and on-chain storage versions to determine if the migration is
+/// needed.
+///
+/// If the current storage version is 1 and the on-chain version is 0, the migration will
+/// proceed. During migration, the module checks if the `SignedSubmissionIndices` storage
+/// item exists. If it does, the module migrates its data to the new storage format.
+///
+/// The migration logic performs the following steps:
+/// - Reads the existing `SignedSubmissionIndices` data from storage.
+/// - Maps the data to the new format, including the current block number.
+/// - Stores the new data in the storage with the updated format.
+/// - Updates the current storage version to 1.
+///
+/// If `SignedSubmissionIndices` does not exist, the migration proceeds without performing
+/// any changes, and only updates the storage version.
+///
+/// Developers should implement specific migration steps for each version change if needed.
+/// The `OnRuntimeUpgrade` trait allows the module to perform complex migrations efficiently
+/// and transparently to the blockchain's users.
 pub mod v1 {
 	use frame_support::{
 		storage::unhashed,
@@ -24,6 +58,8 @@ pub mod v1 {
 	use sp_std::collections::btree_map::BTreeMap;
 
 	use crate::*;
+	
+	/// The migration struct to perform storage updates from storage V0 to V1.
 	pub struct MigrateToV1<T>(sp_std::marker::PhantomData<T>);
 	impl<T: Config> OnRuntimeUpgrade for MigrateToV1<T> {
 		fn on_runtime_upgrade() -> Weight {

--- a/frame/election-provider-multi-phase/src/signed.rs
+++ b/frame/election-provider-multi-phase/src/signed.rs
@@ -52,7 +52,7 @@ pub struct SignedSubmission<AccountId, Balance: HasCompact, Solution> {
 	pub deposit: Balance,
 	/// The raw solution itself.
 	pub raw_solution: RawSolution<Solution>,
-	// The estimated fee `who` paid to submit the solution.
+	/// The estimated fee the account paid to submit the solution.
 	pub call_fee: Balance,
 }
 
@@ -84,15 +84,18 @@ where
 		Some(self.cmp(other))
 	}
 }
-
+/// A type alias for the balance of an account.
 pub type BalanceOf<T> =
 	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+/// A type alias for the positive currency imbalance of an account.
 pub type PositiveImbalanceOf<T> = <<T as Config>::Currency as Currency<
 	<T as frame_system::Config>::AccountId,
 >>::PositiveImbalance;
+/// A type alias for the negative currency imbalance of an account.
 pub type NegativeImbalanceOf<T> = <<T as Config>::Currency as Currency<
 	<T as frame_system::Config>::AccountId,
 >>::NegativeImbalance;
+/// A type alias for a given `SignedSubmission`.
 pub type SignedSubmissionOf<T> = SignedSubmission<
 	<T as frame_system::Config>::AccountId,
 	BalanceOf<T>,

--- a/frame/election-provider-multi-phase/src/signed.rs
+++ b/frame/election-provider-multi-phase/src/signed.rs
@@ -17,6 +17,8 @@
 
 //! The signed phase implementation.
 
+#![deny(missing_docs)]
+
 use crate::{
 	unsigned::MinerConfig, Config, ElectionCompute, Pallet, QueuedSolution, RawSolution,
 	ReadySolution, SignedSubmissionIndices, SignedSubmissionNextIndex, SignedSubmissionsMap,

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -254,9 +254,9 @@ impl<T: Config> Pallet<T> {
 			.map_err(|_| MinerError::PoolSubmissionFailed)
 	}
 
-	// perform basic checks of a solution's validity
-	//
-	// Performance: note that it internally clones the provided solution.
+	/// Perform basic checks on the validity of a solution.
+	///
+	/// Performance: note that it internally clones the provided solution.
 	pub fn basic_checks(
 		raw_solution: &RawSolution<SolutionOf<T::MinerConfig>>,
 		solution_type: &str,

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -242,8 +242,8 @@ pub struct IndexAssignment<VoterIndex, TargetIndex, P: PerThing> {
 }
 
 impl<VoterIndex, TargetIndex, P: PerThing> IndexAssignment<VoterIndex, TargetIndex, P> {
-	/// Represents a new index assignment, mapping voter and target accounts to their respective indices
-	/// in the assignment's snapshot.
+	/// Represents a new index assignment, mapping voter and target accounts to their respective
+	/// indices in the assignment's snapshot.
 	pub fn new<AccountId: IdentifierT>(
 		assignment: &Assignment<AccountId, P>,
 		voter_index: impl Fn(&AccountId) -> Option<VoterIndex>,
@@ -427,14 +427,14 @@ pub trait ElectionProvider: ElectionProviderBase {
 /// data provider at runtime via `forced_input_voters_bound` and `forced_input_target_bound`.
 pub trait InstantElectionProvider: ElectionProviderBase {
 	/// Perform an instant election and return the result.
-    ///
-    /// The `forced_input_voters_bound` and `forced_input_target_bound` parameters are optional
-    /// and allow overriding the number of voters and targets fetched from the data provider. If
-    /// `None` is provided for these parameters, the election provider will use its default
-    /// settings to fetch voters and targets.
-    ///
-    /// The function returns the result of the election as [`BoundedSupportsOf<Self>`], representing
-    /// the elected candidates and their respective supports.
+	///
+	/// The `forced_input_voters_bound` and `forced_input_target_bound` parameters are optional
+	/// and allow overriding the number of voters and targets fetched from the data provider. If
+	/// `None` is provided for these parameters, the election provider will use its default
+	/// settings to fetch voters and targets.
+	///
+	/// The function returns the result of the election as [`BoundedSupportsOf<Self>`], representing
+	/// the elected candidates and their respective supports.
 	fn instant_elect(
 		forced_input_voters_bound: Option<u32>,
 		forced_input_target_bound: Option<u32>,

--- a/frame/election-provider-support/src/lib.rs
+++ b/frame/election-provider-support/src/lib.rs
@@ -242,6 +242,8 @@ pub struct IndexAssignment<VoterIndex, TargetIndex, P: PerThing> {
 }
 
 impl<VoterIndex, TargetIndex, P: PerThing> IndexAssignment<VoterIndex, TargetIndex, P> {
+	/// Represents a new index assignment, mapping voter and target accounts to their respective indices
+	/// in the assignment's snapshot.
 	pub fn new<AccountId: IdentifierT>(
 		assignment: &Assignment<AccountId, P>,
 		voter_index: impl Fn(&AccountId) -> Option<VoterIndex>,
@@ -424,6 +426,15 @@ pub trait ElectionProvider: ElectionProviderBase {
 /// However, it can optionally overwrite the amount of voters and targets that are fetched from the
 /// data provider at runtime via `forced_input_voters_bound` and `forced_input_target_bound`.
 pub trait InstantElectionProvider: ElectionProviderBase {
+	/// Perform an instant election and return the result.
+    ///
+    /// The `forced_input_voters_bound` and `forced_input_target_bound` parameters are optional
+    /// and allow overriding the number of voters and targets fetched from the data provider. If
+    /// `None` is provided for these parameters, the election provider will use its default
+    /// settings to fetch voters and targets.
+    ///
+    /// The function returns the result of the election as [`BoundedSupportsOf<Self>`], representing
+    /// the elected candidates and their respective supports.
 	fn instant_elect(
 		forced_input_voters_bound: Option<u32>,
 		forced_input_target_bound: Option<u32>,
@@ -577,9 +588,10 @@ pub trait SortedListProvider<AccountId> {
 }
 
 /// Something that can provide the `Score` of an account. Similar to [`ElectionProvider`] and
-/// [`ElectionDataProvider`], this should typically be implementing by whoever is supposed to *use*
+/// [`ElectionDataProvider`], this should typically be implemented by whoever is supposed to *use*
 /// `SortedListProvider`.
 pub trait ScoreProvider<AccountId> {
+	/// The score type.
 	type Score;
 
 	/// Get the current `Score` of `who`.

--- a/frame/election-provider-support/src/onchain.rs
+++ b/frame/election-provider-support/src/onchain.rs
@@ -57,6 +57,7 @@ impl From<sp_npos_elections::Error> for Error {
 pub struct OnChainExecution<T: Config>(PhantomData<T>);
 
 #[deprecated(note = "use OnChainExecution, which is bounded by default")]
+/// A simple on-chain implementation of the election provider trait.
 pub type BoundedExecution<T> = OnChainExecution<T>;
 
 /// Configuration trait for an onchain election execution.

--- a/frame/election-provider-support/src/weights.rs
+++ b/frame/election-provider-support/src/weights.rs
@@ -45,7 +45,9 @@ use sp_std::marker::PhantomData;
 
 /// Weight functions needed for pallet_election_provider_support_benchmarking.
 pub trait WeightInfo {
+	/// Returns the weight for the Phragmen voting algorithm.
 	fn phragmen(v: u32, t: u32, d: u32, ) -> Weight;
+	/// Returns the weight for the PhragMMS voting algorithm.
 	fn phragmms(v: u32, t: u32, d: u32, ) -> Weight;
 }
 


### PR DESCRIPTION
This PR fixes the 26 compiler warnings emitted by running `RUSTFLAGS="-W missing_docs" cargo check -p pallet-election-provider-multi-phase` by adding missing documentation throughout the crate.