### PR TITLE
[fix lint warnings: NFTs pallet] fix clippy::missing_errors_doc lint warnings

### DIFF
--- a/frame/nfts/src/common_functions.rs
+++ b/frame/nfts/src/common_functions.rs
@@ -31,7 +31,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Collection::<T, I>::get(collection).map(|i| i.owner)
 	}
 
-	/// Validate the `data` was signed by `signer` and the `signature` is correct.
+	/// Validates the signature of the given data with the provided signer's account ID.
+	///
+	/// # Errors
+	///
+	/// This function returns a `WrongSignature` error if the signature is invalid or the verification process fails.
 	pub fn validate_signature(
 		data: &Vec<u8>,
 		signature: &T::OffchainSignature,

--- a/frame/nfts/src/common_functions.rs
+++ b/frame/nfts/src/common_functions.rs
@@ -35,7 +35,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns a `WrongSignature` error if the signature is invalid or the verification process fails.
+	/// This function returns a `WrongSignature` error if the signature is invalid or the
+	/// verification process fails.
 	pub fn validate_signature(
 		data: &Vec<u8>,
 		signature: &T::OffchainSignature,

--- a/frame/nfts/src/common_functions.rs
+++ b/frame/nfts/src/common_functions.rs
@@ -35,7 +35,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns a `WrongSignature` error if the signature is invalid or the
+	/// This function returns a [`WrongSignature`](crate::Error::WrongSignature) error if the signature is invalid or the
 	/// verification process fails.
 	pub fn validate_signature(
 		data: &Vec<u8>,

--- a/frame/nfts/src/common_functions.rs
+++ b/frame/nfts/src/common_functions.rs
@@ -35,8 +35,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns a [`WrongSignature`](crate::Error::WrongSignature) error if the signature is invalid or the
-	/// verification process fails.
+	/// This function returns a [`WrongSignature`](crate::Error::WrongSignature) error if the
+	/// signature is invalid or the verification process fails.
 	pub fn validate_signature(
 		data: &Vec<u8>,
 		signature: &T::OffchainSignature,

--- a/frame/nfts/src/features/attributes.rs
+++ b/frame/nfts/src/features/attributes.rs
@@ -385,7 +385,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns an `IncorrectData` error if the provided attribute `key` is
+	/// This function returns an [`IncorrectData`](crate::Error::IncorrectData) error if the provided attribute `key` is
 	/// incorrectly formatted.
 	pub fn construct_attribute_key(
 		key: Vec<u8>,
@@ -397,7 +397,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns an `IncorrectData` error if the provided `value` is incorrectly
+	/// This function returns an [`IncorrectData`](crate::Error::IncorrectData) error if the provided `value` is incorrectly
 	/// formatted.
 	pub fn construct_attribute_value(
 		value: Vec<u8>,
@@ -409,7 +409,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns an `IncorrectData` error if the provided pallet attribute is
+	/// This function returns an [`IncorrectData`](crate::Error::IncorrectData) error if the provided pallet attribute is
 	/// incorrectly formatted.
 	pub fn has_system_attribute(
 		collection: &T::CollectionId,

--- a/frame/nfts/src/features/attributes.rs
+++ b/frame/nfts/src/features/attributes.rs
@@ -386,7 +386,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// # Errors
 	///
 	/// This function returns an [`IncorrectData`](crate::Error::IncorrectData) error if the
-	/// provided attribute `key` is incorrectly formatted.
+	/// provided attribute `key` is too long.
 	pub fn construct_attribute_key(
 		key: Vec<u8>,
 	) -> Result<BoundedVec<u8, T::KeyLimit>, DispatchError> {
@@ -398,7 +398,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// # Errors
 	///
 	/// This function returns an [`IncorrectData`](crate::Error::IncorrectData) error if the
-	/// provided `value` is incorrectly formatted.
+	/// provided `value` is too long.
 	pub fn construct_attribute_value(
 		value: Vec<u8>,
 	) -> Result<BoundedVec<u8, T::ValueLimit>, DispatchError> {
@@ -410,7 +410,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// # Errors
 	///
 	/// This function returns an [`IncorrectData`](crate::Error::IncorrectData) error if the
-	/// provided pallet attribute is incorrectly formatted.
+	/// provided pallet attribute is too long.
 	pub fn has_system_attribute(
 		collection: &T::CollectionId,
 		item: &T::ItemId,

--- a/frame/nfts/src/features/attributes.rs
+++ b/frame/nfts/src/features/attributes.rs
@@ -385,7 +385,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns an `IncorrectData` error if the provided attribute `key` is incorrectly formatted.
+	/// This function returns an `IncorrectData` error if the provided attribute `key` is
+	/// incorrectly formatted.
 	pub fn construct_attribute_key(
 		key: Vec<u8>,
 	) -> Result<BoundedVec<u8, T::KeyLimit>, DispatchError> {
@@ -396,7 +397,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns an `IncorrectData` error if the provided `value` is incorrectly formatted.
+	/// This function returns an `IncorrectData` error if the provided `value` is incorrectly
+	/// formatted.
 	pub fn construct_attribute_value(
 		value: Vec<u8>,
 	) -> Result<BoundedVec<u8, T::ValueLimit>, DispatchError> {
@@ -407,7 +409,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns an `IncorrectData` error if the provided pallet attribute is incorrectly formatted.
+	/// This function returns an `IncorrectData` error if the provided pallet attribute is
+	/// incorrectly formatted.
 	pub fn has_system_attribute(
 		collection: &T::CollectionId,
 		item: &T::ItemId,

--- a/frame/nfts/src/features/attributes.rs
+++ b/frame/nfts/src/features/attributes.rs
@@ -381,14 +381,22 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Ok(result)
 	}
 
-	/// A helper method to construct attribute's key.
+	/// A helper method to construct an attribute's key.
+	///
+	/// # Errors
+	///
+	/// This function returns an `IncorrectData` error if the provided attribute `key` is incorrectly formatted.
 	pub fn construct_attribute_key(
 		key: Vec<u8>,
 	) -> Result<BoundedVec<u8, T::KeyLimit>, DispatchError> {
 		Ok(BoundedVec::try_from(key).map_err(|_| Error::<T, I>::IncorrectData)?)
 	}
 
-	/// A helper method to construct attribute's value.
+	/// A helper method to construct an attribute's value.
+	///
+	/// # Errors
+	///
+	/// This function returns an `IncorrectData` error if the provided `value` is incorrectly formatted.
 	pub fn construct_attribute_value(
 		value: Vec<u8>,
 	) -> Result<BoundedVec<u8, T::ValueLimit>, DispatchError> {
@@ -396,6 +404,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	}
 
 	/// A helper method to check whether a system attribute is set for a given item.
+	///
+	/// # Errors
+	///
+	/// This function returns an `IncorrectData` error if the provided pallet attribute is incorrectly formatted.
 	pub fn has_system_attribute(
 		collection: &T::CollectionId,
 		item: &T::ItemId,

--- a/frame/nfts/src/features/attributes.rs
+++ b/frame/nfts/src/features/attributes.rs
@@ -385,8 +385,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns an [`IncorrectData`](crate::Error::IncorrectData) error if the provided attribute `key` is
-	/// incorrectly formatted.
+	/// This function returns an [`IncorrectData`](crate::Error::IncorrectData) error if the
+	/// provided attribute `key` is incorrectly formatted.
 	pub fn construct_attribute_key(
 		key: Vec<u8>,
 	) -> Result<BoundedVec<u8, T::KeyLimit>, DispatchError> {
@@ -397,8 +397,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns an [`IncorrectData`](crate::Error::IncorrectData) error if the provided `value` is incorrectly
-	/// formatted.
+	/// This function returns an [`IncorrectData`](crate::Error::IncorrectData) error if the
+	/// provided `value` is incorrectly formatted.
 	pub fn construct_attribute_value(
 		value: Vec<u8>,
 	) -> Result<BoundedVec<u8, T::ValueLimit>, DispatchError> {
@@ -409,8 +409,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns an [`IncorrectData`](crate::Error::IncorrectData) error if the provided pallet attribute is
-	/// incorrectly formatted.
+	/// This function returns an [`IncorrectData`](crate::Error::IncorrectData) error if the
+	/// provided pallet attribute is incorrectly formatted.
 	pub fn has_system_attribute(
 		collection: &T::CollectionId,
 		item: &T::ItemId,

--- a/frame/nfts/src/features/create_delete_collection.rs
+++ b/frame/nfts/src/features/create_delete_collection.rs
@@ -28,7 +28,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns a `CollectionIdInUse` error if the collection ID is already in use.
+	/// This function returns a [`CollectionIdInUse`](crate::Error::CollectionIdInUse) error if the collection ID is already in use.
 	pub fn do_create_collection(
 		collection: T::CollectionId,
 		owner: T::AccountId,
@@ -78,11 +78,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns a `Dispatch` error in the following cases:
-	/// - If the collection ID is not found (`UnknownCollection`).
-	/// - If the provided `maybe_check_owner` does not match the actual owner (`NoPermission`).
-	/// - If the collection is not empty (contains items) (`CollectionNotEmpty`).
-	/// - If the `witness` does not match the actual collection details (`BadWitness`).
+	/// This function returns a dispatch error in the following cases:
+	/// - If the collection ID is not found ([`UnknownCollection`](crate::Error::UnknownCollection)).
+	/// - If the provided `maybe_check_owner` does not match the actual owner ([`NoPermission`](crate::Error::NoPermission)).
+	/// - If the collection is not empty (contains items) ([`CollectionNotEmpty`](crate::Error::CollectionNotEmpty)).
+	/// - If the `witness` does not match the actual collection details ([`BadWitness`](crate::Error::BadWitness)).
 	pub fn do_destroy_collection(
 		collection: T::CollectionId,
 		witness: DestroyWitness,

--- a/frame/nfts/src/features/create_delete_collection.rs
+++ b/frame/nfts/src/features/create_delete_collection.rs
@@ -78,7 +78,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns an error in the following cases:
+	/// This function returns a `Dispatch` error in the following cases:
 	/// - If the collection ID is not found (`UnknownCollection`).
 	/// - If the provided `maybe_check_owner` does not match the actual owner (`NoPermission`).
 	/// - If the collection is not empty (contains items) (`CollectionNotEmpty`).

--- a/frame/nfts/src/features/create_delete_collection.rs
+++ b/frame/nfts/src/features/create_delete_collection.rs
@@ -65,8 +65,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Self::deposit_event(event);
 		Ok(())
 	}
-	
-	/// Destroy the specified collection with the given `collection`, `witness`, and `maybe_check_owner`.
+
+	/// Destroy the specified collection with the given `collection`, `witness`, and
+	/// `maybe_check_owner`.
 	///
 	/// This function destroys the specified collection if it exists and meets the necessary
 	/// conditions. It checks the provided `witness` against the actual collection details and

--- a/frame/nfts/src/features/create_delete_collection.rs
+++ b/frame/nfts/src/features/create_delete_collection.rs
@@ -28,7 +28,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns a [`CollectionIdInUse`](crate::Error::CollectionIdInUse) error if the collection ID is already in use.
+	/// This function returns a [`CollectionIdInUse`](crate::Error::CollectionIdInUse) error if the
+	/// collection ID is already in use.
 	pub fn do_create_collection(
 		collection: T::CollectionId,
 		owner: T::AccountId,
@@ -79,10 +80,14 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// # Errors
 	///
 	/// This function returns a dispatch error in the following cases:
-	/// - If the collection ID is not found ([`UnknownCollection`](crate::Error::UnknownCollection)).
-	/// - If the provided `maybe_check_owner` does not match the actual owner ([`NoPermission`](crate::Error::NoPermission)).
-	/// - If the collection is not empty (contains items) ([`CollectionNotEmpty`](crate::Error::CollectionNotEmpty)).
-	/// - If the `witness` does not match the actual collection details ([`BadWitness`](crate::Error::BadWitness)).
+	/// - If the collection ID is not found
+	///   ([`UnknownCollection`](crate::Error::UnknownCollection)).
+	/// - If the provided `maybe_check_owner` does not match the actual owner
+	///   ([`NoPermission`](crate::Error::NoPermission)).
+	/// - If the collection is not empty (contains items)
+	///   ([`CollectionNotEmpty`](crate::Error::CollectionNotEmpty)).
+	/// - If the `witness` does not match the actual collection details
+	///   ([`BadWitness`](crate::Error::BadWitness)).
 	pub fn do_destroy_collection(
 		collection: T::CollectionId,
 		witness: DestroyWitness,

--- a/frame/nfts/src/features/create_delete_collection.rs
+++ b/frame/nfts/src/features/create_delete_collection.rs
@@ -19,6 +19,16 @@ use crate::*;
 use frame_support::pallet_prelude::*;
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
+	/// Create a new collection with the given `collection`, `owner`, `admin`, `config`, `deposit`,
+	/// and `event`.
+	///
+	/// This function creates a new collection with the provided parameters. It reserves the
+	/// required deposit from the owner's account, sets the collection details, assigns admin roles,
+	/// and inserts the provided configuration. Finally, it emits the specified event upon success.
+	///
+	/// # Errors
+	///
+	/// This function returns a `CollectionIdInUse` error if the collection ID is already in use.
 	pub fn do_create_collection(
 		collection: T::CollectionId,
 		owner: T::AccountId,
@@ -55,7 +65,23 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Self::deposit_event(event);
 		Ok(())
 	}
-
+	
+	/// Destroy the specified collection with the given `collection`, `witness`, and `maybe_check_owner`.
+	///
+	/// This function destroys the specified collection if it exists and meets the necessary
+	/// conditions. It checks the provided `witness` against the actual collection details and
+	/// removes the collection along with its associated metadata, attributes, and configurations.
+	/// The necessary deposits are returned to the corresponding accounts, and the roles and
+	/// configurations for the collection are cleared. Finally, it emits the `Destroyed` event upon
+	/// successful destruction.
+	///
+	/// # Errors
+	///
+	/// This function returns an error in the following cases:
+	/// - If the collection ID is not found (`UnknownCollection`).
+	/// - If the provided `maybe_check_owner` does not match the actual owner (`NoPermission`).
+	/// - If the collection is not empty (contains items) (`CollectionNotEmpty`).
+	/// - If the `witness` does not match the actual collection details (`BadWitness`).
 	pub fn do_destroy_collection(
 		collection: T::CollectionId,
 		witness: DestroyWitness,

--- a/frame/nfts/src/features/create_delete_item.rs
+++ b/frame/nfts/src/features/create_delete_item.rs
@@ -19,6 +19,21 @@ use crate::*;
 use frame_support::{pallet_prelude::*, traits::ExistenceRequirement};
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
+	/// Mint a new unique item with the given `collection`, `item`, and other minting configuration details.
+	///
+	/// This function performs the minting of a new unique item. It checks if the item does not
+	/// already exist in the given collection, and if the max supply limit (if configured) is not
+	/// reached. It also reserves the required deposit for the item and sets the item details
+	/// accordingly.
+	///
+	/// # Errors
+	///
+	/// This function returns an error in the following cases:
+	/// - If the collection ID is invalid (`UnknownCollection`).
+	/// - If the item already exists in the collection (`AlreadyExists`).
+	/// - If the item configuration already exists (`InconsistentItemConfig`).
+	/// - If the max supply limit (if configured) for the collection is reached (`MaxSupplyReached`).
+	/// - If any error occurs in the `with_details_and_config` closure.
 	pub fn do_mint(
 		collection: T::CollectionId,
 		item: T::ItemId,
@@ -163,6 +178,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Ok(())
 	}
 
+	/// Burns the specified item with the given `collection`, `item`, and `with_details`.
+	///
+	/// # Errors
+	///
+	/// This function returns an error in the following cases:
+	/// - If the collection ID is invalid (`UnknownCollection`)
+	/// - If the item is locked (`ItemLocked`)
 	pub fn do_burn(
 		collection: T::CollectionId,
 		item: T::ItemId,

--- a/frame/nfts/src/features/create_delete_item.rs
+++ b/frame/nfts/src/features/create_delete_item.rs
@@ -29,12 +29,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns a `Dispatch` error in the following cases:
-	/// - If the collection ID is invalid (`UnknownCollection`).
-	/// - If the item already exists in the collection (`AlreadyExists`).
-	/// - If the item configuration already exists (`InconsistentItemConfig`).
-	/// - If the max supply limit (if configured) for the collection is reached
-	///   (`MaxSupplyReached`).
+	/// This function returns a dispatch error in the following cases:
+	/// - If the collection ID is invalid ([`UnknownCollection`](crate::Error::UnknownCollection)).
+	/// - If the item already exists in the collection ([`AlreadyExists`](crate::Error::AlreadyExists)).
+	/// - If the item configuration already exists ([`InconsistentItemConfig`](crate::Error::InconsistentItemConfig)).
+	/// - If the max supply limit (if configured) for the collection is reached ([`MaxSupplyReached`](crate::Error::MaxSupplyReached)).
 	/// - If any error occurs in the `with_details_and_config` closure.
 	pub fn do_mint(
 		collection: T::CollectionId,
@@ -184,9 +183,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns a `Dispatch` error in the following cases:
-	/// - If the collection ID is invalid (`UnknownCollection`)
-	/// - If the item is locked (`ItemLocked`)
+	/// This function returns a dispatch error in the following cases:
+	/// - If the collection ID is invalid ([`UnknownCollection`](crate::Error::UnknownCollection)).
+	/// - If the item is locked ([`ItemLocked`](crate::Error::ItemLocked)).
 	pub fn do_burn(
 		collection: T::CollectionId,
 		item: T::ItemId,

--- a/frame/nfts/src/features/create_delete_item.rs
+++ b/frame/nfts/src/features/create_delete_item.rs
@@ -31,9 +31,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// This function returns a dispatch error in the following cases:
 	/// - If the collection ID is invalid ([`UnknownCollection`](crate::Error::UnknownCollection)).
-	/// - If the item already exists in the collection ([`AlreadyExists`](crate::Error::AlreadyExists)).
-	/// - If the item configuration already exists ([`InconsistentItemConfig`](crate::Error::InconsistentItemConfig)).
-	/// - If the max supply limit (if configured) for the collection is reached ([`MaxSupplyReached`](crate::Error::MaxSupplyReached)).
+	/// - If the item already exists in the collection
+	///   ([`AlreadyExists`](crate::Error::AlreadyExists)).
+	/// - If the item configuration already exists
+	///   ([`InconsistentItemConfig`](crate::Error::InconsistentItemConfig)).
+	/// - If the max supply limit (if configured) for the collection is reached
+	///   ([`MaxSupplyReached`](crate::Error::MaxSupplyReached)).
 	/// - If any error occurs in the `with_details_and_config` closure.
 	pub fn do_mint(
 		collection: T::CollectionId,

--- a/frame/nfts/src/features/create_delete_item.rs
+++ b/frame/nfts/src/features/create_delete_item.rs
@@ -184,7 +184,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns an error in the following cases:
+	/// This function returns a `Dispatch` error in the following cases:
 	/// - If the collection ID is invalid (`UnknownCollection`)
 	/// - If the item is locked (`ItemLocked`)
 	pub fn do_burn(

--- a/frame/nfts/src/features/create_delete_item.rs
+++ b/frame/nfts/src/features/create_delete_item.rs
@@ -29,7 +29,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns an error in the following cases:
+	/// This function returns a `Dispatch` error in the following cases:
 	/// - If the collection ID is invalid (`UnknownCollection`).
 	/// - If the item already exists in the collection (`AlreadyExists`).
 	/// - If the item configuration already exists (`InconsistentItemConfig`).

--- a/frame/nfts/src/features/create_delete_item.rs
+++ b/frame/nfts/src/features/create_delete_item.rs
@@ -19,7 +19,8 @@ use crate::*;
 use frame_support::{pallet_prelude::*, traits::ExistenceRequirement};
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
-	/// Mint a new unique item with the given `collection`, `item`, and other minting configuration details.
+	/// Mint a new unique item with the given `collection`, `item`, and other minting configuration
+	/// details.
 	///
 	/// This function performs the minting of a new unique item. It checks if the item does not
 	/// already exist in the given collection, and if the max supply limit (if configured) is not
@@ -32,7 +33,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// - If the collection ID is invalid (`UnknownCollection`).
 	/// - If the item already exists in the collection (`AlreadyExists`).
 	/// - If the item configuration already exists (`InconsistentItemConfig`).
-	/// - If the max supply limit (if configured) for the collection is reached (`MaxSupplyReached`).
+	/// - If the max supply limit (if configured) for the collection is reached
+	///   (`MaxSupplyReached`).
 	/// - If any error occurs in the `with_details_and_config` closure.
 	pub fn do_mint(
 		collection: T::CollectionId,

--- a/frame/nfts/src/features/metadata.rs
+++ b/frame/nfts/src/features/metadata.rs
@@ -209,6 +209,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	}
 
 	/// A helper method to construct metadata.
+	///
+	/// # Errors
+	///
+	/// This function returns a `IncorrectMetadata` error if the provided metadata is incorrectly formatted.
 	pub fn construct_metadata(
 		metadata: Vec<u8>,
 	) -> Result<BoundedVec<u8, T::StringLimit>, DispatchError> {

--- a/frame/nfts/src/features/metadata.rs
+++ b/frame/nfts/src/features/metadata.rs
@@ -212,7 +212,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns a `IncorrectMetadata` error if the provided metadata is incorrectly formatted.
+	/// This function returns a `IncorrectMetadata` error if the provided metadata is incorrectly
+	/// formatted.
 	pub fn construct_metadata(
 		metadata: Vec<u8>,
 	) -> Result<BoundedVec<u8, T::StringLimit>, DispatchError> {

--- a/frame/nfts/src/features/metadata.rs
+++ b/frame/nfts/src/features/metadata.rs
@@ -212,7 +212,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns a `IncorrectMetadata` error if the provided metadata is incorrectly
+	/// This function returns an [`IncorrectMetadata`](crate::Error::IncorrectMetadata) dispatch error if the provided metadata is incorrectly
 	/// formatted.
 	pub fn construct_metadata(
 		metadata: Vec<u8>,

--- a/frame/nfts/src/features/metadata.rs
+++ b/frame/nfts/src/features/metadata.rs
@@ -213,7 +213,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// # Errors
 	///
 	/// This function returns an [`IncorrectMetadata`](crate::Error::IncorrectMetadata) dispatch
-	/// error if the provided metadata is incorrectly formatted.
+	/// error if the provided metadata is too long.
 	pub fn construct_metadata(
 		metadata: Vec<u8>,
 	) -> Result<BoundedVec<u8, T::StringLimit>, DispatchError> {

--- a/frame/nfts/src/features/metadata.rs
+++ b/frame/nfts/src/features/metadata.rs
@@ -212,8 +212,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns an [`IncorrectMetadata`](crate::Error::IncorrectMetadata) dispatch error if the provided metadata is incorrectly
-	/// formatted.
+	/// This function returns an [`IncorrectMetadata`](crate::Error::IncorrectMetadata) dispatch
+	/// error if the provided metadata is incorrectly formatted.
 	pub fn construct_metadata(
 		metadata: Vec<u8>,
 	) -> Result<BoundedVec<u8, T::StringLimit>, DispatchError> {

--- a/frame/nfts/src/features/transfer.rs
+++ b/frame/nfts/src/features/transfer.rs
@@ -23,11 +23,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns a `Dispatch` error in the following cases:
-	/// - If the collection ID is invalid (`UnknownCollection`)
-	/// - If the item ID is invalid (`UnknownItem`).
-	/// - If the item is locked or transferring it is disabled (`ItemLocked`).
-	/// - If the collection or item is non-transferable (`ItemsNonTransferable`).
+	/// This function returns a dispatch error in the following cases:
+	/// - If the collection ID is invalid ([`UnknownCollection`](crate::Error::UnknownCollection)).
+	/// - If the item ID is invalid ([`UnknownItem`](crate::Error::UnknownItem)).
+	/// - If the item is locked or transferring it is disabled ([`ItemLocked`](crate::Error::ItemLocked)).
+	/// - If the collection or item is non-transferable ([`ItemsNonTransferable`](crate::Error::ItemsNonTransferable)).
 	pub fn do_transfer(
 		collection: T::CollectionId,
 		item: T::ItemId,

--- a/frame/nfts/src/features/transfer.rs
+++ b/frame/nfts/src/features/transfer.rs
@@ -26,8 +26,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// This function returns a dispatch error in the following cases:
 	/// - If the collection ID is invalid ([`UnknownCollection`](crate::Error::UnknownCollection)).
 	/// - If the item ID is invalid ([`UnknownItem`](crate::Error::UnknownItem)).
-	/// - If the item is locked or transferring it is disabled ([`ItemLocked`](crate::Error::ItemLocked)).
-	/// - If the collection or item is non-transferable ([`ItemsNonTransferable`](crate::Error::ItemsNonTransferable)).
+	/// - If the item is locked or transferring it is disabled
+	///   ([`ItemLocked`](crate::Error::ItemLocked)).
+	/// - If the collection or item is non-transferable
+	///   ([`ItemsNonTransferable`](crate::Error::ItemsNonTransferable)).
 	pub fn do_transfer(
 		collection: T::CollectionId,
 		item: T::ItemId,

--- a/frame/nfts/src/features/transfer.rs
+++ b/frame/nfts/src/features/transfer.rs
@@ -19,6 +19,15 @@ use crate::*;
 use frame_support::pallet_prelude::*;
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
+	/// Performs the transfer action for the given `collection`, `item`, `dest`, and `event`.
+	///
+	/// # Errors
+	///
+	/// This function returns an error in the following cases:
+	/// - If the collection ID is invalid (`UnknownCollection`)
+	/// - If the item ID is invalid (`UnknownItem`).
+	/// - If the item is locked or transferring it is disabled (`ItemLocked`).
+	/// - If the collection or item is non-transferable (`ItemsNonTransferable`).
 	pub fn do_transfer(
 		collection: T::CollectionId,
 		item: T::ItemId,

--- a/frame/nfts/src/features/transfer.rs
+++ b/frame/nfts/src/features/transfer.rs
@@ -23,7 +23,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// # Errors
 	///
-	/// This function returns an error in the following cases:
+	/// This function returns a `Dispatch` error in the following cases:
 	/// - If the collection ID is invalid (`UnknownCollection`)
 	/// - If the item ID is invalid (`UnknownItem`).
 	/// - If the item is locked or transferring it is disabled (`ItemLocked`).


### PR DESCRIPTION
This PR fixes the lint warnings emitted by the missing_errors_doc lint in the NFTs pallet by adding an # Errors section to the common helper functions.