### PR TITLE
Update to `x25519-dalek` v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,16 +1894,29 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-rc.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d4ba9852b42210c7538b75484f9daa0655e9a3ac04f693747bb0f02cf3cfe16"
+checksum = "f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2"
 dependencies = [
  "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
  "fiat-crypto",
- "packed_simd_2",
  "platforms",
+ "rustc_version 0.4.0",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -4366,12 +4379,6 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
-
-[[package]]
-name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
@@ -5951,7 +5958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
- "libm 0.2.7",
+ "libm",
 ]
 
 [[package]]
@@ -6065,16 +6072,6 @@ dependencies = [
  "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
  "sha2 0.10.7",
-]
-
-[[package]]
-name = "packed_simd_2"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
-dependencies = [
- "cfg-if",
- "libm 0.1.4",
 ]
 
 [[package]]
@@ -10921,14 +10918,14 @@ checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
 name = "snow"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccba027ba85743e09d15c03296797cad56395089b832b48b5a5217880f57733"
+checksum = "0c9d1425eb528a21de2755c75af4c9b5d57f50a0d4c3b7f1828a4cd03f8ba155"
 dependencies = [
  "aes-gcm 0.9.4",
  "blake2",
  "chacha20poly1305",
- "curve25519-dalek 4.0.0-rc.1",
+ "curve25519-dalek 4.0.0",
  "rand_core 0.6.4",
  "ring 0.16.20",
  "rustc_version 0.4.0",
@@ -11769,7 +11766,7 @@ dependencies = [
  "sp-runtime-interface",
  "sp-std",
  "thiserror",
- "x25519-dalek 2.0.0-pre.1",
+ "x25519-dalek 2.0.0",
 ]
 
 [[package]]
@@ -13529,7 +13526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624e6333e861ef49095d2d678b76ebf30b06bf37effca845be7e5b87c90071b7"
 dependencies = [
  "downcast-rs",
- "libm 0.2.7",
+ "libm",
  "num-traits",
  "paste",
 ]
@@ -13901,7 +13898,7 @@ dependencies = [
  "tokio",
  "webpki 0.21.4",
  "webrtc-util",
- "x25519-dalek 2.0.0-pre.1",
+ "x25519-dalek 2.0.0",
  "x509-parser 0.13.2",
 ]
 
@@ -14299,12 +14296,13 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.0-pre.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5da623d8af10a62342bcbbb230e33e58a63255a58012f8653c578e54bab48df"
+checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
 dependencies = [
- "curve25519-dalek 3.2.0",
+ "curve25519-dalek 4.0.0",
  "rand_core 0.6.4",
+ "serde",
  "zeroize",
 ]
 

--- a/primitives/statement-store/Cargo.toml
+++ b/primitives/statement-store/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = { version = "1.0", optional = true }
 
 # ECIES dependencies
 ed25519-dalek = { version = "1.0", optional = true }
-x25519-dalek = { version = "2.0.0-pre.1", optional = true }
+x25519-dalek = { version = "2.0.0", features = [ "static_secrets" ], optional = true }
 curve25519-dalek = { version = "3.2", optional = true }
 aes-gcm = { version = "0.10", optional = true }
 hkdf = { version = "0.12.0", optional = true }

--- a/primitives/statement-store/src/ecies.rs
+++ b/primitives/statement-store/src/ecies.rs
@@ -71,7 +71,7 @@ fn kdf(shared_secret: &[u8]) -> [u8; AES_KEY_LEN] {
 /// Encrypt `plaintext` with the given public x25519 public key. Decryption can be performed with
 /// the matching secret key.
 pub fn encrypt_x25519(pk: &PublicKey, plaintext: &[u8]) -> Result<Vec<u8>, Error> {
-	let ephemeral_sk = x25519_dalek::StaticSecret::new(OsRng);
+	let ephemeral_sk = x25519_dalek::StaticSecret::random_from_rng(OsRng);
 	let ephemeral_pk = x25519_dalek::PublicKey::from(&ephemeral_sk);
 
 	let mut shared_secret = ephemeral_sk.diffie_hellman(pk).to_bytes().to_vec();
@@ -135,7 +135,7 @@ mod test {
 
 	#[test]
 	fn basic_x25519_encryption() {
-		let sk = SecretKey::new(OsRng);
+		let sk = SecretKey::random_from_rng(OsRng);
 		let pk = PublicKey::from(&sk);
 
 		let plain_message = b"An important secret message";
@@ -159,7 +159,7 @@ mod test {
 
 	#[test]
 	fn fails_on_bad_data() {
-		let sk = SecretKey::new(OsRng);
+		let sk = SecretKey::random_from_rng(OsRng);
 		let pk = PublicKey::from(&sk);
 
 		let plain_message = b"An important secret message";


### PR DESCRIPTION
changes:
- Update to latest `x25519-dalek` dependency.

Substrate master CI is red since this `cargo build` line here pulls in version 2.0.0 instead of the pre-release, which makes the build fail.  
https://github.com/paritytech/substrate/blob/aeb8c3107f79afef081dde2b9aa2866a6596f6ba/scripts/ci/node-template-release/src/main.rs#L237

I will try to see if it makes sense to copy the Substrate Cargo.lock into the template release build, such that it wont blindly update deps when building.
-> Does not work since the lockfile of Substrate needs to be updated to remove the unused deps, but `--locked` would prevent that...