### PR TITLE
Use relative docify paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,18 +1874,18 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "docify"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6491709f76fb7ceb951244daf624d480198b427556084391d6e3c33d3ae74b9"
+checksum = "029de870d175d11969524d91a3fb2cbf6d488b853bff99d41cf65e533ac7d9d2"
 dependencies = [
  "docify_macros",
 ]
 
 [[package]]
 name = "docify_macros"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc5338a9f72ce29a81377d9039798fcc926fb471b2004666caf48e446dffbbf"
+checksum = "cac43324656a1b05eb0186deb51f27d2d891c704c37f34de281ef6297ba193e5"
 dependencies = [
  "common-path",
  "derive-syn-parse",
@@ -1895,6 +1895,7 @@ dependencies = [
  "regex",
  "syn 2.0.18",
  "termcolor",
+ "toml 0.7.4",
  "walkdir",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,37 +1874,11 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "docify"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1b04e6ef3d21119d3eb7b032bca17f99fe041e9c072f30f32cc0e1a2b1f3c4"
-dependencies = [
- "docify_macros 0.1.16",
-]
-
-[[package]]
-name = "docify"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6491709f76fb7ceb951244daf624d480198b427556084391d6e3c33d3ae74b9"
 dependencies = [
- "docify_macros 0.2.0",
-]
-
-[[package]]
-name = "docify_macros"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5610df7f2acf89a1bb5d1a66ae56b1c7fcdcfe3948856fb3ace3f644d70eb7"
-dependencies = [
- "common-path",
- "derive-syn-parse",
- "lazy_static",
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.18",
- "termcolor",
- "walkdir",
+ "docify_macros",
 ]
 
 [[package]]
@@ -6274,7 +6248,7 @@ dependencies = [
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
 dependencies = [
- "docify 0.2.0",
+ "docify",
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-support",
@@ -6738,7 +6712,7 @@ dependencies = [
 name = "pallet-paged-list"
 version = "0.1.0"
 dependencies = [
- "docify 0.1.16",
+ "docify",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/frame/fast-unstake/Cargo.toml
+++ b/frame/fast-unstake/Cargo.toml
@@ -27,7 +27,7 @@ frame-election-provider-support = { default-features = false, path = "../electio
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, path = "../benchmarking" }
 
-docify = "0.2.0"
+docify = "0.2.1"
 
 [dev-dependencies]
 pallet-staking-reward-curve = { version = "4.0.0-dev", path = "../staking/reward-curve" }

--- a/frame/paged-list/Cargo.toml
+++ b/frame/paged-list/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive"] }
-docify = "0.2.0"
+docify = "0.2.1"
 scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, path = "../benchmarking" }

--- a/frame/paged-list/Cargo.toml
+++ b/frame/paged-list/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive"] }
-docify = "0.1.13"
+docify = "0.2.0"
 scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
 
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, path = "../benchmarking" }

--- a/frame/paged-list/src/lib.rs
+++ b/frame/paged-list/src/lib.rs
@@ -39,18 +39,18 @@
 //! ## Examples
 //!
 //! 1. **Appending** some data to the list can happen either by [`Pallet::append_one`]:
-#![doc = docify::embed!("frame/paged-list/src/tests.rs", append_one_works)]
+#![doc = docify::embed!("src/tests.rs", append_one_works)]
 //! 2. or by [`Pallet::append_many`]. This should always be preferred to repeated calls to
 //! [`Pallet::append_one`]:
-#![doc = docify::embed!("frame/paged-list/src/tests.rs", append_many_works)]
+#![doc = docify::embed!("src/tests.rs", append_many_works)]
 //! 3. If you want to append many values (ie. in a loop), then best use the [`Pallet::appender`]:
-#![doc = docify::embed!("frame/paged-list/src/tests.rs", appender_works)]
+#![doc = docify::embed!("src/tests.rs", appender_works)]
 //! 4. **Iterating** over the list can be done with [`Pallet::iter`]. It uses the standard
 //! `Iterator` trait:
-#![doc = docify::embed!("frame/paged-list/src/tests.rs", iter_works)]
+#![doc = docify::embed!("src/tests.rs", iter_works)]
 //! 5. **Draining** elements happens through the [`Pallet::drain`] iterator. Note that even
 //! *peeking* a value will already remove it.
-#![doc = docify::embed!("frame/paged-list/src/tests.rs", drain_works)]
+#![doc = docify::embed!("src/tests.rs", drain_works)]
 //!
 //! ## Pallet API
 //!


### PR DESCRIPTION
Bumping the docify version and using relative paths is needed for the monorepo to find the test files in the new workspace.
