### PR TITLE
Changed LPFee to Permill type in Asset Conversion Pallet

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1557,6 +1557,7 @@ parameter_types! {
 	pub const PoolSetupFee: Balance = 1 * DOLLARS; // should be more or equal to the existential deposit
 	pub const MintMinLiquidity: Balance = 100;  // 100 is good enough when the main currency has 10-12 decimals.
 	pub const LiquidityWithdrawalFee: Permill = Permill::from_percent(0);  // should be non-zero if AllowMultiAssetPools is true, otherwise can be zero.
+	pub const LiquidityPoolFee: Permill = Permill::from_parts(3000); // 0.3%
 }
 
 impl pallet_asset_conversion::Config for Runtime {
@@ -1571,7 +1572,7 @@ impl pallet_asset_conversion::Config for Runtime {
 	type MultiAssetId = NativeOrAssetId<u32>;
 	type PoolAssetId = <Self as pallet_assets::Config<Instance2>>::AssetId;
 	type PalletId = AssetConversionPalletId;
-	type LPFee = ConstU32<3>; // means 0.3%
+	type LPFee = LiquidityPoolFee;
 	type PoolSetupFee = PoolSetupFee;
 	type PoolSetupFeeReceiver = AssetConversionOrigin;
 	type LiquidityWithdrawalFee = LiquidityWithdrawalFee;

--- a/frame/asset-conversion/src/lib.rs
+++ b/frame/asset-conversion/src/lib.rs
@@ -1124,7 +1124,8 @@ pub mod pallet {
 				return Err(Error::<T>::ZeroLiquidity.into())
 			}
 
-			let fee_mult = T::HigherPrecisionBalance::from(1_000_000u32 - T::LPFee::get() * 1_u32);
+			let fee_mult =
+				T::HigherPrecisionBalance::from(1_000_000u32 - T::LPFee::get().deconstruct());
 
 			let amount_in_with_fee =
 				amount_in.checked_mul(&fee_mult).ok_or(Error::<T>::Overflow)?;
@@ -1170,7 +1171,8 @@ pub mod pallet {
 				.checked_mul(&1000u32.into())
 				.ok_or(Error::<T>::Overflow)?;
 
-			let fee_mult = T::HigherPrecisionBalance::from(1_000_000u32 - T::LPFee::get() * 1_u32);
+			let fee_mult =
+				T::HigherPrecisionBalance::from(1_000_000u32 - T::LPFee::get().deconstruct());
 
 			let denominator = reserve_out
 				.checked_sub(&amount_out)

--- a/frame/asset-conversion/src/lib.rs
+++ b/frame/asset-conversion/src/lib.rs
@@ -1124,8 +1124,9 @@ pub mod pallet {
 				return Err(Error::<T>::ZeroLiquidity.into())
 			}
 
-			let fee_mult =
-				T::HigherPrecisionBalance::from(1_000_000u32 - T::LPFee::get().deconstruct());
+			let fee_mult = T::HigherPrecisionBalance::from(
+				(1_000_000u32 - T::LPFee::get().deconstruct()) / 1000, // Reduce to thousand
+			);
 
 			let amount_in_with_fee =
 				amount_in.checked_mul(&fee_mult).ok_or(Error::<T>::Overflow)?;
@@ -1171,8 +1172,9 @@ pub mod pallet {
 				.checked_mul(&1000u32.into())
 				.ok_or(Error::<T>::Overflow)?;
 
-			let fee_mult =
-				T::HigherPrecisionBalance::from(1_000_000u32 - T::LPFee::get().deconstruct());
+			let fee_mult = T::HigherPrecisionBalance::from(
+				(1_000_000u32 - T::LPFee::get().deconstruct()) / 1000, // Reduce to thousand
+			);
 
 			let denominator = reserve_out
 				.checked_sub(&amount_out)

--- a/frame/asset-conversion/src/mock.rs
+++ b/frame/asset-conversion/src/mock.rs
@@ -143,6 +143,7 @@ parameter_types! {
 	pub const AssetConversionPalletId: PalletId = PalletId(*b"py/ascon");
 	pub storage AllowMultiAssetPools: bool = true;
 	pub storage LiquidityWithdrawalFee: Permill = Permill::from_percent(0); // should be non-zero if AllowMultiAssetPools is true, otherwise can be zero
+	pub LiquidityPoolFee: Permill = Permill::from_parts(3000); // 0.3%
 }
 
 ord_parameter_types! {
@@ -159,7 +160,7 @@ impl Config for Test {
 	type PoolAssets = PoolAssets;
 	type PalletId = AssetConversionPalletId;
 	type WeightInfo = ();
-	type LPFee = ConstU32<3>; // means 0.3%
+	type LPFee = LiquidityPoolFee;
 	type PoolSetupFee = ConstU128<100>; // should be more or equal to the existential deposit
 	type PoolSetupFeeReceiver = AssetConversionOrigin;
 	type LiquidityWithdrawalFee = LiquidityWithdrawalFee;

--- a/frame/transaction-payment/asset-conversion-tx-payment/src/mock.rs
+++ b/frame/transaction-payment/asset-conversion-tx-payment/src/mock.rs
@@ -34,7 +34,7 @@ use pallet_transaction_payment::CurrencyAdapter;
 use sp_core::H256;
 use sp_runtime::{
 	traits::{AccountIdConversion, BlakeTwo256, IdentityLookup, SaturatedConversion},
-	Permill,
+	Percent, Permill,
 };
 
 type Block = frame_system::mocking::MockBlock<Runtime>;
@@ -225,6 +225,7 @@ parameter_types! {
 	pub storage AllowMultiAssetPools: bool = false;
 	// should be non-zero if AllowMultiAssetPools is true, otherwise can be zero
 	pub storage LiquidityWithdrawalFee: Permill = Permill::from_percent(0);
+	pub LiquidityPoolFee: Permill = Permill::from_parts(3000); // 0.3%
 	pub const MaxSwapPathLength: u32 = 4;
 }
 
@@ -242,7 +243,7 @@ impl pallet_asset_conversion::Config for Runtime {
 	type PoolAssets = PoolAssets;
 	type PalletId = AssetConversionPalletId;
 	type WeightInfo = ();
-	type LPFee = ConstU32<3>; // means 0.3%
+	type LPFee = LiquidityPoolFee;
 	type PoolSetupFee = ConstU64<100>; // should be more or equal to the existential deposit
 	type PoolSetupFeeReceiver = AssetConversionOrigin;
 	type LiquidityWithdrawalFee = LiquidityWithdrawalFee;


### PR DESCRIPTION
Fixes paritytech/polkadot-sdk#88 

Changed Liquidity Pool fee in Asset Conversion pallet from a Const<u32> to a Permill type.