### PR TITLE
fix: node cli docs

### DIFF
--- a/bin/node/cli/build.rs
+++ b/bin/node/cli/build.rs
@@ -37,14 +37,14 @@ mod cli {
 		rerun_if_git_head_changed();
 	}
 
-	/// Build shell completion scripts for all known shells
+	/// Build shell completion scripts for all known shells.
 	fn build_shell_completion() {
 		for shell in Shell::value_variants() {
 			build_completion(shell);
 		}
 	}
 
-	/// Build the shell auto-completion for a given Shell
+	/// Build the shell auto-completion for a given Shell.
 	fn build_completion(shell: &Shell) {
 		let outdir = match env::var_os("OUT_DIR") {
 			None => return,

--- a/bin/node/cli/doc/shell-completion.adoc
+++ b/bin/node/cli/doc/shell-completion.adoc
@@ -1,7 +1,7 @@
 
 == Shell completion
 
-The Substrate cli command supports shell auto-completion. For this to work, you will need to run the completion script matching you build and system.
+The Substrate cli command supports shell auto-completion. For this to work, you will need to run the completion script matching your build and system.
 
 Assuming you built a release version using `cargo build --release` and use `bash` run the following:
 
@@ -15,7 +15,7 @@ You can find completion scripts for:
 - elvish
 - powershell
 
-To make this change persistent, you can proceed as follow:
+To make this change persistent, you can proceed as follows:
 
 .First install
 
@@ -30,7 +30,7 @@ source $HOME/.bash_profile
 
 .Update
 
-When you build a new version of Substrate, the following will ensure you auto-completion script matches the current binary:
+When you build a new version of Substrate, the following will ensure your auto-completion script matches the current binary:
 
 [source, shell]
 ----

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -199,14 +199,14 @@ pub fn staging_testnet_config() -> ChainSpec {
 	)
 }
 
-/// Helper function to generate a crypto pair from seed
+/// Helper function to generate a crypto pair from seed.
 pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
 	TPublic::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
 }
 
-/// Helper function to generate an account ID from seed
+/// Helper function to generate an account ID from seed.
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
 	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
@@ -214,7 +214,7 @@ where
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }
 
-/// Helper function to generate stash, controller and session key from seed
+/// Helper function to generate stash, controller and session key from seed.
 pub fn authority_keys_from_seed(
 	seed: &str,
 ) -> (AccountId, AccountId, GrandpaId, BabeId, ImOnlineId, AuthorityDiscoveryId) {
@@ -228,7 +228,7 @@ pub fn authority_keys_from_seed(
 	)
 }
 
-/// Helper function to create RuntimeGenesisConfig for testing
+/// Helper function to create RuntimeGenesisConfig for testing.
 pub fn testnet_genesis(
 	initial_authorities: Vec<(
 		AccountId,
@@ -377,7 +377,7 @@ fn development_config_genesis() -> RuntimeGenesisConfig {
 	)
 }
 
-/// Development config (single validator Alice)
+/// Development config (single validator Alice).
 pub fn development_config() -> ChainSpec {
 	ChainSpec::from_genesis(
 		"Development",
@@ -402,7 +402,7 @@ fn local_testnet_genesis() -> RuntimeGenesisConfig {
 	)
 }
 
-/// Local testnet config (multivalidator Alice + Bob)
+/// Local testnet config (multivalidator Alice + Bob).
 pub fn local_testnet_config() -> ChainSpec {
 	ChainSpec::from_genesis(
 		"Local Testnet",
@@ -434,7 +434,7 @@ pub(crate) mod tests {
 		)
 	}
 
-	/// Local testnet config (single validator - Alice)
+	/// Local testnet config (single validator - Alice).
 	pub fn integration_test_config_with_single_authority() -> ChainSpec {
 		ChainSpec::from_genesis(
 			"Integration Test",
@@ -450,7 +450,7 @@ pub(crate) mod tests {
 		)
 	}
 
-	/// Local testnet config (multivalidator Alice + Bob)
+	/// Local testnet config (multivalidator Alice + Bob).
 	pub fn integration_test_config_with_two_authorities() -> ChainSpec {
 		ChainSpec::from_genesis(
 			"Integration Test",

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -51,7 +51,7 @@ type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
 type FullGrandpaBlockImport =
 	grandpa::GrandpaBlockImport<FullBackend, Block, FullClient, FullSelectChain>;
 
-/// The transaction pool type defintion.
+/// The transaction pool type definition.
 pub type TransactionPool = sc_transaction_pool::FullPool<Block, FullClient>;
 
 /// The minimum period of blocks on which justifications will be


### PR DESCRIPTION
The PR makes documentation fixes to the node cli section. There are some grammatical improvements and also ending a doc comment with a terminating `.`.
The changes are needed to make documentation consistent and grammatically correct.
