### PR TITLE
ci: remove `--locked` from `check-runtime-migration` script

### DIFF
--- a/scripts/ci/gitlab/pipeline/build.yml
+++ b/scripts/ci/gitlab/pipeline/build.yml
@@ -36,8 +36,8 @@
       substrate: polkadot-v*
       polkadot: release-v*
     COMPANION_CHECK_COMMAND: >
-      time cargo build --release --locked -p "$NETWORK"-runtime &&
-      time cargo run --locked --release --features try-runtime try-runtime \
+      time cargo build --release -p "$NETWORK"-runtime &&
+      time cargo run --release --features try-runtime try-runtime \
           --runtime ./target/release/wbuild/"$NETWORK"-runtime/target/wasm32-unknown-unknown/release/"$NETWORK"_runtime.wasm \
           --chain=${NETWORK}-dev \
           on-runtime-upgrade --checks=pre-and-post live --uri wss://${NETWORK}-try-runtime-node.parity-chains.parity.io:443


### PR DESCRIPTION
Closes https://github.com/paritytech/pipeline-scripts/issues/104