### PR TITLE
remove unused dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3085,12 +3085,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hex-literal"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
-
-[[package]]
 name = "hkdf"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6978,7 +6972,6 @@ dependencies = [
  "frame-support",
  "frame-support-test",
  "frame-system",
- "hex-literal",
  "log",
  "pallet-balances",
  "parity-scale-codec",

--- a/frame/society/Cargo.toml
+++ b/frame/society/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-hex-literal = "0.3.4"
 log = { version = "0.4.17", default-features = false }
 rand_chacha = { version = "0.2", default-features = false }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }


### PR DESCRIPTION
This is the last reference to hex-literal, which is unused. I guess it was missed from previous refactor.