### PR TITLE
Remove readme from pallet-example-kitchensink's Cargo.toml

### DIFF
--- a/frame/examples/kitchensink/Cargo.toml
+++ b/frame/examples/kitchensink/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT-0"
 homepage = "https://substrate.io"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME example kitchensink pallet"
-readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
Fixes publish from failing.