### PR TITLE
[NFTs] Make owned_item in MintWitness optional

### DIFF
--- a/frame/nfts/src/lib.rs
+++ b/frame/nfts/src/lib.rs
@@ -662,7 +662,7 @@ pub mod pallet {
 		///
 		/// The origin must be Signed and the sender must have sufficient funds free.
 		///
-		/// `ItemDeposit` funds of sender are reserved.
+		/// `CollectionDeposit` funds of sender are reserved.
 		///
 		/// Parameters:
 		/// - `admin`: The admin of this collection. The admin is the initial address of each
@@ -844,6 +844,7 @@ pub mod pallet {
 						MintType::HolderOf(collection_id) => {
 							let MintWitness { owned_item, .. } =
 								witness_data.clone().ok_or(Error::<T, I>::WitnessRequired)?;
+							let owned_item = owned_item.ok_or(Error::<T, I>::BadWitness)?;
 
 							let owns_item = Account::<T, I>::contains_key((
 								&caller,

--- a/frame/nfts/src/tests.rs
+++ b/frame/nfts/src/tests.rs
@@ -427,7 +427,7 @@ fn mint_should_work() {
 				1,
 				42,
 				account(2),
-				Some(MintWitness { owned_item: 42, ..Default::default() })
+				Some(MintWitness { owned_item: Some(42), ..Default::default() })
 			),
 			Error::<Test>::BadWitness
 		);
@@ -436,7 +436,7 @@ fn mint_should_work() {
 			1,
 			42,
 			account(2),
-			Some(MintWitness { owned_item: 43, ..Default::default() })
+			Some(MintWitness { owned_item: Some(43), ..Default::default() })
 		));
 
 		// can't mint twice
@@ -446,7 +446,7 @@ fn mint_should_work() {
 				1,
 				46,
 				account(2),
-				Some(MintWitness { owned_item: 43, ..Default::default() })
+				Some(MintWitness { owned_item: Some(43), ..Default::default() })
 			),
 			Error::<Test>::AlreadyClaimed
 		);

--- a/frame/nfts/src/types.rs
+++ b/frame/nfts/src/types.rs
@@ -133,7 +133,7 @@ impl<AccountId, DepositBalance> CollectionDetails<AccountId, DepositBalance> {
 #[derive(Clone, Encode, Decode, Default, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 pub struct MintWitness<ItemId, Balance> {
 	/// Provide the id of the item in a required collection.
-	pub owned_item: ItemId,
+	pub owned_item: Option<ItemId>,
 	/// The price specified in mint settings.
 	pub mint_price: Option<Balance>,
 }


### PR DESCRIPTION
In the `MintWitness` object, all the fields are supposed to be optional.
We validate them depending on the collection settings: `MintWitness.owned_item` when the `mint_type` = HolderOf and `MintWitness.mint_price` when the mint price is set.
