### PR TITLE
Runtime: avoid duplication and test all signature

### DIFF
--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -2301,8 +2301,22 @@ mod tests {
 	use crate::codec::{Decode, Encode, Input};
 	use sp_core::{
 		crypto::{Pair, UncheckedFrom},
-		ecdsa,
+		ecdsa, ed25519, sr25519,
 	};
+
+	macro_rules! signature_verify_test {
+		($algorithm:ident) => {
+			let msg = &b"test-message"[..];
+			let wrong_msg = &b"test-msg"[..];
+			let (pair, _) = $algorithm::Pair::generate();
+
+			let signature = pair.sign(&msg);
+			assert!($algorithm::Pair::verify(&signature, msg, &pair.public()));
+
+			assert!(signature.verify(msg, &pair.public()));
+			assert!(!signature.verify(wrong_msg, &pair.public()));
+		};
+	}
 
 	mod t {
 		use sp_application_crypto::{app_crypto, sr25519};
@@ -2414,14 +2428,9 @@ mod tests {
 	}
 
 	#[test]
-	fn ecdsa_verify_works() {
-		let msg = &b"test-message"[..];
-		let (pair, _) = ecdsa::Pair::generate();
-
-		let signature = pair.sign(&msg);
-		assert!(ecdsa::Pair::verify(&signature, msg, &pair.public()));
-
-		assert!(signature.verify(msg, &pair.public()));
-		assert!(signature.verify(msg, &pair.public()));
+	fn signature_verify_works() {
+		signature_verify_test!(ed25519);
+		signature_verify_test!(sr25519);
+		signature_verify_test!(ecdsa);
 	}
 }

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -2299,6 +2299,8 @@ pub trait BlockNumberProvider {
 mod tests {
 	use super::*;
 	use crate::codec::{Decode, Encode, Input};
+	#[cfg(feature = "bls-experimental")]
+	use sp_core::{bls377, bls381};
 	use sp_core::{
 		crypto::{Pair, UncheckedFrom},
 		ecdsa, ed25519, sr25519,
@@ -2428,9 +2430,27 @@ mod tests {
 	}
 
 	#[test]
-	fn signature_verify_works() {
+	fn ed25519_verify_works() {
 		signature_verify_test!(ed25519);
+	}
+
+	#[test]
+	fn sr25519_verify_works() {
 		signature_verify_test!(sr25519);
+	}
+
+	#[test]
+	fn ecdsa_verify_works() {
 		signature_verify_test!(ecdsa);
+	}
+
+	#[cfg(feature = "bls-experimental")]
+	fn bls377_verify_works() {
+		signature_verify_test!(bls377)
+	}
+
+	#[cfg(feature = "bls-experimental")]
+	fn bls381_verify_works() {
+		signature_verify_test!(bls381)
 	}
 }

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -76,7 +76,6 @@ std = [
 	"log/std",
 	"sp-offchain/std",
 	"sp-core/std",
-	"sp-core/std",
 	"sp-std/std",
 	"sp-io/std",
 	"frame-support/std",


### PR DESCRIPTION
# Description

I found signature test code following duplication.
https://github.com/paritytech/substrate/blob/fbdf00888d778bab4d31a8938de7bed7e53d2d53/primitives/runtime/src/traits.rs#L2424-L2425

ecdsa error case is not tested and ed25519/sr25519 cases are not tested.
I added following test cases

- ecdsa error
- ed25519 normal/error
- sr25519 normal/error
- bls377 normal/error
- bls381 normal/error

# Checklist

- [x] My PR includes a detailed description as outlined in the "Description" section above
- [x] My PR follows the [labeling requirements](https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc#merge-process) of this project (at minimum one label for each `A`, `B`, `C` and `D` required)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] If this PR alters any external APIs or interfaces used by Polkadot, the corresponding Polkadot PR is ready as well as the corresponding Cumulus PR (optional)