### PR TITLE
Transfer to beneficiary after `transfer_on_hold`

### DIFF
--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -1283,7 +1283,7 @@ where
 		}
 		let frame = self.top_frame_mut();
 		let info = frame.terminate();
-		frame.nested_storage.terminate(&info, beneficiary);
+		frame.nested_storage.terminate(&info, beneficiary.clone());
 
 		info.queue_trie_for_deletion();
 		ContractInfoOf::<T>::remove(&frame.account_id);

--- a/frame/contracts/src/storage/meter.rs
+++ b/frame/contracts/src/storage/meter.rs
@@ -632,7 +632,7 @@ impl<T: Config> Ext<T> for ReservingExt {
 			// Whatever is left in the contract is sent to the termination beneficiary.
 			T::Currency::transfer(
 				&contract,
-				&*beneficiary,
+				&**beneficiary,
 				T::Currency::reducible_balance(&contract, Preservation::Expendable, Polite),
 				Preservation::Expendable,
 			)?;

--- a/frame/contracts/src/storage/meter.rs
+++ b/frame/contracts/src/storage/meter.rs
@@ -463,6 +463,9 @@ where
 		// We need to make sure that the contract's account exists.
 		T::Currency::transfer(origin, contract, ed, Preservation::Preserve)?;
 
+		// A consumer is added at account creation and remove it on termination, otherwise the
+		// runtime could remove the account. As long as a contract exists its account must exist.
+		// With the consumer a correct runtime cannot remove the account.
 		System::<T>::inc_consumers(contract)?;
 
 		// Normally, deposit charges are deferred to be able to coalesce them with refunds.

--- a/frame/contracts/src/storage/meter.rs
+++ b/frame/contracts/src/storage/meter.rs
@@ -462,7 +462,8 @@ where
 
 		// We need to make sure that the contract's account exists.
 		T::Currency::transfer(origin, contract, ed, Preservation::Preserve)?;
-		System::<T>::inc_consumers(&contract)?;
+
+		System::<T>::inc_consumers(contract)?;
 
 		// Normally, deposit charges are deferred to be able to coalesce them with refunds.
 		// However, we need to charge immediately so that the account is created before

--- a/frame/contracts/src/storage/meter.rs
+++ b/frame/contracts/src/storage/meter.rs
@@ -472,9 +472,9 @@ where
 		// We need to make sure that the contract's account exists.
 		T::Currency::transfer(origin, contract, ed, Preservation::Preserve)?;
 
-		// A consumer is added at account creation and remove it on termination, otherwise the
+		// A consumer is added at account creation and removed it on termination, otherwise the
 		// runtime could remove the account. As long as a contract exists its account must exist.
-		// With the consumer a correct runtime cannot remove the account.
+		// With the consumer, a correct runtime cannot remove the account.
 		System::<T>::inc_consumers(contract)?;
 
 		// Normally, deposit charges are deferred to be able to coalesce them with refunds.

--- a/frame/contracts/src/storage/meter.rs
+++ b/frame/contracts/src/storage/meter.rs
@@ -346,7 +346,7 @@ where
 		self.total_deposit.available(&self.limit)
 	}
 
-	/// Returns the status of the currently executed contract.
+	/// Returns the state of the currently executed contract.
 	fn contract_state(&self) -> ContractState<T> {
 		match &self.own_contribution {
 			Contribution::Terminated { deposit: _, beneficiary } =>

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -1600,15 +1600,6 @@ fn self_destruct_works() {
 			vec![
 				EventRecord {
 					phase: Phase::Initialization,
-					event: RuntimeEvent::Balances(pallet_balances::Event::Transfer {
-						from: addr.clone(),
-						to: DJANGO,
-						amount: 100_000 + min_balance,
-					}),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::Initialization,
 					event: RuntimeEvent::Contracts(crate::Event::Terminated {
 						contract: addr.clone(),
 						beneficiary: DJANGO
@@ -1638,6 +1629,15 @@ fn self_destruct_works() {
 					phase: Phase::Initialization,
 					event: RuntimeEvent::System(frame_system::Event::KilledAccount {
 						account: addr.clone()
+					}),
+					topics: vec![],
+				},
+				EventRecord {
+					phase: Phase::Initialization,
+					event: RuntimeEvent::Balances(pallet_balances::Event::Transfer {
+						from: addr.clone(),
+						to: DJANGO,
+						amount: 100_000 + min_balance,
 					}),
 					topics: vec![],
 				},


### PR DESCRIPTION
The order of balance transfers from the contract's accounts during termination is changed so that balance on hold is transferred to the origin before the contract's free balance is transferred to the `beneficiary`. This way we let the contract's account be reaped when the account is emptied.

The struct `Charge` is updated so that the bool `terminated` becomes `status` which is a new `ContractStatus` enum.
```rust
/// The beneficiary of a contract termination.
type BeneficiaryOf<T> = AccountIdOf<T>;

/// The status of a contract.
///
/// In case of termination the beneficiary is indicated.
#[derive(RuntimeDebugNoBound, Clone, PartialEq, Eq)]
pub enum ContractStatus<T: Config> {
	Alive,
	Terminated(BeneficiaryOf<T>),
}
```