### PR TITLE
feature flag to disable consequential Gov V1 hooks

### DIFF
--- a/frame/democracy/Cargo.toml
+++ b/frame/democracy/Cargo.toml
@@ -66,3 +66,6 @@ try-runtime = [
 	"pallet-scheduler/try-runtime",
 	"sp-runtime/try-runtime"
 ]
+# Disable hooks that would be automatically called by the runtime.
+# Useful for migrating from Gov V1 to V2.
+disable-hooks = []

--- a/frame/elections-phragmen/Cargo.toml
+++ b/frame/elections-phragmen/Cargo.toml
@@ -52,6 +52,9 @@ std = [
 	"sp-staking/std",
 	"sp-tracing/std"
 ]
+# Disable hooks that would be automatically called by the runtime.
+# Useful for migrating from Gov V1 to V2.
+disable-hooks = []
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -286,6 +286,7 @@ pub mod pallet {
 		/// What to do at the end of each block.
 		///
 		/// Checks if an election needs to happen or not.
+		#[cfg(not(feature = "disable-hooks"))]
 		fn on_initialize(n: BlockNumberFor<T>) -> Weight {
 			let term_duration = T::TermDuration::get();
 			if !term_duration.is_zero() && (n % term_duration).is_zero() {
@@ -295,6 +296,7 @@ pub mod pallet {
 			}
 		}
 
+		#[cfg(not(feature = "disable-hooks"))]
 		fn integrity_test() {
 			let block_weight = T::BlockWeights::get().max_block;
 			// mind the order.


### PR DESCRIPTION
https://github.com/paritytech/polkadot/pull/7314 requires us to temporarily restore Gov V1 pallets to the runtime.

We need the pallets to be entirely benign. 

We can disable `Calls` using `exclude_parts {Call}`, but still need to prevent hooks from being called.

It was agreed during the last FRAME team call to add a feature flag which would disable hooks we don't want to run. There may be better approaches to disabling hooks (such as creating a new `part` we can use in `exclude_parts`, but that would likely take a long time to implement and unlocking the Gov V1 funds is time sensitive.