### PR TITLE
sc-cli: add no-beefy flag to cli config

### DIFF
--- a/bin/node/cli/benches/block_production.rs
+++ b/bin/node/cli/benches/block_production.rs
@@ -88,6 +88,7 @@ fn new_node(tokio_handle: Handle) -> node_cli::service::NewFullBase {
 		offchain_worker: OffchainWorkerConfig { enabled: true, indexing_enabled: false },
 		force_authoring: false,
 		disable_grandpa: false,
+		disable_beefy: false,
 		dev_key_seed: Some(Sr25519Keyring::Alice.to_seed()),
 		tracing_targets: None,
 		tracing_receiver: Default::default(),

--- a/bin/node/cli/benches/transaction_pool.rs
+++ b/bin/node/cli/benches/transaction_pool.rs
@@ -84,6 +84,7 @@ fn new_node(tokio_handle: Handle) -> node_cli::service::NewFullBase {
 		offchain_worker: OffchainWorkerConfig { enabled: true, indexing_enabled: false },
 		force_authoring: false,
 		disable_grandpa: false,
+		disable_beefy: false,
 		dev_key_seed: Some(Sr25519Keyring::Alice.to_seed()),
 		tracing_targets: None,
 		tracing_receiver: Default::default(),

--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -51,6 +51,10 @@ pub struct RunCmd {
 	#[arg(long)]
 	pub no_grandpa: bool,
 
+	/// Disable BEEFY voter when running in validator mode, otherwise disable the BEEFY observer.
+	#[arg(long)]
+	pub no_beefy: bool,
+
 	/// Listen to all RPC interfaces.
 	/// Default is local. Note: not all RPC methods are safe to be exposed publicly. Use an RPC
 	/// proxy server to filter out dangerous methods. More details:
@@ -311,6 +315,10 @@ impl CliConfiguration for RunCmd {
 
 	fn disable_grandpa(&self) -> Result<bool> {
 		Ok(self.no_grandpa)
+	}
+
+	fn disable_beefy(&self) -> Result<bool> {
+		Ok(self.no_beefy)
 	}
 
 	fn rpc_max_connections(&self) -> Result<u32> {

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -381,6 +381,13 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		Ok(Default::default())
 	}
 
+	/// Returns `Ok(true)` if BEEFY should be disabled
+	///
+	/// By default this is `false`.
+	fn disable_beefy(&self) -> Result<bool> {
+		Ok(Default::default())
+	}
+
 	/// Get the development key seed from the current object
 	///
 	/// By default this is `None`.
@@ -508,6 +515,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 			offchain_worker: self.offchain_worker(&role)?,
 			force_authoring: self.force_authoring()?,
 			disable_grandpa: self.disable_grandpa()?,
+			disable_beefy: self.disable_beefy()?,
 			dev_key_seed: self.dev_key_seed(is_dev)?,
 			tracing_targets: self.tracing_targets()?,
 			tracing_receiver: self.tracing_receiver()?,

--- a/client/cli/src/runner.rs
+++ b/client/cli/src/runner.rs
@@ -280,6 +280,7 @@ mod tests {
 				offchain_worker: Default::default(),
 				force_authoring: false,
 				disable_grandpa: false,
+				disable_beefy: false,
 				dev_key_seed: None,
 				tracing_targets: None,
 				tracing_receiver: Default::default(),

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -112,6 +112,8 @@ pub struct Configuration {
 	pub force_authoring: bool,
 	/// Disable GRANDPA when running in validator mode
 	pub disable_grandpa: bool,
+	/// Disable BEEFY when running in validator mode
+	pub disable_beefy: bool,
 	/// Development key seed.
 	///
 	/// When running in development mode, the seed will be used to generate authority keys by the

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -260,6 +260,7 @@ fn node_config<
 		offchain_worker: Default::default(),
 		force_authoring: false,
 		disable_grandpa: false,
+		disable_beefy: false,
 		dev_key_seed: key_seed,
 		tracing_targets: None,
 		tracing_receiver: Default::default(),


### PR DESCRIPTION
BEEFY is soon expected to run on all substrate-based chains, make it part of `sc-cli`.

Note: in case of `polkadot` binary, CLI doesn't change. `--no-beefy` is moved from polkadot specific cli to `sc-cli`.

polkadot companion: https://github.com/paritytech/polkadot/pull/7600
cumulus companion: https://github.com/paritytech/cumulus/pull/2996