### PR TITLE
dont print proof size

### DIFF
--- a/utils/frame/benchmarking-cli/src/pallet/command.rs
+++ b/utils/frame/benchmarking-cli/src/pallet/command.rs
@@ -633,12 +633,6 @@ impl PalletCmd {
 					println!("{}", comment);
 				}
 				println!();
-
-				println!("-- Proof Sizes --\n");
-				for result in batch.db_results.iter() {
-					println!("{} bytes", result.proof_size);
-				}
-				println!();
 			}
 
 			// Conduct analysis.


### PR DESCRIPTION
I don't know if this is a leftover debugging code or something but it is useless and broke our bencher bot

You can see [here](https://github.com/AcalaNetwork/Acala/actions/runs/5791725354/job/15696975201) it is printing a lot of useless `2496 bytes` in stdout

Please also backport this to 1.0.0 release branch