### PR TITLE
Add GenesisConfig to identity pallet

### DIFF
--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -298,7 +298,7 @@ pub fn testnet_genesis(
 		balances: BalancesConfig {
 			balances: endowed_accounts.iter().cloned().map(|x| (x, ENDOWMENT)).collect(),
 		},
-		identity: IdentityConfig { identities: vec![] },
+		identity: IdentityConfig { registrars: vec![] },
 		indices: IndicesConfig { indices: vec![] },
 		session: SessionConfig {
 			keys: initial_authorities

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -21,9 +21,9 @@
 use grandpa_primitives::AuthorityId as GrandpaId;
 use kitchensink_runtime::{
 	constants::currency::*, wasm_binary_unwrap, BabeConfig, BalancesConfig, Block, CouncilConfig,
-	DemocracyConfig, ElectionsConfig, ImOnlineConfig, IndicesConfig, MaxNominations,
-	NominationPoolsConfig, SessionConfig, SessionKeys, SocietyConfig, StakerStatus, StakingConfig,
-	SudoConfig, SystemConfig, TechnicalCommitteeConfig,
+	DemocracyConfig, ElectionsConfig, IdentityConfig, ImOnlineConfig, IndicesConfig,
+	MaxNominations, NominationPoolsConfig, SessionConfig, SessionKeys, SocietyConfig, StakerStatus,
+	StakingConfig, SudoConfig, SystemConfig, TechnicalCommitteeConfig,
 };
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use sc_chain_spec::ChainSpecExtension;
@@ -298,6 +298,7 @@ pub fn testnet_genesis(
 		balances: BalancesConfig {
 			balances: endowed_accounts.iter().cloned().map(|x| (x, ENDOWMENT)).collect(),
 		},
+		identity: IdentityConfig { identities: vec![] },
 		indices: IndicesConfig { indices: vec![] },
 		session: SessionConfig {
 			keys: initial_authorities

--- a/bin/node/testing/src/genesis.rs
+++ b/bin/node/testing/src/genesis.rs
@@ -52,6 +52,7 @@ pub fn config_endowed(code: Option<&[u8]>, extra_endowed: Vec<AccountId>) -> Run
 			code: code.map(|x| x.to_vec()).unwrap_or_else(|| wasm_binary_unwrap().to_vec()),
 			..Default::default()
 		},
+		identity: Default::default(),
 		indices: IndicesConfig { indices: vec![] },
 		balances: BalancesConfig { balances: endowed },
 		session: SessionConfig {

--- a/bin/node/testing/src/genesis.rs
+++ b/bin/node/testing/src/genesis.rs
@@ -21,8 +21,8 @@
 use crate::keyring::*;
 use kitchensink_runtime::{
 	constants::currency::*, wasm_binary_unwrap, AccountId, AssetsConfig, BabeConfig,
-	BalancesConfig, GluttonConfig, GrandpaConfig, IndicesConfig, RuntimeGenesisConfig,
-	SessionConfig, SocietyConfig, StakerStatus, StakingConfig, SystemConfig,
+	BalancesConfig, GluttonConfig, GrandpaConfig, IdentityConfig, IndicesConfig,
+	RuntimeGenesisConfig, SessionConfig, SocietyConfig, StakerStatus, StakingConfig, SystemConfig,
 	BABE_GENESIS_EPOCH_CONFIG,
 };
 use sp_keyring::{Ed25519Keyring, Sr25519Keyring};
@@ -52,7 +52,9 @@ pub fn config_endowed(code: Option<&[u8]>, extra_endowed: Vec<AccountId>) -> Run
 			code: code.map(|x| x.to_vec()).unwrap_or_else(|| wasm_binary_unwrap().to_vec()),
 			..Default::default()
 		},
-		identity: Default::default(),
+		identity: IdentityConfig {
+			identities: vec![(alice(), "Alice".to_string()), (bob(), "Bob".to_string())],
+		},
 		indices: IndicesConfig { indices: vec![] },
 		balances: BalancesConfig { balances: endowed },
 		session: SessionConfig {

--- a/bin/node/testing/src/genesis.rs
+++ b/bin/node/testing/src/genesis.rs
@@ -26,7 +26,7 @@ use kitchensink_runtime::{
 	BABE_GENESIS_EPOCH_CONFIG,
 };
 use sp_keyring::{Ed25519Keyring, Sr25519Keyring};
-use sp_runtime::Perbill;
+use sp_runtime::{BoundedVec, Perbill};
 
 /// Create genesis runtime configuration for tests.
 pub fn config(code: Option<&[u8]>) -> RuntimeGenesisConfig {
@@ -53,7 +53,10 @@ pub fn config_endowed(code: Option<&[u8]>, extra_endowed: Vec<AccountId>) -> Run
 			..Default::default()
 		},
 		identity: IdentityConfig {
-			identities: vec![(alice(), "Alice".to_string()), (bob(), "Bob".to_string())],
+			identities: vec![
+				(alice(), BoundedVec::try_from("Alice".to_string().as_bytes().to_vec()).unwrap()),
+				(bob(), BoundedVec::try_from("Bob".to_string().as_bytes().to_vec()).unwrap()),
+			],
 		},
 		indices: IndicesConfig { indices: vec![] },
 		balances: BalancesConfig { balances: endowed },

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -79,6 +79,7 @@ mod types;
 pub mod weights;
 
 use frame_support::traits::{BalanceStatus, Currency, OnUnbalanced, ReservableCurrency};
+use scale_info::prelude::string::String;
 use sp_runtime::traits::{AppendZerosInput, Hash, Saturating, StaticLookup, Zero};
 use sp_std::prelude::*;
 pub use weights::WeightInfo;
@@ -203,7 +204,7 @@ pub mod pallet {
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
-		pub identities: Vec<T::AccountId>,
+		pub identities: Vec<(T::AccountId, String)>,
 	}
 
 	#[cfg(feature = "std")]
@@ -216,7 +217,26 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
-			// todo: insert genesis accounts
+			for (account, name) in &self.identities {
+				<IdentityOf<T>>::insert(
+					account,
+					Registration {
+						info: IdentityInfo {
+							display: Data::Raw(BoundedVec::try_from(name.encode()).unwrap()),
+							twitter: Data::None,
+							riot: Data::None,
+							email: Data::None,
+							pgp_fingerprint: None,
+							image: Data::None,
+							legal: Data::None,
+							web: Data::None,
+							additional: BoundedVec::default(),
+						},
+						judgements: BoundedVec::default(),
+						deposit: Zero::zero(),
+					},
+				);
+			}
 		}
 	}
 

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -201,6 +201,25 @@ pub mod pallet {
 		ValueQuery,
 	>;
 
+	#[pallet::genesis_config]
+	pub struct GenesisConfig<T: Config> {
+		pub identities: Vec<T::AccountId>,
+	}
+
+	#[cfg(feature = "std")]
+	impl<T: Config> Default for GenesisConfig<T> {
+		fn default() -> Self {
+			GenesisConfig { identities: Default::default() }
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+		fn build(&self) {
+			// todo: insert genesis accounts
+		}
+	}
+
 	#[pallet::error]
 	pub enum Error<T> {
 		/// Too many subs-accounts.

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -222,7 +222,9 @@ pub mod pallet {
 					account,
 					Registration {
 						info: IdentityInfo {
-							display: Data::Raw(BoundedVec::try_from(name.encode()).unwrap()),
+							display: Data::Raw(
+								BoundedVec::try_from(name.as_bytes().to_vec()).unwrap(),
+							),
 							twitter: Data::None,
 							riot: Data::None,
 							email: Data::None,

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -206,7 +206,6 @@ pub mod pallet {
 		pub identities: Vec<(T::AccountId, Vec<u8>)>,
 	}
 
-	#[cfg(feature = "std")]
 	impl<T: Config> Default for GenesisConfig<T> {
 		fn default() -> Self {
 			GenesisConfig { identities: Default::default() }

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -203,7 +203,7 @@ pub mod pallet {
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
-		pub identities: Vec<(T::AccountId, Vec<u8>)>,
+		pub identities: Vec<(T::AccountId, BoundedVec<u8, ConstU32<32>>)>,
 	}
 
 	impl<T: Config> Default for GenesisConfig<T> {
@@ -220,7 +220,7 @@ pub mod pallet {
 					account,
 					Registration {
 						info: IdentityInfo {
-							display: Data::Raw(BoundedVec::try_from(name.clone()).unwrap()),
+							display: Data::Raw(name.clone()),
 							twitter: Data::None,
 							riot: Data::None,
 							email: Data::None,

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -79,7 +79,6 @@ mod types;
 pub mod weights;
 
 use frame_support::traits::{BalanceStatus, Currency, OnUnbalanced, ReservableCurrency};
-use scale_info::prelude::string::String;
 use sp_runtime::traits::{AppendZerosInput, Hash, Saturating, StaticLookup, Zero};
 use sp_std::prelude::*;
 pub use weights::WeightInfo;
@@ -204,7 +203,7 @@ pub mod pallet {
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
-		pub identities: Vec<(T::AccountId, String)>,
+		pub identities: Vec<(T::AccountId, Vec<u8>)>,
 	}
 
 	#[cfg(feature = "std")]
@@ -222,9 +221,7 @@ pub mod pallet {
 					account,
 					Registration {
 						info: IdentityInfo {
-							display: Data::Raw(
-								BoundedVec::try_from(name.as_bytes().to_vec()).unwrap(),
-							),
+							display: Data::Raw(BoundedVec::try_from(name.clone()).unwrap()),
 							twitter: Data::None,
 							riot: Data::None,
 							email: Data::None,

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -99,6 +99,7 @@ type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
+	use enumflags2::BitFlags;
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
 
@@ -203,37 +204,49 @@ pub mod pallet {
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
-		pub identities: Vec<(T::AccountId, BoundedVec<u8, ConstU32<32>>)>,
+		pub registrars: Vec<(T::AccountId, Vec<(T::AccountId, BoundedVec<u8, ConstU32<32>>)>)>,
 	}
 
 	impl<T: Config> Default for GenesisConfig<T> {
 		fn default() -> Self {
-			GenesisConfig { identities: Default::default() }
+			GenesisConfig { registrars: Default::default() }
 		}
 	}
 
 	#[pallet::genesis_build]
 	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
 		fn build(&self) {
-			for (account, name) in &self.identities {
-				<IdentityOf<T>>::insert(
-					account,
-					Registration {
-						info: IdentityInfo {
-							display: Data::Raw(name.clone()),
-							twitter: Data::None,
-							riot: Data::None,
-							email: Data::None,
-							pgp_fingerprint: None,
-							image: Data::None,
-							legal: Data::None,
-							web: Data::None,
-							additional: BoundedVec::default(),
-						},
-						judgements: BoundedVec::default(),
-						deposit: Zero::zero(),
-					},
+			for (registrar, identities) in &self.registrars {
+				<Registrars<T>>::put(
+					BoundedVec::try_from(vec![Some(RegistrarInfo {
+						account: registrar.clone(),
+						fee: Zero::zero(),
+						fields: IdentityFields(<BitFlags<IdentityField>>::all()),
+					})])
+					.unwrap(),
 				);
+				for (account, name) in identities {
+					let judgements =
+						BoundedVec::try_from(vec![(0, Judgement::KnownGood); 1]).unwrap();
+					<IdentityOf<T>>::insert(
+						account,
+						Registration {
+							info: IdentityInfo {
+								display: Data::Raw(name.clone()),
+								twitter: Data::None,
+								riot: Data::None,
+								email: Data::None,
+								pgp_fingerprint: None,
+								image: Data::None,
+								legal: Data::None,
+								web: Data::None,
+								additional: BoundedVec::default(),
+							},
+							judgements,
+							deposit: Zero::zero(),
+						},
+					);
+				}
 			}
 		}
 	}

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -215,7 +215,7 @@ pub mod pallet {
 	}
 
 	#[pallet::genesis_build]
-	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
 		fn build(&self) {
 			for (account, name) in &self.identities {
 				<IdentityOf<T>>::insert(

--- a/frame/identity/src/tests.rs
+++ b/frame/identity/src/tests.rs
@@ -619,3 +619,28 @@ fn test_has_identity() {
 		));
 	});
 }
+
+#[test]
+fn test_genesis_config_should_register_identities() {
+	let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+	pallet_identity::GenesisConfig::<Test> {
+		identities: vec![(1, "One".to_string()), (2, "Two".to_string()), (3, "Three".to_string())],
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+	let mut ext: sp_io::TestExternalities = t.into();
+	ext.execute_with(|| {
+		assert_eq!(
+			Identity::identity(1).unwrap().info.display,
+			Data::Raw(b"One".to_vec().try_into().unwrap())
+		);
+		assert_eq!(
+			Identity::identity(2).unwrap().info.display,
+			Data::Raw(b"Two".to_vec().try_into().unwrap())
+		);
+		assert_eq!(
+			Identity::identity(3).unwrap().info.display,
+			Data::Raw(b"Three".to_vec().try_into().unwrap())
+		);
+	});
+}

--- a/frame/identity/src/tests.rs
+++ b/frame/identity/src/tests.rs
@@ -625,9 +625,9 @@ fn test_genesis_config_should_register_identities() {
 	let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
 	pallet_identity::GenesisConfig::<Test> {
 		identities: vec![
-			(1, "One".to_string().as_bytes().to_vec()),
-			(2, "Two".to_string().as_bytes().to_vec()),
-			(3, "Three".to_string().as_bytes().to_vec()),
+			(1, BoundedVec::try_from("One".to_string().as_bytes().to_vec()).unwrap()),
+			(2, BoundedVec::try_from("Two".to_string().as_bytes().to_vec()).unwrap()),
+			(3, BoundedVec::try_from("Three".to_string().as_bytes().to_vec()).unwrap()),
 		],
 	}
 	.assimilate_storage(&mut t)

--- a/frame/identity/src/tests.rs
+++ b/frame/identity/src/tests.rs
@@ -624,7 +624,11 @@ fn test_has_identity() {
 fn test_genesis_config_should_register_identities() {
 	let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
 	pallet_identity::GenesisConfig::<Test> {
-		identities: vec![(1, "One".to_string()), (2, "Two".to_string()), (3, "Three".to_string())],
+		identities: vec![
+			(1, "One".to_string().as_bytes().to_vec()),
+			(2, "Two".to_string().as_bytes().to_vec()),
+			(3, "Three".to_string().as_bytes().to_vec()),
+		],
 	}
 	.assimilate_storage(&mut t)
 	.unwrap();


### PR DESCRIPTION
# Description

This change adds a `GenesisConfig` to the identity pallet, allowing downstream users to automatically seed Identities via chainspec config. 

# Checklist

- [x] My PR includes a detailed description as outlined in the "Description" section above
- [x] My PR follows the [labeling requirements](https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.md#merge-process) of this project (at minimum one label for each `A`, `B`, `C` and `D` required)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] If this PR alters any external APIs or interfaces used by Polkadot, the corresponding Polkadot PR is ready as well as the corresponding Cumulus PR (optional)