### PR TITLE
Provide helpful message when incorrectly forcing balance to below ED

### DIFF
--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -730,6 +730,12 @@ pub mod pallet {
 			let existential_deposit = Self::ed();
 
 			let wipeout = new_free < existential_deposit;
+			debug_assert!(
+				!wipeout || <T::Balance as Zero>::is_zero(&new_free),
+				"Attempt to force balance to be {:?} but this is less than ED {:?}",
+				new_free,
+				existential_deposit
+			);
 			let new_free = if wipeout { Zero::zero() } else { new_free };
 
 			// First we try to modify the account's balance to the forced balance.

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -730,12 +730,15 @@ pub mod pallet {
 			let existential_deposit = Self::ed();
 
 			let wipeout = new_free < existential_deposit;
-			debug_assert!(
-				!wipeout || new_free.is_zero(),
-				"Attempt to force balance to be {:?} but this is less than ED {:?}",
-				new_free,
-				existential_deposit
-			);
+			#[cfg(debug_assertions)]
+			if wipeout && !new_free.is_zero() {
+				log::error!(
+					target: LOG_TARGET,
+					"Attempt to force balance to be {:?} but this is less than ED {:?}",
+					new_free,
+					existential_deposit
+				);
+			}
 			let new_free = if wipeout { Zero::zero() } else { new_free };
 
 			// First we try to modify the account's balance to the forced balance.

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -731,7 +731,7 @@ pub mod pallet {
 
 			let wipeout = new_free < existential_deposit;
 			debug_assert!(
-				!wipeout || <T::Balance as Zero>::is_zero(&new_free),
+				!wipeout || new_free.is_zero(),
 				"Attempt to force balance to be {:?} but this is less than ED {:?}",
 				new_free,
 				existential_deposit


### PR DESCRIPTION
Had to debug through some code to find out what was going wrong. This will make it obvious for the next person writing a new test and wondering why setting the balance doesn't work.

I've run all the tests in debug mode to make sure they currently all pass:

```
cargo nextest run --workspace --locked --verbose --features runtime-benchmarks,try-runtime,experimental
...
Summary [ 702.876s] 5452 tests run: 5452 passed (97 slow), 25 skipped
```