### PR TITLE
Expose a couple of APIs for benchmarking

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1888,8 +1888,8 @@ impl OnUnbalanced<Credit<AccountId, Balances>> for IntoAuthor {
 }
 
 parameter_types! {
-	pub storage CoreCount: CoreIndex = 20;
-	pub storage CoretimeRevenue: (BlockNumber, Balance) = Default::default();
+	pub storage CoreCount: Option<CoreIndex> = None;
+	pub storage CoretimeRevenue: Option<(BlockNumber, Balance)> = None;
 }
 
 pub struct CoretimeProvider;
@@ -1911,18 +1911,22 @@ impl CoretimeInterface for CoretimeProvider {
 	) {
 	}
 	fn check_notify_core_count() -> Option<u16> {
-		Some(CoreCount::get())
+		let count = CoreCount::get();
+		CoreCount::set(&None);
+		count
 	}
 	fn check_notify_revenue_info() -> Option<(Self::BlockNumber, Self::Balance)> {
-		Some(CoretimeRevenue::get())
+		let revenue = CoretimeRevenue::get();
+		CoretimeRevenue::set(&None);
+		revenue
 	}
 	#[cfg(feature = "runtime-benchmarks")]
 	fn ensure_notify_core_count(count: u16) {
-		CoreCount::set(&count);
+		CoreCount::set(&Some(count));
 	}
 	#[cfg(feature = "runtime-benchmarks")]
 	fn ensure_notify_revenue_info(when: Self::BlockNumber, revenue: Self::Balance) {
-		CoretimeRevenue::set(&(when, revenue));
+		CoretimeRevenue::set(&Some((when, revenue)));
 	}
 }
 

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1889,6 +1889,7 @@ impl OnUnbalanced<Credit<AccountId, Balances>> for IntoAuthor {
 
 parameter_types! {
 	pub storage CoreCount: CoreIndex = 20;
+	pub storage CoretimeRevenue: (BlockNumber, Balance) = Default::default();
 }
 
 pub struct CoretimeProvider;
@@ -1899,9 +1900,7 @@ impl CoretimeInterface for CoretimeProvider {
 	fn latest() -> Self::BlockNumber {
 		System::block_number()
 	}
-	fn request_core_count(count: CoreIndex) {
-		CoreCount::set(&count);
-	}
+	fn request_core_count(_count: CoreIndex) {}
 	fn request_revenue_info_at(_when: Self::BlockNumber) {}
 	fn credit_account(_who: Self::AccountId, _amount: Self::Balance) {}
 	fn assign_core(
@@ -1915,7 +1914,15 @@ impl CoretimeInterface for CoretimeProvider {
 		Some(CoreCount::get())
 	}
 	fn check_notify_revenue_info() -> Option<(Self::BlockNumber, Self::Balance)> {
-		Some((10u32.into(), 0u32.into()))
+		Some(CoretimeRevenue::get())
+	}
+	#[cfg(feature = "runtime-benchmarks")]
+	fn ensure_notify_core_count(count: u16) {
+		CoreCount::set(&count);
+	}
+	#[cfg(feature = "runtime-benchmarks")]
+	fn ensure_notify_revenue_info(when: Self::BlockNumber, revenue: Self::Balance) {
+		CoretimeRevenue::set(&(when, revenue));
 	}
 }
 

--- a/frame/broker/src/benchmarking.rs
+++ b/frame/broker/src/benchmarking.rs
@@ -703,23 +703,7 @@ mod benches {
 		);
 		T::Currency::set_balance(&Broker::<T>::account_id(), T::Currency::minimum_balance());
 
-		let region = Broker::<T>::do_purchase(caller.clone(), 10u32.into())
-			.map_err(|_| BenchmarkError::Weightless)?;
-
-		let recipient: T::AccountId = account("recipient", 0, SEED);
-
-		Broker::<T>::do_pool(region, None, recipient, Final)
-			.map_err(|_| BenchmarkError::Weightless)?;
-
-		let beneficiary: RelayAccountIdOf<T> = account("beneficiary", 0, SEED);
-		Broker::<T>::do_purchase_credit(caller.clone(), 20u32.into(), beneficiary.clone())
-			.map_err(|_| BenchmarkError::Weightless)?;
-
-		advance_to::<T>(8);
-
 		<T::Coretime as CoretimeInterface>::ensure_notify_revenue_info(10u32.into(), 10u32.into());
-
-		advance_to::<T>(11);
 
 		InstaPoolHistory::<T>::insert(
 			4u32,

--- a/frame/broker/src/coretime_interface.rs
+++ b/frame/broker/src/coretime_interface.rs
@@ -36,7 +36,7 @@ pub trait CoretimeInterface {
 	type AccountId: Parameter;
 
 	/// A (Relay-chain-side) balance.
-	type Balance;
+	type Balance: AtLeast32BitUnsigned;
 
 	/// A (Relay-chain-side) block number.
 	type BlockNumber: AtLeast32BitUnsigned
@@ -105,6 +105,12 @@ pub trait CoretimeInterface {
 	/// notified of revenue information. The Relay-chain must be configured to ensure that only a
 	/// single revenue information destination exists.
 	fn check_notify_revenue_info() -> Option<(Self::BlockNumber, Self::Balance)>;
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn ensure_notify_core_count(count: u16);
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn ensure_notify_revenue_info(when: Self::BlockNumber, revenue: Self::Balance);
 }
 
 impl CoretimeInterface for () {
@@ -130,4 +136,8 @@ impl CoretimeInterface for () {
 	fn check_notify_revenue_info() -> Option<(Self::BlockNumber, Self::Balance)> {
 		None
 	}
+	#[cfg(feature = "runtime-benchmarks")]
+	fn ensure_notify_core_count(_count: u16) {}
+	#[cfg(feature = "runtime-benchmarks")]
+	fn ensure_notify_revenue_info(_when: Self::BlockNumber, _revenue: Self::Balance) {}
 }

--- a/frame/broker/src/coretime_interface.rs
+++ b/frame/broker/src/coretime_interface.rs
@@ -106,9 +106,15 @@ pub trait CoretimeInterface {
 	/// single revenue information destination exists.
 	fn check_notify_revenue_info() -> Option<(Self::BlockNumber, Self::Balance)>;
 
+	/// Ensure that core count is updated to the provided value.
+	///
+	/// This is only used for benchmarking.
 	#[cfg(feature = "runtime-benchmarks")]
 	fn ensure_notify_core_count(count: u16);
 
+	/// Ensure that revenue information is updated to the provided value.
+	///
+	/// This is only used for benchmarking.
 	#[cfg(feature = "runtime-benchmarks")]
 	fn ensure_notify_revenue_info(when: Self::BlockNumber, revenue: Self::Balance);
 }

--- a/frame/broker/src/mock.rs
+++ b/frame/broker/src/mock.rs
@@ -90,7 +90,7 @@ parameter_types! {
 	pub static CoretimeSpending: Vec<(u32, u64)> = Default::default();
 	pub static CoretimeWorkplan: BTreeMap<(u32, CoreIndex), Vec<(CoreAssignment, PartsOf57600)>> = Default::default();
 	pub static CoretimeUsage: BTreeMap<CoreIndex, Vec<(CoreAssignment, PartsOf57600)>> = Default::default();
-	pub static CoretimeInPool: CoreMaskBitCount = Default::default();
+	pub static CoretimeInPool: CoreMaskBitCount = 0;
 	pub static NotifyCoreCount: Vec<u16> = Default::default();
 	pub static NotifyRevenueInfo: Vec<(u32, u64)> = Default::default();
 }

--- a/frame/broker/src/mock.rs
+++ b/frame/broker/src/mock.rs
@@ -91,7 +91,6 @@ parameter_types! {
 	pub static CoretimeWorkplan: BTreeMap<(u32, CoreIndex), Vec<(CoreAssignment, PartsOf57600)>> = Default::default();
 	pub static CoretimeUsage: BTreeMap<CoreIndex, Vec<(CoreAssignment, PartsOf57600)>> = Default::default();
 	pub static CoretimeInPool: CoreMaskBitCount = Default::default();
-	pub static CoretimeOverriddenRevenue: (u32, u64) = Default::default();
 	pub static NotifyCoreCount: Vec<u16> = Default::default();
 	pub static NotifyRevenueInfo: Vec<(u32, u64)> = Default::default();
 }
@@ -110,12 +109,6 @@ impl CoretimeInterface for TestCoretimeProvider {
 	fn request_revenue_info_at(when: Self::BlockNumber) {
 		if when > Self::latest() {
 			panic!("Asking for revenue info in the future {:?} {:?}", when, Self::latest());
-		}
-
-		let (block_number, revenue) = CoretimeOverriddenRevenue::get();
-		if when == block_number {
-			NotifyRevenueInfo::mutate(|s| s.insert(0, (when, revenue)));
-			return
 		}
 
 		let mut total = 0;
@@ -156,7 +149,7 @@ impl CoretimeInterface for TestCoretimeProvider {
 	}
 	#[cfg(feature = "runtime-benchmarks")]
 	fn ensure_notify_revenue_info(when: Self::BlockNumber, revenue: Self::Balance) {
-		CoretimeOverriddenRevenue::set((when, revenue));
+		NotifyRevenueInfo::mutate(|s| s.push((when, revenue)));
 	}
 }
 impl TestCoretimeProvider {


### PR DESCRIPTION
This PR is on top of https://github.com/paritytech/substrate/pull/14568 and adds a couple of APIs in `CoretimeInterface` only for benchmarking.