### PR TITLE
chainHead: Add support for storage closest merkle descendant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,7 +755,7 @@ version = "4.0.0-dev"
 dependencies = [
  "array-bytes",
  "env_logger 0.9.3",
- "hash-db",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value)",
  "log",
  "sp-core",
  "sp-runtime",
@@ -3115,6 +3115,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e7d7786361d7425ae2fe4f9e407eb0efaa0840f5212d109cc018c40c35c6ab4"
 
 [[package]]
+name = "hash-db"
+version = "0.16.0"
+source = "git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value#77f19e2ca5fb45bec3e1dbcca82a9023d75c312d"
+
+[[package]]
 name = "hash256-std-hasher"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3808,7 +3813,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19ea4653859ca2266a86419d3f592d3f22e7a854b482f99180d2498507902048"
 dependencies = [
- "hash-db",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash256-std-hasher",
  "tiny-keccak",
 ]
@@ -4708,7 +4713,15 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808b50db46293432a45e63bc15ea51e0ab4c0a1647b8eb114e31a3e698dd6fbe"
 dependencies = [
- "hash-db",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memory-db"
+version = "0.32.0"
+source = "git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value#77f19e2ca5fb45bec3e1dbcca82a9023d75c312d"
+dependencies = [
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value)",
 ]
 
 [[package]]
@@ -5107,7 +5120,7 @@ dependencies = [
  "derive_more",
  "fs_extra",
  "futures",
- "hash-db",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value)",
  "kitchensink-runtime",
  "kvdb",
  "kvdb-rocksdb",
@@ -8757,7 +8770,7 @@ version = "0.10.0-dev"
 dependencies = [
  "array-bytes",
  "criterion",
- "hash-db",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value)",
  "kitchensink-runtime",
  "kvdb",
  "kvdb-memorydb",
@@ -10404,7 +10417,7 @@ dependencies = [
 name = "sp-api"
 version = "4.0.0-dev"
 dependencies = [
- "hash-db",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value)",
  "log",
  "parity-scale-codec",
  "scale-info",
@@ -10765,7 +10778,7 @@ dependencies = [
  "dyn-clonable",
  "ed25519-zebra",
  "futures",
- "hash-db",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value)",
  "hash256-std-hasher",
  "impl-serde",
  "lazy_static",
@@ -11168,7 +11181,7 @@ version = "0.28.0"
 dependencies = [
  "array-bytes",
  "assert_matches",
- "hash-db",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value)",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -11183,7 +11196,7 @@ dependencies = [
  "sp-trie",
  "thiserror",
  "tracing",
- "trie-db",
+ "trie-db 0.27.1 (git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value)",
 ]
 
 [[package]]
@@ -11290,10 +11303,10 @@ dependencies = [
  "ahash 0.8.3",
  "array-bytes",
  "criterion",
- "hash-db",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value)",
  "hashbrown 0.13.2",
  "lazy_static",
- "memory-db",
+ "memory-db 0.32.0 (git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value)",
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -11305,8 +11318,8 @@ dependencies = [
  "thiserror",
  "tracing",
  "trie-bench",
- "trie-db",
- "trie-root",
+ "trie-db 0.27.1 (git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value)",
+ "trie-root 0.18.0 (git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value)",
  "trie-standardmap",
 ]
 
@@ -11645,7 +11658,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-trie",
- "trie-db",
+ "trie-db 0.27.1 (git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value)",
 ]
 
 [[package]]
@@ -11720,7 +11733,7 @@ dependencies = [
  "sp-version",
  "substrate-test-runtime-client",
  "substrate-wasm-builder",
- "trie-db",
+ "trie-db 0.27.1 (git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value)",
 ]
 
 [[package]]
@@ -12340,12 +12353,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f54b4f9d51d368e62cf7e0730c7c1e18fc658cc84333656bab5b328f44aa964"
 dependencies = [
  "criterion",
- "hash-db",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hasher",
- "memory-db",
+ "memory-db 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
- "trie-db",
- "trie-root",
+ "trie-db 0.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-root 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-standardmap",
 ]
 
