### PR TITLE
asset-conversion pallet: pool's `AccountId` derivation warn docs

### DIFF
--- a/frame/asset-conversion/src/lib.rs
+++ b/frame/asset-conversion/src/lib.rs
@@ -147,6 +147,9 @@ pub mod pallet {
 
 		/// Type that identifies either the native currency or a token class from `Assets`.
 		/// `Ord` is added because of `get_pool_id`.
+		///
+		/// The pool's `AccountId` is derived from this type. Any changes to the type may
+		/// necessitate a migration.
 		type MultiAssetId: AssetId + Ord + From<Self::AssetId>;
 
 		/// Type to convert an `AssetId` into `MultiAssetId`.

--- a/frame/asset-conversion/src/lib.rs
+++ b/frame/asset-conversion/src/lib.rs
@@ -1196,7 +1196,9 @@ pub mod pallet {
 					()
 				);
 			} else {
-				let MultiAssetIdConversionResult::Converted(asset_id) = T::MultiAssetIdConverter::try_convert(asset) else {
+				let MultiAssetIdConversionResult::Converted(asset_id) =
+					T::MultiAssetIdConverter::try_convert(asset)
+				else {
 					return Err(())
 				};
 				let minimal = T::Assets::minimum_balance(asset_id);

--- a/frame/asset-conversion/src/tests.rs
+++ b/frame/asset-conversion/src/tests.rs
@@ -66,7 +66,11 @@ fn pool_assets() -> Vec<u32> {
 
 fn create_tokens(owner: u128, tokens: Vec<NativeOrAssetId<u32>>) {
 	for token_id in tokens {
-		let MultiAssetIdConversionResult::Converted(asset_id) = NativeOrAssetIdConverter::try_convert(&token_id) else { unreachable!("invalid token") };
+		let MultiAssetIdConversionResult::Converted(asset_id) =
+			NativeOrAssetIdConverter::try_convert(&token_id)
+		else {
+			unreachable!("invalid token")
+		};
 		assert_ok!(Assets::force_create(RuntimeOrigin::root(), asset_id, owner, false, 1));
 	}
 }

--- a/frame/asset-conversion/src/types.rs
+++ b/frame/asset-conversion/src/types.rs
@@ -21,6 +21,10 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_std::{cmp::Ordering, marker::PhantomData};
 
+/// Pool ID.
+///
+/// The pool's `AccountId` is derived from this type. Any changes to the type may necessitate a
+/// migration.
 pub(super) type PoolIdOf<T> = (<T as Config>::MultiAssetId, <T as Config>::MultiAssetId);
 
 /// Stores the lp_token asset id a particular pool has been assigned.


### PR DESCRIPTION
Related https://github.com/paritytech/substrate/issues/14784