### PR TITLE
BEEFY: add digest log on consensus reset

### DIFF
--- a/frame/beefy/src/default_weights.rs
+++ b/frame/beefy/src/default_weights.rs
@@ -49,4 +49,8 @@ impl crate::WeightInfo for () {
 			// fetching set id -> session index mappings
 			.saturating_add(DbWeight::get().reads(2))
 	}
+
+	fn set_new_genesis() -> Weight {
+		DbWeight::get().writes(1)
+	}
 }

--- a/frame/beefy/src/mock.rs
+++ b/frame/beefy/src/mock.rs
@@ -300,31 +300,34 @@ pub fn new_test_ext_raw_authorities(authorities: Vec<BeefyId>) -> TestExternalit
 	t.into()
 }
 
+pub fn push_block(i: u32) {
+	System::on_finalize(System::block_number());
+	Session::on_finalize(System::block_number());
+	Staking::on_finalize(System::block_number());
+	Beefy::on_finalize(System::block_number());
+
+	let parent_hash = if System::block_number() > 1 {
+		let hdr = System::finalize();
+		hdr.hash()
+	} else {
+		System::parent_hash()
+	};
+
+	System::reset_events();
+	System::initialize(&(i as u64 + 1), &parent_hash, &Default::default());
+	System::set_block_number((i + 1).into());
+	Timestamp::set_timestamp(System::block_number() * 6000);
+
+	System::on_initialize(System::block_number());
+	Session::on_initialize(System::block_number());
+	Staking::on_initialize(System::block_number());
+	Beefy::on_initialize(System::block_number());
+}
+
 pub fn start_session(session_index: SessionIndex) {
 	for i in Session::current_index()..session_index {
-		System::on_finalize(System::block_number());
-		Session::on_finalize(System::block_number());
-		Staking::on_finalize(System::block_number());
-		Beefy::on_finalize(System::block_number());
-
-		let parent_hash = if System::block_number() > 1 {
-			let hdr = System::finalize();
-			hdr.hash()
-		} else {
-			System::parent_hash()
-		};
-
-		System::reset_events();
-		System::initialize(&(i as u64 + 1), &parent_hash, &Default::default());
-		System::set_block_number((i + 1).into());
-		Timestamp::set_timestamp(System::block_number() * 6000);
-
-		System::on_initialize(System::block_number());
-		Session::on_initialize(System::block_number());
-		Staking::on_initialize(System::block_number());
-		Beefy::on_initialize(System::block_number());
+		push_block(i);
 	}
-
 	assert_eq!(Session::current_index(), session_index);
 }
 

--- a/frame/beefy/src/tests.rs
+++ b/frame/beefy/src/tests.rs
@@ -791,3 +791,24 @@ fn valid_equivocation_reports_dont_pay_fees() {
 		assert_eq!(post_info.pays_fee, Pays::Yes);
 	})
 }
+
+#[test]
+fn set_new_genesis_works() {
+	let authorities = test_authorities();
+
+	new_test_ext_raw_authorities(authorities).execute_with(|| {
+		start_era(1);
+
+		let new_genesis = 10u64;
+		// the call for setting new genesis should work
+		assert_ok!(Beefy::set_new_genesis(RuntimeOrigin::root(), new_genesis,));
+		// verify new genesis was set
+		assert_eq!(Beefy::genesis_block(), Some(new_genesis));
+
+		// setting to old block should fail
+		assert_err!(
+			Beefy::set_new_genesis(RuntimeOrigin::root(), 1u64,),
+			Error::<Test>::InvalidConfiguration,
+		);
+	});
+}

--- a/primitives/consensus/beefy/src/lib.rs
+++ b/primitives/consensus/beefy/src/lib.rs
@@ -209,6 +209,9 @@ pub enum ConsensusLog<AuthorityId: Codec> {
 	/// MMR root hash.
 	#[codec(index = 3)]
 	MmrRoot(MmrRootHash),
+	/// BEEFY consensus has been reset.
+	#[codec(index = 4)]
+	ConsensusReset(ValidatorSet<AuthorityId>),
 }
 
 /// BEEFY vote message.


### PR DESCRIPTION
Deposit `ConsensusLog` on BEEFY consensus reset.

The log can be used by block import (or light clients) to detect any consensus reset without having to rely on state.