### PR TITLE
allow slippage to be set when pay by swap

### DIFF
--- a/frame/transaction-payment/asset-conversion-tx-payment/src/lib.rs
+++ b/frame/transaction-payment/asset-conversion-tx-payment/src/lib.rs
@@ -330,7 +330,7 @@ where
 						len as u32, info, post_info, tip,
 					);
 
-					if let Some(PayByAsset { id, max_fee }) = asset_id {
+					if let Some(PayByAsset { id, .. }) = asset_id {
 						let (used_for_fee, received_exchanged, asset_consumed) = already_withdrawn;
 						let converted_fee = T::OnChargeAssetTransaction::correct_and_deposit_fee(
 							&who,
@@ -341,7 +341,6 @@ where
 							used_for_fee.into(),
 							received_exchanged.into(),
 							id.clone(),
-							max_fee,
 							asset_consumed.into(),
 						)?;
 

--- a/frame/transaction-payment/asset-conversion-tx-payment/src/lib.rs
+++ b/frame/transaction-payment/asset-conversion-tx-payment/src/lib.rs
@@ -148,6 +148,17 @@ pub mod pallet {
 	}
 }
 
+/// Holds parameters for if paying the transaction fee in the non-native asset.
+#[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
+#[scale_info(skip_type_params(T))]
+pub struct PayByAsset<T: Config> {
+	/// The asset id to pay the fee in rather than the native asset.
+	id: ChargeAssetIdOf<T>,
+	/// Effectively sets the max slippage that the user is willing to accept while allowing the
+	/// transaction to go ahead.
+	max_fee: Option<AssetBalanceOf<T>>,
+}
+
 /// Require payment for transaction inclusion and optionally include a tip to gain additional
 /// priority in the queue. Allows paying via both `Currency` as well as `fungibles::Balanced`.
 ///
@@ -159,7 +170,7 @@ pub mod pallet {
 pub struct ChargeAssetTxPayment<T: Config> {
 	#[codec(compact)]
 	tip: BalanceOf<T>,
-	asset_id: Option<ChargeAssetIdOf<T>>,
+	asset: Option<PayByAsset<T>>,
 }
 
 impl<T: Config> ChargeAssetTxPayment<T>
@@ -174,8 +185,8 @@ where
 	ChargeAssetIdOf<T>: Send + Sync,
 {
 	/// Utility constructor. Used only in client/factory code.
-	pub fn from(tip: BalanceOf<T>, asset_id: Option<ChargeAssetIdOf<T>>) -> Self {
-		Self { tip, asset_id }
+	pub fn from(tip: BalanceOf<T>, asset: Option<PayByAsset<T>>) -> Self {
+		Self { tip, asset }
 	}
 
 	/// Fee withdrawal logic that dispatches to either `OnChargeAssetTransaction` or
@@ -191,12 +202,13 @@ where
 		debug_assert!(self.tip <= fee, "tip should be included in the computed fee");
 		if fee.is_zero() {
 			Ok((fee, InitialPayment::Nothing))
-		} else if let Some(asset_id) = &self.asset_id {
+		} else if let Some(PayByAsset { id, max_fee, .. }) = &self.asset {
 			T::OnChargeAssetTransaction::withdraw_fee(
 				who,
 				call,
 				info,
-				asset_id.clone(),
+				id.clone(),
+				*max_fee,
 				fee.into(),
 				self.tip.into(),
 			)
@@ -223,7 +235,7 @@ where
 impl<T: Config> sp_std::fmt::Debug for ChargeAssetTxPayment<T> {
 	#[cfg(feature = "std")]
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
-		write!(f, "ChargeAssetTxPayment<{:?}, {:?}>", self.tip, self.asset_id.encode())
+		write!(f, "ChargeAssetTxPayment<{:?}, {:?}>", self.tip, self.asset.encode())
 	}
 	#[cfg(not(feature = "std"))]
 	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
@@ -256,7 +268,7 @@ where
 		// imbalance resulting from withdrawing the fee
 		InitialPayment<T>,
 		// asset_id for the transaction payment
-		Option<ChargeAssetIdOf<T>>,
+		Option<PayByAsset<T>>,
 	);
 
 	fn additional_signed(&self) -> sp_std::result::Result<(), TransactionValidityError> {
@@ -284,7 +296,7 @@ where
 		len: usize,
 	) -> Result<Self::Pre, TransactionValidityError> {
 		let (_fee, initial_payment) = self.withdraw_fee(who, call, info, len)?;
-		Ok((self.tip, who.clone(), initial_payment, self.asset_id))
+		Ok((self.tip, who.clone(), initial_payment, self.asset))
 	}
 
 	fn post_dispatch(
@@ -318,7 +330,7 @@ where
 						len as u32, info, post_info, tip,
 					);
 
-					if let Some(asset_id) = asset_id {
+					if let Some(PayByAsset { id, max_fee }) = asset_id {
 						let (used_for_fee, received_exchanged, asset_consumed) = already_withdrawn;
 						let converted_fee = T::OnChargeAssetTransaction::correct_and_deposit_fee(
 							&who,
@@ -328,7 +340,8 @@ where
 							tip.into(),
 							used_for_fee.into(),
 							received_exchanged.into(),
-							asset_id.clone(),
+							id.clone(),
+							max_fee,
 							asset_consumed.into(),
 						)?;
 
@@ -336,7 +349,7 @@ where
 							who,
 							actual_fee: converted_fee,
 							tip,
-							asset_id,
+							asset_id: id,
 						});
 					}
 				},

--- a/frame/transaction-payment/asset-conversion-tx-payment/src/payment.rs
+++ b/frame/transaction-payment/asset-conversion-tx-payment/src/payment.rs
@@ -177,7 +177,7 @@ where
 
 			let amount_out_min = if let Some(max_fee) = max_fee {
 				let worst_native_to_asset_rate = T::HigherPrecisionBalance::from(max_fee) /
-					T::HigherPrecisionBalance::from(fee_paid);
+					T::HigherPrecisionBalance::from(corrected_fee);
 				Some(T::HigherPrecisionBalance::from(swap_back) * worst_native_to_asset_rate)
 			} else {
 				None


### PR DESCRIPTION
Currently `None` is passed as the minimum swap return amounts when paying by swap. In a heavy MEV environment this could lead to people paying too much in fees. This PR surfaces the optional `max_fee` parameter so that wallets can (and ideally should) set this to a sensible value to ensure that there is a limit to how much a MEV bot could manipulate the fx rates and the transaction still succeed.