### PR TITLE
docs: example of using `cargo run` with features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ node-cli = { path = "bin/node/cli" }
 # Just uses the `node-cli` main binary. `node-cli` itself also again exposes the node as
 # `substrate-node`.
 
-# `cargo run` on its own doesn't support features. To use features you must explicitly specify
+# `cargo run` on its own doesn't support features. To use features you must explicitly use
 # `node-cli` in your command, e.g. `cargo run -p node-cli --features try-runtime ...`.
 [[bin]]
 name = "substrate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,10 @@ node-cli = { path = "bin/node/cli" }
 # Exists here to be backwards compatible and to support `cargo run` in the workspace.
 #
 # Just uses the `node-cli` main binary. `node-cli` itself also again exposes the node as
-# `substrate-node`. Using `node-cli` directly you can also enable features.
+# `substrate-node`.
+
+# `cargo run` on its own doesn't support features. To use features you must explicitly specify
+# `node-cli` in your command, e.g. `cargo run -p node-cli --features try-runtime ...`.
 [[bin]]
 name = "substrate"
 path = "bin/node/cli/bin/main.rs"


### PR DESCRIPTION
Since https://github.com/paritytech/substrate/pull/14581 `cargo run` doesn't work with features anymore, issue surfaced when @Ank4n was working on https://github.com/paritytech/polkadot-sdk/issues/158.

Insubstantial docs change adding an example of how to use features.