### PR TITLE
fixes #13279 renaming ensure_none to ensure_unsigned

### DIFF
--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -445,7 +445,7 @@ pub mod pallet {
 			equivocation_proof: Box<EquivocationProof<HeaderFor<T>>>,
 			key_owner_proof: T::KeyOwnerProof,
 		) -> DispatchResultWithPostInfo {
-			ensure_none(origin)?;
+			ensure_unsigned(origin)?;
 			T::EquivocationReportSystem::process_evidence(
 				None,
 				(*equivocation_proof, key_owner_proof),

--- a/frame/beefy/src/lib.rs
+++ b/frame/beefy/src/lib.rs
@@ -28,7 +28,7 @@ use frame_support::{
 	BoundedSlice, BoundedVec, Parameter,
 };
 use frame_system::{
-	ensure_none, ensure_signed,
+	ensure_unsigned, ensure_signed,
 	pallet_prelude::{BlockNumberFor, OriginFor},
 };
 use sp_runtime::{
@@ -257,7 +257,7 @@ pub mod pallet {
 			>,
 			key_owner_proof: T::KeyOwnerProof,
 		) -> DispatchResultWithPostInfo {
-			ensure_none(origin)?;
+			ensure_unsigned(origin)?;
 
 			T::EquivocationReportSystem::process_evidence(
 				None,

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -56,7 +56,7 @@ mod pallet_test {
 		}
 
 		pub fn dummy(origin: OriginFor<T>, _n: u32) -> DispatchResult {
-			let _sender = ensure_none(origin)?;
+			let _sender = ensure_unsigned(origin)?;
 			Ok(())
 		}
 

--- a/frame/benchmarking/src/tests_instance.rs
+++ b/frame/benchmarking/src/tests_instance.rs
@@ -70,7 +70,7 @@ mod pallet_test {
 		#[pallet::call_index(1)]
 		#[pallet::weight({0})]
 		pub fn dummy(origin: OriginFor<T>, _n: u32) -> DispatchResult {
-			let _sender = ensure_none(origin)?;
+			let _sender = ensure_unsigned(origin)?;
 			Ok(())
 		}
 	}

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -241,7 +241,7 @@ use frame_support::{
 	weights::Weight,
 	DefaultNoBound, EqNoBound, PartialEqNoBound,
 };
-use frame_system::{ensure_none, offchain::SendTransactionTypes, pallet_prelude::BlockNumberFor};
+use frame_system::{ensure_unsigned, offchain::SendTransactionTypes, pallet_prelude::BlockNumberFor};
 use scale_info::TypeInfo;
 use sp_arithmetic::{
 	traits::{CheckedAdd, Zero},
@@ -922,7 +922,7 @@ pub mod pallet {
 			raw_solution: Box<RawSolution<SolutionOf<T::MinerConfig>>>,
 			witness: SolutionOrSnapshotSize,
 		) -> DispatchResult {
-			ensure_none(origin)?;
+			ensure_unsigned(origin)?;
 			let error_message = "Invalid unsigned submission must produce invalid block and \
 				 deprive validator from their authoring reward.";
 

--- a/frame/examples/basic/README.md
+++ b/frame/examples/basic/README.md
@@ -99,7 +99,7 @@ Copy and paste this template from frame/examples/basic/src/lib.rs into file
 
 // What origins are used and supported in this pallet (root, signed, none)
 // i.e. root when <code>\`ensure_root\`</code> used
-// i.e. none when <code>\`ensure_none\`</code> used
+// i.e. none when <code>\`ensure_unsigned\`</code> used
 // i.e. signed when <code>\`ensure_signed\`</code> used
 
 <code>\`inherent\`</code> <INSERT_DESCRIPTION>

--- a/frame/examples/basic/src/lib.rs
+++ b/frame/examples/basic/src/lib.rs
@@ -126,7 +126,7 @@
 //!
 //! // What origins are used and supported in this pallet (root, signed, none)
 //! // i.e. root when <code>\`ensure_root\`</code> used
-//! // i.e. none when <code>\`ensure_none\`</code> used
+//! // i.e. none when <code>\`ensure_unsigned\`</code> used
 //! // i.e. signed when <code>\`ensure_signed\`</code> used
 //!
 //! <code>\`inherent\`</code> <INSERT_DESCRIPTION>
@@ -440,7 +440,7 @@ pub mod pallet {
 	// to the above bullets: `::Signed(AccountId)`, `::Root` and `::None`. You should always match
 	// against them as the first thing you do in your function. There are three convenience calls
 	// in system that do the matching for you and return a convenient result: `ensure_signed`,
-	// `ensure_root` and `ensure_none`.
+	// `ensure_root` and `ensure_unsigned`.
 	#[pallet::call(weight(<T as Config>::WeightInfo))]
 	impl<T: Config> Pallet<T> {
 		/// This is your public interface. Be extremely careful.

--- a/frame/examples/offchain-worker/src/lib.rs
+++ b/frame/examples/offchain-worker/src/lib.rs
@@ -263,7 +263,7 @@ pub mod pallet {
 			price: u32,
 		) -> DispatchResultWithPostInfo {
 			// This ensures that the function can only be called via unsigned transaction.
-			ensure_none(origin)?;
+			ensure_unsigned(origin)?;
 			// Add the price to the on-chain list, but mark it as coming from an empty address.
 			Self::add_price(None, price);
 			// now increment the block number at which we expect next unsigned transaction.
@@ -280,7 +280,7 @@ pub mod pallet {
 			_signature: T::Signature,
 		) -> DispatchResultWithPostInfo {
 			// This ensures that the function can only be called via unsigned transaction.
-			ensure_none(origin)?;
+			ensure_unsigned(origin)?;
 			// Add the price to the on-chain list, but mark it as coming from an empty address.
 			Self::add_price(None, price_payload.price);
 			// now increment the block number at which we expect next unsigned transaction.

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -770,7 +770,7 @@ mod tests {
 			}
 
 			pub fn some_unsigned_message(origin: OriginFor<T>) -> DispatchResult {
-				frame_system::ensure_none(origin)?;
+				frame_system::ensure_unsigned(origin)?;
 				Ok(())
 			}
 
@@ -786,7 +786,7 @@ mod tests {
 
 			#[pallet::weight((0, DispatchClass::Mandatory))]
 			pub fn inherent_call(origin: OriginFor<T>) -> DispatchResult {
-				frame_system::ensure_none(origin)?;
+				frame_system::ensure_unsigned(origin)?;
 				Ok(())
 			}
 

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -231,7 +231,7 @@ pub mod pallet {
 			equivocation_proof: Box<EquivocationProof<T::Hash, BlockNumberFor<T>>>,
 			key_owner_proof: T::KeyOwnerProof,
 		) -> DispatchResultWithPostInfo {
-			ensure_none(origin)?;
+			ensure_unsigned(origin)?;
 
 			T::EquivocationReportSystem::process_evidence(
 				None,

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -398,7 +398,7 @@ pub mod pallet {
 			// we can skip doing it here again.
 			_signature: <T::AuthorityId as RuntimeAppPublic>::Signature,
 		) -> DispatchResult {
-			ensure_none(origin)?;
+			ensure_unsigned(origin)?;
 
 			let current_session = T::ValidatorSet::session_index();
 			let exists =

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -993,7 +993,19 @@ where
 }
 
 /// Ensure that the origin `o` represents an unsigned extrinsic. Returns `Ok` or an `Err` otherwise.
+#[deprecated(note = "Renamed to 'ensure_unsigned' to reduce ambiguity")]
 pub fn ensure_none<OuterOrigin, AccountId>(o: OuterOrigin) -> Result<(), BadOrigin>
+where
+	OuterOrigin: Into<Result<RawOrigin<AccountId>, OuterOrigin>>,
+{
+	match o.into() {
+		Ok(RawOrigin::None) => Ok(()),
+		_ => Err(BadOrigin),
+	}
+}
+
+/// Ensure that the origin `o` represents an unsigned extrinsic. Returns `Ok` or an `Err` otherwise.
+pub fn ensure_unsigned<OuterOrigin, AccountId>(o: OuterOrigin) -> Result<(), BadOrigin>
 where
 	OuterOrigin: Into<Result<RawOrigin<AccountId>, OuterOrigin>>,
 {
@@ -1785,7 +1797,7 @@ impl<T: Config> Lookup for ChainContext<T> {
 
 /// Prelude to be used alongside pallet macro, for ease of use.
 pub mod pallet_prelude {
-	pub use crate::{ensure_none, ensure_root, ensure_signed, ensure_signed_or_root};
+	pub use crate::{ensure_none, ensure_root, ensure_signed, ensure_signed_or_root, ensure_unsigned};
 
 	/// Type alias for the `Origin` associated type of system config.
 	pub type OriginFor<T> = <T as crate::Config>::RuntimeOrigin;

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -200,7 +200,7 @@ pub mod pallet {
 			DispatchClass::Mandatory
 		))]
 		pub fn set(origin: OriginFor<T>, #[pallet::compact] now: T::Moment) -> DispatchResult {
-			ensure_none(origin)?;
+			ensure_unsigned(origin)?;
 			assert!(!DidUpdate::<T>::exists(), "Timestamp must be updated only once in the block");
 			let prev = Self::now();
 			assert!(

--- a/frame/transaction-storage/src/lib.rs
+++ b/frame/transaction-storage/src/lib.rs
@@ -284,7 +284,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			proof: TransactionStorageProof,
 		) -> DispatchResultWithPostInfo {
-			ensure_none(origin)?;
+			ensure_unsigned(origin)?;
 			ensure!(!ProofChecked::<T>::get(), Error::<T>::DoubleCheck);
 			let number = <frame_system::Pallet<T>>::block_number();
 			let period = <StoragePeriod<T>>::get();

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -203,7 +203,7 @@ pub mod pallet {
 			calls: Vec<<T as Config>::RuntimeCall>,
 		) -> DispatchResultWithPostInfo {
 			// Do not allow the `None` origin.
-			if ensure_none(origin.clone()).is_ok() {
+			if ensure_unsigned(origin.clone()).is_ok() {
 				return Err(BadOrigin.into())
 			}
 
@@ -325,7 +325,7 @@ pub mod pallet {
 			calls: Vec<<T as Config>::RuntimeCall>,
 		) -> DispatchResultWithPostInfo {
 			// Do not allow the `None` origin.
-			if ensure_none(origin.clone()).is_ok() {
+			if ensure_unsigned(origin.clone()).is_ok() {
 				return Err(BadOrigin.into())
 			}
 
@@ -434,7 +434,7 @@ pub mod pallet {
 			calls: Vec<<T as Config>::RuntimeCall>,
 		) -> DispatchResultWithPostInfo {
 			// Do not allow the `None` origin.
-			if ensure_none(origin.clone()).is_ok() {
+			if ensure_unsigned(origin.clone()).is_ok() {
 				return Err(BadOrigin.into())
 			}
 


### PR DESCRIPTION
# Description

This fixes paritytech/polkadot-sdk#220 by renaming `ensure_none` to `ensure_unsigned` to avoid confusions.

In order to avoid breaking APIs, I kept the previous function only marking it as `deprecated` & appending new function export (instead of replacing by the previous one).

As this is my first commit to this repo, I definitely appreciate any help or advice & ready to reflect on code ASAP.