### PR TITLE
add account lifecycle callbacks to pallet-assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4604,6 +4604,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "impl-trait-for-tuples",
  "pallet-balances",
  "parity-scale-codec",
  "sp-core",

--- a/frame/assets/Cargo.toml
+++ b/frame/assets/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
+impl-trait-for-tuples = "0.2.1"
 sp-std = { version = "3.0.0", default-features = false, path = "../../primitives/std" }
 # Needed for various traits. In our case, `OnFinalize`.
 sp-runtime = { version = "3.0.0", default-features = false, path = "../../primitives/runtime" }

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -211,6 +211,12 @@ pub mod pallet {
 
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
+
+		/// Lifecycle callback for when a new account is created.
+		type OnAccountCreated: OnAccountCreated<Self::AccountId, Self::AssetId>;
+
+		/// Lifecycle callback for when an account is reaped.
+		type OnAccountKilled: OnAccountKilled<Self::AccountId, Self::AssetId>;
 	}
 
 	#[pallet::storage]

--- a/frame/assets/src/tests.rs
+++ b/frame/assets/src/tests.rs
@@ -632,3 +632,22 @@ fn force_asset_status_should_work(){
 		assert_eq!(Assets::total_supply(0), 200);
 	});
 }
+
+#[test]
+fn account_lifecycle_callbacks_should_work() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Assets::force_create(Origin::root(), 0, 1, true, 1));
+
+		assert_eq!(NewAccount::get(), None);
+		assert_ok!(Assets::mint(Origin::signed(1), 0, 1, 100));
+		assert_eq!(NewAccount::get(), Some((0, 1)));
+		assert_ok!(Assets::mint(Origin::signed(1), 0, 2, 100));
+		assert_eq!(NewAccount::get(), Some((0, 2)));
+
+		assert_eq!(KilledAccount::get(), None);
+		assert_ok!(Assets::burn(Origin::signed(1), 0, 1, 100));
+		assert_eq!(KilledAccount::get(), Some((0, 1)));
+		assert_ok!(Assets::burn(Origin::signed(1), 0, 2, 100));
+		assert_eq!(KilledAccount::get(), Some((0, 2)));
+	});
+}

--- a/frame/assets/src/types.rs
+++ b/frame/assets/src/types.rs
@@ -185,3 +185,17 @@ impl From<TransferFlags> for DebitFlags {
 		}
 	}
 }
+
+/// Handler for when a new account for `asset` has been created.
+#[impl_trait_for_tuples::impl_for_tuples(30)]
+pub trait OnAccountCreated<AccountId, AssetId> {
+	/// A new account `who` has been registered.
+	fn on_new_account(asset: AssetId, who: &AccountId);
+}
+
+/// The account with the given id was reaped for `asset`.
+#[impl_trait_for_tuples::impl_for_tuples(30)]
+pub trait OnAccountKilled<AccountId, AssetId> {
+	/// The account with the given id was reaped.
+	fn on_killed_account(asset: AssetId, who: &AccountId);
+}


### PR DESCRIPTION
This PR introduces account lifecycle callbacks to pallet-assets.
This allows reacting to the combination of asset and account id individually as opposed to the general account lifecycle of `frame_system`.

This is an exploratory PR to solicit feedback. Happy to adjust, fix tests and write a companion if this can move forward.

### Motivation
We use orml-tokens mutation hooks to take actions on created and killed accounts, triggered here: 
https://github.com/open-web3-stack/open-runtime-module-library/blob/73b4ee04e402f240f270bfe83f59fc2837dbaf51/tokens/src/lib.rs#L791-L795)

in HydraDX:
https://github.com/galacticcouncil/HydraDX-node/blob/24823f0e91d2dbe2bb7743404d7763d9296d7412/pallets/transaction-multi-payment/src/lib.rs#L467-L477

In order to use pallet-assets we would need similar hooks there.

Polkadot companion: (*if applicable*)

Cumulus companion: (*if applicable*)

### Checklist

- [ ] My PR includes a detailed description as outlined in the "Description" section above
- [ ] My PR follows the [labeling requirements](https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc#merge-process) of this project (at minimum one label for each `A`, `B`, `C` and `D` required)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] If this PR alters any external APIs or interfaces used by Polkadot, the corresponding Polkadot PR is ready as well as the corresponding Cumulus PR (optional)

