### PR TITLE
sc-consensus-beefy: restart voter on pallet reset

### DIFF
--- a/client/consensus/beefy/src/communication/peers.rs
+++ b/client/consensus/beefy/src/communication/peers.rs
@@ -24,7 +24,7 @@ use std::collections::{HashMap, VecDeque};
 
 /// Report specifying a reputation change for a given peer.
 #[derive(Debug, PartialEq)]
-pub(crate) struct PeerReport {
+pub struct PeerReport {
 	pub who: PeerId,
 	pub cost_benefit: ReputationChange,
 }

--- a/client/consensus/beefy/src/communication/request_response/incoming_requests_handler.rs
+++ b/client/consensus/beefy/src/communication/request_response/incoming_requests_handler.rs
@@ -18,7 +18,7 @@
 
 use codec::DecodeAll;
 use futures::{channel::oneshot, StreamExt};
-use log::{debug, error, trace};
+use log::{debug, trace};
 use sc_client_api::BlockBackend;
 use sc_network::{
 	config as netconfig, config::RequestResponseConfig, types::ProtocolName, PeerId,
@@ -182,7 +182,9 @@ where
 	}
 
 	/// Run [`BeefyJustifsRequestHandler`].
-	pub async fn run(mut self) {
+	///
+	/// Should never end, returns `Error` otherwise.
+	pub async fn run(&mut self) -> Error {
 		trace!(target: BEEFY_SYNC_LOG_TARGET, "🥩 Running BeefyJustifsRequestHandler");
 
 		while let Ok(request) = self
@@ -215,9 +217,6 @@ where
 				},
 			}
 		}
-		error!(
-			target: crate::LOG_TARGET,
-			"🥩 On-demand requests receiver stream terminated, closing worker."
-		);
+		Error::RequestsReceiverStreamClosed
 	}
 }

--- a/client/consensus/beefy/src/communication/request_response/mod.rs
+++ b/client/consensus/beefy/src/communication/request_response/mod.rs
@@ -75,7 +75,7 @@ pub struct JustificationRequest<B: Block> {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum Error {
+pub enum Error {
 	#[error(transparent)]
 	Client(#[from] sp_blockchain::Error),
 
@@ -102,4 +102,7 @@ pub(crate) enum Error {
 
 	#[error("Internal error while getting response.")]
 	ResponseError,
+
+	#[error("On-demand requests receiver stream terminated.")]
+	RequestsReceiverStreamClosed,
 }

--- a/client/consensus/beefy/src/error.rs
+++ b/client/consensus/beefy/src/error.rs
@@ -34,8 +34,18 @@ pub enum Error {
 	Signature(String),
 	#[error("Session uninitialized")]
 	UninitSession,
-	#[error("pallet-beefy was reset, please restart voter")]
+	#[error("pallet-beefy was reset")]
 	ConsensusReset,
+	#[error("Block import stream terminated")]
+	BlockImportStreamTerminated,
+	#[error("Gossip Engine terminated")]
+	GossipEngineTerminated,
+	#[error("Finality proofs gossiping stream terminated")]
+	FinalityProofGossipStreamTerminated,
+	#[error("Finality stream terminated")]
+	FinalityStreamTerminated,
+	#[error("Votes gossiping stream terminated")]
+	VotesGossipStreamTerminated,
 }
 
 #[cfg(test)]

--- a/primitives/consensus/beefy/src/mmr.rs
+++ b/primitives/consensus/beefy/src/mmr.rs
@@ -162,6 +162,12 @@ mod mmr_root_provider {
 		_phantom: PhantomData<B>,
 	}
 
+	impl<B, R> Clone for MmrRootProvider<B, R> {
+		fn clone(&self) -> Self {
+			Self { runtime: self.runtime.clone(), _phantom: PhantomData }
+		}
+	}
+
 	impl<B, R> MmrRootProvider<B, R>
 	where
 		B: Block,


### PR DESCRIPTION
When detecting pallet-beefy consensus reset, just reinitialize the worker and continue without bringing down the task (and possibly the node).