### PR TITLE
return proof size on manually created blocks (for tests only)

### DIFF
--- a/client/consensus/manual-seal/src/lib.rs
+++ b/client/consensus/manual-seal/src/lib.rs
@@ -180,7 +180,7 @@ pub async fn run_manual_seal<B, BI, CB, E, C, TP, SC, CS, CIDP, P>(
 	TransactionFor<C, B>: 'static,
 	TP: TransactionPool<Block = B>,
 	CIDP: CreateInherentDataProviders<B, ()>,
-	P: Send + Sync + 'static,
+	P: codec::Encode + Send + Sync + 'static,
 {
 	while let Some(command) = commands_stream.next().await {
 		match command {
@@ -242,7 +242,7 @@ pub async fn run_instant_seal<B, BI, CB, E, C, TP, SC, CIDP, P>(
 	TransactionFor<C, B>: 'static,
 	TP: TransactionPool<Block = B>,
 	CIDP: CreateInherentDataProviders<B, ()>,
-	P: Send + Sync + 'static,
+	P: codec::Encode + Send + Sync + 'static,
 {
 	// instant-seal creates blocks as soon as transactions are imported
 	// into the transaction pool.
@@ -296,7 +296,7 @@ pub async fn run_instant_seal_and_finalize<B, BI, CB, E, C, TP, SC, CIDP, P>(
 	TransactionFor<C, B>: 'static,
 	TP: TransactionPool<Block = B>,
 	CIDP: CreateInherentDataProviders<B, ()>,
-	P: Send + Sync + 'static,
+	P: codec::Encode + Send + Sync + 'static,
 {
 	// Creates and finalizes blocks as soon as transactions are imported
 	// into the transaction pool.
@@ -475,7 +475,8 @@ mod tests {
 					needs_justification: false,
 					bad_justification: false,
 					is_new_best: true,
-				}
+				},
+				proof_size: 0
 			}
 		);
 		// assert that there's a new block in the db.
@@ -641,7 +642,8 @@ mod tests {
 					needs_justification: false,
 					bad_justification: false,
 					is_new_best: true,
-				}
+				},
+				proof_size: 0
 			}
 		);
 		// assert that there's a new block in the db.
@@ -727,7 +729,8 @@ mod tests {
 					needs_justification: false,
 					bad_justification: false,
 					is_new_best: true
-				}
+				},
+				proof_size: 0
 			}
 		);
 

--- a/client/consensus/manual-seal/src/lib.rs
+++ b/client/consensus/manual-seal/src/lib.rs
@@ -566,7 +566,8 @@ mod tests {
 					needs_justification: false,
 					bad_justification: false,
 					is_new_best: true,
-				}
+				},
+				proof_size: created_block.proof_size
 			}
 		);
 		// assert that there's a new block in the db.

--- a/client/consensus/manual-seal/src/rpc.rs
+++ b/client/consensus/manual-seal/src/rpc.rs
@@ -97,6 +97,8 @@ pub struct CreatedBlock<Hash> {
 	pub hash: Hash,
 	/// some extra details about the import operation
 	pub aux: ImportedAux,
+	/// uncompacted storage proof size (zero mean that there is no proof)
+	pub proof_size: usize,
 }
 
 impl<Hash> ManualSeal<Hash> {

--- a/client/consensus/manual-seal/src/seal_block.rs
+++ b/client/consensus/manual-seal/src/seal_block.rs
@@ -88,7 +88,7 @@ pub async fn seal_block<B, BI, SC, C, E, TP, CIDP, P>(
 	SC: SelectChain<B>,
 	TransactionFor<C, B>: 'static,
 	CIDP: CreateInherentDataProviders<B, ()>,
-	P: Send + Sync + 'static,
+	P: codec::Encode + Send + Sync + 'static,
 {
 	let future = async {
 		if pool.status().ready == 0 && !create_empty {
@@ -136,6 +136,7 @@ pub async fn seal_block<B, BI, SC, C, E, TP, CIDP, P>(
 
 		let (header, body) = proposal.block.deconstruct();
 		let proof = proposal.proof;
+		let proof_size = proof.encoded_size();
 		let mut params = BlockImportParams::new(BlockOrigin::Own, header.clone());
 		params.body = Some(body);
 		params.finalized = finalize;
@@ -154,8 +155,11 @@ pub async fn seal_block<B, BI, SC, C, E, TP, CIDP, P>(
 		post_header.digest_mut().logs.extend(params.post_digests.iter().cloned());
 
 		match block_import.import_block(params).await? {
-			ImportResult::Imported(aux) =>
-				Ok(CreatedBlock { hash: <B as BlockT>::Header::hash(&post_header), aux }),
+			ImportResult::Imported(aux) => Ok(CreatedBlock {
+				hash: <B as BlockT>::Header::hash(&post_header),
+				aux,
+				proof_size,
+			}),
 			other => Err(other.into()),
 		}
 	};


### PR DESCRIPTION
# Description

Return proof size on manually created blocks (for tests only)

- What does this PR do?
The goal of this change is to be able to get the size of the storage proof of the block in test context.
- Why are these changes needed?
To be able to check PoV limits in end2end tests like typescript tests
- How were these changes implemented and what do they affect?

# Checklist

- [x] My PR includes a detailed description as outlined in the "Description" section above
- [x] My PR follows the [labeling requirements](https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc#merge-process) of this project (at minimum one label for each `A`, `B`, `C` and `D` required)