@@ -12355,7 +12368,19 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "767abe6ffed88a1889671a102c2861ae742726f52e0a5a425b92c9fbfa7e9c85"
 dependencies = [
- "hash-db",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.13.2",
+ "log",
+ "rustc-hex",
+ "smallvec",
+]
+
+[[package]]
+name = "trie-db"
+version = "0.27.1"
+source = "git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value#77f19e2ca5fb45bec3e1dbcca82a9023d75c312d"
+dependencies = [
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value)",
  "hashbrown 0.13.2",
  "log",
  "rustc-hex",
@@ -12368,7 +12393,15 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ed310ef5ab98f5fa467900ed906cb9232dd5376597e00fd4cba2a449d06c0b"
 dependencies = [
- "hash-db",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "trie-root"
+version = "0.18.0"
+source = "git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value#77f19e2ca5fb45bec3e1dbcca82a9023d75c312d"
+dependencies = [
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=lexnv/expose_merkle_value)",
 ]
 
 [[package]]
@@ -12377,7 +12410,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "684aafb332fae6f83d7fe10b3fbfdbe39a1b3234c4e2a618f030815838519516"
 dependencies = [
- "hash-db",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hasher",
 ]
 

--- a/bin/node/bench/Cargo.toml
+++ b/bin/node/bench/Cargo.toml
@@ -33,7 +33,7 @@ sc-basic-authorship = { version = "0.10.0-dev", path = "../../../client/basic-au
 sp-inherents = { version = "4.0.0-dev", path = "../../../primitives/inherents" }
 sp-timestamp = { version = "4.0.0-dev", default-features = false, path = "../../../primitives/timestamp" }
 sp-tracing = { version = "10.0.0", path = "../../../primitives/tracing" }
-hash-db = "0.16.0"
+hash-db = { git = "https://github.com/paritytech/trie.git", branch = "lexnv/expose_merkle_value" }
 tempfile = "3.1.0"
 fs_extra = "1"
 rand = { version = "0.8.5", features = ["small_rng"] }

--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -476,6 +476,20 @@ pub trait StorageProvider<Block: BlockT, B: Backend<Block>> {
 		child_info: &ChildInfo,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<Block::Hash>>;
+
+	/// Given a block's `Hash` and a key, return the closest merkle value.
+	fn closest_merkle_value(
+		&self,
+		hash: Block::Hash,
+		key: &StorageKey,
+	) -> sp_blockchain::Result<Option<Block::Hash>>;
+
+	/// Given a block's `Hash`, a key and a child storage key, return the closest merkle value.
+	fn child_closest_merkle_value(
+		&self,
+		hash: Block::Hash,
+		key: &StorageKey,
+	) -> sp_blockchain::Result<Option<Block::Hash>>;
 }
 
 /// Client backend.

--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -488,6 +488,7 @@ pub trait StorageProvider<Block: BlockT, B: Backend<Block>> {
 	fn child_closest_merkle_value(
 		&self,
 		hash: Block::Hash,
+		child_info: &ChildInfo,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<Block::Hash>>;
 }

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", features = [
 	"derive",
 ] }
-hash-db = "0.16.0"
+hash-db = { git = "https://github.com/paritytech/trie.git", branch = "lexnv/expose_merkle_value" }
 kvdb = "0.13.0"
 kvdb-memorydb = "0.13.0"
 kvdb-rocksdb = { version = "0.19.0", optional = true }

--- a/client/db/src/bench.rs
+++ b/client/db/src/bench.rs
@@ -383,6 +383,24 @@ impl<B: BlockT> StateBackend<HashingFor<B>> for BenchmarkingState<B> {
 			.child_storage_hash(child_info, key)
 	}
 
