### PR TITLE
Move block announce validation from `ChainSync` to `SyncingEngine`

### DIFF
--- a/client/network/common/src/sync.rs
+++ b/client/network/common/src/sync.rs
@@ -27,7 +27,7 @@ use futures::Stream;
 
 use libp2p_identity::PeerId;
 
-use message::{BlockAnnounce, BlockData, BlockRequest, BlockResponse};
+use message::{BlockData, BlockRequest, BlockResponse};
 use sc_consensus::{import_queue::RuntimeOrigin, IncomingBlock};
 use sp_consensus::BlockOrigin;
 use sp_runtime::{
@@ -155,38 +155,6 @@ pub enum OnStateData<Block: BlockT> {
 pub enum ImportResult<B: BlockT> {
 	BlockImport(BlockOrigin, Vec<IncomingBlock<B>>),
 	JustificationImport(RuntimeOrigin, B::Hash, NumberFor<B>, Justifications),
-}
-
-/// Value polled from `ChainSync`
-#[derive(Debug)]
-pub enum PollResult<B: BlockT> {
-	Import(ImportResult<B>),
-	Announce(PollBlockAnnounceValidation<B::Header>),
-}
-
-/// Result of [`ChainSync::poll_block_announce_validation`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PollBlockAnnounceValidation<H> {
-	/// The announcement failed at validation.
-	///
-	/// The peer reputation should be decreased.
-	Failure {
-		/// Who sent the processed block announcement?
-		who: PeerId,
-		/// Should the peer be disconnected?
-		disconnect: bool,
-	},
-	/// The announcement does not require further handling.
-	Nothing {
-		/// Who sent the processed block announcement?
-		who: PeerId,
-		/// Was this their new best block?
-		is_best: bool,
-		/// The announcement.
-		announce: BlockAnnounce<H>,
-	},
-	/// The block announcement should be skipped.
-	Skip,
 }
 
 /// Sync operation mode.
@@ -408,29 +376,6 @@ pub trait ChainSync<Block: BlockT>: Send {
 	/// Notify about finalization of the given block.
 	fn on_block_finalized(&mut self, hash: &Block::Hash, number: NumberFor<Block>);
 
-	/// Push a block announce validation.
-	///
-	/// It is required that [`ChainSync::poll_block_announce_validation`] is called
-	/// to check for finished block announce validations.
-	fn push_block_announce_validation(
-		&mut self,
-		who: PeerId,
-		hash: Block::Hash,
-		announce: BlockAnnounce<Block::Header>,
-		is_best: bool,
-	);
-
-	/// Poll block announce validation.
-	///
-	/// Block announce validations can be pushed by using
-	/// [`ChainSync::push_block_announce_validation`].
-	///
-	/// This should be polled until it returns [`Poll::Pending`].
-	fn poll_block_announce_validation(
-		&mut self,
-		cx: &mut std::task::Context<'_>,
-	) -> Poll<PollBlockAnnounceValidation<Block::Header>>;
-
 	/// Call when a peer has disconnected.
 	/// Canceled obsolete block request may result in some blocks being ready for
 	/// import, so this functions checks for such blocks and returns them.
@@ -451,10 +396,7 @@ pub trait ChainSync<Block: BlockT>: Send {
 	/// Internally calls [`ChainSync::poll_block_announce_validation()`] and
 	/// this function should be polled until it returns [`Poll::Pending`] to
 	/// consume all pending events.
-	fn poll(
-		&mut self,
-		cx: &mut std::task::Context,
-	) -> Poll<PollBlockAnnounceValidation<Block::Header>>;
+	fn poll(&mut self, cx: &mut std::task::Context) -> Poll<()>;
 
 	/// Send block request to peer
 	fn send_block_request(&mut self, who: PeerId, request: BlockRequest<Block>);

--- a/client/network/sync/src/engine.rs
+++ b/client/network/sync/src/engine.rs
@@ -618,23 +618,15 @@ where
 		peer.known_blocks.insert(hash);
 		peer.last_notification_received = Instant::now();
 
-		if peer.info.roles.is_full() {
-			let is_best = match announce.state.unwrap_or(BlockState::Best) {
-				BlockState::Best => true,
-				BlockState::Normal => false,
-			};
-
-			self.push_block_announce_validation_inner(who, hash, announce, is_best);
+		if !peer.info.roles.is_full() {
+			return
 		}
-	}
 
-	fn push_block_announce_validation_inner(
-		&mut self,
-		who: PeerId,
-		hash: B::Hash,
-		announce: BlockAnnounce<B::Header>,
-		is_best: bool,
-	) {
+		let is_best = match announce.state.unwrap_or(BlockState::Best) {
+			BlockState::Best => true,
+			BlockState::Normal => false,
+		};
+
 		let header = &announce.header;
 		let number = *header.number();
 		debug!(
@@ -731,6 +723,7 @@ where
 		);
 	}
 
+	/// Poll for finished block announce validations and notify `ChainSync`.
 	fn poll_block_announce_validation(
 		&mut self,
 		cx: &mut std::task::Context,

--- a/client/network/sync/src/mock.rs
+++ b/client/network/sync/src/mock.rs
@@ -22,7 +22,7 @@
 use futures::task::Poll;
 use libp2p::PeerId;
 use sc_network_common::sync::{
-	message::{BlockData, BlockRequest, BlockResponse},
+	message::{BlockAnnounce, BlockData, BlockRequest, BlockResponse},
 	BadPeer, ChainSync as ChainSyncT, Metrics, OnBlockData, OnBlockJustification,
 	OpaqueBlockResponse, PeerInfo, SyncStatus,
 };
@@ -71,6 +71,12 @@ mockall::mock! {
 			success: bool,
 		);
 		fn on_block_finalized(&mut self, hash: &Block::Hash, number: NumberFor<Block>);
+		fn on_validated_block_announce(
+			&mut self,
+			is_best: bool,
+			who: PeerId,
+			announce: &BlockAnnounce<Block::Header>,
+		);
 		fn peer_disconnected(&mut self, who: &PeerId);
 		fn metrics(&self) -> Metrics;
 		fn block_response_into_blocks(

--- a/client/network/sync/src/mock.rs
+++ b/client/network/sync/src/mock.rs
@@ -22,9 +22,9 @@
 use futures::task::Poll;
 use libp2p::PeerId;
 use sc_network_common::sync::{
-	message::{BlockAnnounce, BlockData, BlockRequest, BlockResponse},
+	message::{BlockData, BlockRequest, BlockResponse},
 	BadPeer, ChainSync as ChainSyncT, Metrics, OnBlockData, OnBlockJustification,
-	OpaqueBlockResponse, PeerInfo, PollBlockAnnounceValidation, SyncStatus,
+	OpaqueBlockResponse, PeerInfo, SyncStatus,
 };
 use sp_runtime::traits::{Block as BlockT, NumberFor};
 
@@ -71,17 +71,6 @@ mockall::mock! {
 			success: bool,
 		);
 		fn on_block_finalized(&mut self, hash: &Block::Hash, number: NumberFor<Block>);
-		fn push_block_announce_validation(
-			&mut self,
-			who: PeerId,
-			hash: Block::Hash,
-			announce: BlockAnnounce<Block::Header>,
-			is_best: bool,
-		);
-		fn poll_block_announce_validation<'a>(
-			&mut self,
-			cx: &mut std::task::Context<'a>,
-		) -> Poll<PollBlockAnnounceValidation<Block::Header>>;
 		fn peer_disconnected(&mut self, who: &PeerId);
 		fn metrics(&self) -> Metrics;
 		fn block_response_into_blocks(
@@ -92,7 +81,7 @@ mockall::mock! {
 		fn poll<'a>(
 			&mut self,
 			cx: &mut std::task::Context<'a>,
-		) -> Poll<PollBlockAnnounceValidation<Block::Header>>;
+		) -> Poll<()>;
 		fn send_block_request(
 			&mut self,
 			who: PeerId,


### PR DESCRIPTION
This PR is part of Sync 2.0 preparation work. Resolves https://github.com/paritytech/substrate/issues/14380.