### PR TITLE
Dinonard/limited contracts migration

### DIFF
--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -363,17 +363,20 @@ pub mod pallet {
 				let mut consumed_weight = Weight::zero();
 
 				loop {
-					let (result, weight) = Migration::<T>::migrate(migration_weight_limit.saturating_sub(consumed_weight));
+					let (result, weight) = Migration::<T>::migrate(
+						migration_weight_limit.saturating_sub(consumed_weight),
+					);
 					consumed_weight.saturating_accrue(weight);
-	
+
 					match result {
-						// There is not enough weight to perform a migration, or make any progress, we
-						// just return the remaining weight.
-						NoMigrationPerformed | InProgress { steps_done: 0 } => return remaining_weight.saturating_sub(consumed_weight),
+						// There is not enough weight to perform a migration, or make any progress,
+						// we just return the remaining weight.
+						NoMigrationPerformed | InProgress { steps_done: 0 } =>
+							return remaining_weight.saturating_sub(consumed_weight),
 						// Migration is still in progress, we can start the next step.
 						InProgress { .. } => continue,
-						// Either no migration is in progress, or we are done with all migrations, we
-						// can do some more other work with the remaining weight.
+						// Either no migration is in progress, or we are done with all migrations,
+						// we can do some more other work with the remaining weight.
 						Completed | NoMigrationInProgress => break,
 					}
 				}

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -28,9 +28,9 @@ use crate::{
 	tests::test_utils::{get_contract, get_contract_checked},
 	wasm::{Determinism, ReturnCode as RuntimeReturnCode},
 	weights::WeightInfo,
-	BalanceOf, Code, CodeHash, CodeInfoOf, CollectEvents, Config, ContractInfo, ContractInfoOf,
-	DebugInfo, DefaultAddressGenerator, DeletionQueueCounter, Error, MigrationInProgress,
-	NoopMigration, Origin, Pallet, PristineCode, Schedule, AutoLimit,
+	AutoLimit, BalanceOf, Code, CodeHash, CodeInfoOf, CollectEvents, Config, ContractInfo,
+	ContractInfoOf, DebugInfo, DefaultAddressGenerator, DeletionQueueCounter, Error,
+	MigrationInProgress, NoopMigration, Origin, Pallet, PristineCode, Schedule,
 };
 use assert_matches::assert_matches;
 use codec::Encode;
@@ -657,8 +657,7 @@ fn auto_migration_control_works() {
 		assert_eq!(AutoLimit::<Test>::get(), Some(weight));
 
 		assert_noop!(
-			Contracts::control_auto_migration(
-				RuntimeOrigin::signed(ALICE), None),
+			Contracts::control_auto_migration(RuntimeOrigin::signed(ALICE), None),
 			sp_runtime::traits::BadOrigin,
 		);
 	})


### PR DESCRIPTION
Introduce a way to limit or disable automatic `pallet-contracts` migration.

Although migration code is well tested & benchmarked, it's safer to do migration via custom extrinsic calls instead of relying on the automated, unavoidable, `on_idle` hook calls.

This PR introduces the possibility to disable automatic migration, or to limit it to smaller weight.
