### PR TITLE
Added Asset Conversion swap*_credit functions

### DIFF
--- a/frame/asset-conversion/src/lib.rs
+++ b/frame/asset-conversion/src/lib.rs
@@ -762,11 +762,12 @@ pub mod pallet {
 			path: BoundedVec<T::MultiAssetId, T::MaxSwapPathLength>,
 			amount_out: T::AssetBalance,
 			credit_in: Credit<T::AccountId, T::AssetBalance>,
-		) -> Result<CreditPair<T::AccountId, T::AssetBalance>, DispatchError>
+		) -> Result<
+			(Credit<T::AccountId, T::AssetBalance>, Credit<T::AccountId, T::AssetBalance>),
+			DispatchError,
+		>
 		where
 			T::AssetBalance: Balanced<T::AccountId>,
-			(T::MultiAssetId, T::AssetBalance): Into<Debt<T::AccountId, T::AssetBalance>>
-				+ Into<Credit<T::AccountId, T::AssetBalance>>,
 		{
 			ensure!(amount_out > Zero::zero(), Error::<T>::ZeroAmount);
 			ensure!(credit_in.peek() > Zero::zero(), Error::<T>::ZeroAmount);
@@ -777,44 +778,11 @@ pub mod pallet {
 			let amount_in =
 				*amounts.first().defensive_ok_or("get_amounts_in() returned an empty result")?;
 
-			ensure!(amount_in <= credit_in.peek(), Error::<T>::ProvidedMaximumNotSufficientForSwap);
-
-			let out_credit = Self::do_swap_credit(&amounts, path)?;
-
-			let same_or_other = credit_in
-				.offset((path[0].clone(), amount_in).into())
-				.map_err(|_| Error::<T>::AssetCreditMismatch)?;
-
-			let in_leftover = match same_or_other {
-				SameOrOther::Same(credit) => credit,
-				_ => unreachable!("credit_in.peek() <= amount_in"),
-			};
-
-			Ok(CreditPair { in_leftover, out_credit })
-		}
-
-		pub fn do_swap_tokens_for_exact_tokens_credit2(
-			path: BoundedVec<T::MultiAssetId, T::MaxSwapPathLength>,
-			amount_out: T::AssetBalance,
-			credit_in: Credit<T::AccountId, T::AssetBalance>,
-		) -> Result<
-			(Credit<T::AccountId, T::AssetBalance>, Credit<T::AccountId, T::AssetBalance>),
-			DispatchError,
-		> {
-			ensure!(amount_out > Zero::zero(), Error::<T>::ZeroAmount);
-			ensure!(credit_in.peek() > Zero::zero(), Error::<T>::ZeroAmount);
-
-			Self::validate_swap_path(&path)?;
-
-			let amounts = Self::get_amounts_in(&amount_out, &path)?;
-			let amount_in =
-				*amounts.first().defensive_ok_or("get_amounts_in() returned an empty result")?;
-
-			ensure!(amount_in <= credit_in.peek(), Error::<T>::ProvidedMaximumNotSufficientForSwap);
+			ensure!(credit_in.peek() >= amount_in, Error::<T>::ProvidedMaximumNotSufficientForSwap);
 
 			let (credit_in, credit_change) = credit_in.split(amount_in);
 
-			let out_credit = Self::do_swap_credit2(credit_in, &amounts, path)?;
+			let out_credit = Self::do_swap_credit(credit_in, &amounts, path)?;
 
 			Ok((credit_change, out_credit))
 		}
@@ -896,56 +864,78 @@ pub mod pallet {
 			result
 		}
 
-		/// Credit an `amount` of `asset_id` in `to` account.
-		fn credit_resolve(
-			asset_id: T::MultiAssetId,
-			to: &T::AccountId,
-			amount: T::AssetBalance,
-		) -> Result<(), DispatchError>
-		where
-			T::AssetBalance: Balanced<T::AccountId>,
-			(T::MultiAssetId, T::AssetBalance): Into<Credit<T::AccountId, T::AssetBalance>>,
-		{
-			let credit: Credit<T::AccountId, T::AssetBalance> = (asset_id, amount).into();
+		// /// Credit an `amount` of `asset_id` in `to` account.
+		// fn credit_resolve(
+		// 	asset_id: T::MultiAssetId,
+		// 	to: &T::AccountId,
+		// 	amount: T::AssetBalance,
+		// ) -> Result<(), DispatchError>
+		// where
+		// 	T::AssetBalance: Balanced<T::AccountId>,
+		// 	(T::MultiAssetId, T::AssetBalance): Into<Credit<T::AccountId, T::AssetBalance>>,
+		// {
+		// 	let credit: Credit<T::AccountId, T::AssetBalance> = (asset_id, amount).into();
+		//
+		// 	// Resolve is swallowing the inner Self::deposit DispatchError..
+		// 	T::AssetBalance::resolve(&to, credit).map_err(|_| Error::<T>::Overflow)?;
+		//
+		// 	Ok(())
+		// }
 
-			// Resolve is swallowing the inner Self::deposit DispatchError..
-			T::AssetBalance::resolve(&to, credit).map_err(|_| Error::<T>::Overflow)?;
-
-			Ok(())
-		}
-
-		/// Remove an `amount` of `asset_id` `from` account and return it as a credit imbalance.
-		fn credit_settle(
-			asset_id: T::MultiAssetId,
-			from: &T::AccountId,
-			amount: T::AssetBalance,
-		) -> Result<Credit<T::AccountId, T::AssetBalance>, DispatchError>
-		where
-			T::AssetBalance: Balanced<T::AccountId>,
-			(T::MultiAssetId, T::AssetBalance): Into<Debt<T::AccountId, T::AssetBalance>>,
-		{
-			let debt: Debt<T::AccountId, T::AssetBalance> = (asset_id, amount).into();
-
-			// Settle is swallowing the inner Self::deposit DispatchError..
-			Ok(T::AssetBalance::settle(&from, debt, Preserve).map_err(|_| Error::<T>::Overflow)?)
-		}
+		// /// Remove an `amount` of `asset_id` `from` account and return it as a credit imbalance.
+		// fn credit_settle(
+		// 	asset_id: T::MultiAssetId,
+		// 	from: &T::AccountId,
+		// 	amount: T::AssetBalance,
+		// ) -> Result<Credit<T::AccountId, T::AssetBalance>, DispatchError>
+		// where
+		// 	T::AssetBalance: Balanced<T::AccountId>,
+		// 	(T::MultiAssetId, T::AssetBalance): Into<Debt<T::AccountId, T::AssetBalance>>,
+		// {
+		// 	let debt: Debt<T::AccountId, T::AssetBalance> = (asset_id, amount).into();
+		//
+		// 	// Settle is swallowing the inner Self::deposit DispatchError..
+		// 	Ok(T::AssetBalance::settle(&from, debt, Preserve).map_err(|_| Error::<T>::Overflow)?)
+		// }
 
 		/// TODO
 		fn credit_resolve(
 			asset_id: T::MultiAssetId,
 			to: &T::AccountId,
 			credit: Credit<T::AccountId, T::AssetBalance>,
-		) -> Result<(), DispatchError> {
+		) -> Result<(), DispatchError>
+		where
+			T::AssetBalance: Balanced<T::AccountId>,
+			// T::AssetBalance: From<Inspect<T::AccountId>::Balance>
+		{
 			// TODO similar to Self::transfer, use MultiAssetIdConverter to determine whether to use
 			// T::Assets or T:Currency
-			Ok(())
+
+			let result = match T::MultiAssetIdConverter::try_convert(&asset_id) {
+				MultiAssetIdConversionResult::Converted(asset_id) =>
+					T::AssetBalance::resolve(&to, credit).map_err(|_| Error::<T>::Overflow)?,
+				MultiAssetIdConversionResult::Native => {
+					T::Currency::mint_into(
+						to,
+						Self::convert_asset_balance_to_native_balance(credit.peek())?,
+					)?;
+					Ok(())
+				},
+				MultiAssetIdConversionResult::Unsupported(_) =>
+					Err(Error::<T>::UnsupportedAsset.into()),
+			};
+
+			Ok(result)
 		}
 
 		fn withdraw(
 			asset_id: T::MultiAssetId,
 			from: &T::AccountId,
 			amount: T::AssetBalance,
-		) -> Result<Credit<T::AccountId, T::AssetBalance>, DispatchError> {
+		) -> Result<Credit<T::AccountId, T::AssetBalance>, DispatchError>
+		where
+			T::AssetBalance: Balanced<T::AccountId>,
+		{
 			// TODO similar to Self::transfer, use MultiAssetIdConverter to determine whether to use
 			// T::Assets or T:Currency
 		}
@@ -1034,62 +1024,65 @@ pub mod pallet {
 			Ok(())
 		}
 
+		// pub(crate) fn do_swap_credit(
+		// 	amounts: &Vec<T::AssetBalance>,
+		// 	path: BoundedVec<T::MultiAssetId, T::MaxSwapPathLength>,
+		// ) -> Result<Credit<T::AccountId, T::AssetBalance>, DispatchError>
+		// where
+		// 	T::AssetBalance: Balanced<T::AccountId>,
+		// 	(T::MultiAssetId, T::AssetBalance): Into<Debt<T::AccountId, T::AssetBalance>>
+		// 		+ Into<Credit<T::AccountId, T::AssetBalance>>,
+		// {
+		// 	ensure!(amounts.len() > 1, Error::<T>::CorrespondenceError);
+		//
+		// 	return if let Some([asset1, asset2]) = &path.get(0..2) {
+		// 		let pool_id = Self::get_pool_id(asset1.clone(), asset2.clone());
+		// 		let pool_account = Self::get_pool_account(&pool_id);
+		// 		// amounts should always contain a corresponding element to path.
+		// 		let first_amount = amounts.first().ok_or(Error::<T>::CorrespondenceError)?;
+		//
+		// 		// Pool account needs enough balance in asset 1 for the swap, but we don't want to
+		// 		// actually transfer the funds, since that would require a sender account, so we
+		// 		// instead resolve the credit into the pool_account.
+		// 		Self::credit_resolve(asset1.clone(), &pool_account, *first_amount)?;
+		//
+		// 		let mut i = 0;
+		// 		let path_len = path.len() as u32;
+		// 		for assets_pair in path.windows(2) {
+		// 			if let [asset1, asset2] = assets_pair {
+		// 				let pool_id = Self::get_pool_id(asset1.clone(), asset2.clone());
+		// 				let pool_account = Self::get_pool_account(&pool_id);
+		//
+		// 				let amount_out =
+		// 					amounts.get((i + 1) as usize).ok_or(Error::<T>::CorrespondenceError)?;
+		//
+		// 				let reserve = Self::get_balance(&pool_account, asset2)?;
+		// 				let reserve_left = reserve.saturating_sub(*amount_out);
+		// 				Self::validate_minimal_amount(reserve_left, asset2)
+		// 					.map_err(|_| Error::<T>::ReserveLeftLessThanMinimal)?;
+		//
+		// 				// Same as credit but use settle instead of resolve, and get a Credit<> out
+		// 				// TODO: This will only work for path vectors of size 2 (no hops).
+		// 				// TODO: Emit a newly created event called SwapCreditExecuted
+		// 				return Ok(Self::credit_settle(asset2.clone(), &pool_account, *amount_out)?)
+		// 			}
+		// 			i.saturating_inc();
+		// 		}
+		//
+		// 		Err(Error::<T>::InvalidPath.into())
+		// 	} else {
+		// 		Err(Error::<T>::InvalidPath.into())
+		// 	}
+		// }
+
 		pub(crate) fn do_swap_credit(
+			credit_in: Credit<T::AccountId, T::AssetBalance>,
 			amounts: &Vec<T::AssetBalance>,
 			path: BoundedVec<T::MultiAssetId, T::MaxSwapPathLength>,
 		) -> Result<Credit<T::AccountId, T::AssetBalance>, DispatchError>
 		where
 			T::AssetBalance: Balanced<T::AccountId>,
-			(T::MultiAssetId, T::AssetBalance): Into<Debt<T::AccountId, T::AssetBalance>>
-				+ Into<Credit<T::AccountId, T::AssetBalance>>,
 		{
-			ensure!(amounts.len() > 1, Error::<T>::CorrespondenceError);
-
-			return if let Some([asset1, asset2]) = &path.get(0..2) {
-				let pool_id = Self::get_pool_id(asset1.clone(), asset2.clone());
-				let pool_account = Self::get_pool_account(&pool_id);
-				// amounts should always contain a corresponding element to path.
-				let first_amount = amounts.first().ok_or(Error::<T>::CorrespondenceError)?;
-
-				// Pool account needs enough balance in asset 1 for the swap, but we don't want to
-				// actually transfer the funds, since that would require a sender account, so we
-				// instead resolve the credit into the pool_account.
-				Self::credit_resolve(asset1.clone(), &pool_account, *first_amount)?;
-
-				let mut i = 0;
-				let path_len = path.len() as u32;
-				for assets_pair in path.windows(2) {
-					if let [asset1, asset2] = assets_pair {
-						let pool_id = Self::get_pool_id(asset1.clone(), asset2.clone());
-						let pool_account = Self::get_pool_account(&pool_id);
-
-						let amount_out =
-							amounts.get((i + 1) as usize).ok_or(Error::<T>::CorrespondenceError)?;
-
-						let reserve = Self::get_balance(&pool_account, asset2)?;
-						let reserve_left = reserve.saturating_sub(*amount_out);
-						Self::validate_minimal_amount(reserve_left, asset2)
-							.map_err(|_| Error::<T>::ReserveLeftLessThanMinimal)?;
-
-						// Same as credit but use settle instead of resolve, and get a Credit<> out
-						// TODO: This will only work for path vectors of size 2 (no hops).
-						// TODO: Emit a newly created event called SwapCreditExecuted
-						return Ok(Self::credit_settle(asset2.clone(), &pool_account, *amount_out)?)
-					}
-					i.saturating_inc();
-				}
-
-				Err(Error::<T>::InvalidPath.into())
-			} else {
-				Err(Error::<T>::InvalidPath.into())
-			}
-		}
-
-		pub(crate) fn do_swap_credit2(
-			credit_in: Credit<T::AccountId, T::AssetBalance>,
-			amounts: &Vec<T::AssetBalance>,
-			path: BoundedVec<T::MultiAssetId, T::MaxSwapPathLength>,
-		) -> Result<Credit<T::AccountId, T::AssetBalance>, DispatchError> {
 			ensure!(amounts.len() > 1, Error::<T>::CorrespondenceError);
 
 			if let Some([asset1, asset2]) = &path.get(0..2) {
@@ -1098,9 +1091,13 @@ pub mod pallet {
 				// amounts should always contain a corresponding element to path.
 				let first_amount = amounts.first().ok_or(Error::<T>::CorrespondenceError)?;
 
-				// TODO ensure credit_in.peak() == first_amount
-				// TODO ensure credit_asset_id == asset1
-				Self::credit_resolve(asset1, &pool_account, credit_in)?;
+				ensure!(
+					credit_in.peek() >= first_amount,
+					Error::<T>::ProvidedMinimumNotSufficientForSwap
+				);
+				ensure!(credit_in.asset() == asset1, Error::<T>::AssetCreditMismatch);
+
+				Self::credit_resolve(asset1.clone(), &pool_account, credit_in)?;
 
 				let mut i = 0;
 				let path_len = path.len() as u32;
@@ -1112,7 +1109,6 @@ pub mod pallet {
 						let amount_out =
 							amounts.get((i + 1) as usize).ok_or(Error::<T>::CorrespondenceError)?;
 
-						// TODO copy past from original swap, please validate
 						let to = if i < path_len - 2 {
 							let asset3 = path.get((i + 2) as usize).ok_or(Error::<T>::PathError)?;
 							Some(Self::get_pool_account(&Self::get_pool_id(
@@ -1130,15 +1126,17 @@ pub mod pallet {
 
 						if to.is_some() {
 							// TODO transfer as in original swap
-							// Self::transfer(asset2, &pool_account, &to, *amount_out, true)?;
+							// Wouldn't this transfer between pool accounts? Shouldn't we do it
+							// with credits instead? Also, this implies more than one asset hop.
+							Self::transfer(asset2, &pool_account, &to.unwrap(), *amount_out, true)?;
 						} else {
-							// TODO let credit_out = Self::withdraw(asset2.clone(), &pool_account,
-							// *amount_out)
+							return Ok(Self::withdraw(asset2.clone(), &pool_account, *amount_out)?)
 						}
 					}
 					i.saturating_inc();
 				}
 
+				Err(Error::<T>::InvalidPath.into())
 			// TODO deposit event
 			} else {
 				Err(Error::<T>::InvalidPath.into())
@@ -1501,28 +1499,28 @@ impl<T: Config> Swap<T::AccountId, T::HigherPrecisionBalance, T::MultiAssetId> f
 		Ok(amount_out.into())
 	}
 
-	fn swap_tokens_for_exact_tokens_credit(
-		path: Vec<T::MultiAssetId>,
-		amount_out: T::HigherPrecisionBalance,
-		credit_in: Credit<T::AccountId, T::HigherPrecisionBalance>,
-	) -> Result<CreditPair<T::AccountId, T::HigherPrecisionBalance>, DispatchError>
-	where
-		T::HigherPrecisionBalance: Balanced<T::AccountId>,
-		T::AssetBalance: Balanced<T::AccountId>,
-		(T::MultiAssetId, T::AssetBalance):
-			Into<Debt<T::AccountId, T::AssetBalance>> + Into<Credit<T::AccountId, T::AssetBalance>>,
-	{
-		let path = path.try_into().map_err(|_| Error::<T>::PathError)?;
-		let amount_in_ab = Self::convert_hpb_to_asset_balance(credit_in.peek())?;
-		let amount_in: Credit<T::AccountId, T::AssetBalance> = (path[0], amount_in_ab).into();
-		let out = Self::do_swap_tokens_for_exact_tokens_credit(
-			path,
-			Self::convert_hpb_to_asset_balance(amount_out)?,
-			amount_in,
-		)?;
-		// TODO: convert out credits to HPB
-		Ok(out.into())
-	}
+	// fn swap_tokens_for_exact_tokens_credit(
+	// 	path: Vec<T::MultiAssetId>,
+	// 	amount_out: T::HigherPrecisionBalance,
+	// 	credit_in: Credit<T::AccountId, T::HigherPrecisionBalance>,
+	// ) -> Result<CreditPair<T::AccountId, T::HigherPrecisionBalance>, DispatchError>
+	// where
+	// 	T::HigherPrecisionBalance: Balanced<T::AccountId>,
+	// 	T::AssetBalance: Balanced<T::AccountId>,
+	// 	(T::MultiAssetId, T::AssetBalance):
+	// 		Into<Debt<T::AccountId, T::AssetBalance>> + Into<Credit<T::AccountId, T::AssetBalance>>,
+	// {
+	// 	let path = path.try_into().map_err(|_| Error::<T>::PathError)?;
+	// 	let amount_in_ab = Self::convert_hpb_to_asset_balance(credit_in.peek())?;
+	// 	let amount_in: Credit<T::AccountId, T::AssetBalance> = (path[0], amount_in_ab).into();
+	// 	let out = Self::do_swap_tokens_for_exact_tokens_credit(
+	// 		path,
+	// 		Self::convert_hpb_to_asset_balance(amount_out)?,
+	// 		amount_in,
+	// 	)?;
+	// 	// TODO: convert out credits to HPB
+	// 	Ok(out.into())
+	// }
 
 	fn swap_tokens_for_exact_tokens(
 		sender: T::AccountId,
@@ -1546,8 +1544,23 @@ impl<T: Config> Swap<T::AccountId, T::HigherPrecisionBalance, T::MultiAssetId> f
 	}
 }
 
-impl<T: Config> SwapCredit<T::AccountId, T::AssetBalance, T::MultiAssetId> for Pallet<T> {
-	// TODO fn swap_exact_tokens_for_tokens_credit()
+impl<T: Config> SwapCredit<T::AccountId, T::AssetBalance, T::MultiAssetId> for Pallet<T>
+where
+	T::AssetBalance: Balanced<T::AccountId>,
+{
+	// fn swap_exact_tokens_for_tokens_credit(
+	// 	path: Vec<T::MultiAssetId>,
+	// 	credit_in: Credit<T::AccountId, T::AssetBalance>,
+	// 	amount_out_min: Option<T::AssetBalance>,
+	// ) -> Result<Credit<T::AccountId, T::AssetBalance>, DispatchError>
+	// where
+	// 	T::AssetBalance: Balanced<T::AccountId>,
+	// {
+	// 	let path = path.try_into().map_err(|_| Error::<T>::PathError)?;
+	// 	// TODO
+	// 	let out = Self::do_swap_tokens_for_exact_tokens_credit(path, amount_out_min, credit_in)?;
+	// 	Ok(out.0)
+	// }
 
 	fn swap_tokens_for_exact_tokens_credit(
 		path: Vec<T::MultiAssetId>,
@@ -1558,7 +1571,7 @@ impl<T: Config> SwapCredit<T::AccountId, T::AssetBalance, T::MultiAssetId> for P
 		DispatchError,
 	> {
 		let path = path.try_into().map_err(|_| Error::<T>::PathError)?;
-		let out = Self::do_swap_tokens_for_exact_tokens_credit2(path, amount_out, credit_in)?;
+		let out = Self::do_swap_tokens_for_exact_tokens_credit(path, amount_out, credit_in)?;
 		Ok(out)
 	}
 }

--- a/frame/asset-conversion/src/tests.rs
+++ b/frame/asset-conversion/src/tests.rs
@@ -66,7 +66,11 @@ fn pool_assets() -> Vec<u32> {
 
 fn create_tokens(owner: u128, tokens: Vec<NativeOrAssetId<u32>>) {
 	for token_id in tokens {
-		let MultiAssetIdConversionResult::Converted(asset_id) = NativeOrAssetIdConverter::try_convert(&token_id) else { unreachable!("invalid token") };
+		let MultiAssetIdConversionResult::Converted(asset_id) =
+			NativeOrAssetIdConverter::try_convert(&token_id)
+		else {
+			unreachable!("invalid token")
+		};
 		assert_ok!(Assets::force_create(RuntimeOrigin::root(), asset_id, owner, false, 1));
 	}
 }

--- a/frame/asset-conversion/src/types.rs
+++ b/frame/asset-conversion/src/types.rs
@@ -19,6 +19,7 @@ use super::*;
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::traits::fungibles::Credit;
+use frame_system::Account;
 use scale_info::TypeInfo;
 use sp_std::{cmp::Ordering, marker::PhantomData};
 
@@ -150,18 +151,35 @@ pub trait Swap<AccountId, Balance, MultiAssetId> {
 	) -> Result<Balance, DispatchError>;
 }
 
-pub trait SwapCredit<AccountId, Balance: Balanced<AccountId>, MultiAssetId> {
-	// fn swap_exact_tokens_for_tokens(
+pub trait SwapCredit<AccountId, MultiAssetId, Balance, Fungible, Fungibles>
+where
+	Fungible: BalancedFungible<AccountId>,
+	Fungibles: Balanced<AccountId>,
+{
+	// fn swap_exact_native_tokens_for_tokens(
 	// 	path: Vec<MultiAssetId>,
-	// 	credit_in: Credit<AccountId, Balance>,
-	// 	amount_out_min: Option<Balance>,
-	// ) -> Result<Credit<AccountId, Balance>, DispatchError>;
+	// 	credit_in: CreditFungible<AccountId, Fungible>,
+	// 	amount_out_min: Option<AssetBalance>,
+	// ) -> Result<Credit<AccountId, Fungibles>, DispatchError>;
 
-	fn swap_tokens_for_exact_tokens(
+	// fn swap_native_tokens_for_exact_tokens(
+	// 	path: Vec<MultiAssetId>,
+	// 	amount_out: AssetBalance,
+	// 	credit_in: CreditFungible<AccountId, Fungible>,
+	// ) -> Result<(CreditFungible<AccountId, Fungible>, Credit<AccountId, Fungibles>),
+	//   DispatchError>;
+
+	// fn swap_exact_tokens_for_native_tokens(
+	// 	path: Vec<MultiAssetId>,
+	// 	credit_in: Credit<AccountId, Fungibles>,
+	// 	amount_out_min: Option<Balance>,
+	// ) -> Result<CreditFungible<AccountId, Fungible>, DispatchError>;
+
+	fn swap_tokens_for_exact_native_tokens(
 		path: Vec<MultiAssetId>,
 		amount_out: Balance,
-		credit_in: Credit<AccountId, Balance>,
-	) -> Result<(Credit<AccountId, Balance>, Credit<AccountId, Balance>), DispatchError>;
+		credit_in: Credit<AccountId, Fungibles>,
+	) -> Result<(Credit<AccountId, Fungibles>, CreditFungible<AccountId, Fungible>), DispatchError>;
 }
 
 /// An implementation of MultiAssetId that can be either Native or an asset.

--- a/frame/asset-conversion/src/types.rs
+++ b/frame/asset-conversion/src/types.rs
@@ -19,6 +19,7 @@ use super::*;
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
+use frame_support::traits::fungibles::Credit;
 use sp_std::{cmp::Ordering, marker::PhantomData};
 
 pub(super) type PoolIdOf<T> = (<T as Config>::MultiAssetId, <T as Config>::MultiAssetId);
@@ -97,6 +98,12 @@ pub trait Swap<AccountId, Balance, MultiAssetId> {
 		send_to: AccountId,
 		keep_alive: bool,
 	) -> Result<Balance, DispatchError>;
+
+	fn swap_exact_tokens_for_tokens_credit(
+		path: Vec<MultiAssetId>,
+		amount_in: Credit<AccountId, Balance>,
+		amount_out_min: Option<Balance>,
+	) -> Result<Credit<AccountId, Balance>, DispatchError>;
 
 	/// Take the `path[0]` asset and swap some amount for `amount_out` of the `path[1]`. If an
 	/// `amount_in_max` is specified, it will return an error if acquiring `amount_out` would be

--- a/frame/asset-conversion/src/types.rs
+++ b/frame/asset-conversion/src/types.rs
@@ -105,32 +105,32 @@ pub trait Swap<AccountId, Balance, MultiAssetId> {
 		keep_alive: bool,
 	) -> Result<Balance, DispatchError>;
 
-	/// Swap `amount_in_max` of asset `path[0]` for asset `path[1]` declared in `amount_out`.
-	/// It will return an error if acquiring `amount_out` would be too costly.
-	///
-	/// Thus it is on the RPC side to ensure that `amount_in` is enough to acquire `amount_out`.
-	///
-	/// Uses the `amount_in` imbalance to offset into the pool account.
-	///
-	/// If successful, returns the amount of `path[1]` acquired for the `amount_in`
-	/// along with the leftovers from `amount_in` as an imbalance.
-	/// They could be credited somewhere as the type implies, but can also be dropped.
-	///
-	/// Note: This method effectively prevents overswapping, so that the
-	/// returned `CreditPair::in_leftover` can then be directly refunded in the initial asset
-	/// without swapping back from the `path[1]` asset.
-	///
-	/// `amount_in` is not optional due to the fact that it is a balance to be offset
-	/// (credited to the pool), and not an amount to be acquired from a sender.
-	///
-	/// If this function returns an error, no credit will be taken from amount_in, like a no-op.
-	fn swap_tokens_for_exact_tokens_credit(
-		path: Vec<MultiAssetId>,
-		amount_out: Balance,
-		credit_in: Credit<AccountId, Balance>,
-	) -> Result<CreditPair<AccountId, Balance>, DispatchError>
-	where
-		Balance: Balanced<AccountId>;
+	// /// Swap `amount_in_max` of asset `path[0]` for asset `path[1]` declared in `amount_out`.
+	// /// It will return an error if acquiring `amount_out` would be too costly.
+	// ///
+	// /// Thus it is on the RPC side to ensure that `amount_in` is enough to acquire `amount_out`.
+	// ///
+	// /// Uses the `amount_in` imbalance to offset into the pool account.
+	// ///
+	// /// If successful, returns the amount of `path[1]` acquired for the `amount_in`
+	// /// along with the leftovers from `amount_in` as an imbalance.
+	// /// They could be credited somewhere as the type implies, but can also be dropped.
+	// ///
+	// /// Note: This method effectively prevents overswapping, so that the
+	// /// returned `CreditPair::in_leftover` can then be directly refunded in the initial asset
+	// /// without swapping back from the `path[1]` asset.
+	// ///
+	// /// `amount_in` is not optional due to the fact that it is a balance to be offset
+	// /// (credited to the pool), and not an amount to be acquired from a sender.
+	// ///
+	// /// If this function returns an error, no credit will be taken from amount_in, like a no-op.
+	// fn swap_tokens_for_exact_tokens_credit(
+	// 	path: Vec<MultiAssetId>,
+	// 	amount_out: Balance,
+	// 	credit_in: Credit<AccountId, Balance>,
+	// ) -> Result<CreditPair<AccountId, Balance>, DispatchError>
+	// where
+	// 	Balance: Balanced<AccountId>;
 
 	/// Take the `path[0]` asset and swap some amount for `amount_out` of the `path[1]`. If an
 	/// `amount_in_max` is specified, it will return an error if acquiring `amount_out` would be
@@ -150,12 +150,12 @@ pub trait Swap<AccountId, Balance, MultiAssetId> {
 	) -> Result<Balance, DispatchError>;
 }
 
-pub trait SwapCredit<AccountId, Balance, MultiAssetId> {
-	fn swap_exact_tokens_for_tokens_credit(
-		path: Vec<MultiAssetId>,
-		credit_in: Credit<AccountId, Balance>,
-		amount_out_min: Option<Balance>,
-	) -> Result<Credit<AccountId, Balance>, DispatchError>;
+pub trait SwapCredit<AccountId, Balance: Balanced<AccountId>, MultiAssetId> {
+	// fn swap_exact_tokens_for_tokens_credit(
+	// 	path: Vec<MultiAssetId>,
+	// 	credit_in: Credit<AccountId, Balance>,
+	// 	amount_out_min: Option<Balance>,
+	// ) -> Result<Credit<AccountId, Balance>, DispatchError>;
 
 	fn swap_tokens_for_exact_tokens_credit(
 		path: Vec<MultiAssetId>,

--- a/frame/asset-conversion/src/types.rs
+++ b/frame/asset-conversion/src/types.rs
@@ -150,6 +150,20 @@ pub trait Swap<AccountId, Balance, MultiAssetId> {
 	) -> Result<Balance, DispatchError>;
 }
 
+pub trait SwapCredit<AccountId, Balance, MultiAssetId> {
+	fn swap_exact_tokens_for_tokens_credit(
+		path: Vec<MultiAssetId>,
+		credit_in: Credit<AccountId, Balance>,
+		amount_out_min: Option<Balance>,
+	) -> Result<Credit<AccountId, Balance>, DispatchError>;
+
+	fn swap_tokens_for_exact_tokens_credit(
+		path: Vec<MultiAssetId>,
+		amount_out: Balance,
+		credit_in: Credit<AccountId, Balance>,
+	) -> Result<(Credit<AccountId, Balance>, Credit<AccountId, Balance>), DispatchError>;
+}
+
 /// An implementation of MultiAssetId that can be either Native or an asset.
 #[derive(Decode, Encode, Default, MaxEncodedLen, TypeInfo, Clone, Copy, Debug)]
 pub enum NativeOrAssetId<AssetId>

--- a/frame/asset-conversion/src/types.rs
+++ b/frame/asset-conversion/src/types.rs
@@ -151,13 +151,13 @@ pub trait Swap<AccountId, Balance, MultiAssetId> {
 }
 
 pub trait SwapCredit<AccountId, Balance: Balanced<AccountId>, MultiAssetId> {
-	// fn swap_exact_tokens_for_tokens_credit(
+	// fn swap_exact_tokens_for_tokens(
 	// 	path: Vec<MultiAssetId>,
 	// 	credit_in: Credit<AccountId, Balance>,
 	// 	amount_out_min: Option<Balance>,
 	// ) -> Result<Credit<AccountId, Balance>, DispatchError>;
 
-	fn swap_tokens_for_exact_tokens_credit(
+	fn swap_tokens_for_exact_tokens(
 		path: Vec<MultiAssetId>,
 		amount_out: Balance,
 		credit_in: Credit<AccountId, Balance>,


### PR DESCRIPTION
Part of the effort of [Paying XCM Execution Fees with foreign assets](https://github.com/paritytech/cumulus/pull/2854)

This PR attempts to add swap operations that do not require an origin or destination for the funds (and thus will not mutate global state), and only operates within Imbalances, proper for usage within XCM.

- [ ] Proper imbalances types for `swap_exact` and `swap_for_exact`
- [ ] Implement `do_swap_credit` and probably `transfer_credit`
- [ ] Expand the tests to use the new swap*_credit functions