+	fn closest_merkle_value(&self, key: &[u8]) -> Result<Option<B::Hash>, Self::Error> {
+		self.add_read_key(None, key);
+		self.state.borrow().as_ref().ok_or_else(state_err)?.closest_merkle_value(key)
+	}
+
+	fn child_closest_merkle_value(
+		&self,
+		child_info: &ChildInfo,
+		key: &[u8],
+	) -> Result<Option<B::Hash>, Self::Error> {
+		self.add_read_key(None, key);
+		self.state
+			.borrow()
+			.as_ref()
+			.ok_or_else(state_err)?
+			.child_closest_merkle_value(child_info, key)
+	}
+
 	fn exists_storage(&self, key: &[u8]) -> Result<bool, Self::Error> {
 		self.add_read_key(None, key);
 		self.state.borrow().as_ref().ok_or_else(state_err)?.exists_storage(key)

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -215,6 +215,18 @@ impl<B: BlockT> StateBackend<HashingFor<B>> for RefTrackingState<B> {
 		self.state.child_storage_hash(child_info, key)
 	}
 
+	fn closest_merkle_value(&self, key: &[u8]) -> Result<Option<B::Hash>, Self::Error> {
+		self.state.closest_merkle_value(key)
+	}
+
+	fn child_closest_merkle_value(
+		&self,
+		child_info: &ChildInfo,
+		key: &[u8],
+	) -> Result<Option<B::Hash>, Self::Error> {
+		self.state.child_closest_merkle_value(child_info, key)
+	}
+
 	fn exists_storage(&self, key: &[u8]) -> Result<bool, Self::Error> {
 		self.state.exists_storage(key)
 	}

--- a/client/db/src/record_stats_state.rs
+++ b/client/db/src/record_stats_state.rs
@@ -145,6 +145,18 @@ impl<S: StateBackend<HashingFor<B>>, B: BlockT> StateBackend<HashingFor<B>>
 		self.state.child_storage_hash(child_info, key)
 	}
 
+	fn closest_merkle_value(&self, key: &[u8]) -> Result<Option<B::Hash>, Self::Error> {
+		self.state.closest_merkle_value(key)
+	}
+
+	fn child_closest_merkle_value(
+		&self,
+		child_info: &ChildInfo,
+		key: &[u8],
+	) -> Result<Option<B::Hash>, Self::Error> {
+		self.state.child_closest_merkle_value(child_info, key)
+	}
+
 	fn exists_storage(&self, key: &[u8]) -> Result<bool, Self::Error> {
 		self.state.exists_storage(key)
 	}

--- a/client/rpc-spec-v2/src/chain_head/chain_head.rs
+++ b/client/rpc-spec-v2/src/chain_head/chain_head.rs
@@ -27,7 +27,7 @@ use crate::{
 		api::ChainHeadApiServer,
 		chain_head_follow::ChainHeadFollower,
 		error::Error as ChainHeadRpcError,
-		event::{FollowEvent, MethodResponse, OperationError, StorageQuery, StorageQueryType},
+		event::{FollowEvent, MethodResponse, OperationError, StorageQuery},
 		hex_string,
 		subscription::{SubscriptionManagement, SubscriptionManagementError},
 	},
@@ -329,19 +329,12 @@ where
 		let items = items
 			.into_iter()
 			.map(|query| {
-				if query.query_type == StorageQueryType::ClosestDescendantMerkleValue {
-					// Note: remove this once all types are implemented.
-					return Err(ChainHeadRpcError::InvalidParam(
-						"Storage query type not supported".into(),
-					))
-				}
-
 				Ok(StorageQuery {
 					key: StorageKey(parse_hex_param(query.key)?),
 					query_type: query.query_type,
 				})
 			})
-			.collect::<Result<Vec<_>, _>>()?;
+			.collect::<Result<Vec<_>, ChainHeadRpcError>>()?;
 
 		let child_trie = child_trie
 			.map(|child_trie| parse_hex_param(child_trie))

--- a/client/rpc-spec-v2/src/chain_head/test_utils.rs
+++ b/client/rpc-spec-v2/src/chain_head/test_utils.rs
@@ -198,6 +198,23 @@ impl<
 	) -> sp_blockchain::Result<Option<Block::Hash>> {
 		self.client.child_storage_hash(hash, child_info, key)
 	}
