### PR TITLE
Logging improvements

### DIFF
--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -554,6 +554,11 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		Ok(self.shared_params().disable_log_color())
 	}
 
+	/// Should use UTC time in log output?
+	fn use_utc_log_time(&self) -> Result<bool> {
+		Ok(self.shared_params().use_utc_log_time())
+	}
+
 	/// Initialize substrate. This must be done only once per process.
 	///
 	/// This method:
@@ -606,6 +611,10 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 
 		if self.disable_log_color()? {
 			logger.with_colors(false);
+		}
+
+		if self.use_utc_log_time()? {
+			logger.with_utc(true);
 		}
 
 		// Call hook for custom profiling setup.

--- a/client/cli/src/params/shared_params.rs
+++ b/client/cli/src/params/shared_params.rs
@@ -114,7 +114,7 @@ impl SharedParams {
 
 	/// Should the log color output be disabled?
 	pub fn disable_log_color(&self) -> bool {
-		self.disable_log_color
+		std::env::var("NO_COLOR").map_or(self.disable_log_color, |no_color| no_color == "1")
 	}
 
 	/// Is log reloading enabled

--- a/client/cli/src/params/shared_params.rs
+++ b/client/cli/src/params/shared_params.rs
@@ -56,6 +56,10 @@ pub struct SharedParams {
 	#[arg(long)]
 	pub disable_log_color: bool,
 
+	/// Use UTC time in log output.
+	#[arg(long)]
+	pub use_utc_log_time: bool,
+
 	/// Enable feature to dynamically update and reload the log filter.
 	/// Be aware that enabling this feature can lead to a performance decrease up to factor six or
 	/// more. Depending on the global logging level the performance decrease changes.
@@ -115,6 +119,11 @@ impl SharedParams {
 	/// Should the log color output be disabled?
 	pub fn disable_log_color(&self) -> bool {
 		std::env::var("NO_COLOR").map_or(self.disable_log_color, |no_color| no_color == "1")
+	}
+
+	/// Should use UTC time in log output?
+	pub fn use_utc_log_time(&self) -> bool {
+		self.use_utc_log_time
 	}
 
 	/// Is log reloading enabled

--- a/client/tracing/src/logging/mod.rs
+++ b/client/tracing/src/logging/mod.rs
@@ -28,7 +28,7 @@ mod fast_local_time;
 mod layers;
 mod stderr_writer;
 
-pub(crate) type DefaultLogger = stderr_writer::MakeStderrWriter;
+pub(crate) type DefaultLogger = MakeStderrWriter;
 
 pub use directives::*;
 pub use sc_tracing_proc_macro::*;
@@ -41,7 +41,7 @@ use tracing_subscriber::{
 		format, FormatEvent, FormatFields, Formatter, Layer as FmtLayer, MakeWriter,
 		SubscriberBuilder,
 	},
-	layer::{self, SubscriberExt},
+	layer::SubscriberExt,
 	registry::LookupSpan,
 	EnvFilter, FmtSubscriber, Layer, Registry,
 };
@@ -104,8 +104,8 @@ where
 	N: for<'writer> FormatFields<'writer> + 'static,
 	E: FormatEvent<Registry, N> + 'static,
 	W: MakeWriter + 'static,
-	F: layer::Layer<Formatter<N, E, W>> + Send + Sync + 'static,
-	FmtLayer<Registry, N, E, W>: layer::Layer<Registry> + Send + Sync + 'static,
+	F: Layer<Formatter<N, E, W>> + Send + Sync + 'static,
+	FmtLayer<Registry, N, E, W>: Layer<Registry> + Send + Sync + 'static,
 {
 	// Accept all valid directives and print invalid ones
 	fn parse_user_directives(mut env_filter: EnvFilter, dirs: &str) -> Result<EnvFilter> {
@@ -166,12 +166,12 @@ where
 
 	// If we're only logging `INFO` entries then we'll use a simplified logging format.
 	let detailed_output = match max_level_hint {
-		Some(level) if level <= tracing_subscriber::filter::LevelFilter::INFO => false,
+		Some(level) if level <= LevelFilter::INFO => false,
 		_ => true,
 	} || detailed_output;
 
 	let enable_color = force_colors.unwrap_or_else(|| atty::is(atty::Stream::Stderr));
-	let timer = fast_local_time::FastLocalTime { with_fractional: detailed_output };
+	let timer = FastLocalTime { with_fractional: detailed_output };
 
 	let event_format = EventFormat {
 		timer,
@@ -440,7 +440,7 @@ mod tests {
 			let test_directives = "test-target=info";
 			let _guard = init_logger(&test_directives);
 
-			log::info!(target: "test-target", "{}", EXPECTED_LOG_MESSAGE);
+			info!(target: "test-target", "{}", EXPECTED_LOG_MESSAGE);
 		}
 	}
 
@@ -475,7 +475,7 @@ mod tests {
 
 	#[crate::logging::prefix_logs_with(EXPECTED_NODE_NAME)]
 	fn prefix_in_log_lines_process() {
-		log::info!("{}", EXPECTED_LOG_MESSAGE);
+		info!("{}", EXPECTED_LOG_MESSAGE);
 	}
 
 	/// This is not an actual test, it is used by the `do_not_write_with_colors_on_tty` test.


### PR DESCRIPTION
This is something that bothered me for a long time. Defaulting logs to local time is confusing when debugging issues happening on machines all around the world.

This PR primarily introduces `--use-utc-log-time` CLI argument that reverts time format to what tracing-subscriber uses by default.

While at it I also added support for [`NO_COLOR`](https://no-color.org/), though better approach might be to remove `--disable-log-color` altogether and use `supports-color` that automatically takes this environment variable into account (see https://github.com/tokio-rs/tracing/issues/2388 and https://github.com/tokio-rs/tracing/issues/2214).

Fixes https://github.com/paritytech/substrate/issues/11734