### PR TITLE
Relax Send/Sync/Clone requirements for Pair

### DIFF
--- a/NEW-PR
+++ b/NEW-PR
@@ -1,0 +1,1 @@
+https://users.rust-lang.org/t/phantomdata-t-vs-phantomdata-fn-t-t-what-about-send-and-sync/73782/6

--- a/NEW-PR
+++ b/NEW-PR
@@ -1,1 +1,0 @@
-https://users.rust-lang.org/t/phantomdata-t-vs-phantomdata-fn-t-t-what-about-send-and-sync/73782/6

--- a/client/consensus/aura/src/import_queue.rs
+++ b/client/consensus/aura/src/import_queue.rs
@@ -44,7 +44,7 @@ use sp_runtime::{
 	traits::{Block as BlockT, Header, NumberFor},
 	DigestItem,
 };
-use std::{fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
+use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 
 /// check a header has been signed by the right key. If the slot is too far in the future, an error
 /// will be returned. If it's successful, returns the pre-header and the digest item
@@ -168,7 +168,7 @@ where
 	C: ProvideRuntimeApi<B> + Send + Sync + sc_client_api::backend::AuxStore,
 	C::Api: BlockBuilderApi<B> + AuraApi<B, AuthorityId<P>> + ApiExt<B>,
 	P: Pair,
-	P::Public: Hash + Codec + Debug,
+	P::Public: Codec + Debug,
 	P::Signature: Codec,
 	CIDP: CreateInherentDataProviders<B, ()> + Send + Sync,
 	CIDP::InherentDataProviders: InherentDataProviderExt + Send + Sync,
@@ -365,7 +365,7 @@ where
 		+ Sync
 		+ 'static,
 	P: Pair + 'static,
-	P::Public: Hash + Debug + Codec,
+	P::Public: Codec + Debug,
 	P::Signature: Codec,
 	S: sp_core::traits::SpawnEssentialNamed,
 	CIDP: CreateInherentDataProviders<Block, ()> + Sync + Send + 'static,

--- a/client/consensus/aura/src/import_queue.rs
+++ b/client/consensus/aura/src/import_queue.rs
@@ -22,7 +22,7 @@ use crate::{
 	authorities, standalone::SealVerificationError, AuthorityId, CompatibilityMode, Error,
 	LOG_TARGET,
 };
-use codec::{Codec, Decode, Encode};
+use codec::Codec;
 use log::{debug, info, trace};
 use prometheus_endpoint::Registry;
 use sc_client_api::{backend::AuxStore, BlockOf, UsageProvider};
@@ -60,9 +60,9 @@ fn check_header<C, B: BlockT, P: Pair>(
 	check_for_equivocation: CheckForEquivocation,
 ) -> Result<CheckedHeader<B::Header, (Slot, DigestItem)>, Error<B>>
 where
+	P::Public: Codec,
 	P::Signature: Codec,
 	C: sc_client_api::backend::AuxStore,
-	P::Public: Encode + Decode + PartialEq + Clone,
 {
 	let check_result =
 		crate::standalone::check_header_slot_and_seal::<B, P>(slot_now, header, authorities);
@@ -101,11 +101,11 @@ where
 /// A verifier for Aura blocks.
 pub struct AuraVerifier<C, P, CIDP, N> {
 	client: Arc<C>,
-	phantom: PhantomData<P>,
 	create_inherent_data_providers: CIDP,
 	check_for_equivocation: CheckForEquivocation,
 	telemetry: Option<TelemetryHandle>,
 	compatibility_mode: CompatibilityMode<N>,
+	_phantom: PhantomData<fn() -> P>,
 }
 
 impl<C, P, CIDP, N> AuraVerifier<C, P, CIDP, N> {
@@ -122,14 +122,13 @@ impl<C, P, CIDP, N> AuraVerifier<C, P, CIDP, N> {
 			check_for_equivocation,
 			telemetry,
 			compatibility_mode,
-			phantom: PhantomData,
+			_phantom: PhantomData,
 		}
 	}
 }
 
 impl<C, P, CIDP, N> AuraVerifier<C, P, CIDP, N>
 where
-	P: Send + Sync + 'static,
 	CIDP: Send,
 {
 	async fn check_inherents<B: BlockT>(
@@ -168,9 +167,9 @@ impl<B: BlockT, C, P, CIDP> Verifier<B> for AuraVerifier<C, P, CIDP, NumberFor<B
 where
 	C: ProvideRuntimeApi<B> + Send + Sync + sc_client_api::backend::AuxStore,
 	C::Api: BlockBuilderApi<B> + AuraApi<B, AuthorityId<P>> + ApiExt<B>,
-	P: Pair + Send + Sync + 'static,
-	P::Public: Send + Sync + Hash + Eq + Clone + Decode + Encode + Debug + 'static,
-	P::Signature: Encode + Decode,
+	P: Pair,
+	P::Public: Hash + Codec + Debug,
+	P::Signature: Codec,
 	CIDP: CreateInherentDataProviders<B, ()> + Send + Sync,
 	CIDP::InherentDataProviders: InherentDataProviderExt + Send + Sync,
 {
@@ -365,9 +364,9 @@ where
 		+ Send
 		+ Sync
 		+ 'static,
-	P: Pair + Send + Sync + 'static,
-	P::Public: Clone + Eq + Send + Sync + Hash + Debug + Encode + Decode,
-	P::Signature: Encode + Decode,
+	P: Pair + 'static,
+	P::Public: Hash + Debug + Codec,
+	P::Signature: Codec,
 	S: sp_core::traits::SpawnEssentialNamed,
 	CIDP: CreateInherentDataProviders<Block, ()> + Sync + Send + 'static,
 	CIDP::InherentDataProviders: InherentDataProviderExt + Send + Sync,

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! NOTE: Aura itself is designed to be generic over the crypto used.
 #![forbid(missing_docs, unsafe_code)]
-use std::{fmt::Debug, hash::Hash, marker::PhantomData, pin::Pin, sync::Arc};
+use std::{fmt::Debug, marker::PhantomData, pin::Pin, sync::Arc};
 
 use codec::Codec;
 use futures::prelude::*;
@@ -172,8 +172,8 @@ pub fn start_aura<P, B, C, SC, I, PF, SO, L, CIDP, BS, Error>(
 ) -> Result<impl Future<Output = ()>, ConsensusError>
 where
 	P: Pair,
-	P::Public: AppPublic + Hash + Member,
-	P::Signature: TryFrom<Vec<u8>> + Hash + Member + Codec,
+	P::Public: AppPublic + Member,
+	P::Signature: TryFrom<Vec<u8>> + Member + Codec,
 	B: BlockT,
 	C: ProvideRuntimeApi<B> + BlockOf + AuxStore + HeaderBackend<B> + Send + Sync,
 	C::Api: AuraApi<B, AuthorityId<P>>,
@@ -281,8 +281,8 @@ where
 	PF: Environment<B, Error = Error> + Send + Sync + 'static,
 	PF::Proposer: Proposer<B, Error = Error, Transaction = sp_api::TransactionFor<C, B>>,
 	P: Pair,
-	P::Public: AppPublic + Hash + Member + Codec,
-	P::Signature: TryFrom<Vec<u8>> + Hash + Member + Codec,
+	P::Public: AppPublic + Member,
+	P::Signature: TryFrom<Vec<u8>> + Member + Codec,
 	I: BlockImport<B, Transaction = sp_api::TransactionFor<C, B>> + Send + Sync + 'static,
 	Error: std::error::Error + Send + From<ConsensusError> + 'static,
 	SO: SyncOracle + Send + Sync + Clone,
@@ -333,8 +333,8 @@ where
 	E::Proposer: Proposer<B, Error = Error, Transaction = sp_api::TransactionFor<C, B>>,
 	I: BlockImport<B, Transaction = sp_api::TransactionFor<C, B>> + Send + Sync + 'static,
 	P: Pair,
-	P::Public: AppPublic + Member + Codec + Hash,
-	P::Signature: TryFrom<Vec<u8>> + Member + Codec + Hash + Debug,
+	P::Public: AppPublic + Member,
+	P::Signature: TryFrom<Vec<u8>> + Member + Codec,
 	SO: SyncOracle + Send + Clone + Sync,
 	L: sc_consensus::JustificationSyncLink<B>,
 	BS: BackoffAuthoringBlocksStrategy<NumberFor<B>> + Send + Sync + 'static,

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -172,7 +172,7 @@ pub fn start_aura<P, B, C, SC, I, PF, SO, L, CIDP, BS, Error>(
 ) -> Result<impl Future<Output = ()>, ConsensusError>
 where
 	P: Pair,
-	P::Public: AppPublic + Hash + Member + Codec,
+	P::Public: AppPublic + Hash + Member,
 	P::Signature: TryFrom<Vec<u8>> + Hash + Member + Codec,
 	B: BlockT,
 	C: ProvideRuntimeApi<B> + BlockOf + AuxStore + HeaderBackend<B> + Send + Sync,

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -32,9 +32,8 @@
 #![forbid(missing_docs, unsafe_code)]
 use std::{fmt::Debug, hash::Hash, marker::PhantomData, pin::Pin, sync::Arc};
 
+use codec::Codec;
 use futures::prelude::*;
-
-use codec::{Codec, Decode, Encode};
 
 use sc_client_api::{backend::AuxStore, BlockOf};
 use sc_consensus::{BlockImport, BlockImportParams, ForkChoiceStrategy, StateAction};
@@ -48,7 +47,7 @@ use sp_application_crypto::AppPublic;
 use sp_blockchain::HeaderBackend;
 use sp_consensus::{BlockOrigin, Environment, Error as ConsensusError, Proposer, SelectChain};
 use sp_consensus_slots::Slot;
-use sp_core::crypto::{Pair, Public};
+use sp_core::crypto::Pair;
 use sp_inherents::CreateInherentDataProviders;
 use sp_keystore::KeystorePtr;
 use sp_runtime::traits::{Block as BlockT, Header, Member, NumberFor};
@@ -172,9 +171,9 @@ pub fn start_aura<P, B, C, SC, I, PF, SO, L, CIDP, BS, Error>(
 	}: StartAuraParams<C, SC, I, PF, SO, L, CIDP, BS, NumberFor<B>>,
 ) -> Result<impl Future<Output = ()>, ConsensusError>
 where
-	P: Pair + Send + Sync,
-	P::Public: AppPublic + Hash + Member + Encode + Decode,
-	P::Signature: TryFrom<Vec<u8>> + Hash + Member + Encode + Decode,
+	P: Pair,
+	P::Public: AppPublic + Hash + Member + Codec,
+	P::Signature: TryFrom<Vec<u8>> + Hash + Member + Codec,
 	B: BlockT,
 	C: ProvideRuntimeApi<B> + BlockOf + AuxStore + HeaderBackend<B> + Send + Sync,
 	C::Api: AuraApi<B, AuthorityId<P>>,
@@ -281,9 +280,9 @@ where
 	C::Api: AuraApi<B, AuthorityId<P>>,
 	PF: Environment<B, Error = Error> + Send + Sync + 'static,
 	PF::Proposer: Proposer<B, Error = Error, Transaction = sp_api::TransactionFor<C, B>>,
-	P: Pair + Send + Sync,
-	P::Public: AppPublic + Hash + Member + Encode + Decode,
-	P::Signature: TryFrom<Vec<u8>> + Hash + Member + Encode + Decode,
+	P: Pair,
+	P::Public: AppPublic + Hash + Member + Codec,
+	P::Signature: TryFrom<Vec<u8>> + Hash + Member + Codec,
 	I: BlockImport<B, Transaction = sp_api::TransactionFor<C, B>> + Send + Sync + 'static,
 	Error: std::error::Error + Send + From<ConsensusError> + 'static,
 	SO: SyncOracle + Send + Sync + Clone,
@@ -303,7 +302,7 @@ where
 		block_proposal_slot_portion,
 		max_block_proposal_slot_portion,
 		compatibility_mode,
-		_key_type: PhantomData::<P>,
+		_phantom: PhantomData::<fn() -> P>,
 	}
 }
 
@@ -320,7 +319,7 @@ struct AuraWorker<C, E, I, P, SO, L, BS, N> {
 	max_block_proposal_slot_portion: Option<SlotProportion>,
 	telemetry: Option<TelemetryHandle>,
 	compatibility_mode: CompatibilityMode<N>,
-	_key_type: PhantomData<P>,
+	_phantom: PhantomData<fn() -> P>,
 }
 
 #[async_trait::async_trait]
@@ -333,9 +332,9 @@ where
 	E: Environment<B, Error = Error> + Send + Sync,
 	E::Proposer: Proposer<B, Error = Error, Transaction = sp_api::TransactionFor<C, B>>,
 	I: BlockImport<B, Transaction = sp_api::TransactionFor<C, B>> + Send + Sync + 'static,
-	P: Pair + Send + Sync,
-	P::Public: AppPublic + Public + Member + Encode + Decode + Hash,
-	P::Signature: TryFrom<Vec<u8>> + Member + Encode + Decode + Hash + Debug,
+	P: Pair,
+	P::Public: AppPublic + Member + Codec + Hash,
+	P::Signature: TryFrom<Vec<u8>> + Member + Codec + Hash + Debug,
 	SO: SyncOracle + Send + Clone + Sync,
 	L: sc_consensus::JustificationSyncLink<B>,
 	BS: BackoffAuthoringBlocksStrategy<NumberFor<B>> + Send + Sync + 'static,
@@ -806,10 +805,10 @@ mod tests {
 			force_authoring: false,
 			backoff_authoring_blocks: Some(BackoffAuthoringOnFinalizedHeadLagging::default()),
 			telemetry: None,
-			_key_type: PhantomData::<AuthorityPair>,
 			block_proposal_slot_portion: SlotProportion::new(0.5),
 			max_block_proposal_slot_portion: None,
 			compatibility_mode: Default::default(),
+			_phantom: PhantomData::<fn() -> AuthorityPair>,
 		};
 
 		let head = Header::new(
@@ -856,10 +855,10 @@ mod tests {
 			force_authoring: false,
 			backoff_authoring_blocks: Option::<()>::None,
 			telemetry: None,
-			_key_type: PhantomData::<AuthorityPair>,
 			block_proposal_slot_portion: SlotProportion::new(0.5),
 			max_block_proposal_slot_portion: None,
 			compatibility_mode: Default::default(),
+			_phantom: PhantomData::<fn() -> AuthorityPair>,
 		};
 
 		let head = client.expect_header(client.info().genesis_hash).unwrap();

--- a/client/consensus/common/src/import_queue.rs
+++ b/client/consensus/common/src/import_queue.rs
@@ -95,7 +95,7 @@ pub struct IncomingBlock<B: BlockT> {
 
 /// Verify a justification of a block
 #[async_trait::async_trait]
-pub trait Verifier<B: BlockT>: Send + Sync {
+pub trait Verifier<B: BlockT>: Send {
 	/// Verify the given block data and return the `BlockImportParams` to
 	/// continue the block import process.
 	async fn verify(

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -486,7 +486,7 @@ pub trait ByteArray: AsRef<[u8]> + AsMut<[u8]> + for<'a> TryFrom<&'a [u8], Error
 }
 
 /// Trait suitable for typical cryptographic key public type.
-pub trait Public: ByteArray + Derive + CryptoType + PartialEq + Eq + Clone + Send + Sync {}
+pub trait Public: CryptoType + ByteArray + Derive + PartialEq + Eq + Clone + Send {}
 
 /// An opaque 32-byte cryptographic identifier.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, MaxEncodedLen, TypeInfo)]
@@ -834,7 +834,7 @@ impl sp_std::str::FromStr for SecretUri {
 ///
 /// For now it just specifies how to create a key from a phrase and derivation path.
 #[cfg(feature = "full_crypto")]
-pub trait Pair: CryptoType + Sized + Clone + Send + Sync + 'static {
+pub trait Pair: CryptoType + Sized {
 	/// The type which is used to encode a public key.
 	type Public: Public + Hash;
 


### PR DESCRIPTION
In general `Pair` trait is not strictly required to be `Send/Sync/Clone`.

Secrets throughout the codebase are constructed and destroyed asap (as should be).

In some situation these bounds could even be detrimental; some components may require the secrets to not be shared across threads (in practice silently moved to another stack without cleaning up the previous location) or cloned  (e.g. in cases where the backend doesn't implement something like `zeroize` to clean-up memory).

Furthermore, secrets provided by some backends may not allow for these bounds. For example the upcoming Bandersnatch `ring-vrf` secret is  not `Sync`. So  here there is not much space for options wrt this trait bound.

---

The only place where these bounds are currently *vacuously* required is in AURA code.

Here some components are generic over the key type and these components are required to be `Send`.
However the `Pair` is not part of the components struct instance and the generic is only used as a bound to a particular key type and thus authority id type (i.e. these structs contain a `PhantomData<Pair>`).

The issue is easily addressed by using `PhantomData<fn() -> Pair>` instead of `PhantomData<Pair>`.
`PhantomData<fn() -> Pair>` is both `Send` and `Sync` (regardless of `Pair` bounds).

That is, the types with `PhantomData` doesn't own a `Pair`, but instead they can potentially produce `Pair`s (this is the big difference).

---

The PR also contains trivial cleanups and removal of other bounds where possible

---

cumulus companion: https://github.com/paritytech/cumulus/pull/2941

required by https://github.com/paritytech/substrate/pull/14412

Nomicon ref (not published yet): https://github.com/rust-lang/nomicon/pull/411