+
+	fn closest_merkle_value(
+		&self,
+		hash: <Block as BlockT>::Hash,
+		key: &StorageKey,
+	) -> sp_blockchain::Result<Option<<Block as BlockT>::Hash>> {
+		self.client.closest_merkle_value(hash, key)
+	}
+
+	fn child_closest_merkle_value(
+		&self,
+		hash: <Block as BlockT>::Hash,
+		child_info: &ChildInfo,
+		key: &StorageKey,
+	) -> sp_blockchain::Result<Option<<Block as BlockT>::Hash>> {
+		self.client.child_closest_merkle_value(hash, child_info, key)
+	}
 }
 
 impl<Block: BlockT, Client: CallApiAt<Block>> CallApiAt<Block> for ChainHeadMockClient<Client> {

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -1561,15 +1561,20 @@ where
 		hash: <Block as BlockT>::Hash,
 		key: &StorageKey,
 	) -> blockchain::Result<Option<<Block as BlockT>::Hash>> {
-		Ok(None)
+		self.state_at(hash)?
+			.closest_merkle_value(&key.0)
+			.map_err(|e| sp_blockchain::Error::from_state(Box::new(e)))
 	}
 
 	fn child_closest_merkle_value(
 		&self,
 		hash: <Block as BlockT>::Hash,
+		child_info: &ChildInfo,
 		key: &StorageKey,
 	) -> blockchain::Result<Option<<Block as BlockT>::Hash>> {
-		Ok(None)
+		self.state_at(hash)?
+			.child_closest_merkle_value(child_info, &key.0)
+			.map_err(|e| sp_blockchain::Error::from_state(Box::new(e)))
 	}
 }
 

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -1555,6 +1555,22 @@ where
 			.child_storage_hash(child_info, &key.0)
 			.map_err(|e| sp_blockchain::Error::from_state(Box::new(e)))
 	}
+
+	fn closest_merkle_value(
+		&self,
+		hash: <Block as BlockT>::Hash,
+		key: &StorageKey,
+	) -> blockchain::Result<Option<<Block as BlockT>::Hash>> {
+		Ok(None)
+	}
+
+	fn child_closest_merkle_value(
+		&self,
+		hash: <Block as BlockT>::Hash,
+		key: &StorageKey,
+	) -> blockchain::Result<Option<<Block as BlockT>::Hash>> {
+		Ok(None)
+	}
 }
 
 impl<B, E, Block, RA> HeaderMetadata<Block> for Client<B, E, Block, RA>

