### PR TITLE
Rhmb/beefy slashing fisherman

### DIFF
--- a/client/consensus/beefy/src/communication/fisherman.rs
+++ b/client/consensus/beefy/src/communication/fisherman.rs
@@ -148,7 +148,7 @@ where
 	R: ProvideRuntimeApi<B> + Send + Sync,
 	R::Api: BeefyApi<B>,
 {
-	/// Check `vote` for contained finalized block against expected payload.
+	/// Check `vote` for contained block against expected payload.
 	///
 	/// Note: this fn expects `vote.commitment.block_number` to be finalized.
 	fn check_vote(
@@ -159,9 +159,7 @@ where
 		let (header, expected_payload) = self.expected_header_and_payload(number)?;
 		if vote.commitment.payload != expected_payload {
 			let validator_set = self.active_validator_set_at(&header)?;
-			// TODO: create/get grandpa proof for block number
-			let grandpa_proof = ();
-			let proof = InvalidForkVoteProof { vote, grandpa_proof };
+			let proof = InvalidForkVoteProof { vote };
 			self.report_invalid_fork_vote(proof, &header, &expected_payload, &validator_set)?;
 		}
 		Ok(())
@@ -178,7 +176,6 @@ where
 		let (header, expected_payload) = self.expected_header_and_payload(number)?;
 		if commitment.payload != expected_payload {
 			// TODO: create/get grandpa proof for block number
-			let grandpa_proof = ();
 			let validator_set = self.active_validator_set_at(&header)?;
 			if signatures.len() != validator_set.validators().len() {
 				// invalid proof
@@ -190,7 +187,7 @@ where
 				if let Some(signature) = signature {
 					let vote =
 						VoteMessage { commitment: commitment.clone(), id: id.clone(), signature };
-					let proof = InvalidForkVoteProof { vote, grandpa_proof };
+					let proof = InvalidForkVoteProof { vote };
 					self.report_invalid_fork_vote(
 						proof,
 						&header,

--- a/client/consensus/beefy/src/communication/fisherman.rs
+++ b/client/consensus/beefy/src/communication/fisherman.rs
@@ -98,7 +98,7 @@ where
 			.ok_or_else(|| Error::Backend("could not get BEEFY validator set".into()))
 	}
 
-	fn report_fork_equivocation(
+	pub(crate) fn report_fork_equivocation(
 		&self,
 		proof: ForkEquivocationProof<NumberFor<B>, AuthorityId, Signature, B::Header>,
 	) -> Result<(), Error> {

--- a/client/consensus/beefy/src/communication/fisherman.rs
+++ b/client/consensus/beefy/src/communication/fisherman.rs
@@ -36,22 +36,19 @@ use sp_runtime::{
 use std::{marker::PhantomData, sync::Arc};
 
 pub(crate) trait BeefyFisherman<B: Block>: Send + Sync {
-	/// Check `vote` for contained finalized block against expected payload.
-	///
-	/// Note: this fn expects `vote.commitment.block_number` to be finalized.
+	/// Check `vote` for contained block against expected payload.
 	fn check_vote(
 		&self,
 		vote: VoteMessage<NumberFor<B>, AuthorityId, Signature>,
 	) -> Result<(), Error>;
 
+	/// Check `signed_commitment` for contained block against expected payload.
 	fn check_signed_commitment(
 		&self,
 		signed_commitment: SignedCommitment<NumberFor<B>, Signature>,
 	) -> Result<(), Error>;
 
-	/// Check `proof` for contained finalized block against expected payload.
-	///
-	/// Note: this fn expects block referenced in `proof` to be finalized.
+	/// Check `proof` for contained block against expected payload.
 	fn check_proof(&self, proof: BeefyVersionedFinalityProof<B>) -> Result<(), Error>;
 }
 
@@ -207,8 +204,6 @@ where
 	R::Api: BeefyApi<B, AuthorityId>,
 {
 	/// Check `vote` for contained block against expected payload.
-	///
-	/// Note: this fn expects `vote.commitment.block_number` to be finalized.
 	fn check_vote(
 		&self,
 		vote: VoteMessage<NumberFor<B>, AuthorityId, Signature>,

--- a/client/consensus/beefy/src/communication/fisherman.rs
+++ b/client/consensus/beefy/src/communication/fisherman.rs
@@ -238,7 +238,7 @@ where
 		Ok(())
 	}
 
-	/// Check `proof` for contained finalized block against expected payload.
+	/// Check `proof` for contained block against expected payload.
 	///
 	/// Note: this fn expects block referenced in `proof` to be finalized.
 	fn check_proof(&self, proof: BeefyVersionedFinalityProof<B>) -> Result<(), Error> {

--- a/client/consensus/beefy/src/communication/fisherman.rs
+++ b/client/consensus/beefy/src/communication/fisherman.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-	error::Error, justification::BeefyVersionedFinalityProof, keystore::BeefySignatureHasher,
+	error::Error, justification::BeefyVersionedFinalityProof, keystore::{BeefyKeystore, BeefySignatureHasher},
 	LOG_TARGET,
 };
 use log::debug;
@@ -57,6 +57,7 @@ pub(crate) trait BeefyFisherman<B: Block>: Send + Sync {
 pub(crate) struct Fisherman<B: Block, BE, R, P> {
 	pub backend: Arc<BE>,
 	pub runtime: Arc<R>,
+	pub key_store: Arc<BeefyKeystore>,
 	pub payload_provider: P,
 	pub _phantom: PhantomData<B>,
 }

--- a/client/consensus/beefy/src/communication/fisherman.rs
+++ b/client/consensus/beefy/src/communication/fisherman.rs
@@ -156,9 +156,8 @@ where
 	fn report_fork_equivocation(
 		&self,
 		proof: ForkEquivocationProof<NumberFor<B>, AuthorityId, Signature, B::Header>,
-		correct_header: &B::Header,
 	) -> Result<(), Error> {
-		let validator_set = self.active_validator_set_at(correct_header)?;
+		let validator_set = self.active_validator_set_at(&proof.correct_header)?;
 		let set_id = validator_set.id();
 
 		if proof.commitment.validator_set_id != set_id ||
@@ -168,7 +167,7 @@ where
 			return Ok(())
 		}
 
-		let hash = correct_header.hash();
+		let hash = proof.correct_header.hash();
 		let offender_ids = proof.signatories.iter().cloned().map(|(id, _sig)| id).collect::<Vec<_>>();
 		let runtime_api = self.runtime.runtime_api();
 
@@ -219,7 +218,7 @@ where
 		if vote.commitment.payload != expected_payload {
 			let validator_set = self.active_validator_set_at(&correct_header)?;
 			let proof = ForkEquivocationProof { commitment: vote.commitment, signatories: vec![(vote.id, vote.signature)], correct_header: correct_header.clone() };
-			self.report_fork_equivocation(proof, &correct_header)?;
+			self.report_fork_equivocation(proof)?;
 		}
 		Ok(())
 	}
@@ -259,10 +258,7 @@ where
 																		.filter_map(|(id, signature)| signature.map(|sig| (id, sig))).collect();
 
 			let proof = ForkEquivocationProof { commitment, signatories, correct_header: correct_header.clone() };
-			self.report_fork_equivocation(
-				proof,
-				&correct_header,
-			)?;
+			self.report_fork_equivocation(proof)?;
 		}
 		Ok(())
 	}

--- a/client/consensus/beefy/src/communication/fisherman.rs
+++ b/client/consensus/beefy/src/communication/fisherman.rs
@@ -26,7 +26,7 @@ use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_consensus_beefy::{
 	check_invalid_fork_proof,
-	crypto::{AuthorityId, Signature},
+	ecdsa_crypto::{AuthorityId, Signature},
 	BeefyApi, InvalidForkCommitmentProof, Payload, PayloadProvider, ValidatorSet, VoteMessage, Commitment, OpaqueKeyOwnershipProof, SignedCommitment,
 };
 use sp_runtime::{
@@ -70,7 +70,7 @@ where
 	BE: Backend<B>,
 	P: PayloadProvider<B>,
 	R: ProvideRuntimeApi<B> + Send + Sync,
-	R::Api: BeefyApi<B>,
+	R::Api: BeefyApi<B, AuthorityId>,
 {
 	fn expected_header_and_payload(&self, number: NumberFor<B>) -> Result<(B::Header, Payload), Error> {
 		// This should be un-ambiguous since `number` is finalized.
@@ -205,7 +205,7 @@ where
 	BE: Backend<B>,
 	P: PayloadProvider<B>,
 	R: ProvideRuntimeApi<B> + Send + Sync,
-	R::Api: BeefyApi<B>,
+	R::Api: BeefyApi<B, AuthorityId>,
 {
 	/// Check `vote` for contained block against expected payload.
 	///

--- a/client/consensus/beefy/src/communication/fisherman.rs
+++ b/client/consensus/beefy/src/communication/fisherman.rs
@@ -27,7 +27,7 @@ use sp_blockchain::HeaderBackend;
 use sp_consensus_beefy::{
 	check_invalid_fork_proof,
 	crypto::{AuthorityId, Signature},
-	BeefyApi, InvalidForkCommitmentProof, Payload, PayloadProvider, ValidatorSet, VoteMessage, Commitment, OpaqueKeyOwnershipProof,
+	BeefyApi, InvalidForkCommitmentProof, Payload, PayloadProvider, ValidatorSet, VoteMessage, Commitment, OpaqueKeyOwnershipProof, SignedCommitment,
 };
 use sp_runtime::{
 	generic::BlockId,
@@ -42,6 +42,11 @@ pub(crate) trait BeefyFisherman<B: Block>: Send + Sync {
 	fn check_vote(
 		&self,
 		vote: VoteMessage<NumberFor<B>, AuthorityId, Signature>,
+	) -> Result<(), Error>;
+
+	fn check_signed_commitment(
+		&self,
+		signed_commitment: SignedCommitment<NumberFor<B>, Signature>,
 	) -> Result<(), Error>;
 
 	/// Check `proof` for contained finalized block against expected payload.
@@ -96,12 +101,64 @@ where
 			.ok_or_else(|| Error::Backend("could not get BEEFY validator set".into()))
 	}
 
+	fn report_invalid_payload(
+		&self,
+		signed_commitment: SignedCommitment<NumberFor<B>, Signature>,
+		correct_payload: &Payload,
+		correct_header: &B::Header,
+	) -> Result<(), Error> {
+		let validator_set = self.active_validator_set_at(correct_header)?;
+		let set_id = validator_set.id();
+
+		let proof = InvalidForkCommitmentProof {
+			commitment: signed_commitment.commitment.clone(),
+			signatories: vec![],
+			expected_payload: correct_payload.clone(),
+		};
+
+		if signed_commitment.commitment.validator_set_id != set_id ||
+			signed_commitment.commitment.payload != *correct_payload ||
+			!check_invalid_fork_proof::<NumberFor<B>, AuthorityId, BeefySignatureHasher>(&proof)
+		{
+			debug!(target: LOG_TARGET, "🥩 Skip report for bad invalid fork proof {:?}", proof);
+			return Ok(())
+		}
+
+		let offender_ids = proof.signatories.iter().cloned().map(|(id, _sig)| id).collect::<Vec<_>>();
+		let runtime_api = self.runtime.runtime_api();
+
+		// generate key ownership proof at that block
+		let key_owner_proofs = offender_ids.iter()
+										   .filter_map(|id| {
+											   match runtime_api.generate_key_ownership_proof(correct_header.hash(), set_id, id.clone()) {
+												   Ok(Some(proof)) => Some(Ok(proof)),
+												   Ok(None) => {
+													   debug!(
+														   target: LOG_TARGET,
+														   "🥩 Invalid fork vote offender not part of the authority set."
+													   );
+													   None
+												   },
+												   Err(e) => Some(Err(Error::RuntimeApi(e))),
+											   }
+										   })
+										   .collect::<Result<_, _>>()?;
+
+		// submit invalid fork vote report at **best** block
+		let best_block_hash = self.backend.blockchain().info().best_hash;
+		runtime_api
+			.submit_report_invalid_fork_unsigned_extrinsic(best_block_hash, proof, key_owner_proofs)
+			.map_err(Error::RuntimeApi)?;
+
+		Ok(())
+	}
+
 	fn report_invalid_fork_commitments(
 		&self,
 		proof: InvalidForkCommitmentProof<NumberFor<B>, AuthorityId, Signature>,
 		correct_header: &B::Header,
-		validator_set: &ValidatorSet<AuthorityId>, // validator set active at the time
 	) -> Result<(), Error> {
+		let validator_set = self.active_validator_set_at(correct_header)?;
 		let set_id = validator_set.id();
 
 		if proof.commitment.validator_set_id != set_id ||
@@ -162,7 +219,21 @@ where
 		if vote.commitment.payload != expected_payload {
 			let validator_set = self.active_validator_set_at(&header)?;
 			let proof = InvalidForkCommitmentProof { commitment: vote.commitment, signatories: vec![(vote.id, vote.signature)], expected_payload };
-			self.report_invalid_fork_commitments(proof, &header, &validator_set)?;
+			self.report_invalid_fork_commitments(proof, &header)?;
+		}
+		Ok(())
+	}
+
+	/// Check `commitment` for contained block against expected payload.
+	fn check_signed_commitment(
+		&self,
+		signed_commitment: SignedCommitment<NumberFor<B>, Signature>,
+	) -> Result<(), Error> {
+		let number = signed_commitment.commitment.block_number;
+		let (header, expected_payload) = self.expected_header_and_payload(number)?;
+		if signed_commitment.commitment.payload != expected_payload {
+			let validator_set = self.active_validator_set_at(&header)?;
+			self.report_invalid_payload(signed_commitment, &expected_payload, &header)?;
 		}
 		Ok(())
 	}
@@ -191,7 +262,6 @@ where
 			self.report_invalid_fork_commitments(
 				proof,
 				&header,
-				&validator_set,
 			)?;
 		}
 		Ok(())

--- a/client/consensus/beefy/src/communication/fisherman.rs
+++ b/client/consensus/beefy/src/communication/fisherman.rs
@@ -1,0 +1,113 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::justification::BeefyVersionedFinalityProof;
+use sc_client_api::Backend;
+use sp_api::ProvideRuntimeApi;
+use sp_blockchain::HeaderBackend;
+use sp_consensus_beefy::{
+	crypto::{AuthorityId, Signature},
+	BeefyApi, Payload, PayloadProvider, VoteMessage,
+};
+use sp_runtime::{
+	generic::BlockId,
+	traits::{Block, NumberFor},
+};
+use std::{marker::PhantomData, sync::Arc};
+
+pub(crate) trait BeefyFisherman<B: Block>: Send + Sync {
+	/// Check `vote` for contained finalized block against expected payload.
+	///
+	/// Note: this fn expects `vote.commitment.block_number` to be finalized.
+	fn check_vote(
+		&self,
+		vote: VoteMessage<NumberFor<B>, AuthorityId, Signature>,
+	) -> Result<(), sp_blockchain::Error>;
+
+	/// Check `proof` for contained finalized block against expected payload.
+	///
+	/// Note: this fn expects block referenced in `proof` to be finalized.
+	fn check_proof(
+		&self,
+		proof: BeefyVersionedFinalityProof<B>,
+	) -> Result<(), sp_blockchain::Error>;
+}
+
+/// Helper wrapper used to check gossiped votes for (historical) equivocations,
+/// and report any such protocol infringements.
+pub(crate) struct Fisherman<B: Block, BE, R, P> {
+	pub backend: Arc<BE>,
+	pub runtime: Arc<R>,
+	pub payload_provider: P,
+	pub _phantom: PhantomData<B>,
+}
+
+impl<B, BE, R, P> Fisherman<B, BE, R, P>
+where
+	B: Block,
+	BE: Backend<B>,
+	P: PayloadProvider<B>,
+{
+	fn expected_payload(&self, number: NumberFor<B>) -> Result<Payload, sp_blockchain::Error> {
+		// This should be un-ambiguous since `number` is finalized.
+		let hash = self.backend.blockchain().expect_block_hash_from_id(&BlockId::Number(number))?;
+		let header = self.backend.blockchain().expect_header(hash)?;
+		self.payload_provider
+			.payload(&header)
+			.ok_or_else(|| sp_blockchain::Error::Backend("BEEFY Payload not found".into()))
+	}
+}
+
+impl<B, BE, R, P> BeefyFisherman<B> for Fisherman<B, BE, R, P>
+where
+	B: Block,
+	BE: Backend<B>,
+	P: PayloadProvider<B>,
+	R: ProvideRuntimeApi<B> + Send + Sync,
+	R::Api: BeefyApi<B>,
+{
+	/// Check `vote` for contained finalized block against expected payload.
+	///
+	/// Note: this fn expects `vote.commitment.block_number` to be finalized.
+	fn check_vote(
+		&self,
+		vote: VoteMessage<NumberFor<B>, AuthorityId, Signature>,
+	) -> Result<(), sp_blockchain::Error> {
+		let number = vote.commitment.block_number;
+		let expected = self.expected_payload(number)?;
+		if vote.commitment.payload != expected {
+			// TODO: report equivocation
+		}
+		Ok(())
+	}
+
+	/// Check `proof` for contained finalized block against expected payload.
+	///
+	/// Note: this fn expects block referenced in `proof` to be finalized.
+	fn check_proof(
+		&self,
+		proof: BeefyVersionedFinalityProof<B>,
+	) -> Result<(), sp_blockchain::Error> {
+		let payload = proof.payload();
+		let expected = self.expected_payload(*proof.number())?;
+		if payload != &expected {
+			// TODO: report equivocation
+		}
+		Ok(())
+	}
+}

--- a/client/consensus/beefy/src/communication/fisherman.rs
+++ b/client/consensus/beefy/src/communication/fisherman.rs
@@ -147,13 +147,13 @@ where
 		// submit invalid fork vote report at **best** block
 		let best_block_hash = self.backend.blockchain().info().best_hash;
 		runtime_api
-			.submit_report_invalid_fork_unsigned_extrinsic(best_block_hash, proof, key_owner_proofs)
+			.submit_report_fork_equivocation_unsigned_extrinsic(best_block_hash, proof, key_owner_proofs)
 			.map_err(Error::RuntimeApi)?;
 
 		Ok(())
 	}
 
-	fn report_invalid_fork_commitments(
+	fn report_fork_equivocation(
 		&self,
 		proof: ForkEquivocationProof<NumberFor<B>, AuthorityId, Signature>,
 		correct_header: &B::Header,
@@ -192,7 +192,7 @@ where
 		// submit invalid fork vote report at **best** block
 		let best_block_hash = self.backend.blockchain().info().best_hash;
 		runtime_api
-			.submit_report_invalid_fork_unsigned_extrinsic(best_block_hash, proof, key_owner_proofs)
+			.submit_report_fork_equivocation_unsigned_extrinsic(best_block_hash, proof, key_owner_proofs)
 			.map_err(Error::RuntimeApi)?;
 
 		Ok(())
@@ -219,7 +219,7 @@ where
 		if vote.commitment.payload != expected_payload {
 			let validator_set = self.active_validator_set_at(&header)?;
 			let proof = ForkEquivocationProof { commitment: vote.commitment, signatories: vec![(vote.id, vote.signature)], expected_payload };
-			self.report_invalid_fork_commitments(proof, &header)?;
+			self.report_fork_equivocation(proof, &header)?;
 		}
 		Ok(())
 	}
@@ -259,7 +259,7 @@ where
 																		.filter_map(|(id, signature)| signature.map(|sig| (id, sig))).collect();
 
 			let proof = ForkEquivocationProof { commitment, signatories, expected_payload };
-			self.report_invalid_fork_commitments(
+			self.report_fork_equivocation(
 				proof,
 				&header,
 			)?;

--- a/client/consensus/beefy/src/communication/fisherman.rs
+++ b/client/consensus/beefy/src/communication/fisherman.rs
@@ -119,8 +119,16 @@ where
 			return Ok(())
 		}
 
-		let hash = proof.correct_header.hash();
 		let offender_ids = proof.signatories.iter().cloned().map(|(id, _sig)| id).collect::<Vec<_>>();
+		if let Some(local_id) = self.key_store.authority_id(validator_set.validators()) {
+			if offender_ids.contains(&local_id) {
+				debug!(target: LOG_TARGET, "🥩 Skip equivocation report for own equivocation");
+				// TODO: maybe error here instead?
+				return Ok(())
+			}
+		}
+
+		let hash = proof.correct_header.hash();
 		let runtime_api = self.runtime.runtime_api();
 
 		// generate key ownership proof at that block

--- a/client/consensus/beefy/src/communication/gossip.rs
+++ b/client/consensus/beefy/src/communication/gossip.rs
@@ -298,6 +298,10 @@ where
 					// We know `vote` is for some past (finalized) block. Have fisherman check
 					// for equivocations. Best-effort, ignore errors such as state pruned.
 					let _ = self.fisherman.check_vote(vote);
+					// TODO: maybe raise cost reputation when seeing votes that are intentional
+					// spam: votes that trigger fisherman reports, but don't go through either
+					// because signer is/was not authority or similar reasons.
+					// The idea is to more quickly disconnect neighbors which are attempting DoS.
 					return Action::Discard(cost::OUTDATED_MESSAGE)
 				},
 				Consider::Accept => {},
@@ -347,6 +351,10 @@ where
 				// We know `proof` is for some past (finalized) block. Have fisherman check
 				// for equivocations. Best-effort, ignore errors such as state pruned.
 				let _ = self.fisherman.check_proof(proof);
+				// TODO: maybe raise cost reputation when seeing votes that are intentional
+				// spam: votes that trigger fisherman reports, but don't go through either because
+				// signer is/was not authority or similar reasons.
+				// The idea is to more quickly disconnect neighbors which are attempting DoS.
 				return Action::Discard(cost::OUTDATED_MESSAGE)
 			},
 			Consider::Accept => {},

--- a/client/consensus/beefy/src/communication/gossip.rs
+++ b/client/consensus/beefy/src/communication/gossip.rs
@@ -237,7 +237,7 @@ pub(crate) struct GossipValidator<B: Block, F> {
 	next_rebroadcast: Mutex<Instant>,
 	known_peers: Arc<Mutex<KnownPeers<B>>>,
 	report_sender: TracingUnboundedSender<PeerReport>,
-	fisherman: F,
+	pub(crate) fisherman: F,
 }
 
 impl<B, F> GossipValidator<B, F>

--- a/client/consensus/beefy/src/communication/mod.rs
+++ b/client/consensus/beefy/src/communication/mod.rs
@@ -21,6 +21,7 @@
 pub mod notification;
 pub mod request_response;
 
+pub(crate) mod fisherman;
 pub(crate) mod gossip;
 pub(crate) mod peers;
 

--- a/client/consensus/beefy/src/lib.rs
+++ b/client/consensus/beefy/src/lib.rs
@@ -32,6 +32,7 @@ use crate::{
 	metrics::register_metrics,
 	round::Rounds,
 	worker::PersistedState,
+	keystore::BeefyKeystore,
 };
 use futures::{stream::Fuse, StreamExt};
 use log::{error, info};
@@ -243,6 +244,8 @@ pub async fn start_beefy_gadget<B, BE, C, N, P, R, S>(
 		on_demand_justifications_handler,
 	} = beefy_params;
 
+	let key_store: Arc<BeefyKeystore> = Arc::new(key_store.into());
+
 	let BeefyNetworkParams {
 		network,
 		sync,
@@ -255,6 +258,7 @@ pub async fn start_beefy_gadget<B, BE, C, N, P, R, S>(
 	let fisherman = Fisherman {
 		backend: backend.clone(),
 		runtime: runtime.clone(),
+		key_store: key_store.clone(),
 		payload_provider: payload_provider.clone(),
 		_phantom: PhantomData,
 	};
@@ -318,7 +322,7 @@ pub async fn start_beefy_gadget<B, BE, C, N, P, R, S>(
 		payload_provider,
 		runtime,
 		sync,
-		key_store: key_store.into(),
+		key_store,
 		gossip_engine,
 		gossip_validator,
 		gossip_report_stream,

--- a/client/consensus/beefy/src/round.rs
+++ b/client/consensus/beefy/src/round.rs
@@ -22,7 +22,7 @@ use codec::{Decode, Encode};
 use log::debug;
 use sp_consensus_beefy::{
 	ecdsa_crypto::{AuthorityId, Signature},
-	Commitment, EquivocationProof, SignedCommitment, ValidatorSet, ValidatorSetId, VoteMessage,
+	Commitment, VoteEquivocationProof, SignedCommitment, ValidatorSet, ValidatorSetId, VoteMessage,
 };
 use sp_runtime::traits::{Block, NumberFor};
 use std::collections::BTreeMap;
@@ -61,7 +61,7 @@ pub fn threshold(authorities: usize) -> usize {
 pub enum VoteImportResult<B: Block> {
 	Ok,
 	RoundConcluded(SignedCommitment<NumberFor<B>, Signature>),
-	Equivocation(EquivocationProof<NumberFor<B>, AuthorityId, Signature>),
+	Equivocation(VoteEquivocationProof<NumberFor<B>, AuthorityId, Signature>),
 	Invalid,
 	Stale,
 }
@@ -153,7 +153,7 @@ where
 					target: LOG_TARGET,
 					"🥩 detected equivocated vote: 1st: {:?}, 2nd: {:?}", previous_vote, vote
 				);
-				return VoteImportResult::Equivocation(EquivocationProof {
+				return VoteImportResult::Equivocation(VoteEquivocationProof {
 					first: previous_vote.clone(),
 					second: vote,
 				})
@@ -203,7 +203,7 @@ mod tests {
 	use sc_network_test::Block;
 
 	use sp_consensus_beefy::{
-		known_payloads::MMR_ROOT_ID, Commitment, EquivocationProof, Keyring, Payload,
+		known_payloads::MMR_ROOT_ID, Commitment, VoteEquivocationProof, Keyring, Payload,
 		SignedCommitment, ValidatorSet, VoteMessage,
 	};
 
@@ -485,7 +485,7 @@ mod tests {
 		let mut alice_vote2 = alice_vote1.clone();
 		alice_vote2.commitment = commitment2;
 
-		let expected_result = VoteImportResult::Equivocation(EquivocationProof {
+		let expected_result = VoteImportResult::Equivocation(VoteEquivocationProof {
 			first: alice_vote1.clone(),
 			second: alice_vote2.clone(),
 		});

--- a/client/consensus/beefy/src/tests.rs
+++ b/client/consensus/beefy/src/tests.rs
@@ -56,7 +56,7 @@ use sp_consensus_beefy::{
 	ecdsa_crypto::{AuthorityId, Signature},
 	known_payloads,
 	mmr::{find_mmr_root_digest, MmrRootProvider},
-	BeefyApi, Commitment, ConsensusLog, EquivocationProof, Keyring as BeefyKeyring, MmrRootHash,
+	BeefyApi, Commitment, ConsensusLog, VoteEquivocationProof, Keyring as BeefyKeyring, MmrRootHash,
 	OpaqueKeyOwnershipProof, Payload, SignedCommitment, ValidatorSet, ValidatorSetId,
 	VersionedFinalityProof, VoteMessage, BEEFY_ENGINE_ID,
 };
@@ -271,7 +271,7 @@ pub(crate) struct TestApi {
 	pub validator_set: BeefyValidatorSet,
 	pub mmr_root_hash: MmrRootHash,
 	pub reported_equivocations:
-		Option<Arc<Mutex<Vec<EquivocationProof<NumberFor<Block>, AuthorityId, Signature>>>>>,
+		Option<Arc<Mutex<Vec<VoteEquivocationProof<NumberFor<Block>, AuthorityId, Signature>>>>>,
 }
 
 impl TestApi {
@@ -325,7 +325,7 @@ sp_api::mock_impl_runtime_apis! {
 		}
 
 		fn submit_report_equivocation_unsigned_extrinsic(
-			proof: EquivocationProof<NumberFor<Block>, AuthorityId, Signature>,
+			proof: VoteEquivocationProof<NumberFor<Block>, AuthorityId, Signature>,
 			_dummy: OpaqueKeyOwnershipProof,
 		) -> Option<()> {
 			if let Some(equivocations_buf) = self.inner.reported_equivocations.as_ref() {

--- a/client/consensus/beefy/src/tests.rs
+++ b/client/consensus/beefy/src/tests.rs
@@ -254,6 +254,9 @@ impl<B: BlockT> BeefyFisherman<B> for DummyFisherman<B> {
 	fn check_proof(&self, _: BeefyVersionedFinalityProof<B>) -> Result<(), Error> {
 		Ok(())
 	}
+	fn check_signed_commitment(&self, _: SignedCommitment<NumberFor<B>, Signature>) -> Result<(), Error> {
+		Ok(())
+	}
 	fn check_vote(
 		&self,
 		_: VoteMessage<NumberFor<B>, AuthorityId, Signature>,

--- a/client/consensus/beefy/src/tests.rs
+++ b/client/consensus/beefy/src/tests.rs
@@ -44,7 +44,7 @@ use sc_consensus::{
 };
 use sc_network::{config::RequestResponseConfig, ProtocolName};
 use sc_network_test::{
-	Block, BlockImportAdapter, FullPeerConfig, PassThroughVerifier, Peer, PeersClient,
+	Block, BlockImportAdapter, Header, FullPeerConfig, PassThroughVerifier, Peer, PeersClient,
 	PeersFullClient, TestNetFactory,
 };
 use sc_utils::notification::NotificationReceiver;
@@ -1406,7 +1406,7 @@ async fn gossipped_finality_proofs() {
 
 	// Simulate Charlie vote on #2
 	let header = net.lock().peer(2).client().as_client().expect_header(finalize).unwrap();
-	let mmr_root = find_mmr_root_digest::<Block>(&header).unwrap();
+	let mmr_root = find_mmr_root_digest::<Header>(&header).unwrap();
 	let payload = Payload::from_single_entry(known_payloads::MMR_ROOT_ID, mmr_root.encode());
 	let commitment = Commitment { payload, block_number, validator_set_id: validator_set.id() };
 	let signature = sign_commitment(&BeefyKeyring::Charlie, &commitment);

--- a/client/consensus/beefy/src/tests.rs
+++ b/client/consensus/beefy/src/tests.rs
@@ -56,7 +56,7 @@ use sp_consensus_beefy::{
 	ecdsa_crypto::{AuthorityId, Signature},
 	known_payloads,
 	mmr::{find_mmr_root_digest, MmrRootProvider},
-	BeefyApi, Commitment, ConsensusLog, VoteEquivocationProof, Keyring as BeefyKeyring, MmrRootHash,
+	BeefyApi, Commitment, ConsensusLog, ForkEquivocationProof, VoteEquivocationProof, Keyring as BeefyKeyring, MmrRootHash,
 	OpaqueKeyOwnershipProof, Payload, SignedCommitment, ValidatorSet, ValidatorSetId,
 	VersionedFinalityProof, VoteMessage, BEEFY_ENGINE_ID,
 };
@@ -1318,9 +1318,9 @@ async fn beefy_reports_vote_equivocations() {
 	}
 
 	// Verify expected equivocation
-	let alice_reported_equivocations = api_alice.reported_vote_equivocations.as_ref().unwrap().lock();
-	assert_eq!(alice_reported_equivocations.len(), 1);
-	let equivocation_proof = alice_reported_equivocations.get(0).unwrap();
+	let alice_reported_vote_equivocations = api_alice.reported_vote_equivocations.as_ref().unwrap().lock();
+	assert_eq!(alice_reported_vote_equivocations.len(), 1);
+	let equivocation_proof = alice_reported_vote_equivocations.get(0).unwrap();
 	assert_eq!(equivocation_proof.first.id, BeefyKeyring::Bob.public());
 	assert_eq!(equivocation_proof.first.commitment.block_number, 1);
 

--- a/client/consensus/beefy/src/tests.rs
+++ b/client/consensus/beefy/src/tests.rs
@@ -29,6 +29,7 @@ use crate::{
 		},
 		request_response::{on_demand_justifications_protocol_config, BeefyJustifsRequestHandler},
 	},
+	error::Error,
 	gossip_protocol_name,
 	justification::*,
 	load_or_init_voter_state, wait_for_runtime_pallet, BeefyRPCLinks, BeefyVoterLinks, KnownPeers,
@@ -250,13 +251,13 @@ pub(crate) struct DummyFisherman<B> {
 }
 
 impl<B: BlockT> BeefyFisherman<B> for DummyFisherman<B> {
-	fn check_proof(&self, _: BeefyVersionedFinalityProof<B>) -> Result<(), sp_blockchain::Error> {
+	fn check_proof(&self, _: BeefyVersionedFinalityProof<B>) -> Result<(), Error> {
 		Ok(())
 	}
 	fn check_vote(
 		&self,
 		_: VoteMessage<NumberFor<B>, AuthorityId, Signature>,
-	) -> Result<(), sp_blockchain::Error> {
+	) -> Result<(), Error> {
 		Ok(())
 	}
 }

--- a/client/consensus/beefy/src/tests.rs
+++ b/client/consensus/beefy/src/tests.rs
@@ -324,7 +324,7 @@ sp_api::mock_impl_runtime_apis! {
 			Some(self.inner.validator_set.clone())
 		}
 
-		fn submit_report_equivocation_unsigned_extrinsic(
+		fn submit_report_vote_equivocation_unsigned_extrinsic(
 			proof: VoteEquivocationProof<NumberFor<Block>, AuthorityId, Signature>,
 			_dummy: OpaqueKeyOwnershipProof,
 		) -> Option<()> {

--- a/client/consensus/beefy/src/tests.rs
+++ b/client/consensus/beefy/src/tests.rs
@@ -273,7 +273,7 @@ pub(crate) struct TestApi {
 	pub reported_vote_equivocations:
 		Option<Arc<Mutex<Vec<VoteEquivocationProof<NumberFor<Block>, AuthorityId, Signature>>>>>,
 	pub reported_fork_equivocations:
-		Option<Arc<Mutex<Vec<VoteEquivocationProof<NumberFor<Block>, AuthorityId, Signature>>>>>,
+		Option<Arc<Mutex<Vec<ForkEquivocationProof<NumberFor<Block>, AuthorityId, Signature, Header>>>>>,
 }
 
 impl TestApi {
@@ -303,6 +303,7 @@ impl TestApi {
 
 	pub fn allow_equivocations(&mut self) {
 		self.reported_vote_equivocations = Some(Arc::new(Mutex::new(vec![])));
+		self.reported_fork_equivocations = Some(Arc::new(Mutex::new(vec![])));
 	}
 }
 
@@ -333,6 +334,18 @@ sp_api::mock_impl_runtime_apis! {
 			_dummy: OpaqueKeyOwnershipProof,
 		) -> Option<()> {
 			if let Some(equivocations_buf) = self.inner.reported_vote_equivocations.as_ref() {
+				equivocations_buf.lock().push(proof);
+				None
+			} else {
+				panic!("Equivocations not expected, but following proof was reported: {:?}", proof);
+			}
+		}
+
+		fn submit_report_fork_equivocation_unsigned_extrinsic(
+			proof: ForkEquivocationProof<NumberFor<Block>, AuthorityId, Signature, Header>,
+			_dummy: Vec<OpaqueKeyOwnershipProof>,
+		) -> Option<()> {
+			if let Some(equivocations_buf) = self.inner.reported_fork_equivocations.as_ref() {
 				equivocations_buf.lock().push(proof);
 				None
 			} else {

--- a/client/consensus/beefy/src/worker.rs
+++ b/client/consensus/beefy/src/worker.rs
@@ -43,7 +43,7 @@ use sp_consensus::SyncOracle;
 use sp_consensus_beefy::{
 	check_equivocation_proof,
 	ecdsa_crypto::{AuthorityId, Signature},
-	BeefyApi, Commitment, ConsensusLog, EquivocationProof, PayloadProvider, ValidatorSet,
+	BeefyApi, Commitment, ConsensusLog, VoteEquivocationProof, PayloadProvider, ValidatorSet,
 	VersionedFinalityProof, VoteMessage, BEEFY_ENGINE_ID,
 };
 use sp_runtime::{
@@ -934,7 +934,7 @@ where
 	/// isn't necessarily the best block if there are pending authority set changes.
 	pub(crate) fn report_equivocation(
 		&self,
-		proof: EquivocationProof<NumberFor<B>, AuthorityId, Signature>,
+		proof: VoteEquivocationProof<NumberFor<B>, AuthorityId, Signature>,
 	) -> Result<(), Error> {
 		let rounds = self.persisted_state.voting_oracle.active_rounds()?;
 		let (validators, validator_set_id) = (rounds.validators(), rounds.validator_set_id());

--- a/client/consensus/beefy/src/worker.rs
+++ b/client/consensus/beefy/src/worker.rs
@@ -981,7 +981,7 @@ where
 		// submit equivocation report at **best** block
 		let best_block_hash = self.backend.blockchain().info().best_hash;
 		runtime_api
-			.submit_report_equivocation_unsigned_extrinsic(best_block_hash, proof, key_owner_proof)
+			.submit_report_vote_equivocation_unsigned_extrinsic(best_block_hash, proof, key_owner_proof)
 			.map_err(Error::RuntimeApi)?;
 
 		Ok(())

--- a/client/consensus/beefy/src/worker.rs
+++ b/client/consensus/beefy/src/worker.rs
@@ -41,7 +41,7 @@ use sp_api::{BlockId, ProvideRuntimeApi};
 use sp_arithmetic::traits::{AtLeast32Bit, Saturating};
 use sp_consensus::SyncOracle;
 use sp_consensus_beefy::{
-	check_equivocation_proof,
+	check_vote_equivocation_proof,
 	ecdsa_crypto::{AuthorityId, Signature},
 	BeefyApi, Commitment, ConsensusLog, VoteEquivocationProof, PayloadProvider, ValidatorSet,
 	VersionedFinalityProof, VoteMessage, BEEFY_ENGINE_ID,
@@ -940,7 +940,7 @@ where
 		let (validators, validator_set_id) = (rounds.validators(), rounds.validator_set_id());
 		let offender_id = proof.offender_id().clone();
 
-		if !check_equivocation_proof::<_, _, BeefySignatureHasher>(&proof) {
+		if !check_vote_equivocation_proof::<_, _, BeefySignatureHasher>(&proof) {
 			debug!(target: LOG_TARGET, "🥩 Skip report for bad equivocation {:?}", proof);
 			return Ok(())
 		} else if let Some(local_id) = self.key_store.authority_id(validators) {

--- a/client/consensus/beefy/src/worker.rs
+++ b/client/consensus/beefy/src/worker.rs
@@ -1157,9 +1157,11 @@ pub(crate) mod tests {
 			known_peers,
 			None,
 		);
-		// Push 1 block - will start first session.
-		let hashes = peer.push_blocks(1, false);
-		backend.finalize_block(hashes[0], None).unwrap();
+		// If chain's still at genesis, push 1 block to start first session.
+		if backend.blockchain().info().best_hash == backend.blockchain().info().genesis_hash {
+			let hashes = peer.push_blocks(1, false);
+			backend.finalize_block(hashes[0], None).unwrap();
+		}
 		let first_header = backend
 			.blockchain()
 			.expect_header(backend.blockchain().info().best_hash)

--- a/frame/beefy/src/equivocation.rs
+++ b/frame/beefy/src/equivocation.rs
@@ -154,7 +154,7 @@ where
 		use frame_system::offchain::SubmitTransaction;
 		let (equivocation_proof, key_owner_proof) = evidence;
 
-		let call = Call::report_equivocation_unsigned {
+		let call = Call::report_vote_equivocation_unsigned {
 			equivocation_proof: Box::new(equivocation_proof),
 			key_owner_proof,
 		};
@@ -238,12 +238,12 @@ where
 }
 
 /// Methods for the `ValidateUnsigned` implementation:
-/// It restricts calls to `report_equivocation_unsigned` to local calls (i.e. extrinsics generated
+/// It restricts calls to `report_vote_equivocation_unsigned` to local calls (i.e. extrinsics generated
 /// on this node) or that already in a block. This guarantees that only block authors can include
 /// unsigned equivocation reports.
 impl<T: Config> Pallet<T> {
 	pub fn validate_unsigned(source: TransactionSource, call: &Call<T>) -> TransactionValidity {
-		if let Call::report_equivocation_unsigned { equivocation_proof, key_owner_proof } = call {
+		if let Call::report_vote_equivocation_unsigned { equivocation_proof, key_owner_proof } = call {
 			// discard equivocation report not coming from the local node
 			match source {
 				TransactionSource::Local | TransactionSource::InBlock => { /* allowed */ },
@@ -281,7 +281,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub fn pre_dispatch(call: &Call<T>) -> Result<(), TransactionValidityError> {
-		if let Call::report_equivocation_unsigned { equivocation_proof, key_owner_proof } = call {
+		if let Call::report_vote_equivocation_unsigned { equivocation_proof, key_owner_proof } = call {
 			let evidence = (*equivocation_proof.clone(), key_owner_proof.clone());
 			T::EquivocationReportSystem::check_evidence(evidence)
 		} else {

--- a/frame/beefy/src/equivocation.rs
+++ b/frame/beefy/src/equivocation.rs
@@ -125,6 +125,7 @@ where
 pub struct EquivocationReportSystem<T, R, P, L>(sp_std::marker::PhantomData<(T, R, P, L)>);
 
 /// Equivocation evidence convenience alias.
+// TODO: use an enum that takes either `EquivocationProof` or `InvalidForkVoteProof`
 pub type EquivocationEvidenceFor<T> = (
 	EquivocationProof<
 		BlockNumberFor<T>,

--- a/frame/beefy/src/equivocation.rs
+++ b/frame/beefy/src/equivocation.rs
@@ -211,7 +211,7 @@ where
 			.ok_or(Error::<T>::InvalidKeyOwnershipProof)?;
 
 		// Validate equivocation proof (check votes are different and signatures are valid).
-		if !sp_consensus_beefy::check_equivocation_proof(&equivocation_proof) {
+		if !sp_consensus_beefy::check_vote_equivocation_proof(&equivocation_proof) {
 			return Err(Error::<T>::InvalidVoteEquivocationProof.into())
 		}
 

--- a/frame/beefy/src/equivocation.rs
+++ b/frame/beefy/src/equivocation.rs
@@ -41,7 +41,7 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 use log::{error, info};
-use sp_consensus_beefy::{EquivocationProof, ValidatorSetId, KEY_TYPE as BEEFY_KEY_TYPE};
+use sp_consensus_beefy::{VoteEquivocationProof, ValidatorSetId, KEY_TYPE as BEEFY_KEY_TYPE};
 use sp_runtime::{
 	transaction_validity::{
 		InvalidTransaction, TransactionPriority, TransactionSource, TransactionValidity,
@@ -125,9 +125,9 @@ where
 pub struct EquivocationReportSystem<T, R, P, L>(sp_std::marker::PhantomData<(T, R, P, L)>);
 
 /// Equivocation evidence convenience alias.
-// TODO: use an enum that takes either `EquivocationProof` or `InvalidForkVoteProof`
+// TODO: use an enum that takes either `VoteEquivocationProof` or `ForkEquivocationProof`
 pub type EquivocationEvidenceFor<T> = (
-	EquivocationProof<
+	VoteEquivocationProof<
 		BlockNumberFor<T>,
 		<T as Config>::BeefyId,
 		<<T as Config>::BeefyId as RuntimeAppPublic>::Signature,

--- a/frame/beefy/src/equivocation.rs
+++ b/frame/beefy/src/equivocation.rs
@@ -212,15 +212,15 @@ where
 
 		// Validate equivocation proof (check votes are different and signatures are valid).
 		if !sp_consensus_beefy::check_equivocation_proof(&equivocation_proof) {
-			return Err(Error::<T>::InvalidEquivocationProof.into())
+			return Err(Error::<T>::InvalidVoteEquivocationProof.into())
 		}
 
 		// Check that the session id for the membership proof is within the
 		// bounds of the set id reported in the equivocation.
 		let set_id_session_index =
-			crate::SetIdSession::<T>::get(set_id).ok_or(Error::<T>::InvalidEquivocationProof)?;
+			crate::SetIdSession::<T>::get(set_id).ok_or(Error::<T>::InvalidVoteEquivocationProof)?;
 		if session_index != set_id_session_index {
-			return Err(Error::<T>::InvalidEquivocationProof.into())
+			return Err(Error::<T>::InvalidVoteEquivocationProof.into())
 		}
 
 		let offence = EquivocationOffence {

--- a/frame/beefy/src/equivocation.rs
+++ b/frame/beefy/src/equivocation.rs
@@ -79,8 +79,8 @@ where
 	pub session_index: SessionIndex,
 	/// The size of the validator set at the time of the offence.
 	pub validator_set_count: u32,
-	/// The authority which produced this equivocation.
-	pub offender: Offender,
+	/// The authorities which produced this equivocation.
+	pub offenders: Vec<Offender>,
 }
 
 impl<Offender: Clone, N> Offence<Offender> for EquivocationOffence<Offender, N>
@@ -91,7 +91,7 @@ where
 	type TimeSlot = TimeSlot<N>;
 
 	fn offenders(&self) -> Vec<Offender> {
-		vec![self.offender.clone()]
+		self.offenders.clone()
 	}
 
 	fn session_index(&self) -> SessionIndex {
@@ -227,7 +227,7 @@ where
 			time_slot: TimeSlot { set_id, round },
 			session_index,
 			validator_set_count,
-			offender,
+			offenders: vec![offender],
 		};
 
 		R::report_offence(reporter.into_iter().collect(), offence)

--- a/frame/beefy/src/lib.rs
+++ b/frame/beefy/src/lib.rs
@@ -112,8 +112,6 @@ pub mod pallet {
 		/// Defines methods to publish, check and process an equivocation offence.
 		type EquivocationReportSystem: OffenceReportSystem<
 			Option<Self::AccountId>,
-			// TODO: make below an enum that takes either `VoteEquivocationProof` or
-			// `InvalidForkCommitmentProof`
 			EquivocationEvidenceFor<Self>,
 		>;
 	}
@@ -199,6 +197,8 @@ pub mod pallet {
 		InvalidKeyOwnershipProof,
 		/// An equivocation proof provided as part of a voter equivocation report is invalid.
 		InvalidVoteEquivocationProof,
+		/// An equivocation proof provided as part of a fork equivocation report is invalid.
+		InvalidForkEquivocationProof,
 		/// A given equivocation report is valid but already previously reported.
 		DuplicateOffenceReport,
 	}
@@ -286,7 +286,7 @@ pub mod pallet {
 		))]
 		pub fn report_fork_equivocation(
 			origin: OriginFor<T>,
-			fork_equivocation_proof: Box<
+			equivocation_proof: Box<
 				ForkEquivocationProof<
 					BlockNumberFor<T>,
 					T::BeefyId,
@@ -315,18 +315,19 @@ pub mod pallet {
 		/// block authors will call it (validated in `ValidateUnsigned`), as such
 		/// if the block author is defined it will be defined as the equivocation
 		/// reporter.
+		/// TODO: fix key_owner_proofs[0].validator_count()
 		#[pallet::call_index(3)]
-		#[pallet::weight(T::WeightInfo::report_equivocation(key_owner_proof.validator_count(), T::MaxNominators::get(),))]
+		#[pallet::weight(T::WeightInfo::report_equivocation(key_owner_proofs[0].validator_count(), T::MaxNominators::get(),))]
 		pub fn report_fork_equivocation_unsigned(
 			origin: OriginFor<T>,
-			fork_equivocation_proof: Box<
+			equivocation_proof: Box<
 				ForkEquivocationProof<
 					BlockNumberFor<T>,
 					T::BeefyId,
 					<T::BeefyId as RuntimeAppPublic>::Signature,
 				>,
 			>,
-			key_owner_proof: T::KeyOwnerProof,
+			key_owner_proofs: Vec<T::KeyOwnerProof>,
 		) -> DispatchResultWithPostInfo {
 			ensure_none(origin)?;
 

--- a/frame/beefy/src/lib.rs
+++ b/frame/beefy/src/lib.rs
@@ -389,13 +389,18 @@ impl<T: Config> Pallet<T> {
 	/// a call to `report_fork_equivocation_unsigned` and will push the transaction
 	/// to the pool. Only useful in an offchain context.
 	pub fn submit_unsigned_fork_equivocation_report(
-		_fork_equivocation_proof: sp_consensus_beefy::ForkEquivocationProof<BlockNumberFor<T>, T::BeefyId,
+		fork_equivocation_proof: sp_consensus_beefy::ForkEquivocationProof<BlockNumberFor<T>, T::BeefyId,
 			<T::BeefyId as RuntimeAppPublic>::Signature, HeaderFor<T>
 >,
-		_key_owner_proofs: Vec<T::KeyOwnerProof>,
+		key_owner_proofs: Vec<T::KeyOwnerProof>,
 	) -> Option<()> {
-		// T::EquivocationReportSystem::publish_evidence((fork_equivocation_proof, key_owner_proofs)).ok()
-		None
+		T::EquivocationReportSystem::publish_evidence(
+			EquivocationEvidenceFor::<T>::ForkEquivocationProof(
+				fork_equivocation_proof,
+				key_owner_proofs,
+			),
+		)
+		.ok()
 	}
 
 	fn change_authorities(

--- a/frame/beefy/src/lib.rs
+++ b/frame/beefy/src/lib.rs
@@ -249,7 +249,7 @@ pub mod pallet {
 			key_owner_proof.validator_count(),
 			T::MaxNominators::get(),
 		))]
-		pub fn report_equivocation_unsigned(
+		pub fn report_vote_equivocation_unsigned(
 			origin: OriginFor<T>,
 			equivocation_proof: Box<
 				VoteEquivocationProof<
@@ -278,9 +278,9 @@ pub mod pallet {
 			key_owner_proof.validator_count(),
 			T::MaxNominators::get(),
 		))]
-		pub fn report_invalid_fork_commitment(
+		pub fn report_fork_equivocation(
 			origin: OriginFor<T>,
-			invalid_fork_proof: Box<
+			fork_equivocation_proof: Box<
 				ForkEquivocationProof<
 					BlockNumberFor<T>,
 					T::BeefyId,
@@ -294,7 +294,7 @@ pub mod pallet {
 			// TODO:
 			// T::EquivocationReportSystem::process_evidence(
 			// 	Some(reporter),
-			// 	(*invalid_fork_proof, key_owner_proof),
+			// 	(*fork_equivocation_proof, key_owner_proof),
 			// )?;
 			// Waive the fee since the report is valid and beneficial
 			Ok(Pays::No.into())
@@ -311,9 +311,9 @@ pub mod pallet {
 		/// reporter.
 		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::report_equivocation(key_owner_proof.validator_count(), T::MaxNominators::get(),))]
-		pub fn report_invalid_fork_commitment_unsigned(
+		pub fn report_fork_equivocation_unsigned(
 			origin: OriginFor<T>,
-			invalid_fork_proof: Box<
+			fork_equivocation_proof: Box<
 				ForkEquivocationProof<
 					BlockNumberFor<T>,
 					T::BeefyId,
@@ -327,7 +327,7 @@ pub mod pallet {
 			// TODO:
 			// T::EquivocationReportSystem::process_evidence(
 			// 	None,
-			// 	(*invalid_fork_proof, key_owner_proof),
+			// 	(*fork_equivocation_proof, key_owner_proof),
 			// )?;
 			Ok(Pays::No.into())
 		}
@@ -358,7 +358,7 @@ impl<T: Config> Pallet<T> {
 	/// Submits an extrinsic to report an equivocation. This method will create
 	/// an unsigned extrinsic with a call to `report_equivocation_unsigned` and
 	/// will push the transaction to the pool. Only useful in an offchain context.
-	pub fn submit_unsigned_equivocation_report(
+	pub fn submit_unsigned_vote_equivocation_report(
 		equivocation_proof: VoteEquivocationProof<
 			BlockNumberFor<T>,
 			T::BeefyId,
@@ -371,15 +371,15 @@ impl<T: Config> Pallet<T> {
 
 	/// Submits an extrinsic to report an invalid fork signed by potentially
 	/// multiple signatories. This method will create an unsigned extrinsic with
-	/// a call to `report_invalid_fork_unsigned` and will push the transaction
+	/// a call to `report_fork_equivocation_unsigned` and will push the transaction
 	/// to the pool. Only useful in an offchain context.
-	pub fn submit_unsigned_invalid_fork_report(
-		_invalid_fork_proof: sp_consensus_beefy::ForkEquivocationProof<BlockNumberFor<T>, T::BeefyId,
+	pub fn submit_unsigned_fork_equivocation_report(
+		_fork_equivocation_proof: sp_consensus_beefy::ForkEquivocationProof<BlockNumberFor<T>, T::BeefyId,
 			<T::BeefyId as RuntimeAppPublic>::Signature,
 >,
 		_key_owner_proofs: Vec<T::KeyOwnerProof>,
 	) -> Option<()> {
-		// T::EquivocationReportSystem::publish_evidence((invalid_fork_proof, key_owner_proofs)).ok()
+		// T::EquivocationReportSystem::publish_evidence((fork_equivocation_proof, key_owner_proofs)).ok()
 		None
 	}
 

--- a/frame/beefy/src/lib.rs
+++ b/frame/beefy/src/lib.rs
@@ -279,9 +279,10 @@ pub mod pallet {
 		/// invalid fork proof and validate the given key ownership proof
 		/// against the extracted offender. If both are valid, the offence
 		/// will be reported.
+		// TODO: fix key_owner_proofs[0].validator_count()
 		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::report_equivocation(
-			key_owner_proof.validator_count(),
+			key_owner_proofs[0].validator_count(),
 			T::MaxNominators::get(),
 		))]
 		pub fn report_fork_equivocation(
@@ -293,15 +294,14 @@ pub mod pallet {
 					<T::BeefyId as RuntimeAppPublic>::Signature,
 				>,
 			>,
-			key_owner_proof: T::KeyOwnerProof,
+			key_owner_proofs: Vec<T::KeyOwnerProof>,
 		) -> DispatchResultWithPostInfo {
 			let reporter = ensure_signed(origin)?;
 
-			// TODO:
-			// T::EquivocationReportSystem::process_evidence(
-			// 	Some(reporter),
-			// 	(*fork_equivocation_proof, key_owner_proof),
-			// )?;
+			T::EquivocationReportSystem::process_evidence(
+				Some(reporter),
+				EquivocationEvidenceFor::ForkEquivocationProof(*equivocation_proof, key_owner_proofs),
+			)?;
 			// Waive the fee since the report is valid and beneficial
 			Ok(Pays::No.into())
 		}
@@ -315,7 +315,7 @@ pub mod pallet {
 		/// block authors will call it (validated in `ValidateUnsigned`), as such
 		/// if the block author is defined it will be defined as the equivocation
 		/// reporter.
-		/// TODO: fix key_owner_proofs[0].validator_count()
+		// TODO: fix key_owner_proofs[0].validator_count()
 		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::report_equivocation(key_owner_proofs[0].validator_count(), T::MaxNominators::get(),))]
 		pub fn report_fork_equivocation_unsigned(

--- a/frame/beefy/src/lib.rs
+++ b/frame/beefy/src/lib.rs
@@ -197,8 +197,8 @@ pub mod pallet {
 	pub enum Error<T> {
 		/// A key ownership proof provided as part of an equivocation report is invalid.
 		InvalidKeyOwnershipProof,
-		/// An equivocation proof provided as part of an equivocation report is invalid.
-		InvalidEquivocationProof,
+		/// An equivocation proof provided as part of a voter equivocation report is invalid.
+		InvalidVoteEquivocationProof,
 		/// A given equivocation report is valid but already previously reported.
 		DuplicateOffenceReport,
 	}

--- a/frame/beefy/src/lib.rs
+++ b/frame/beefy/src/lib.rs
@@ -366,6 +366,20 @@ impl<T: Config> Pallet<T> {
 		T::EquivocationReportSystem::publish_evidence((equivocation_proof, key_owner_proof)).ok()
 	}
 
+	/// Submits an extrinsic to report an invalid fork signed by potentially
+	/// multiple signatories. This method will create an unsigned extrinsic with
+	/// a call to `report_invalid_fork_unsigned` and will push the transaction
+	/// to the pool. Only useful in an offchain context.
+	pub fn submit_unsigned_invalid_fork_report(
+		_invalid_fork_proof: sp_consensus_beefy::InvalidForkCommitmentProof<BlockNumberFor<T>, T::BeefyId,
+			<T::BeefyId as RuntimeAppPublic>::Signature,
+>,
+		_key_owner_proofs: Vec<T::KeyOwnerProof>,
+	) -> Option<()> {
+		// T::EquivocationReportSystem::publish_evidence((invalid_fork_proof, key_owner_proofs)).ok()
+		None
+	}
+
 	fn change_authorities(
 		new: BoundedVec<T::BeefyId, T::MaxAuthorities>,
 		queued: BoundedVec<T::BeefyId, T::MaxAuthorities>,

--- a/frame/beefy/src/lib.rs
+++ b/frame/beefy/src/lib.rs
@@ -113,7 +113,7 @@ pub mod pallet {
 		type EquivocationReportSystem: OffenceReportSystem<
 			Option<Self::AccountId>,
 			// TODO: make below an enum that takes either `EquivocationProof` or
-			// `InvalidForkVoteProof`
+			// `InvalidForkCommitmentProof`
 			EquivocationEvidenceFor<Self>,
 		>;
 	}

--- a/frame/beefy/src/lib.rs
+++ b/frame/beefy/src/lib.rs
@@ -229,7 +229,10 @@ pub mod pallet {
 
 			T::EquivocationReportSystem::process_evidence(
 				Some(reporter),
-				(*equivocation_proof, key_owner_proof),
+				EquivocationEvidenceFor::VoteEquivocationProof(
+					*equivocation_proof,
+					key_owner_proof,
+				),
 			)?;
 			// Waive the fee since the report is valid and beneficial
 			Ok(Pays::No.into())
@@ -264,7 +267,10 @@ pub mod pallet {
 
 			T::EquivocationReportSystem::process_evidence(
 				None,
-				(*equivocation_proof, key_owner_proof),
+				EquivocationEvidenceFor::<T>::VoteEquivocationProof(
+					*equivocation_proof,
+					key_owner_proof,
+				),
 			)?;
 			Ok(Pays::No.into())
 		}
@@ -366,7 +372,13 @@ impl<T: Config> Pallet<T> {
 		>,
 		key_owner_proof: T::KeyOwnerProof,
 	) -> Option<()> {
-		T::EquivocationReportSystem::publish_evidence((equivocation_proof, key_owner_proof)).ok()
+		T::EquivocationReportSystem::publish_evidence(
+			EquivocationEvidenceFor::<T>::VoteEquivocationProof(
+				equivocation_proof,
+				key_owner_proof,
+			),
+		)
+		.ok()
 	}
 
 	/// Submits an extrinsic to report an invalid fork signed by potentially

--- a/frame/beefy/src/lib.rs
+++ b/frame/beefy/src/lib.rs
@@ -63,7 +63,7 @@ const LOG_TARGET: &str = "runtime::beefy";
 pub mod pallet {
 	use super::*;
 	use frame_system::pallet_prelude::BlockNumberFor;
-	use sp_consensus_beefy::InvalidForkCommitmentProof;
+	use sp_consensus_beefy::ForkEquivocationProof;
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
@@ -281,7 +281,7 @@ pub mod pallet {
 		pub fn report_invalid_fork_commitment(
 			origin: OriginFor<T>,
 			invalid_fork_proof: Box<
-				InvalidForkCommitmentProof<
+				ForkEquivocationProof<
 					BlockNumberFor<T>,
 					T::BeefyId,
 					<T::BeefyId as RuntimeAppPublic>::Signature,
@@ -314,7 +314,7 @@ pub mod pallet {
 		pub fn report_invalid_fork_commitment_unsigned(
 			origin: OriginFor<T>,
 			invalid_fork_proof: Box<
-				InvalidForkCommitmentProof<
+				ForkEquivocationProof<
 					BlockNumberFor<T>,
 					T::BeefyId,
 					<T::BeefyId as RuntimeAppPublic>::Signature,
@@ -374,7 +374,7 @@ impl<T: Config> Pallet<T> {
 	/// a call to `report_invalid_fork_unsigned` and will push the transaction
 	/// to the pool. Only useful in an offchain context.
 	pub fn submit_unsigned_invalid_fork_report(
-		_invalid_fork_proof: sp_consensus_beefy::InvalidForkCommitmentProof<BlockNumberFor<T>, T::BeefyId,
+		_invalid_fork_proof: sp_consensus_beefy::ForkEquivocationProof<BlockNumberFor<T>, T::BeefyId,
 			<T::BeefyId as RuntimeAppPublic>::Signature,
 >,
 		_key_owner_proofs: Vec<T::KeyOwnerProof>,

--- a/frame/beefy/src/lib.rs
+++ b/frame/beefy/src/lib.rs
@@ -41,7 +41,7 @@ use sp_staking::{offence::OffenceReportSystem, SessionIndex};
 use sp_std::prelude::*;
 
 use sp_consensus_beefy::{
-	AuthorityIndex, BeefyAuthorityId, ConsensusLog, EquivocationProof, OnNewValidatorSet,
+	AuthorityIndex, BeefyAuthorityId, ConsensusLog, VoteEquivocationProof, OnNewValidatorSet,
 	ValidatorSet, BEEFY_ENGINE_ID, GENESIS_AUTHORITY_SET_ID,
 };
 
@@ -112,7 +112,7 @@ pub mod pallet {
 		/// Defines methods to publish, check and process an equivocation offence.
 		type EquivocationReportSystem: OffenceReportSystem<
 			Option<Self::AccountId>,
-			// TODO: make below an enum that takes either `EquivocationProof` or
+			// TODO: make below an enum that takes either `VoteEquivocationProof` or
 			// `InvalidForkCommitmentProof`
 			EquivocationEvidenceFor<Self>,
 		>;
@@ -217,7 +217,7 @@ pub mod pallet {
 		pub fn report_equivocation(
 			origin: OriginFor<T>,
 			equivocation_proof: Box<
-				EquivocationProof<
+				VoteEquivocationProof<
 					BlockNumberFor<T>,
 					T::BeefyId,
 					<T::BeefyId as RuntimeAppPublic>::Signature,
@@ -252,7 +252,7 @@ pub mod pallet {
 		pub fn report_equivocation_unsigned(
 			origin: OriginFor<T>,
 			equivocation_proof: Box<
-				EquivocationProof<
+				VoteEquivocationProof<
 					BlockNumberFor<T>,
 					T::BeefyId,
 					<T::BeefyId as RuntimeAppPublic>::Signature,
@@ -359,7 +359,7 @@ impl<T: Config> Pallet<T> {
 	/// an unsigned extrinsic with a call to `report_equivocation_unsigned` and
 	/// will push the transaction to the pool. Only useful in an offchain context.
 	pub fn submit_unsigned_equivocation_report(
-		equivocation_proof: EquivocationProof<
+		equivocation_proof: VoteEquivocationProof<
 			BlockNumberFor<T>,
 			T::BeefyId,
 			<T::BeefyId as RuntimeAppPublic>::Signature,

--- a/frame/beefy/src/lib.rs
+++ b/frame/beefy/src/lib.rs
@@ -274,7 +274,10 @@ pub mod pallet {
 		/// against the extracted offender. If both are valid, the offence
 		/// will be reported.
 		#[pallet::call_index(2)]
-		#[pallet::weight(T::WeightInfo::report_equivocation(key_owner_proof.validator_count()))]
+		#[pallet::weight(T::WeightInfo::report_equivocation(
+			key_owner_proof.validator_count(),
+			T::MaxNominators::get(),
+		))]
 		pub fn report_invalid_fork_commitment(
 			origin: OriginFor<T>,
 			invalid_fork_proof: Box<
@@ -307,7 +310,7 @@ pub mod pallet {
 		/// if the block author is defined it will be defined as the equivocation
 		/// reporter.
 		#[pallet::call_index(3)]
-		#[pallet::weight(T::WeightInfo::report_equivocation(key_owner_proof.validator_count()))]
+		#[pallet::weight(T::WeightInfo::report_equivocation(key_owner_proof.validator_count(), T::MaxNominators::get(),))]
 		pub fn report_invalid_fork_commitment_unsigned(
 			origin: OriginFor<T>,
 			invalid_fork_proof: Box<

--- a/frame/beefy/src/lib.rs
+++ b/frame/beefy/src/lib.rs
@@ -63,7 +63,7 @@ const LOG_TARGET: &str = "runtime::beefy";
 pub mod pallet {
 	use super::*;
 	use frame_system::pallet_prelude::BlockNumberFor;
-	use sp_consensus_beefy::InvalidForkVoteProof;
+	use sp_consensus_beefy::InvalidForkCommitmentProof;
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
@@ -275,10 +275,10 @@ pub mod pallet {
 		/// will be reported.
 		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::report_equivocation(key_owner_proof.validator_count()))]
-		pub fn report_invalid_fork_vote(
+		pub fn report_invalid_fork_commitment(
 			origin: OriginFor<T>,
 			invalid_fork_proof: Box<
-				InvalidForkVoteProof<
+				InvalidForkCommitmentProof<
 					BlockNumberFor<T>,
 					T::BeefyId,
 					<T::BeefyId as RuntimeAppPublic>::Signature,
@@ -297,9 +297,9 @@ pub mod pallet {
 			Ok(Pays::No.into())
 		}
 
-		/// Report voter voting on invalid fork. This method will verify the
+		/// Report commitment on invalid fork. This method will verify the
 		/// invalid fork proof and validate the given key ownership proof
-		/// against the extracted offender. If both are valid, the offence
+		/// against the extracted offenders. If both are valid, the offence
 		/// will be reported.
 		///
 		/// This extrinsic must be called unsigned and it is expected that only
@@ -308,10 +308,10 @@ pub mod pallet {
 		/// reporter.
 		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::report_equivocation(key_owner_proof.validator_count()))]
-		pub fn report_invalid_fork_vote_unsigned(
+		pub fn report_invalid_fork_commitment_unsigned(
 			origin: OriginFor<T>,
 			invalid_fork_proof: Box<
-				InvalidForkVoteProof<
+				InvalidForkCommitmentProof<
 					BlockNumberFor<T>,
 					T::BeefyId,
 					<T::BeefyId as RuntimeAppPublic>::Signature,

--- a/frame/beefy/src/lib.rs
+++ b/frame/beefy/src/lib.rs
@@ -29,7 +29,7 @@ use frame_support::{
 };
 use frame_system::{
 	ensure_none, ensure_signed,
-	pallet_prelude::{BlockNumberFor, OriginFor},
+	pallet_prelude::{BlockNumberFor, OriginFor, HeaderFor},
 };
 use sp_runtime::{
 	generic::DigestItem,
@@ -292,6 +292,7 @@ pub mod pallet {
 					BlockNumberFor<T>,
 					T::BeefyId,
 					<T::BeefyId as RuntimeAppPublic>::Signature,
+					HeaderFor<T>
 				>,
 			>,
 			key_owner_proofs: Vec<T::KeyOwnerProof>,
@@ -325,6 +326,7 @@ pub mod pallet {
 					BlockNumberFor<T>,
 					T::BeefyId,
 					<T::BeefyId as RuntimeAppPublic>::Signature,
+					HeaderFor<T>,
 				>,
 			>,
 			key_owner_proofs: Vec<T::KeyOwnerProof>,
@@ -388,7 +390,7 @@ impl<T: Config> Pallet<T> {
 	/// to the pool. Only useful in an offchain context.
 	pub fn submit_unsigned_fork_equivocation_report(
 		_fork_equivocation_proof: sp_consensus_beefy::ForkEquivocationProof<BlockNumberFor<T>, T::BeefyId,
-			<T::BeefyId as RuntimeAppPublic>::Signature,
+			<T::BeefyId as RuntimeAppPublic>::Signature, HeaderFor<T>
 >,
 		_key_owner_proofs: Vec<T::KeyOwnerProof>,
 	) -> Option<()> {

--- a/frame/beefy/src/mock.rs
+++ b/frame/beefy/src/mock.rs
@@ -40,7 +40,7 @@ use crate as pallet_beefy;
 
 pub use sp_consensus_beefy::{
 	ecdsa_crypto::{AuthorityId as BeefyId, AuthoritySignature as BeefySignature},
-	ConsensusLog, EquivocationProof, BEEFY_ENGINE_ID,
+	ConsensusLog, VoteEquivocationProof, BEEFY_ENGINE_ID,
 };
 
 impl_opaque_keys! {

--- a/frame/beefy/src/tests.rs
+++ b/frame/beefy/src/tests.rs
@@ -19,7 +19,7 @@ use std::vec;
 
 use codec::Encode;
 use sp_consensus_beefy::{
-	check_vote_equivocation_proof, generate_equivocation_proof, known_payloads::MMR_ROOT_ID,
+	check_vote_equivocation_proof, generate_vote_equivocation_proof, known_payloads::MMR_ROOT_ID,
 	Keyring as BeefyKeyring, Payload, ValidatorSet, KEY_TYPE as BEEFY_KEY_TYPE,
 };
 
@@ -212,7 +212,7 @@ fn should_sign_and_verify() {
 
 	// generate an equivocation proof, with two votes in the same round for
 	// same payload signed by the same key
-	let equivocation_proof = generate_equivocation_proof(
+	let equivocation_proof = generate_vote_equivocation_proof(
 		(1, payload1.clone(), set_id, &BeefyKeyring::Bob),
 		(1, payload1.clone(), set_id, &BeefyKeyring::Bob),
 	);
@@ -221,7 +221,7 @@ fn should_sign_and_verify() {
 
 	// generate an equivocation proof, with two votes in different rounds for
 	// different payloads signed by the same key
-	let equivocation_proof = generate_equivocation_proof(
+	let equivocation_proof = generate_vote_equivocation_proof(
 		(1, payload1.clone(), set_id, &BeefyKeyring::Bob),
 		(2, payload2.clone(), set_id, &BeefyKeyring::Bob),
 	);
@@ -229,7 +229,7 @@ fn should_sign_and_verify() {
 	assert!(!check_vote_equivocation_proof::<_, _, Keccak256>(&equivocation_proof));
 
 	// generate an equivocation proof, with two votes by different authorities
-	let equivocation_proof = generate_equivocation_proof(
+	let equivocation_proof = generate_vote_equivocation_proof(
 		(1, payload1.clone(), set_id, &BeefyKeyring::Alice),
 		(1, payload2.clone(), set_id, &BeefyKeyring::Bob),
 	);
@@ -237,7 +237,7 @@ fn should_sign_and_verify() {
 	assert!(!check_vote_equivocation_proof::<_, _, Keccak256>(&equivocation_proof));
 
 	// generate an equivocation proof, with two votes in different set ids
-	let equivocation_proof = generate_equivocation_proof(
+	let equivocation_proof = generate_vote_equivocation_proof(
 		(1, payload1.clone(), set_id, &BeefyKeyring::Bob),
 		(1, payload2.clone(), set_id + 1, &BeefyKeyring::Bob),
 	);
@@ -247,7 +247,7 @@ fn should_sign_and_verify() {
 	// generate an equivocation proof, with two votes in the same round for
 	// different payloads signed by the same key
 	let payload2 = Payload::from_single_entry(MMR_ROOT_ID, vec![128]);
-	let equivocation_proof = generate_equivocation_proof(
+	let equivocation_proof = generate_vote_equivocation_proof(
 		(1, payload1, set_id, &BeefyKeyring::Bob),
 		(1, payload2, set_id, &BeefyKeyring::Bob),
 	);
@@ -291,7 +291,7 @@ fn report_equivocation_current_set_works() {
 		let payload2 = Payload::from_single_entry(MMR_ROOT_ID, vec![128]);
 		// generate an equivocation proof, with two votes in the same round for
 		// different payloads signed by the same key
-		let equivocation_proof = generate_equivocation_proof(
+		let equivocation_proof = generate_vote_equivocation_proof(
 			(block_num, payload1, set_id, &equivocation_keyring),
 			(block_num, payload2, set_id, &equivocation_keyring),
 		);
@@ -377,7 +377,7 @@ fn report_equivocation_old_set_works() {
 		let payload1 = Payload::from_single_entry(MMR_ROOT_ID, vec![42]);
 		let payload2 = Payload::from_single_entry(MMR_ROOT_ID, vec![128]);
 		// generate an equivocation proof for the old set,
-		let equivocation_proof = generate_equivocation_proof(
+		let equivocation_proof = generate_vote_equivocation_proof(
 			(block_num, payload1, old_set_id, &equivocation_keyring),
 			(block_num, payload2, old_set_id, &equivocation_keyring),
 		);
@@ -439,7 +439,7 @@ fn report_equivocation_invalid_set_id() {
 		let payload1 = Payload::from_single_entry(MMR_ROOT_ID, vec![42]);
 		let payload2 = Payload::from_single_entry(MMR_ROOT_ID, vec![128]);
 		// generate an equivocation for a future set
-		let equivocation_proof = generate_equivocation_proof(
+		let equivocation_proof = generate_vote_equivocation_proof(
 			(block_num, payload1, set_id + 1, &equivocation_keyring),
 			(block_num, payload2, set_id + 1, &equivocation_keyring),
 		);
@@ -481,7 +481,7 @@ fn report_equivocation_invalid_session() {
 		let payload1 = Payload::from_single_entry(MMR_ROOT_ID, vec![42]);
 		let payload2 = Payload::from_single_entry(MMR_ROOT_ID, vec![128]);
 		// generate an equivocation proof at following era set id = 2
-		let equivocation_proof = generate_equivocation_proof(
+		let equivocation_proof = generate_vote_equivocation_proof(
 			(block_num, payload1, set_id, &equivocation_keyring),
 			(block_num, payload2, set_id, &equivocation_keyring),
 		);
@@ -525,7 +525,7 @@ fn report_equivocation_invalid_key_owner_proof() {
 		let payload1 = Payload::from_single_entry(MMR_ROOT_ID, vec![42]);
 		let payload2 = Payload::from_single_entry(MMR_ROOT_ID, vec![128]);
 		// generate an equivocation proof for the authority at index 0
-		let equivocation_proof = generate_equivocation_proof(
+		let equivocation_proof = generate_vote_equivocation_proof(
 			(block_num, payload1, set_id + 1, &equivocation_keyring),
 			(block_num, payload2, set_id + 1, &equivocation_keyring),
 		);
@@ -584,31 +584,31 @@ fn report_equivocation_invalid_equivocation_proof() {
 
 		// both votes target the same block number and payload,
 		// there is no equivocation.
-		assert_invalid_equivocation_proof(generate_equivocation_proof(
+		assert_invalid_equivocation_proof(generate_vote_equivocation_proof(
 			(block_num, payload1.clone(), set_id, &equivocation_keyring),
 			(block_num, payload1.clone(), set_id, &equivocation_keyring),
 		));
 
 		// votes targeting different rounds, there is no equivocation.
-		assert_invalid_equivocation_proof(generate_equivocation_proof(
+		assert_invalid_equivocation_proof(generate_vote_equivocation_proof(
 			(block_num, payload1.clone(), set_id, &equivocation_keyring),
 			(block_num + 1, payload2.clone(), set_id, &equivocation_keyring),
 		));
 
 		// votes signed with different authority keys
-		assert_invalid_equivocation_proof(generate_equivocation_proof(
+		assert_invalid_equivocation_proof(generate_vote_equivocation_proof(
 			(block_num, payload1.clone(), set_id, &equivocation_keyring),
 			(block_num, payload1.clone(), set_id, &BeefyKeyring::Charlie),
 		));
 
 		// votes signed with a key that isn't part of the authority set
-		assert_invalid_equivocation_proof(generate_equivocation_proof(
+		assert_invalid_equivocation_proof(generate_vote_equivocation_proof(
 			(block_num, payload1.clone(), set_id, &equivocation_keyring),
 			(block_num, payload1.clone(), set_id, &BeefyKeyring::Dave),
 		));
 
 		// votes targeting different set ids
-		assert_invalid_equivocation_proof(generate_equivocation_proof(
+		assert_invalid_equivocation_proof(generate_vote_equivocation_proof(
 			(block_num, payload1, set_id, &equivocation_keyring),
 			(block_num, payload2, set_id + 1, &equivocation_keyring),
 		));
@@ -639,7 +639,7 @@ fn report_equivocation_validate_unsigned_prevents_duplicates() {
 
 		let payload1 = Payload::from_single_entry(MMR_ROOT_ID, vec![42]);
 		let payload2 = Payload::from_single_entry(MMR_ROOT_ID, vec![128]);
-		let equivocation_proof = generate_equivocation_proof(
+		let equivocation_proof = generate_vote_equivocation_proof(
 			(block_num, payload1, set_id, &equivocation_keyring),
 			(block_num, payload2, set_id, &equivocation_keyring),
 		);
@@ -743,7 +743,7 @@ fn valid_equivocation_reports_dont_pay_fees() {
 		// generate equivocation proof
 		let payload1 = Payload::from_single_entry(MMR_ROOT_ID, vec![42]);
 		let payload2 = Payload::from_single_entry(MMR_ROOT_ID, vec![128]);
-		let equivocation_proof = generate_equivocation_proof(
+		let equivocation_proof = generate_vote_equivocation_proof(
 			(block_num, payload1, set_id, &equivocation_keyring),
 			(block_num, payload2, set_id, &equivocation_keyring),
 		);

--- a/frame/beefy/src/tests.rs
+++ b/frame/beefy/src/tests.rs
@@ -300,7 +300,7 @@ fn report_equivocation_current_set_works() {
 		let key_owner_proof = Historical::prove((BEEFY_KEY_TYPE, &equivocation_key)).unwrap();
 
 		// report the equivocation and the tx should be dispatched successfully
-		assert_ok!(Beefy::report_equivocation_unsigned(
+		assert_ok!(Beefy::report_vote_equivocation_unsigned(
 			RuntimeOrigin::none(),
 			Box::new(equivocation_proof),
 			key_owner_proof,
@@ -383,7 +383,7 @@ fn report_equivocation_old_set_works() {
 		);
 
 		// report the equivocation and the tx should be dispatched successfully
-		assert_ok!(Beefy::report_equivocation_unsigned(
+		assert_ok!(Beefy::report_vote_equivocation_unsigned(
 			RuntimeOrigin::none(),
 			Box::new(equivocation_proof),
 			key_owner_proof,
@@ -446,7 +446,7 @@ fn report_equivocation_invalid_set_id() {
 
 		// the call for reporting the equivocation should error
 		assert_err!(
-			Beefy::report_equivocation_unsigned(
+			Beefy::report_vote_equivocation_unsigned(
 				RuntimeOrigin::none(),
 				Box::new(equivocation_proof),
 				key_owner_proof,
@@ -489,7 +489,7 @@ fn report_equivocation_invalid_session() {
 		// report an equivocation for the current set using an key ownership
 		// proof from the previous set, the session should be invalid.
 		assert_err!(
-			Beefy::report_equivocation_unsigned(
+			Beefy::report_vote_equivocation_unsigned(
 				RuntimeOrigin::none(),
 				Box::new(equivocation_proof),
 				key_owner_proof,
@@ -537,7 +537,7 @@ fn report_equivocation_invalid_key_owner_proof() {
 		// report an equivocation for the current set using a key ownership
 		// proof for a different key than the one in the equivocation proof.
 		assert_err!(
-			Beefy::report_equivocation_unsigned(
+			Beefy::report_vote_equivocation_unsigned(
 				RuntimeOrigin::none(),
 				Box::new(equivocation_proof),
 				invalid_key_owner_proof,
@@ -568,7 +568,7 @@ fn report_equivocation_invalid_equivocation_proof() {
 
 		let assert_invalid_equivocation_proof = |equivocation_proof| {
 			assert_err!(
-				Beefy::report_equivocation_unsigned(
+				Beefy::report_vote_equivocation_unsigned(
 					RuntimeOrigin::none(),
 					Box::new(equivocation_proof),
 					key_owner_proof.clone(),
@@ -646,7 +646,7 @@ fn report_equivocation_validate_unsigned_prevents_duplicates() {
 
 		let key_owner_proof = Historical::prove((BEEFY_KEY_TYPE, &equivocation_key)).unwrap();
 
-		let call = Call::report_equivocation_unsigned {
+		let call = Call::report_vote_equivocation_unsigned {
 			equivocation_proof: Box::new(equivocation_proof.clone()),
 			key_owner_proof: key_owner_proof.clone(),
 		};
@@ -681,7 +681,7 @@ fn report_equivocation_validate_unsigned_prevents_duplicates() {
 		assert_ok!(<Beefy as sp_runtime::traits::ValidateUnsigned>::pre_dispatch(&call));
 
 		// we submit the report
-		Beefy::report_equivocation_unsigned(
+		Beefy::report_vote_equivocation_unsigned(
 			RuntimeOrigin::none(),
 			Box::new(equivocation_proof),
 			key_owner_proof,
@@ -752,7 +752,7 @@ fn valid_equivocation_reports_dont_pay_fees() {
 		let key_owner_proof = Historical::prove((BEEFY_KEY_TYPE, &equivocation_key)).unwrap();
 
 		// check the dispatch info for the call.
-		let info = Call::<Test>::report_equivocation_unsigned {
+		let info = Call::<Test>::report_vote_equivocation_unsigned {
 			equivocation_proof: Box::new(equivocation_proof.clone()),
 			key_owner_proof: key_owner_proof.clone(),
 		}
@@ -763,7 +763,7 @@ fn valid_equivocation_reports_dont_pay_fees() {
 		assert_eq!(info.pays_fee, Pays::Yes);
 
 		// report the equivocation.
-		let post_info = Beefy::report_equivocation_unsigned(
+		let post_info = Beefy::report_vote_equivocation_unsigned(
 			RuntimeOrigin::none(),
 			Box::new(equivocation_proof.clone()),
 			key_owner_proof.clone(),
@@ -777,7 +777,7 @@ fn valid_equivocation_reports_dont_pay_fees() {
 
 		// report the equivocation again which is invalid now since it is
 		// duplicate.
-		let post_info = Beefy::report_equivocation_unsigned(
+		let post_info = Beefy::report_vote_equivocation_unsigned(
 			RuntimeOrigin::none(),
 			Box::new(equivocation_proof),
 			key_owner_proof,

--- a/frame/beefy/src/tests.rs
+++ b/frame/beefy/src/tests.rs
@@ -19,7 +19,7 @@ use std::vec;
 
 use codec::Encode;
 use sp_consensus_beefy::{
-	check_equivocation_proof, generate_equivocation_proof, known_payloads::MMR_ROOT_ID,
+	check_vote_equivocation_proof, generate_equivocation_proof, known_payloads::MMR_ROOT_ID,
 	Keyring as BeefyKeyring, Payload, ValidatorSet, KEY_TYPE as BEEFY_KEY_TYPE,
 };
 
@@ -217,7 +217,7 @@ fn should_sign_and_verify() {
 		(1, payload1.clone(), set_id, &BeefyKeyring::Bob),
 	);
 	// expect invalid equivocation proof
-	assert!(!check_equivocation_proof::<_, _, Keccak256>(&equivocation_proof));
+	assert!(!check_vote_equivocation_proof::<_, _, Keccak256>(&equivocation_proof));
 
 	// generate an equivocation proof, with two votes in different rounds for
 	// different payloads signed by the same key
@@ -226,7 +226,7 @@ fn should_sign_and_verify() {
 		(2, payload2.clone(), set_id, &BeefyKeyring::Bob),
 	);
 	// expect invalid equivocation proof
-	assert!(!check_equivocation_proof::<_, _, Keccak256>(&equivocation_proof));
+	assert!(!check_vote_equivocation_proof::<_, _, Keccak256>(&equivocation_proof));
 
 	// generate an equivocation proof, with two votes by different authorities
 	let equivocation_proof = generate_equivocation_proof(
@@ -234,7 +234,7 @@ fn should_sign_and_verify() {
 		(1, payload2.clone(), set_id, &BeefyKeyring::Bob),
 	);
 	// expect invalid equivocation proof
-	assert!(!check_equivocation_proof::<_, _, Keccak256>(&equivocation_proof));
+	assert!(!check_vote_equivocation_proof::<_, _, Keccak256>(&equivocation_proof));
 
 	// generate an equivocation proof, with two votes in different set ids
 	let equivocation_proof = generate_equivocation_proof(
@@ -242,7 +242,7 @@ fn should_sign_and_verify() {
 		(1, payload2.clone(), set_id + 1, &BeefyKeyring::Bob),
 	);
 	// expect invalid equivocation proof
-	assert!(!check_equivocation_proof::<_, _, Keccak256>(&equivocation_proof));
+	assert!(!check_vote_equivocation_proof::<_, _, Keccak256>(&equivocation_proof));
 
 	// generate an equivocation proof, with two votes in the same round for
 	// different payloads signed by the same key
@@ -252,7 +252,7 @@ fn should_sign_and_verify() {
 		(1, payload2, set_id, &BeefyKeyring::Bob),
 	);
 	// expect valid equivocation proof
-	assert!(check_equivocation_proof::<_, _, Keccak256>(&equivocation_proof));
+	assert!(check_vote_equivocation_proof::<_, _, Keccak256>(&equivocation_proof));
 }
 
 #[test]

--- a/frame/beefy/src/tests.rs
+++ b/frame/beefy/src/tests.rs
@@ -451,7 +451,7 @@ fn report_equivocation_invalid_set_id() {
 				Box::new(equivocation_proof),
 				key_owner_proof,
 			),
-			Error::<Test>::InvalidEquivocationProof,
+			Error::<Test>::InvalidVoteEquivocationProof,
 		);
 	});
 }
@@ -494,7 +494,7 @@ fn report_equivocation_invalid_session() {
 				Box::new(equivocation_proof),
 				key_owner_proof,
 			),
-			Error::<Test>::InvalidEquivocationProof,
+			Error::<Test>::InvalidVoteEquivocationProof,
 		);
 	});
 }
@@ -573,7 +573,7 @@ fn report_equivocation_invalid_equivocation_proof() {
 					Box::new(equivocation_proof),
 					key_owner_proof.clone(),
 				),
-				Error::<Test>::InvalidEquivocationProof,
+				Error::<Test>::InvalidVoteEquivocationProof,
 			);
 		};
 

--- a/primitives/consensus/beefy/src/commitment.rs
+++ b/primitives/consensus/beefy/src/commitment.rs
@@ -247,6 +247,21 @@ impl<N, S> From<SignedCommitment<N, S>> for VersionedFinalityProof<N, S> {
 	}
 }
 
+impl<N, S> VersionedFinalityProof<N, S> {
+	/// Provide reference to inner `Payload`.
+	pub fn payload(&self) -> &Payload {
+		match self {
+			VersionedFinalityProof::V1(inner) => &inner.commitment.payload,
+		}
+	}
+	/// Block number this proof is for.
+	pub fn number(&self) -> &N {
+		match self {
+			VersionedFinalityProof::V1(inner) => &inner.commitment.block_number,
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/primitives/consensus/beefy/src/commitment.rs
+++ b/primitives/consensus/beefy/src/commitment.rs
@@ -81,7 +81,7 @@ where
 	}
 }
 
-/// A commitment with matching GRANDPA validators' signatures.
+/// A commitment with matching BEEFY validators' signatures.
 ///
 /// Note that SCALE-encoding of the structure is optimized for size efficiency over the wire,
 /// please take a look at custom [`Encode`] and [`Decode`] implementations and
@@ -90,7 +90,7 @@ where
 pub struct SignedCommitment<TBlockNumber, TSignature> {
 	/// The commitment signatures are collected for.
 	pub commitment: Commitment<TBlockNumber>,
-	/// GRANDPA validators' signatures for the commitment.
+	/// BEEFY validators' signatures for the commitment.
 	///
 	/// The length of this `Vec` must match number of validators in the current set (see
 	/// [Commitment::validator_set_id]).

--- a/primitives/consensus/beefy/src/lib.rs
+++ b/primitives/consensus/beefy/src/lib.rs
@@ -351,6 +351,7 @@ where
 /// finalized by GRANDPA.
 pub fn check_fork_equivocation_proof<Number, Id, MsgHash, Header>(
 	proof: &ForkEquivocationProof<Number, Id, <Id as RuntimeAppPublic>::Signature, Header>,
+	expected_header_hash: &Header::Hash,
 ) -> bool
 where
 	Id: BeefyAuthorityId<MsgHash> + PartialEq,
@@ -359,6 +360,10 @@ where
 	Header: sp_api::HeaderT,
 {
 	let ForkEquivocationProof { commitment, signatories, correct_header } = proof;
+
+	if correct_header.hash() != *expected_header_hash {
+		return false
+	}
 
 	let expected_mmr_root_digest = mmr::find_mmr_root_digest::<Header>(correct_header);
 	let expected_payload = expected_mmr_root_digest.map(|mmr_root| {

--- a/primitives/consensus/beefy/src/lib.rs
+++ b/primitives/consensus/beefy/src/lib.rs
@@ -299,9 +299,9 @@ where
 	BeefyAuthorityId::<MsgHash>::verify(authority_id, signature, &encoded_commitment)
 }
 
-/// Verifies the equivocation proof by making sure that both votes target
+/// Verifies the vote equivocation proof by making sure that both votes target
 /// different blocks and that its signatures are valid.
-pub fn check_equivocation_proof<Number, Id, MsgHash>(
+pub fn check_vote_equivocation_proof<Number, Id, MsgHash>(
 	report: &VoteEquivocationProof<Number, Id, <Id as RuntimeAppPublic>::Signature>,
 ) -> bool
 where

--- a/primitives/consensus/beefy/src/lib.rs
+++ b/primitives/consensus/beefy/src/lib.rs
@@ -251,10 +251,10 @@ impl<Number, Id, Signature> VoteEquivocationProof<Number, Id, Signature> {
 	}
 }
 
-/// Proof of invalid commitment on a given set id.
-/// This proof shows commitment signed on a different fork than finalized by GRANDPA.
+/// Proof of authority misbehavior on a given set id.
+/// This proof shows commitment signed on a different fork.
 #[derive(Clone, Debug, Decode, Encode, PartialEq, TypeInfo)]
-pub struct InvalidForkCommitmentProof<Number, Id, Signature> {
+pub struct ForkEquivocationProof<Number, Id, Signature> {
 	/// Commitment for a block on different fork than one at the same height in
 	/// this client's chain.
 	/// TODO: maybe replace {commitment, signatories} with SignedCommitment
@@ -268,7 +268,7 @@ pub struct InvalidForkCommitmentProof<Number, Id, Signature> {
 	pub expected_payload: Payload,
 }
 
-impl<Number, Id, Signature> InvalidForkCommitmentProof<Number, Id, Signature> {
+impl<Number, Id, Signature> ForkEquivocationProof<Number, Id, Signature> {
 	/// Returns the authority id of the misbehaving voter.
 	pub fn offender_ids(&self) -> Vec<&Id> {
 		self.signatories.iter().map(|(id, _)| id).collect()
@@ -345,15 +345,15 @@ where
 /// finalized by GRANDPA. This is fine too, since the slashing risk of committing to
 /// an incorrect block implies validators will only sign blocks they *know* will be
 /// finalized by GRANDPA.
-pub fn check_invalid_fork_proof<Number, Id, MsgHash>(
-	proof: &InvalidForkCommitmentProof<Number, Id, <Id as RuntimeAppPublic>::Signature>,
+pub fn check_fork_equivocation_proof<Number, Id, MsgHash>(
+	proof: &ForkEquivocationProof<Number, Id, <Id as RuntimeAppPublic>::Signature>,
 ) -> bool
 where
 	Id: BeefyAuthorityId<MsgHash> + PartialEq,
 	Number: Clone + Encode + PartialEq,
 	MsgHash: Hash,
 {
-	let InvalidForkCommitmentProof { commitment, signatories, expected_payload } = proof;
+	let ForkEquivocationProof { commitment, signatories, expected_payload } = proof;
 
 	// check that `payload` on the `vote` is different that the `expected_payload` (checked first
 	// since cheap failfast).
@@ -442,7 +442,7 @@ sp_api::decl_runtime_apis! {
 		/// hardcoded to return `None`). Only useful in an offchain context.
 		fn submit_report_invalid_fork_unsigned_extrinsic(
 			invalid_fork_proof:
-				InvalidForkCommitmentProof<NumberFor<Block>, AuthorityId, <AuthorityId as RuntimeAppPublic>::Signature>,
+				ForkEquivocationProof<NumberFor<Block>, AuthorityId, <AuthorityId as RuntimeAppPublic>::Signature>,
 			key_owner_proofs: Vec<OpaqueKeyOwnershipProof>,
 		) -> Option<()>;
 

--- a/primitives/consensus/beefy/src/lib.rs
+++ b/primitives/consensus/beefy/src/lib.rs
@@ -229,14 +229,14 @@ pub struct VoteMessage<Number, Id, Signature> {
 /// BEEFY happens when a voter votes on the same round/block for different payloads.
 /// Proving is achieved by collecting the signed commitments of conflicting votes.
 #[derive(Clone, Debug, Decode, Encode, PartialEq, TypeInfo)]
-pub struct EquivocationProof<Number, Id, Signature> {
+pub struct VoteEquivocationProof<Number, Id, Signature> {
 	/// The first vote in the equivocation.
 	pub first: VoteMessage<Number, Id, Signature>,
 	/// The second vote in the equivocation.
 	pub second: VoteMessage<Number, Id, Signature>,
 }
 
-impl<Number, Id, Signature> EquivocationProof<Number, Id, Signature> {
+impl<Number, Id, Signature> VoteEquivocationProof<Number, Id, Signature> {
 	/// Returns the authority id of the equivocator.
 	pub fn offender_id(&self) -> &Id {
 		&self.first.id
@@ -302,7 +302,7 @@ where
 /// Verifies the equivocation proof by making sure that both votes target
 /// different blocks and that its signatures are valid.
 pub fn check_equivocation_proof<Number, Id, MsgHash>(
-	report: &EquivocationProof<Number, Id, <Id as RuntimeAppPublic>::Signature>,
+	report: &VoteEquivocationProof<Number, Id, <Id as RuntimeAppPublic>::Signature>,
 ) -> bool
 where
 	Id: BeefyAuthorityId<MsgHash> + PartialEq,
@@ -428,7 +428,7 @@ sp_api::decl_runtime_apis! {
 		/// hardcoded to return `None`). Only useful in an offchain context.
 		fn submit_report_equivocation_unsigned_extrinsic(
 			equivocation_proof:
-				EquivocationProof<NumberFor<Block>, AuthorityId, <AuthorityId as RuntimeAppPublic>::Signature>,
+				VoteEquivocationProof<NumberFor<Block>, AuthorityId, <AuthorityId as RuntimeAppPublic>::Signature>,
 			key_owner_proof: OpaqueKeyOwnershipProof,
 		) -> Option<()>;
 

--- a/primitives/consensus/beefy/src/lib.rs
+++ b/primitives/consensus/beefy/src/lib.rs
@@ -426,8 +426,8 @@ sp_api::decl_runtime_apis! {
 		/// `None` when creation of the extrinsic fails, e.g. if equivocation
 		/// reporting is disabled for the given runtime (i.e. this method is
 		/// hardcoded to return `None`). Only useful in an offchain context.
-		fn submit_report_equivocation_unsigned_extrinsic(
-			equivocation_proof:
+		fn submit_report_vote_equivocation_unsigned_extrinsic(
+			vote_equivocation_proof:
 				VoteEquivocationProof<NumberFor<Block>, AuthorityId, <AuthorityId as RuntimeAppPublic>::Signature>,
 			key_owner_proof: OpaqueKeyOwnershipProof,
 		) -> Option<()>;
@@ -440,8 +440,8 @@ sp_api::decl_runtime_apis! {
 		/// `None` when creation of the extrinsic fails, e.g. if equivocation
 		/// reporting is disabled for the given runtime (i.e. this method is
 		/// hardcoded to return `None`). Only useful in an offchain context.
-		fn submit_report_invalid_fork_unsigned_extrinsic(
-			invalid_fork_proof:
+		fn submit_report_fork_equivocation_unsigned_extrinsic(
+			fork_equivocation_proof:
 				ForkEquivocationProof<NumberFor<Block>, AuthorityId, <AuthorityId as RuntimeAppPublic>::Signature>,
 			key_owner_proofs: Vec<OpaqueKeyOwnershipProof>,
 		) -> Option<()>;

--- a/primitives/consensus/beefy/src/lib.rs
+++ b/primitives/consensus/beefy/src/lib.rs
@@ -389,7 +389,7 @@ impl<AuthorityId> OnNewValidatorSet<AuthorityId> for () {
 /// the runtime API boundary this type is unknown and as such we keep this
 /// opaque representation, implementors of the runtime API will have to make
 /// sure that all usages of `OpaqueKeyOwnershipProof` refer to the same type.
-#[derive(Decode, Encode, PartialEq, TypeInfo)]
+#[derive(Decode, Encode, PartialEq, TypeInfo, Clone)]
 pub struct OpaqueKeyOwnershipProof(Vec<u8>);
 impl OpaqueKeyOwnershipProof {
 	/// Create a new `OpaqueKeyOwnershipProof` using the given encoded

--- a/primitives/consensus/beefy/src/lib.rs
+++ b/primitives/consensus/beefy/src/lib.rs
@@ -355,7 +355,8 @@ where
 {
 	let InvalidForkCommitmentProof { commitment, signatories, expected_payload } = proof;
 
-	// check that `payload` on the `vote` is different that the `expected_payload` (checked first since cheap failfast).
+	// check that `payload` on the `vote` is different that the `expected_payload` (checked first
+	// since cheap failfast).
 	if &commitment.payload != expected_payload {
 		// check check each signatory's signature on the commitment.
 		// if any are invalid, equivocation report is invalid
@@ -405,7 +406,8 @@ impl OpaqueKeyOwnershipProof {
 }
 
 sp_api::decl_runtime_apis! {
-	/// API necessary for BEEFY voters.
+	/// API necessary for BEEFY voters. Due to the significant conceptual
+	/// overlap, in large part, this is lifted from the GRANDPA API.
 	#[api_version(3)]
 	pub trait BeefyApi<AuthorityId> where
 		AuthorityId : Codec + RuntimeAppPublic,

--- a/primitives/consensus/beefy/src/lib.rs
+++ b/primitives/consensus/beefy/src/lib.rs
@@ -442,7 +442,7 @@ sp_api::decl_runtime_apis! {
 		/// hardcoded to return `None`). Only useful in an offchain context.
 		fn submit_report_invalid_fork_unsigned_extrinsic(
 			invalid_fork_proof:
-				InvalidForkCommitmentProof<NumberFor<Block>, crypto::AuthorityId, crypto::Signature>,
+				InvalidForkCommitmentProof<NumberFor<Block>, AuthorityId, <AuthorityId as RuntimeAppPublic>::Signature>,
 			key_owner_proofs: Vec<OpaqueKeyOwnershipProof>,
 		) -> Option<()>;
 

--- a/primitives/consensus/beefy/src/mmr.rs
+++ b/primitives/consensus/beefy/src/mmr.rs
@@ -205,7 +205,7 @@ mod mmr_root_provider {
 mod tests {
 	use super::*;
 	use crate::H256;
-	use sp_runtime::{traits::BlakeTwo256, Digest, DigestItem, OpaqueExtrinsic};
+	use sp_runtime::{traits::BlakeTwo256, Digest, DigestItem};
 
 	#[test]
 	fn should_construct_version_correctly() {

--- a/primitives/consensus/beefy/src/mmr.rs
+++ b/primitives/consensus/beefy/src/mmr.rs
@@ -162,6 +162,12 @@ mod mmr_root_provider {
 		_phantom: PhantomData<B>,
 	}
 
+	impl<B, R> Clone for MmrRootProvider<B, R> {
+		fn clone(&self) -> Self {
+			Self { runtime: self.runtime.clone(), _phantom: PhantomData }
+		}
+	}
+
 	impl<B, R> MmrRootProvider<B, R>
 	where
 		B: Block,
@@ -184,7 +190,7 @@ mod mmr_root_provider {
 	impl<B: Block, R> PayloadProvider<B> for MmrRootProvider<B, R>
 	where
 		B: Block,
-		R: ProvideRuntimeApi<B>,
+		R: ProvideRuntimeApi<B> + Send + Sync + 'static,
 		R::Api: MmrApi<B, MmrRootHash, NumberFor<B>>,
 	{
 		fn payload(&self, header: &B::Header) -> Option<Payload> {

--- a/primitives/consensus/beefy/src/payload.rs
+++ b/primitives/consensus/beefy/src/payload.rs
@@ -43,7 +43,7 @@ pub mod known_payloads {
 pub struct Payload(Vec<(BeefyPayloadId, Vec<u8>)>);
 
 impl Payload {
-	/// Construct a new payload given an initial vallue
+	/// Construct a new payload given an initial value
 	pub fn from_single_entry(id: BeefyPayloadId, value: Vec<u8>) -> Self {
 		Self(vec![(id, value)])
 	}

--- a/primitives/consensus/beefy/src/payload.rs
+++ b/primitives/consensus/beefy/src/payload.rs
@@ -75,7 +75,7 @@ impl Payload {
 }
 
 /// Trait for custom BEEFY payload providers.
-pub trait PayloadProvider<B: Block> {
+pub trait PayloadProvider<B: Block>: Clone + Send + Sync + 'static {
 	/// Provide BEEFY payload if available for `header`.
 	fn payload(&self, header: &B::Header) -> Option<Payload>;
 }

--- a/primitives/consensus/beefy/src/test_utils.rs
+++ b/primitives/consensus/beefy/src/test_utils.rs
@@ -17,7 +17,7 @@
 
 #![cfg(feature = "std")]
 
-use crate::{ecdsa_crypto, Commitment, VoteEquivocationProof, Payload, ValidatorSetId, VoteMessage};
+use crate::{ecdsa_crypto, Commitment, ForkEquivocationProof, VoteEquivocationProof, Payload, ValidatorSetId, VoteMessage};
 use codec::Encode;
 use sp_core::{ecdsa, keccak_256, Pair};
 use std::collections::HashMap;
@@ -91,20 +91,28 @@ impl From<Keyring> for ecdsa_crypto::Public {
 	}
 }
 
+fn signed_vote(block_number: u64, payload: Payload, validator_set_id: ValidatorSetId, keyring: &Keyring) -> VoteMessage<u64, ecdsa_crypto::Public, ecdsa_crypto::Signature> {
+	let commitment = Commitment { validator_set_id, block_number, payload };
+	let signature = keyring.sign(&commitment.encode());
+	VoteMessage { commitment, id: keyring.public(), signature }
+}
+
 /// Create a new `VoteEquivocationProof` based on given arguments.
 pub fn generate_vote_equivocation_proof(
 	vote1: (u64, Payload, ValidatorSetId, &Keyring),
 	vote2: (u64, Payload, ValidatorSetId, &Keyring),
 ) -> VoteEquivocationProof<u64, ecdsa_crypto::Public, ecdsa_crypto::Signature> {
-	let signed_vote = |block_number: u64,
-	                   payload: Payload,
-	                   validator_set_id: ValidatorSetId,
-	                   keyring: &Keyring| {
-		let commitment = Commitment { validator_set_id, block_number, payload };
-		let signature = keyring.sign(&commitment.encode());
-		VoteMessage { commitment, id: keyring.public(), signature }
-	};
 	let first = signed_vote(vote1.0, vote1.1, vote1.2, vote1.3);
 	let second = signed_vote(vote2.0, vote2.1, vote2.2, vote2.3);
 	VoteEquivocationProof { first, second }
+}
+
+/// Create a new `ForkEquivocationProof` based on given arguments.
+pub fn generate_fork_equivocation_proof_vote<Header>(
+	vote: (u64, Payload, ValidatorSetId, &Keyring),
+	correct_header: Header,
+) -> ForkEquivocationProof<u64, ecdsa_crypto::Public, ecdsa_crypto::Signature, Header> {
+	let signed_vote = signed_vote(vote.0, vote.1, vote.2, vote.3);
+	let signatories = vec![(signed_vote.id, signed_vote.signature)];
+	ForkEquivocationProof { commitment: signed_vote.commitment, signatories, correct_header }
 }

--- a/primitives/consensus/beefy/src/test_utils.rs
+++ b/primitives/consensus/beefy/src/test_utils.rs
@@ -91,8 +91,8 @@ impl From<Keyring> for ecdsa_crypto::Public {
 	}
 }
 
-/// Create a new `EquivocationProof` based on given arguments.
-pub fn generate_equivocation_proof(
+/// Create a new `VoteEquivocationProof` based on given arguments.
+pub fn generate_vote_equivocation_proof(
 	vote1: (u64, Payload, ValidatorSetId, &Keyring),
 	vote2: (u64, Payload, ValidatorSetId, &Keyring),
 ) -> VoteEquivocationProof<u64, ecdsa_crypto::Public, ecdsa_crypto::Signature> {

--- a/primitives/consensus/beefy/src/test_utils.rs
+++ b/primitives/consensus/beefy/src/test_utils.rs
@@ -17,7 +17,7 @@
 
 #![cfg(feature = "std")]
 
-use crate::{ecdsa_crypto, Commitment, EquivocationProof, Payload, ValidatorSetId, VoteMessage};
+use crate::{ecdsa_crypto, Commitment, VoteEquivocationProof, Payload, ValidatorSetId, VoteMessage};
 use codec::Encode;
 use sp_core::{ecdsa, keccak_256, Pair};
 use std::collections::HashMap;
@@ -95,7 +95,7 @@ impl From<Keyring> for ecdsa_crypto::Public {
 pub fn generate_equivocation_proof(
 	vote1: (u64, Payload, ValidatorSetId, &Keyring),
 	vote2: (u64, Payload, ValidatorSetId, &Keyring),
-) -> EquivocationProof<u64, ecdsa_crypto::Public, ecdsa_crypto::Signature> {
+) -> VoteEquivocationProof<u64, ecdsa_crypto::Public, ecdsa_crypto::Signature> {
 	let signed_vote = |block_number: u64,
 	                   payload: Payload,
 	                   validator_set_id: ValidatorSetId,
@@ -106,5 +106,5 @@ pub fn generate_equivocation_proof(
 	};
 	let first = signed_vote(vote1.0, vote1.1, vote1.2, vote1.3);
 	let second = signed_vote(vote2.0, vote2.1, vote2.2, vote2.3);
-	EquivocationProof { first, second }
+	VoteEquivocationProof { first, second }
 }


### PR DESCRIPTION
# Description
Builds on and supersedes #14520.
The original scope was to support slashing validators equivocating by virtue of a gossiped vote which votes on a fork that has not been finalized.

This PR's aim differs in the following ways:
1. we do not slash for voting on unfinalized payloads, but rather for payloads that differ from the payload known to the runtime. As such, we do not check GRANDPA finalization.
2. while slashing equivocations detected in votes is also supported, the scope is extended to (and the focus placed on) equivocations detected in a `SignedCommitment`

## Rationale for 1.
Since GRANDPA finalization proof is not checked, which leads to slashing on
forks that may not be finalized. This is fine since honest validators will not be slashed on the chain finalized by GRANDPA, which is the only chain that ultimately matters. The only material difference not checking GRANDPA proofs makes is that validators are not slashed for signing BEEFY commitments prior to the blocks committed to being finalized by GRANDPA. This is fine too, since the slashing risk of committing to an incorrect block implies validators will only sign blocks they *know* will be finalized by GRANDPA.

## Rationale for 2.
While dishonest might gossip their equivocating votes via the standard gossip protocol, this hurts the prospect of their attack, and opens the door for the colluders to get slashed even if they don't ultimately carry out the attack on, for instance, the Ethereum bridge. Instead, we should face the reality that we will likely only detect the attack once it is carried out, that is: an equivocating payload of a [`submitInitial`/`submitInitialWithHandover`](https://github.com/Snowfork/snowbridge/blob/b92b1db7d9622534780c711860c95d9b1242a588/contracts/src/BeefyClient.sol#L217-L262) call is detected in Ethereum's mempool / a block.

## Proposed Solution

### Runtime

- two new extrinsic submission calls in `pallet_beefy`: `submit_unsigned_vote_equivocation_report` (previously `report_equivocation`) for vote equivocations (`VoteEquivocationProof`), and `submit_unsigned_fork_equivocation_report` for fork equivocations (`ForkEquivocationProof`), the latter whether detected in votes, `SignedCommitment`, or `VersionedFinalityProof`
- verify commitment's `mmr_root` != on-chain `mmr_root`
- report offense to staking so offending vote author / `SignedCommitment` signatories get slashed

### Client-side
- adds "fisherman" capabilities to voter gossip - on detecting votes for historical forks, it builds the required proof of misbehavior and submits report.

Closes #14505

### TODOs
- [ ] Polkadot companion
- [ ] Fish for equivocations on Ethereum (not scope of this PR - [best home is probably Snowfork's relayer])
- [ ] More robust mechanism than `<frame_system::Pallet<System>>::block_hash` for verifying header included in `ForkEquivocationProof`
- [ ] Extend test coverage