--- a/primitives/api/Cargo.toml
+++ b/primitives/api/Cargo.toml
@@ -22,7 +22,7 @@ sp-externalities = { version = "0.19.0", default-features = false, optional = tr
 sp-version = { version = "22.0.0", default-features = false, path = "../version" }
 sp-state-machine = { version = "0.28.0", default-features = false, optional = true, path = "../state-machine" }
 sp-trie = { version = "22.0.0", default-features = false, optional = true, path = "../trie" }
-hash-db = { version = "0.16.0", optional = true }
+hash-db = { git = "https://github.com/paritytech/trie.git", branch = "lexnv/expose_merkle_value" , optional = true }
 thiserror = { version = "1.0.30", optional = true }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 sp-metadata-ir = { version = "0.1.0", default-features = false, optional = true, path = "../metadata-ir" }

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.163", optional = true,  default-features = false, featu
 bounded-collections = { version = "0.1.8", default-features = false }
 primitive-types = { version = "0.12.0", default-features = false, features = ["codec", "scale-info"] }
 impl-serde = { version = "0.4.0", default-features = false, optional = true }
-hash-db = { version = "0.16.0", default-features = false }
+hash-db = {  git = "https://github.com/paritytech/trie.git", branch = "lexnv/expose_merkle_value", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 bs58 = { version = "0.4.0", default-features = false, optional = true }
 rand = { version = "0.8.5", features = ["small_rng"],  optional = true }

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-hash-db = { version = "0.16.0", default-features = false }
+hash-db = { git = "https://github.com/paritytech/trie.git", branch = "lexnv/expose_merkle_value", default-features = false }
 log = { version = "0.4.17", default-features = false }
 parking_lot = { version = "0.12.1", optional = true }
 rand = { version = "0.8.5", optional = true }
@@ -27,7 +27,7 @@ sp-externalities = { version = "0.19.0", default-features = false, path = "../ex
 sp-panic-handler = { version = "8.0.0", optional = true, path = "../panic-handler" }
 sp-std = { version = "8.0.0", default-features = false, path = "../std" }
 sp-trie = { version = "22.0.0", default-features = false, path = "../trie" }
-trie-db = { version = "0.27.1", default-features = false }
+trie-db = { git = "https://github.com/paritytech/trie.git", branch = "lexnv/expose_merkle_value", default-features = false }
 
 [dev-dependencies]
 array-bytes = "6.1"

--- a/primitives/state-machine/src/backend.rs
+++ b/primitives/state-machine/src/backend.rs
@@ -191,7 +191,17 @@ pub trait Backend<H: Hasher>: sp_std::fmt::Debug {
 	/// Get keyed storage value hash or None if there is nothing associated.
 	fn storage_hash(&self, key: &[u8]) -> Result<Option<H::Out>, Self::Error>;
 
-	/// Get keyed child storage or None if there is nothing associated.
+	/// Get the merkle value or None if there is nothing associated.
+	fn closest_merkle_value(&self, key: &[u8]) -> Result<Option<H::Out>, Self::Error>;
+
+	/// Get the child merkle value or None if there is nothing associated.
+	fn child_closest_merkle_value(
+		&self,
+		child_info: &ChildInfo,
+		key: &[u8],
+	) -> Result<Option<H::Out>, Self::Error>;
+
+	/// Get child keyed child storage or None if there is nothing associated.
 	fn child_storage(
 		&self,
 		child_info: &ChildInfo,

--- a/primitives/state-machine/src/trie_backend.rs
+++ b/primitives/state-machine/src/trie_backend.rs
@@ -405,6 +405,18 @@ where
 		self.essence.child_storage(child_info, key)
 	}
 
+	fn closest_merkle_value(&self, key: &[u8]) -> Result<Option<H::Out>, Self::Error> {
+		Ok(None)
+	}
+
+	fn child_closest_merkle_value(
+		&self,
+		child_info: &ChildInfo,
+		key: &[u8],
+	) -> Result<Option<H::Out>, Self::Error> {
+		Ok(None)
+	}
+
 	fn next_storage_key(&self, key: &[u8]) -> Result<Option<StorageKey>, Self::Error> {
 		let (is_cached, mut cache) = access_cache(&self.next_storage_key_cache, Option::take)
 			.map(|cache| (cache.last_key == key, cache))

--- a/primitives/state-machine/src/trie_backend.rs
+++ b/primitives/state-machine/src/trie_backend.rs
@@ -406,7 +406,7 @@ where
 	}
 
 	fn closest_merkle_value(&self, key: &[u8]) -> Result<Option<H::Out>, Self::Error> {
-		Ok(None)
+		self.essence.closest_merkle_value(key)
 	}
 
 	fn child_closest_merkle_value(
@@ -414,7 +414,7 @@ where
 		child_info: &ChildInfo,
 		key: &[u8],
 	) -> Result<Option<H::Out>, Self::Error> {
-		Ok(None)
+		self.essence.child_closest_merkle_value(child_info, key)
 	}
 
 	fn next_storage_key(&self, key: &[u8]) -> Result<Option<StorageKey>, Self::Error> {

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -21,16 +21,16 @@ harness = false
 ahash = { version = "0.8.2", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 hashbrown = { version = "0.13.2", optional = true }
-hash-db = { version = "0.16.0", default-features = false }
+hash-db = { git = "https://github.com/paritytech/trie.git", branch = "lexnv/expose_merkle_value", default-features = false }
 lazy_static = { version = "1.4.0", optional = true }
-memory-db = { version = "0.32.0", default-features = false }
+memory-db = { git = "https://github.com/paritytech/trie.git", branch = "lexnv/expose_merkle_value", default-features = false }
 nohash-hasher = { version = "0.2.0", optional = true }
 parking_lot = { version = "0.12.1", optional = true }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.30", optional = true }
 tracing = { version = "0.1.29", optional = true }
-trie-db = { version = "0.27.0", default-features = false }
-trie-root = { version = "0.18.0", default-features = false }
+trie-db = { git = "https://github.com/paritytech/trie.git", branch = "lexnv/expose_merkle_value", default-features = false }
+trie-root = { git = "https://github.com/paritytech/trie.git", branch = "lexnv/expose_merkle_value", default-features = false }
 sp-core = { version = "21.0.0", default-features = false, path = "../core" }
 sp-std = { version = "8.0.0", default-features = false, path = "../std" }
 schnellru = { version = "0.2.1", optional = true }

--- a/primitives/trie/src/lib.rs
+++ b/primitives/trie/src/lib.rs
@@ -295,6 +295,24 @@ pub fn read_trie_value<L: TrieLayout, DB: hash_db::HashDBRef<L::Hash, trie_db::D
 		.get(key)
 }
 
+/// Read the closest merkle value from the trie.
+pub fn read_trie_closest_merkle_value<L: TrieLayout, DB>(
+	db: &DB,
+	root: &TrieHash<L>,
+	key: &[u8],
+	recorder: Option<&mut dyn TrieRecorder<TrieHash<L>>>,
+	cache: Option<&mut dyn TrieCache<L::Codec>>,
+) -> Result<Option<TrieHash<L>>, Box<TrieError<L>>>
+where
+	DB: hash_db::HashDBRef<L::Hash, trie_db::DBValue>,
+{
+	TrieDBBuilder::<L>::new(db, root)
+		.with_optional_cache(cache)
+		.with_optional_recorder(recorder)
+		.build()
+		.get_closest_merkle_value(key)
+}
+
 /// Read a value from the trie with given Query.
 pub fn read_trie_value_with<
 	L: TrieLayout,
@@ -395,6 +413,26 @@ where
 		.with_optional_cache(cache)
 		.build()
 		.get_hash(key)
+}
+
+/// Read the closest merkle value from the child trie.
+pub fn read_child_trie_closest_merkle_value<L: TrieConfiguration, DB>(
+	keyspace: &[u8],
+	db: &DB,
+	root: &TrieHash<L>,
+	key: &[u8],
+	recorder: Option<&mut dyn TrieRecorder<TrieHash<L>>>,
+	cache: Option<&mut dyn TrieCache<L::Codec>>,
+) -> Result<Option<TrieHash<L>>, Box<TrieError<L>>>
+where
+	DB: hash_db::HashDBRef<L::Hash, trie_db::DBValue>,
+{
+	let db = KeySpacedDB::new(db, keyspace);
+	TrieDBBuilder::<L>::new(&db, &root)
+		.with_optional_recorder(recorder)
+		.with_optional_cache(cache)
+		.build()
+		.get_closest_merkle_value(key)
 }
 
 /// Read a value from the child trie with given query.

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -40,7 +40,7 @@ pallet-timestamp = { version = "4.0.0-dev", default-features = false, path = "..
 sp-consensus-grandpa = { version = "4.0.0-dev", default-features = false, path = "../../primitives/consensus/grandpa", features = ["serde"] }
 sp-trie = { version = "22.0.0", default-features = false, path = "../../primitives/trie" }
 sp-transaction-pool = { version = "4.0.0-dev", default-features = false, path = "../../primitives/transaction-pool" }
-trie-db = { version = "0.27.0", default-features = false }
+trie-db = { git = "https://github.com/paritytech/trie.git", branch = "lexnv/expose_merkle_value", default-features = false }
 sc-service = { version = "0.10.0-dev", default-features = false, optional = true, features = ["test-helpers"], path = "../../client/service" }
 sp-state-machine = { version = "0.28.0", default-features = false, path = "../../primitives/state-machine" }
 sp-externalities = { version = "0.19.0", default-features = false, path = "../../primitives/externalities" }

--- a/utils/binary-merkle-tree/Cargo.toml
+++ b/utils/binary-merkle-tree/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://substrate.io"
 [dependencies]
 array-bytes = { version = "6.1", optional = true }
 log = { version = "0.4", default-features = false, optional = true }
-hash-db = { version = "0.16.0", default-features = false }
+hash-db = { git = "https://github.com/paritytech/trie.git", branch = "lexnv/expose_merkle_value", default-features = false }
 
 [dev-dependencies]
 array-bytes = "6.1"

--- a/utils/frame/rpc/state-trie-migration-rpc/Cargo.toml
+++ b/utils/frame/rpc/state-trie-migration-rpc/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1", features = ["derive"] }
 sp-core = { path = "../../../../primitives/core" }
 sp-state-machine = { path = "../../../../primitives/state-machine" }
 sp-trie = { path = "../../../../primitives/trie" }
-trie-db = "0.27.0"
+trie-db = { git = "https://github.com/paritytech/trie.git", branch = "lexnv/expose_merkle_value", default-features = false }
 
 jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
 


### PR DESCRIPTION
This PR adds support for fetching the closest merkle value of some key.

Builds on top of
- https://github.com/paritytech/substrate/pull/14755
- https://github.com/paritytech/trie/pull/199


Closes: https://github.com/paritytech/substrate/issues/14550

// @paritytech/subxt-team 